### PR TITLE
refactor(browser): убрать хардкод USER_AGENT → account.user_agent (#9)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -3,6 +3,10 @@
 
 account:
   storage_state_file: data/storage_state/hh_session.json
+  # user_agent опционален. Закомментирован/отсутствует — Playwright ставит свой
+  # родной User-Agent. Раскомментируйте и впишите строку, только если hh.ru
+  # требует конкретный UA. Хардкода Chrome/xxx в коде нет (см. #9).
+  # user_agent: "Mozilla/5.0 ... Chrome/XXX Safari/537.36"
 
 throttle:
   min_delay_seconds: 8

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -4,7 +4,7 @@ import logging
 
 from playwright.sync_api import sync_playwright
 
-from .browser import HH_BASE_URL, USER_AGENT
+from .browser import HH_BASE_URL
 from .config import AppConfig
 
 logger = logging.getLogger("hhru_bot.auth")
@@ -23,11 +23,15 @@ def login(config: AppConfig) -> None:
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=False)
-        context = browser.new_context(
-            user_agent=USER_AGENT,
-            viewport={"width": 1366, "height": 900},
-            locale="ru-RU",
-        )
+        context_kwargs: dict = {
+            "viewport": {"width": 1366, "height": 900},
+            "locale": "ru-RU",
+        }
+        # user_agent пробрасывается из account.user_agent; без него — родной UA
+        # Playwright (хардкода Chrome/xxx здесь нет, см. #9).
+        if config.user_agent:
+            context_kwargs["user_agent"] = config.user_agent
+        context = browser.new_context(**context_kwargs)
         page = context.new_page()
         page.goto(f"{HH_BASE_URL}/account/login", wait_until="domcontentloaded")
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -10,21 +10,27 @@ logger = logging.getLogger("hhru_bot.browser")
 
 HH_BASE_URL = "https://hh.ru"
 
-USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-)
-
 
 @contextmanager
-def launch_context(storage_state_file: Path, headless: bool = False):
+def launch_context(
+    storage_state_file: Path,
+    headless: bool = False,
+    user_agent: str | None = None,
+):
+    """Контекст браузера с сохранённой сессией.
+
+    user_agent: None (по умолчанию) — пусть Playwright ставит свой родной UA;
+    строка — переопределить UA (если требует hh.ru). Хардкода Chrome/xxx здесь
+    намеренно нет.
+    """
     with sync_playwright() as p:
         browser: Browser = p.chromium.launch(headless=headless)
