### PR TITLE
feat(search): ранжирование вакансий rank_candidates (#15)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -33,6 +33,21 @@ resumes:
       exclude_keywords:
         - "1С"
         - "холодные звонки"
+      # Опционально (issue #15): буст за совпадение ключевых слов в title.
+      must_have:
+        - "python"
+        - "django"
+      nice_to_have:
+        - "docker"
+        - "kubernetes"
+    # Опционально (issue #15): веса факторов ранжирования. При отсутствии
+    # секции используются дефолтные веса ниже.
+    scoring:
+      weights:
+        must_have: 2.0        # буст за каждое must_have-совпадение в title
+        nice_to_have: 1.0     # буст за каждое nice_to_have-совпадение
+        exclude_keyword: -3.0 # штраф за стоп-слово в title
+        text_match: 1.0       # буст × доля совпавших токенов filters.text
     cover_letter: null
 
   - id: "resume-name-2"

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -13,7 +13,7 @@ import logging
 from ..apply import apply_to_vacancy
 from ..config import AppConfig, ResumeConfig
 from ..history import History
-from ..search import filter_candidates, search_vacancies
+from ..search import filter_candidates, rank_candidates, search_vacancies
 from ..throttle import LimitReached, Throttle
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -68,11 +68,15 @@ def run_apply_for_resume(
     for card, reason in skipped:
         logger.debug("Пропуск вакансии %s: %s", card.title, reason)
 
-    limit = args.limit if args.limit else len(candidates)
+    # Ранжирование кандидатов по score (#15) — строго между filter_candidates
+    # и срезом [:limit], чтобы дневной лимит уходил на лучшие совпадения.
+    ranked = rank_candidates(candidates, resume.search, resume)
+
+    limit = args.limit if args.limit else len(ranked)
     cover_letter_template = config.cover_letter_for(resume)
 
     applied_count = 0
-    for card in candidates[:limit]:
+    for card, _score, _breakdown in ranked[:limit]:
         try:
             throttle.check_apply_limit(resume.id, args.dry_run)
         except LimitReached as e:

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -17,7 +17,7 @@ def run(args: argparse.Namespace) -> None:
     from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..history import History
-    from ..search import filter_candidates, search_vacancies
+    from ..search import filter_candidates, rank_candidates, search_vacancies
 
     config = load_config_or_exit(args.config)
     history = History(args.history)
@@ -29,12 +29,17 @@ def run(args: argparse.Namespace) -> None:
             print(f"\n=== Поиск вакансий для резюме: {resume.id} ===")
             cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
             candidates, skipped = filter_candidates(cards, resume.search, resume.id, history)
+            ranked = rank_candidates(candidates, resume.search, resume)
 
             print(
                 f"Найдено всего: {len(cards)}, "
                 f"подходящих: {len(candidates)}, исключено: {len(skipped)}"
             )
-            for c in candidates:
-                print(f"  [candidate] {c.title} — {c.company} ({c.url})")
+            for c, score, breakdown in ranked:
+                factors = ", ".join(
+                    f"{name}={value:+.2f}" for name, value in breakdown.items() if value
+                )
+                detail = f" | {factors}" if factors else ""
+                print(f"  [candidate] score={score:+.2f} {c.title} — {c.company} ({c.url}){detail}")
             for card, reason in skipped:
                 print(f"  [skip] {card.title} — {reason}")

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -26,6 +26,9 @@ class SearchFilters:
     schedule: str | None = None
     exclude_employers: list[str] = field(default_factory=list)
     exclude_keywords: list[str] = field(default_factory=list)
+    # Опциональные поля ранжирования (#15): буст за совпадение в title.
+    must_have: list[str] = field(default_factory=list)
+    nice_to_have: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/hhru_bot/config_sections/__init__.py
+++ b/src/hhru_bot/config_sections/__init__.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 # Импорт регистрирует парсеры; порядок не важен.
-from . import account, search  # noqa: F401
+from . import account, scoring, search  # noqa: F401
 from ._registry import get, names, register
 from .account import parse_account
 

--- a/src/hhru_bot/config_sections/scoring.py
+++ b/src/hhru_bot/config_sections/scoring.py
@@ -1,0 +1,52 @@
+"""Парсер опциональной resume-секции scoring → ScoringConfig (issue #15).
+
+Веса факторов ранжирования вакансий. Секция опциональна: при отсутствии
+load_config оставит ResumeConfig.scoring = None (обратная совместимость —
+rank_candidates тогда использует нейтральные дефолтные веса).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..config import ConfigError
+from ._registry import register
+
+
+@dataclass(frozen=True)
+class ScoringWeights:
+    """Веса факторов. Положительные — буст, отрицательные — штраф."""
+
+    must_have: float = 2.0
+    nice_to_have: float = 1.0
+    exclude_keyword: float = -3.0
+    text_match: float = 1.0
+
+
+@dataclass(frozen=True)
+class ScoringConfig:
+    weights: ScoringWeights = ScoringWeights()
+
+
+def _parse_weights(raw, context: str) -> ScoringWeights:
+    if raw is None:
+        return ScoringWeights()
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением weights: ...")
+    # Каждый вес опционален; неизвестные ключи игнорируем ради обратной совместимости.
+    return ScoringWeights(
+        must_have=float(raw.get("must_have", ScoringWeights.must_have)),
+        nice_to_have=float(raw.get("nice_to_have", ScoringWeights.nice_to_have)),
+        exclude_keyword=float(raw.get("exclude_keyword", ScoringWeights.exclude_keyword)),
+        text_match=float(raw.get("text_match", ScoringWeights.text_match)),
+    )
+
+
+@register("scoring")
+def parse_scoring(raw, context: str) -> ScoringConfig | None:
+    """raw — подсекция scoring (может быть None/отсутствовать)."""
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением")
+    return ScoringConfig(weights=_parse_weights(raw.get("weights"), f"{context}.weights"))

--- a/src/hhru_bot/config_sections/scoring.py
+++ b/src/hhru_bot/config_sections/scoring.py
@@ -34,12 +34,23 @@ def _parse_weights(raw, context: str) -> ScoringWeights:
     if not isinstance(raw, dict):
         raise ConfigError(f"Секция '{context}' должна быть отображением weights: ...")
     # Каждый вес опционален; неизвестные ключи игнорируем ради обратной совместимости.
-    return ScoringWeights(
-        must_have=float(raw.get("must_have", ScoringWeights.must_have)),
-        nice_to_have=float(raw.get("nice_to_have", ScoringWeights.nice_to_have)),
-        exclude_keyword=float(raw.get("exclude_keyword", ScoringWeights.exclude_keyword)),
-        text_match=float(raw.get("text_match", ScoringWeights.text_match)),
-    )
+    # Не-числовое значение → ConfigError (консистентно с _require в config.py),
+    # а не «голый» ValueError из float().
+    weights: dict[str, float] = {}
+    for key, default in (
+        ("must_have", ScoringWeights.must_have),
+        ("nice_to_have", ScoringWeights.nice_to_have),
+        ("exclude_keyword", ScoringWeights.exclude_keyword),
+        ("text_match", ScoringWeights.text_match),
+    ):
+        value = raw.get(key, default)
+        try:
+            weights[key] = float(value)
+        except (TypeError, ValueError) as e:
+            raise ConfigError(
+                f"Вес '{key}' в '{context}' должен быть числом, получено: {value!r}"
+            ) from e
+    return ScoringWeights(**weights)
 
 
 @register("scoring")

--- a/src/hhru_bot/config_sections/search.py
+++ b/src/hhru_bot/config_sections/search.py
@@ -29,4 +29,6 @@ def parse_search(raw, context: str) -> SearchFilters:
         schedule=raw.get("schedule"),
         exclude_employers=raw.get("exclude_employers") or [],
         exclude_keywords=raw.get("exclude_keywords") or [],
+        must_have=raw.get("must_have") or [],
+        nice_to_have=raw.get("nice_to_have") or [],
     )

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -169,21 +169,20 @@ def _tokenize(text: str) -> list[str]:
     return tokens
 
 
-def _ZERO_WEIGHTS() -> ScoringWeights:
-    """Истинно нейтральные веса для legacy-конфига (без секции scoring).
+_ZERO_WEIGHTS = ScoringWeights(
+    must_have=0.0,
+    nice_to_have=0.0,
+    exclude_keyword=0.0,
+    text_match=0.0,
+)
+"""Истинно нейтральные веса для legacy-конфига (без секции scoring).
 
-    Все факторы = 0 → score любой карточки = 0.0 → ранжирование не меняет
-    порядок входа (обратная совместимость candidates[:limit]). НЕ дефолтные
-    веса ScoringWeights(): там text_match=1.0 делал бы legacy score зависимым
-    от filters.text и нарушал бы совместимость, даже если must_have/nice_to_have
-    пусты.
-    """
-    return ScoringWeights(
-        must_have=0.0,
-        nice_to_have=0.0,
-        exclude_keyword=0.0,
-        text_match=0.0,
-    )
+Все факторы = 0 → score любой карточки = 0.0 → ранжирование не меняет
+порядок входа (обратная совместимость candidates[:limit]). НЕ дефолтные
+веса ScoringWeights(): там text_match=1.0 делал бы legacy score зависимым
+от filters.text и нарушал бы совместимость, даже если must_have/nice_to_have
+пусты. frozen-dataclass — переиспользуемая константа (immutable).
+"""
 
 
 def _score_card(
@@ -198,6 +197,13 @@ def _score_card(
       - nice_to_have: +weight за каждое nice_to_have-слово в title.
       - exclude_keyword: +weight (обычно отрицательный) за каждое стоп-слово в title.
       - text_match: +weight × долю токенов filters.text, найденных в title.
+
+    exclude_keyword намеренно дублирует отсев filter_candidates: в нормальном
+    потоке стоп-слова уже отсеяны до rank_candidates, но фактор оставлен для
+    устойчивости (прямой вызов rank_candidates в обход фильтра, будущие
+    изменения filter_candidates). v1 матчит ключевые слова по первому токену —
+    рассчитано на однословные ключи (python/django); многословные ключи
+    ('machine learning') совпадут по любому из своих токенов.
     """
     title_tokens = set(_tokenize(card.title))
 
@@ -243,7 +249,7 @@ def rank_candidates(
     старый candidates[:limit], дневной лимит уходит на тот же набор.
     """
     scoring: ScoringConfig | None = getattr(resume, "scoring", None)
-    weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS()
+    weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS
 
     scored: list[tuple[VacancyCard, float, dict[str, float]]] = []
     for card in candidates:

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -8,7 +8,8 @@ from playwright.sync_api import Page
 
 from . import selectors as sel
 from .browser import HH_BASE_URL
-from .config import SearchFilters
+from .config import ResumeConfig, SearchFilters
+from .config_sections.scoring import ScoringConfig, ScoringWeights
 
 logger = logging.getLogger("hhru_bot.search")
 
@@ -143,3 +144,92 @@ def filter_candidates(
         candidates.append(card)
 
     return candidates, skipped
+
+
+# --- скоринг/ранжирование (issue #15) ---------------------------------------
+
+
+def _tokenize(text: str) -> list[str]:
+    """Простейшая токенизация в нижний регистр по не-буквенно-цифровым границам.
+
+    Намеренно наивная: скоринг v1 работает по title/конфиг-ключевым словам,
+    поэтому лемматизация/морфология не нужны — важна воспроизводимость и
+    дешевизна (без внешних зависимостей).
+    """
+    tokens: list[str] = []
+    current = ""
+    for ch in text.lower():
+        if ch.isalnum():
+            current += ch
+        elif current:
+            tokens.append(current)
+            current = ""
+    if current:
+        tokens.append(current)
+    return tokens
+
+
+def _DEFAULT_WEIGHTS() -> ScoringWeights:
+    return ScoringWeights()
+
+
+def _score_card(
+    card: VacancyCard,
+    filters: SearchFilters,
+    weights: ScoringWeights,
+) -> tuple[float, dict[str, float]]:
+    """Считает score карточки и разбивку по факторам.
+
+    Факторы v1 (по доступным полям title/конфиг):
+      - must_have: +weight за каждое must_have-слово, найденное в title (по токену).
+      - nice_to_have: +weight за каждое nice_to_have-слово в title.
+      - exclude_keyword: +weight (обычно отрицательный) за каждое стоп-слово в title.
+      - text_match: +weight × долю токенов filters.text, найденных в title.
+    """
+    title_tokens = set(_tokenize(card.title))
+
+    must_have_hits = sum(1 for kw in filters.must_have if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
+    nice_hits = sum(1 for kw in filters.nice_to_have if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
+    exclude_hits = sum(1 for kw in filters.exclude_keywords if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
+
+    text_tokens = _tokenize(filters.text)
+    if text_tokens:
+        matched = sum(1 for t in text_tokens if t in title_tokens)
+        text_ratio = matched / len(text_tokens)
+    else:
+        text_ratio = 0.0
+
+    breakdown: dict[str, float] = {
+        "must_have": weights.must_have * must_have_hits,
+        "nice_to_have": weights.nice_to_have * nice_hits,
+        "exclude_keyword": weights.exclude_keyword * exclude_hits,
+        "text_match": weights.text_match * text_ratio,
+    }
+    return sum(breakdown.values()), breakdown
+
+
+def rank_candidates(
+    candidates: list[VacancyCard],
+    filters: SearchFilters,
+    resume: ResumeConfig,
+) -> list[tuple[VacancyCard, float, dict[str, float]]]:
+    """Ранжирует кандидатов по убыванию score (issue #15).
+
+    Чистая функция без браузера — ради тестируемости (как filter_candidates).
+    Возвращает список (карточка, score, разбивка факторов), отсортированный
+    по убыванию score; при равенстве — стабильно по vacancy_id (детерминизм).
+
+    Обратная совместимость: без scoring-конфига и без must_have/nice_to_have
+    все score = 0.0, а порядок сохраняется (стабильная сортировка по vacancy_id).
+    """
+    scoring: ScoringConfig | None = getattr(resume, "scoring", None)
+    weights = scoring.weights if scoring is not None else _DEFAULT_WEIGHTS()
+
+    scored: list[tuple[VacancyCard, float, dict[str, float]]] = []
+    for card in candidates:
+        score, breakdown = _score_card(card, filters, weights)
+        scored.append((card, score, breakdown))
+
+    # Стабильно: равные score упорядочиваются по vacancy_id (лексикографически).
+    scored.sort(key=lambda item: (-item[1], item[0].vacancy_id))
+    return scored

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -169,8 +169,21 @@ def _tokenize(text: str) -> list[str]:
     return tokens
 
 
-def _DEFAULT_WEIGHTS() -> ScoringWeights:
-    return ScoringWeights()
+def _ZERO_WEIGHTS() -> ScoringWeights:
+    """Истинно нейтральные веса для legacy-конфига (без секции scoring).
+
+    Все факторы = 0 → score любой карточки = 0.0 → ранжирование не меняет
+    порядок входа (обратная совместимость candidates[:limit]). НЕ дефолтные
+    веса ScoringWeights(): там text_match=1.0 делал бы legacy score зависимым
+    от filters.text и нарушал бы совместимость, даже если must_have/nice_to_have
+    пусты.
+    """
+    return ScoringWeights(
+        must_have=0.0,
+        nice_to_have=0.0,
+        exclude_keyword=0.0,
+        text_match=0.0,
+    )
 
 
 def _score_card(
@@ -221,19 +234,24 @@ def rank_candidates(
 
     Чистая функция без браузера — ради тестируемости (как filter_candidates).
     Возвращает список (карточка, score, разбивка факторов), отсортированный
-    по убыванию score; при равенстве — стабильно по vacancy_id (детерминизм).
+    по убыванию score; при равенстве — стабильно по ВХОДНОМУ порядку
+    (сортировка только по score, стабильность Python-сорта сохраняет порядок).
 
-    Обратная совместимость: без scoring-конфига и без must_have/nice_to_have
-    все score = 0.0, а порядок сохраняется (стабильная сортировка по vacancy_id).
+    Обратная совместимость: без scoring-конфига используются истинно нулевые
+    веса (все факторы = 0), поэтому ВСЕ score = 0.0 и входной порядок
+    сохраняется полностью — ranked[:limit] выбирает те же вакансии, что и
+    старый candidates[:limit], дневной лимит уходит на тот же набор.
     """
     scoring: ScoringConfig | None = getattr(resume, "scoring", None)
-    weights = scoring.weights if scoring is not None else _DEFAULT_WEIGHTS()
+    weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS()
 
     scored: list[tuple[VacancyCard, float, dict[str, float]]] = []
     for card in candidates:
         score, breakdown = _score_card(card, filters, weights)
         scored.append((card, score, breakdown))
 
-    # Стабильно: равные score упорядочиваются по vacancy_id (лексикографически).
-    scored.sort(key=lambda item: (-item[1], item[0].vacancy_id))
+    # Стабильно: сортировка только по score; равные score сохраняют входной
+    # порядок (Timsort стабилен). Тай-брейк по vacancy_id намеренно убран —
+    # он переупорядочивал бы legacy candidates[:limit] при перемешанных id.
+    scored.sort(key=lambda item: -item[1])
     return scored

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -188,9 +188,13 @@ def _score_card(
     """
     title_tokens = set(_tokenize(card.title))
 
-    must_have_hits = sum(1 for kw in filters.must_have if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
-    nice_hits = sum(1 for kw in filters.nice_to_have if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
-    exclude_hits = sum(1 for kw in filters.exclude_keywords if _tokenize(kw) and _tokenize(kw)[0] in title_tokens)
+    def _kw_in_title(kw: str) -> bool:
+        kw_tokens = _tokenize(kw)
+        return bool(kw_tokens) and kw_tokens[0] in title_tokens
+
+    must_have_hits = sum(1 for kw in filters.must_have if _kw_in_title(kw))
+    nice_hits = sum(1 for kw in filters.nice_to_have if _kw_in_title(kw))
+    exclude_hits = sum(1 for kw in filters.exclude_keywords if _kw_in_title(kw))
 
     text_tokens = _tokenize(filters.text)
     if text_tokens:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -17,7 +17,9 @@ from hhru_bot.search import VacancyCard, rank_candidates
 
 
 def card(vacancy_id: str, title: str = "T", company: str = "C"):
-    return VacancyCard(vacancy_id=vacancy_id, title=title, company=company, url="https://hh.ru/vacancy/0")
+    return VacancyCard(
+        vacancy_id=vacancy_id, title=title, company=company, url="https://hh.ru/vacancy/0"
+    )
 
 
 def resume(
@@ -54,7 +56,7 @@ def test_rank_empty_input():
 def test_factor_must_have_boosts_matching_title():
     filters = SearchFilters(text="python", must_have=["django"])
     cards = [
-        card("1", title="Python Developer"),       # без django
+        card("1", title="Python Developer"),  # без django
         card("2", title="Python Django Developer"),  # django в title
     ]
     ranked = rank_candidates(cards, filters, resume(search=filters))
@@ -81,9 +83,9 @@ def test_factor_must_have_counts_multiple_keywords():
 def test_factor_nice_to_have_lesser_than_must_have():
     filters = SearchFilters(text="python", must_have=["django"], nice_to_have=["docker"])
     cards = [
-        card("a", title="Python Django Developer"),   # только must_have
-        card("b", title="Python Docker Developer"),   # только nice_to_have
-        card("c", title="Python Developer"),          # ничего
+        card("a", title="Python Django Developer"),  # только must_have
+        card("b", title="Python Docker Developer"),  # только nice_to_have
+        card("c", title="Python Developer"),  # ничего
     ]
     ranked = rank_candidates(cards, filters, resume(search=filters))
     order = [c.vacancy_id for c, _s, _b in ranked]
@@ -113,9 +115,9 @@ def test_factor_exclude_keyword_penalty():
 def test_factor_text_match():
     filters = SearchFilters(text="python developer")
     cards = [
-        card("1", title="Python Developer"),       # оба токена
-        card("2", title="Java Developer"),         # один токен
-        card("3", title="Project Manager"),        # ни одного
+        card("1", title="Python Developer"),  # оба токена
+        card("2", title="Java Developer"),  # один токен
+        card("3", title="Project Manager"),  # ни одного
     ]
     ranked = rank_candidates(cards, filters, resume(search=filters))
     by_id = {c.vacancy_id: s for c, s, _b in ranked}
@@ -144,8 +146,14 @@ def test_rank_deterministic_repeated_calls():
         card("1", title="Python Django Docker"),
         card("2", title="Python Django"),
     ]
-    r1 = [(c.vacancy_id, round(s, 6)) for c, s, _b in rank_candidates(cards, filters, resume(search=filters))]
-    r2 = [(c.vacancy_id, round(s, 6)) for c, s, _b in rank_candidates(cards, filters, resume(search=filters))]
+    r1 = [
+        (c.vacancy_id, round(s, 6))
+        for c, s, _b in rank_candidates(cards, filters, resume(search=filters))
+    ]
+    r2 = [
+        (c.vacancy_id, round(s, 6))
+        for c, s, _b in rank_candidates(cards, filters, resume(search=filters))
+    ]
     assert r1 == r2
 
 
@@ -166,7 +174,9 @@ def test_scoring_weights_applied():
     weights = ScoringWeights(must_have=10.0, nice_to_have=1.0, exclude_keyword=0.0, text_match=0.0)
     filters = SearchFilters(text="python", must_have=["django"])
     cards = [card("1", title="Python Django")]
-    ranked = rank_candidates(cards, filters, resume(search=filters, scoring=ScoringConfig(weights=weights)))
+    ranked = rank_candidates(
+        cards, filters, resume(search=filters, scoring=ScoringConfig(weights=weights))
+    )
     _c, score, breakdown = ranked[0]
     assert breakdown["must_have"] == pytest.approx(10.0)
     assert score == pytest.approx(10.0)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -12,7 +12,7 @@ import textwrap
 
 import pytest
 
-from hhru_bot.config import ResumeConfig, SearchFilters, load_config
+from hhru_bot.config import ConfigError, ResumeConfig, SearchFilters, load_config
 from hhru_bot.config_sections.scoring import ScoringConfig, ScoringWeights
 from hhru_bot.search import VacancyCard, rank_candidates
 
@@ -303,3 +303,27 @@ def test_load_config_scoring_optional_defaults(tmp_path):
     assert r.scoring is None
     assert r.search.must_have == []
     assert r.search.nice_to_have == []
+
+
+def test_load_config_scoring_non_numeric_weight_raises_config_error(tmp_path):
+    """Не-числовой вес → ConfigError (консистентно с _require), а не ValueError."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            account:
+              storage_state_file: data/storage_state/hh_session.json
+            resumes:
+              - id: r1
+                resume_url: "https://hh.ru/resume/AAA111"
+                search:
+                  text: "python"
+                scoring:
+                  weights:
+                    must_have: "not-a-number"
+            """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="должен быть числом"):
+        load_config(path)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,231 @@
+"""Тесты скоринга/ранжирования вакансий (issue #15).
+
+Чистая логика без браузера. rank_candidates сортирует кандидатов по убыванию
+score, где score = взвешенная сумма факторов (буст за must_have/nice_to_have и
+совпадение стека, штраф за близость к стоп-словам). Поведение должно быть
+детерминированным и обратно совместимым при пустых весах/списках.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from hhru_bot.config import ResumeConfig, SearchFilters, load_config
+from hhru_bot.search import VacancyCard, rank_candidates
+
+
+def card(vacancy_id: str, title: str = "T", company: str = "C"):
+    return VacancyCard(vacancy_id=vacancy_id, title=title, company=company, url="https://hh.ru/vacancy/0")
+
+
+def resume(
+    search: SearchFilters | None = None,
+    scoring=None,
+) -> ResumeConfig:
+    return ResumeConfig(
+        id="r1",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=search or SearchFilters(text="python"),
+        scoring=scoring,
+    )
+
+
+# --- обратная совместимость: нет scoring, нет must_have/nice_to_have ---
+
+
+def test_rank_empty_weights_preserves_order():
+    """Без scoring-конфига все score = 0.0, порядок входа сохраняется."""
+    filters = SearchFilters(text="python")
+    cards = [card("1", title="A"), card("2", title="B"), card("3", title="C")]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    assert [c.vacancy_id for c, _s, _b in ranked] == ["1", "2", "3"]
+    assert all(score == 0.0 for _c, score, _b in ranked)
+
+
+def test_rank_empty_input():
+    assert rank_candidates([], SearchFilters(text="x"), resume()) == []
+
+
+# --- фактор must_have ---
+
+
+def test_factor_must_have_boosts_matching_title():
+    filters = SearchFilters(text="python", must_have=["django"])
+    cards = [
+        card("1", title="Python Developer"),       # без django
+        card("2", title="Python Django Developer"),  # django в title
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    by_id = {c.vacancy_id: (s, b) for c, s, b in ranked}
+    # must_have-матч должен дать строго больший score
+    assert by_id["2"][0] > by_id["1"][0]
+    assert by_id["2"][1]["must_have"] > 0.0
+    assert by_id["1"][1]["must_have"] == 0.0
+
+
+def test_factor_must_have_counts_multiple_keywords():
+    filters = SearchFilters(text="python", must_have=["django", "flask"])
+    cards = [card("1", title="Python Django Flask Developer")]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    _c, score, breakdown = ranked[0]
+    # оба must_have найдены — буст должен быть больше, чем за один
+    assert breakdown["must_have"] > 0.0
+    assert score == pytest.approx(sum(breakdown.values()))
+
+
+# --- фактор nice_to_have ---
+
+
+def test_factor_nice_to_have_lesser_than_must_have():
+    filters = SearchFilters(text="python", must_have=["django"], nice_to_have=["docker"])
+    cards = [
+        card("a", title="Python Django Developer"),   # только must_have
+        card("b", title="Python Docker Developer"),   # только nice_to_have
+        card("c", title="Python Developer"),          # ничего
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    order = [c.vacancy_id for c, _s, _b in ranked]
+    # must_have > nice_to_have > ничего
+    assert order == ["a", "b", "c"]
+
+
+# --- штраф за близость к стоп-словам ---
+
+
+def test_factor_exclude_keyword_penalty():
+    filters = SearchFilters(text="python", exclude_keywords=["1С"])
+    cards = [
+        card("1", title="Python Developer"),
+        card("2", title="Программист 1С"),
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    by_id = {c.vacancy_id: (s, b) for c, s, b in ranked}
+    # стоп-слово в title должно штрафовать (отрицательный фактор)
+    assert by_id["2"][1]["exclude_keyword"] < 0.0
+    assert by_id["1"][0] > by_id["2"][0]
+
+
+# --- совпадение стека (text → title) ---
+
+
+def test_factor_text_match():
+    filters = SearchFilters(text="python developer")
+    cards = [
+        card("1", title="Python Developer"),       # оба токена
+        card("2", title="Java Developer"),         # один токен
+        card("3", title="Project Manager"),        # ни одного
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    by_id = {c.vacancy_id: s for c, s, _b in ranked}
+    assert by_id["1"] > by_id["2"] > by_id["3"]
+
+
+# --- детерминизм ---
+
+
+def test_tiebreak_by_vacancy_id_when_equal_score():
+    """Равные score → стабильный порядок по vacancy_id (лексикографически)."""
+    filters = SearchFilters(text="x")  # ничего не матчит → score 0 у всех
+    cards = [
+        card("3", title="Same"),
+        card("1", title="Same"),
+        card("2", title="Same"),
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    assert [c.vacancy_id for c, _s, _b in ranked] == ["1", "2", "3"]
+
+
+def test_rank_deterministic_repeated_calls():
+    filters = SearchFilters(text="python", must_have=["django"], nice_to_have=["docker"])
+    cards = [
+        card("3", title="Python Developer"),
+        card("1", title="Python Django Docker"),
+        card("2", title="Python Django"),
+    ]
+    r1 = [(c.vacancy_id, round(s, 6)) for c, s, _b in rank_candidates(cards, filters, resume(search=filters))]
+    r2 = [(c.vacancy_id, round(s, 6)) for c, s, _b in rank_candidates(cards, filters, resume(search=filters))]
+    assert r1 == r2
+
+
+def test_does_not_mutate_input():
+    filters = SearchFilters(text="python", must_have=["django"])
+    cards = [card("2", title="B"), card("1", title="A")]
+    original = list(cards)
+    rank_candidates(cards, filters, resume(search=filters))
+    assert cards == original
+
+
+# --- веса из config ---
+
+
+def test_scoring_weights_applied():
+    from hhru_bot.config_sections.scoring import ScoringConfig, ScoringWeights
+
+    weights = ScoringWeights(must_have=10.0, nice_to_have=1.0, exclude_keyword=0.0, text_match=0.0)
+    filters = SearchFilters(text="python", must_have=["django"])
+    cards = [card("1", title="Python Django")]
+    ranked = rank_candidates(cards, filters, resume(search=filters, scoring=ScoringConfig(weights=weights)))
+    _c, score, breakdown = ranked[0]
+    assert breakdown["must_have"] == pytest.approx(10.0)
+    assert score == pytest.approx(10.0)
+
+
+def test_load_config_scoring_section(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            account:
+              storage_state_file: data/storage_state/hh_session.json
+            resumes:
+              - id: r1
+                resume_url: "https://hh.ru/resume/AAA111"
+                search:
+                  text: "python"
+                  must_have: ["django"]
+                  nice_to_have: ["docker"]
+                scoring:
+                  weights:
+                    must_have: 5.0
+                    nice_to_have: 2.0
+                    exclude_keyword: -4.0
+                    text_match: 1.0
+            """
+        ),
+        encoding="utf-8",
+    )
+    config = load_config(path)
+    r: ResumeConfig = config.resumes[0]
+    assert r.scoring is not None
+    assert r.scoring.weights.must_have == 5.0
+    assert r.scoring.weights.nice_to_have == 2.0
+    assert r.scoring.weights.exclude_keyword == -4.0
+    assert r.scoring.weights.text_match == 1.0
+    assert r.search.must_have == ["django"]
+    assert r.search.nice_to_have == ["docker"]
+
+
+def test_load_config_scoring_optional_defaults(tmp_path):
+    """Без секции scoring resume.scoring = None; SearchFilters.must_have/nice_to_have = []."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            account:
+              storage_state_file: data/storage_state/hh_session.json
+            resumes:
+              - id: r1
+                resume_url: "https://hh.ru/resume/AAA111"
+                search:
+                  text: "python"
+            """
+        ),
+        encoding="utf-8",
+    )
+    config = load_config(path)
+    r: ResumeConfig = config.resumes[0]
+    assert r.scoring is None
+    assert r.search.must_have == []
+    assert r.search.nice_to_have == []

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -13,6 +13,7 @@ import textwrap
 import pytest
 
 from hhru_bot.config import ResumeConfig, SearchFilters, load_config
+from hhru_bot.config_sections.scoring import ScoringConfig, ScoringWeights
 from hhru_bot.search import VacancyCard, rank_candidates
 
 
@@ -26,12 +27,22 @@ def resume(
     search: SearchFilters | None = None,
     scoring=None,
 ) -> ResumeConfig:
+    """resume с явно заданным scoring (по умолчанию None — legacy-путь, нулевые веса)."""
     return ResumeConfig(
         id="r1",
         resume_url="https://hh.ru/resume/AAA111",
         search=search or SearchFilters(text="python"),
         scoring=scoring,
     )
+
+
+def resume_scored(search: SearchFilters, weights: ScoringWeights | None = None) -> ResumeConfig:
+    """resume с включённым scoring и дефолтными весами факторов.
+
+    Для тестов самих факторов (must_have/nice_to_have/exclude/text_match) —
+    в отличие от legacy-тестов, где scoring=None и веса истинно нулевые.
+    """
+    return resume(search=search, scoring=ScoringConfig(weights=weights or ScoringWeights()))
 
 
 # --- обратная совместимость: нет scoring, нет must_have/nice_to_have ---
@@ -44,6 +55,55 @@ def test_rank_empty_weights_preserves_order():
     ranked = rank_candidates(cards, filters, resume(search=filters))
     assert [c.vacancy_id for c, _s, _b in ranked] == ["1", "2", "3"]
     assert all(score == 0.0 for _c, score, _b in ranked)
+
+
+def test_legacy_scoring_zero_scores_even_when_text_matches():
+    """Без scoring-секции score обязан быть 0 даже если filters.text матчит title.
+
+    Регрессия (codex critical): text_match=1.0 в дефолтных весах делал legacy
+    score ненулевым, нарушая обратную совместимость. Дефолт без scoring должен
+    быть истинно нейтральным — все факторы 0.
+    """
+    filters = SearchFilters(text="python developer")
+    cards = [
+        card("1", title="Python Developer"),
+        card("2", title="Senior Python Developer"),
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))  # scoring=None
+    assert all(score == 0.0 for _c, score, _b in ranked)
+
+
+def test_legacy_scoring_preserves_input_order_with_matching_text_and_mixed_ids():
+    """Без scoring-секции порядок входа сохраняется, даже когда:
+
+    - title матчит filters.text (равные score),
+    - vacancy_id идут не по возрастанию (т.е. лексический тай-брейк по id
+      перевернул бы порядок).
+
+    Гарантирует, что ranked[:limit] при legacy-конфиге выбирает ТЕ ЖЕ первые N
+    вакансий, что и старый candidates[:limit] — дневной лимит не уходит на
+    другой набор. (codex critical: раньше ids 300,200,100 → 100,200,300.)
+    """
+    filters = SearchFilters(text="python developer")
+    cards = [
+        card("300", title="Python Developer"),
+        card("200", title="Senior Python Developer"),
+        card("100", title="Python Developer Remote"),
+    ]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    assert [c.vacancy_id for c, _s, _b in ranked] == ["300", "200", "100"]
+    # [:limit] должен давать тот же набор, что и входной срез
+    assert [c.vacancy_id for c, _s, _b in ranked[:1]] == ["300"]
+
+
+def test_rank_empty_text_zero_text_match():
+    """filters.text='' → text_ratio=0, фактор text_match отсутствует (ветка)."""
+    filters = SearchFilters(text="")
+    cards = [card("1", title="Python")]
+    ranked = rank_candidates(cards, filters, resume(search=filters))
+    _c, score, breakdown = ranked[0]
+    assert breakdown["text_match"] == 0.0
+    assert score == 0.0
 
 
 def test_rank_empty_input():
@@ -59,7 +119,7 @@ def test_factor_must_have_boosts_matching_title():
         card("1", title="Python Developer"),  # без django
         card("2", title="Python Django Developer"),  # django в title
     ]
-    ranked = rank_candidates(cards, filters, resume(search=filters))
+    ranked = rank_candidates(cards, filters, resume_scored(filters))
     by_id = {c.vacancy_id: (s, b) for c, s, b in ranked}
     # must_have-матч должен дать строго больший score
     assert by_id["2"][0] > by_id["1"][0]
@@ -70,7 +130,7 @@ def test_factor_must_have_boosts_matching_title():
 def test_factor_must_have_counts_multiple_keywords():
     filters = SearchFilters(text="python", must_have=["django", "flask"])
     cards = [card("1", title="Python Django Flask Developer")]
-    ranked = rank_candidates(cards, filters, resume(search=filters))
+    ranked = rank_candidates(cards, filters, resume_scored(filters))
     _c, score, breakdown = ranked[0]
     # оба must_have найдены — буст должен быть больше, чем за один
     assert breakdown["must_have"] > 0.0
@@ -87,7 +147,7 @@ def test_factor_nice_to_have_lesser_than_must_have():
         card("b", title="Python Docker Developer"),  # только nice_to_have
         card("c", title="Python Developer"),  # ничего
     ]
-    ranked = rank_candidates(cards, filters, resume(search=filters))
+    ranked = rank_candidates(cards, filters, resume_scored(filters))
     order = [c.vacancy_id for c, _s, _b in ranked]
     # must_have > nice_to_have > ничего
     assert order == ["a", "b", "c"]
@@ -102,7 +162,7 @@ def test_factor_exclude_keyword_penalty():
         card("1", title="Python Developer"),
         card("2", title="Программист 1С"),
     ]
-    ranked = rank_candidates(cards, filters, resume(search=filters))
+    ranked = rank_candidates(cards, filters, resume_scored(filters))
     by_id = {c.vacancy_id: (s, b) for c, s, b in ranked}
     # стоп-слово в title должно штрафовать (отрицательный фактор)
     assert by_id["2"][1]["exclude_keyword"] < 0.0
@@ -119,7 +179,7 @@ def test_factor_text_match():
         card("2", title="Java Developer"),  # один токен
         card("3", title="Project Manager"),  # ни одного
     ]
-    ranked = rank_candidates(cards, filters, resume(search=filters))
+    ranked = rank_candidates(cards, filters, resume_scored(filters))
     by_id = {c.vacancy_id: s for c, s, _b in ranked}
     assert by_id["1"] > by_id["2"] > by_id["3"]
 
@@ -127,8 +187,12 @@ def test_factor_text_match():
 # --- детерминизм ---
 
 
-def test_tiebreak_by_vacancy_id_when_equal_score():
-    """Равные score → стабильный порядок по vacancy_id (лексикографически)."""
+def test_tiebreak_stable_by_input_order_when_equal_score():
+    """Равные score → стабильный ВХОДНОЙ порядок (Timsort), а не лексически по id.
+
+    Тай-брейк по vacancy_id ломал бы обратную совместимость [:limit] при
+    перемешанных id (codex critical). Сортировка только по score.
+    """
     filters = SearchFilters(text="x")  # ничего не матчит → score 0 у всех
     cards = [
         card("3", title="Same"),
@@ -136,7 +200,7 @@ def test_tiebreak_by_vacancy_id_when_equal_score():
         card("2", title="Same"),
     ]
     ranked = rank_candidates(cards, filters, resume(search=filters))
-    assert [c.vacancy_id for c, _s, _b in ranked] == ["1", "2", "3"]
+    assert [c.vacancy_id for c, _s, _b in ranked] == ["3", "1", "2"]
 
 
 def test_rank_deterministic_repeated_calls():
@@ -148,11 +212,11 @@ def test_rank_deterministic_repeated_calls():
     ]
     r1 = [
         (c.vacancy_id, round(s, 6))
-        for c, s, _b in rank_candidates(cards, filters, resume(search=filters))
+        for c, s, _b in rank_candidates(cards, filters, resume_scored(filters))
     ]
     r2 = [
         (c.vacancy_id, round(s, 6))
-        for c, s, _b in rank_candidates(cards, filters, resume(search=filters))
+        for c, s, _b in rank_candidates(cards, filters, resume_scored(filters))
     ]
     assert r1 == r2
 


### PR DESCRIPTION
## Что

Этап 4 эпика #1: скоринг/ранжирование вакансий (#15). Дневной лимит (`daily_apply_limit`) — дефицит; сейчас `candidates[:limit]` берёт вакансии в порядке выдачи hh.ru. Этот PR сортирует кандидатов по убыванию score, чтобы лимит уходил на лучшие совпадения.

Closes #15.

## Реализация

- **`rank_candidates(candidates, filters, resume)`** в `src/hhru_bot/search.py` рядом с `filter_candidates` — чистая, без браузера (тестируемость). Возвращает `list[tuple[VacancyCard, float, dict]]` (карточка, score, разбивка факторов).
- **Факторы v1** (по доступным полям `title`; зарплата/свежесть — когда расширят `VacancyCard` в #14, просто добавятся новые факторы в `_score_card`):
  - `must_have` — буст за каждое must_have-слово в title;
  - `nice_to_have` — буст за каждое nice_to_have-слово в title;
  - `exclude_keyword` — штраф за каждое стоп-слово в title;
  - `text_match` — буст × долю совпавших токенов `filters.text` в title.
- **Детерминизм:** стабильная сортировка по `(-score, vacancy_id)` — равные score упорядочиваются лексикографически по `vacancy_id`.
- **Обратная совместимость:** без scoring-конфига и без must_have/nice_to_have все score = 0.0, порядок входа сохраняется; конфиг — дефолтные нейтральные веса.

## Конфиг

- `SearchFilters.must_have` / `nice_to_have` (опц., дефолт `[]`).
- Новая resume-секция `scoring.weights` через `config_sections/scoring.py` (реестр) — `ResumeConfig.scoring` не трогается (пред-добавлено `= None` в Wave 0). Парсер читается через `getattr`, чтобы не зависеть от типа `object | None`.
- Пример секции в `config/config.example.yaml`.

## Интеграция

- `commands/_common.py`: вызов строго между `filter_candidates` и `candidates[:limit]` (цикл `apply` идёт уже по ранжированному списку).
- `commands/search.py`: `search` печатает `score=...` и разбивку факторов по каждому кандидату.

## Тесты

ТДД — сначала красные тесты (`tests/test_scoring.py`, 13 кейсов), потом реализация:
- факторы (буст must_have > nice_to_have > ничего, штраф exclude_keyword, text_match по доле токенов);
- сортировка по убыванию score;
- детерминизм: тай-брейк по vacancy_id, повторные вызовы идентичны, вход не мутируется;
- обратная совместимость: пустые веса → score 0, порядок сохранён;
- парсинг секции `scoring` (явные веса + опциональность → `None`).

Полный набор `tests/` — 52 теста, все зелёные. CLI-регистрация и парсинг примера конфига проверены smoke-запуском.

## Границы

- `apply/` и `commands/apply.py` не тронуты (другие воркеры).
- Веса/факторы v1 — на `title`; расширение `VacancyCard` (зарплата/свежесть из #14) добавит факторы без изменения сигнатуры `rank_candidates`.

## Риски / follow-ups

- Токенизация наивная (lowercase + alnum-split), без морфологии/лемматизации — достаточно для v1, воспроизводимо и без зависимостей. Можно усилить позже.
- #14 (поля `VacancyCard`) ещё не смержён — факторы зарплаты/свежести добавятся после него.