-        context_kwargs = {
-            "user_agent": USER_AGENT,
+        context_kwargs: dict = {
             "viewport": {"width": 1366, "height": 900},
             "locale": "ru-RU",
         }
+        if user_agent:
+            context_kwargs["user_agent"] = user_agent
         if storage_state_file.exists():
             context_kwargs["storage_state"] = str(storage_state_file)
             logger.info("Загружена сохранённая сессия: %s", storage_state_file)

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -30,7 +30,9 @@ def run(args: argparse.Namespace) -> None:
     resumes = resumes_from_args(config, args)
     throttle = Throttle(config.throttle, history)
 
-    with launch_context(config.storage_state_file, headless=args.headless) as context:
+    with launch_context(
+        config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+    ) as context:
         page = context.new_page()
         for resume in resumes:
             run_apply_for_resume(page, config, resume, history, throttle, args)

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -25,7 +25,9 @@ def run(args: argparse.Namespace) -> None:
     resumes = resumes_from_args(config, args)
     throttle = Throttle(config.throttle, history)
 
-    with launch_context(config.storage_state_file, headless=args.headless) as context:
+    with launch_context(
+        config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+    ) as context:
         page = context.new_page()
         for resume in resumes:
             print(f"\n=== Поднятие резюме: {resume.id} ===")

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -23,7 +23,9 @@ def run(args: argparse.Namespace) -> None:
     history = History(args.history)
     resumes = resumes_from_args(config, args)
 
-    with launch_context(config.storage_state_file, headless=args.headless) as context:
+    with launch_context(
+        config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+    ) as context:
         page = context.new_page()
         for resume in resumes:
             print(f"\n=== Поиск вакансий для резюме: {resume.id} ===")

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -51,6 +51,8 @@ class AppConfig:
     throttle: ThrottleConfig
     cover_letter_default: str
     resumes: list[ResumeConfig]
+    # None = родной UA Playwright. Пробрасывается из account.user_agent (см. parse_account).
+    user_agent: str | None = None
 
     def get_resume(self, resume_id: str) -> ResumeConfig:
         for resume in self.resumes:
@@ -93,7 +95,9 @@ def load_config(path: str | Path) -> AppConfig:
     if not raw:
         raise ConfigError(f"Конфиг {path} пуст или некорректен")
 
-    storage_state_file = parse_account(raw.get("account"))
+    account = parse_account(raw.get("account"))
+    storage_state_file = account.storage_state_file
+    user_agent = account.user_agent
 
     throttle_raw = raw.get("throttle", {})
     throttle = ThrottleConfig(
@@ -139,6 +143,7 @@ def load_config(path: str | Path) -> AppConfig:
         throttle=throttle,
         cover_letter_default=cover_letter_default,
         resumes=resumes,
+        user_agent=user_agent,
     )
 
 

--- a/src/hhru_bot/config_sections/account.py
+++ b/src/hhru_bot/config_sections/account.py
@@ -38,6 +38,7 @@ def parse_account(raw) -> AccountConfig:
         raise ConfigError("Поле 'user_agent' (account) должно быть строкой")
     return AccountConfig(
         storage_state_file=PROJECT_ROOT / storage_state_file,
+        # `or None` намеренно: пустая строка трактуется как «не задано» → родной UA.
         user_agent=user_agent or None,
     )
 

--- a/src/hhru_bot/config_sections/account.py
+++ b/src/hhru_bot/config_sections/account.py
@@ -1,14 +1,24 @@
-"""Парсер корневой секции account → storage_state_file (Path).
+"""Парсер корневой секции account → AccountConfig.
 
-Обёртка над текущим парсингом account. #9 расширит AccountConfig (например,
-user_agent) здесь, не трогая load_config.
+Обёртка над текущим парсингом account. #9 расширил AccountConfig опциональным
+user_agent: если поле не задано в конфиге, browser/auth не передают user_agent
+в Playwright new_context и тот ставит свой родной UA.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import PROJECT_ROOT, ConfigError
+
+
+@dataclass
+class AccountConfig:
+    storage_state_file: Path
+    # None = пусть Playwright ставит родной UA (по умолчанию). Задайте строку,
+    # только если hh.ru требует конкретный User-Agent.
+    user_agent: str | None = None
 
 
 def _require(mapping: dict, key: str, context: str):
@@ -17,12 +27,19 @@ def _require(mapping: dict, key: str, context: str):
     return mapping[key]
 
 
-def parse_account(raw) -> Path:
-    """raw — корневая секция account. Возвращает абсолютный путь к файлу сессии."""
-    account = _require(raw, "storage_state_file", "account") if raw else None
-    if account is None:
+def parse_account(raw) -> AccountConfig:
+    """raw — корневая секция account. Возвращает AccountConfig."""
+    if not raw:
         raise ConfigError("В конфиге отсутствует обязательное поле 'storage_state_file' (account)")
-    return PROJECT_ROOT / account
+    storage_state_file = _require(raw, "storage_state_file", "account")
+    # user_agent опционален: None = родной UA Playwright (никакого хардкода).
+    user_agent = raw.get("user_agent")
+    if user_agent is not None and not isinstance(user_agent, str):
+        raise ConfigError("Поле 'user_agent' (account) должно быть строкой")
+    return AccountConfig(
+        storage_state_file=PROJECT_ROOT / storage_state_file,
+        user_agent=user_agent or None,
+    )
 
 
 # account — корневая секция, не resume-подсекция, поэтому в реестр resume-секций

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,3 +157,29 @@ def test_get_resume_not_found(tmp_path):
     config = load_config(_write_config(tmp_path, _minimal_config()))
     with pytest.raises(ConfigError, match="не найдено"):
         config.get_resume("nope")
+
+
+def test_load_config_account_user_agent_default_none(tmp_path):
+    # user_agent не задан → None → браузер использует родной UA Playwright (#9).
+    config = load_config(_write_config(tmp_path, _minimal_config()))
+    assert config.user_agent is None
+
+
+def test_load_config_account_user_agent_explicit(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+          user_agent: "Mozilla/5.0 (X11; Linux x86_64) Chrome/999.0 Safari/537.36"
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/FFF666"
+            search:
+              text: "x"
+        """,
+    )
+    config = load_config(path)
+    assert config.user_agent == (
+        "Mozilla/5.0 (X11; Linux x86_64) Chrome/999.0 Safari/537.36"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,4 @@ def test_load_config_account_user_agent_explicit(tmp_path):
         """,
     )
     config = load_config(path)
-    assert config.user_agent == (
-        "Mozilla/5.0 (X11; Linux x86_64) Chrome/999.0 Safari/537.36"
-    )
+    assert config.user_agent == ("Mozilla/5.0 (X11; Linux x86_64) Chrome/999.0 Safari/537.36")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -181,3 +181,22 @@ def test_load_config_account_user_agent_explicit(tmp_path):
     )
     config = load_config(path)
     assert config.user_agent == ("Mozilla/5.0 (X11; Linux x86_64) Chrome/999.0 Safari/537.36")
+
+
+def test_load_config_account_user_agent_wrong_type(tmp_path):
+    # user_agent не-строка → ConfigError (контракт валидации типа, #9).
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+          user_agent: 123
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/GGG777"
+            search:
+              text: "x"
+        """,
+    )
+    with pytest.raises(ConfigError, match="user_agent"):
+        load_config(path)


### PR DESCRIPTION
Closes #9 — Этап 0: убрать устаревший хардкод USER_AGENT.

## Что менялось

После Wave 0 (PR #22) `USER_AGENT` жил в `src/hhru_bot/browser.py`, а парсинг секции `account` делегирован в `config_sections/account.py`. Этот PR убирает устаревший хардкод `Chrome/124` и выносит User-Agent в опциональный `account.user_agent`.

Реализован второй вариант из ишью (вынести в конфиг), т.к. он соответствует заложенной архитектуре — в шапке `config_sections/account.py` уже стояла заглушка «#9 расширит AccountConfig (например, user_agent) здесь».

## Изменения

- **`config_sections/account.py`** — `parse_account` возвращает `AccountConfig` (`storage_state_file` + `user_agent=None`). `user_agent` опционален и валидируется как строка.
- **`config.py`** — `AppConfig.user_agent: str | None = None`, распаковывается из `parse_account`.
- **`browser.launch_context`** — `user_agent` теперь параметр (`str | None`); при `None` не передаётся в `new_context`, и Playwright ставит свой родной UA. Хардкода Chrome/xxx больше нет.
- **`auth.login`** — убран импорт `USER_AGENT`, UA берётся из `config.user_agent` (учтена связь `auth.py` ↔ `browser`, отмеченная в ишью).
- **`commands/{apply,bump,search}`** — прокидывают `config.user_agent` в `launch_context`.
- **`config.example.yaml`** — закомментированный пример `account.user_agent` с пояснением, что по умолчанию используется родной UA.

## Поведение по умолчанию

Если `account.user_agent` не задан (текущее поведение большинства конфигов) → `config.user_agent is None` → браузер использует **родной UA Playwright**. Никаких устаревших хардкодов.

## Тесты

`PYTHONPATH=src python3 -m pytest tests/ -q` → 41 passed.

Добавлены 2 characterization-теста в `tests/test_config.py`:
- `test_load_config_account_user_agent_default_none` — без `user_agent` в конфиге `config.user_agent is None`.
- `test_load_config_account_user_agent_explicit` — явная строка пробрасывается как есть.

CLI smoke: `python3 -m hhru_bot.cli --help` — все команды регистрируются, импорты чистые, `USER_AGENT` больше нигде не упоминается (`grep -rn USER_AGENT src/ tests/` пусто).

## Риски / follow-ups

- Поведение браузера меняется: раньше всегда шёл захардкоженный Chrome/124, теперь — родной UA Playwright (на момент установки `chromium`). Это намеренное изменение из ишью; если hh.ru начнёт блокировать — пользователь впишет `account.user_agent` в конфиг.
- Перед первым боевым `apply`/`bump` всё равно нужна сверка непроверенных селекторов (см. `selectors.py`) — к UA отношения не имеет.