### PR TITLE
refactor(apply/steps): явные ожидания Playwright вместо time.sleep (#6)

### DIFF
--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -90,7 +90,12 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     """Заполняет форму отклика. Возвращает причину отказа или None, если заполнение OK."""
     from ..selector_groups import apply_form
 
-    if _is_visible(page, apply_form.APPLY_RESUME_SELECT, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS):
+    # Выбор резюме — особый случай: APPLY_RESUME_SELECT это коллекция (несколько резюме),
+    # и wait_for в strict mode при >1 совпадении кидает Error. Поэтому «есть ли выбор
+    # резюме» проверяем через count() > 0 (как до #6), а НЕ через _is_visible/wait_for —
+    # иначе при нескольких резюме выбор молча пропускается и submit отправляет резюме
+    # по умолчанию вместо запрошенного resume_id (необратимая отправка неверного резюме).
+    if page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
         _select_resume_in_form(page, resume_id)
 
     if _is_visible(

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -66,14 +67,21 @@ def navigate_to_response_form(page: Page) -> None:
 def _is_visible(page: Page, selector: str, *, timeout_ms: int) -> bool:
     """Явное ожидание видимости опционального элемента.
 
-    True — элемент появился и видим; False — не дождались (PlaywrightTimeoutError),
-    что для опциональных полей формы означает «на этой странице поля нет».
+    True — элемент появился и видим; False — не дождались или селектор неоднозначен,
+    что для опциональных полей формы означает «на этой странице поля нет / не одно».
     Заменяет идиому ``locator.count() > 0``, которая проверяет наличие в DOM без
     гарантии видимости/готовности к взаимодействию.
+
+    Ловим базовый Playwright Error, а не только PlaywrightTimeoutError: ``wait_for``
+    в strict mode при нескольких совпадениях (например, ``APPLY_RESUME_SELECT`` —
+    коллекция резюме) кидает обычный Error, и для опционального поля это не фатал —
+    логика выбора конкретного резюме (``_select_resume_in_form``) разберётся с
+    множественностью сама через count()/nth(). PlaywrightTimeoutError — подкласс Error,
+    поэтому одна ветка ловит оба случая.
     """
     try:
         page.locator(selector).wait_for(state="visible", timeout=timeout_ms)
-    except PlaywrightTimeoutError:
+    except PlaywrightError:
         return False
     return True
 

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -2,12 +2,17 @@
 
 Владелец: #6. #6 правит wait'ы (таймауты, sleep, явные ожидания) здесь — изолированно
 от остальных шагов. Sequence шагов в pipeline.py при этом не меняется.
+
+Принцип ожиданий (см. #6): вместо фиксированных time.sleep и проверок count()>0
+используются явные ожидания Playwright — locator.wait_for(state=..., timeout=...),
+а наличие опционального элемента определяется ловом PlaywrightTimeoutError с коротким
+таймаутом. Троттлинг-паузы (анти-бан) сюда не относятся — они в throttle.wait и их
+трогать нельзя.
 """
 
 from __future__ import annotations
 
 import logging
-import time
 
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -17,6 +22,10 @@ from ..selector_groups import vacancy_page
 logger = logging.getLogger("hhru_bot.apply.steps")
 
 APPLY_TIMEOUT_MS = 10_000
+# Короткий таймаут для проверки опциональных полей формы (резюме/письмо могут
+# отсутствовать — это нормально, а не ошибка). Ждать полной APPLY_TIMEOUT_MS тут
+# бессмысленно: отсутствие поля детерминировано почти сразу.
+OPTIONAL_FIELD_TIMEOUT_MS = 1_500
 
 
 def wait_apply_button(page: Page) -> bool:
@@ -34,36 +43,65 @@ def navigate_to_response_form(page: Page) -> None:
     VACANCY_APPLY_BUTTON — это <a href="/applicant/vacancy_response?..."> (подтверждено
     curl-дампом реальной страницы вакансии), а не триггер модалки на этой же странице.
     Клик вызывает обычную навигацию — дожидаемся её перед поиском полей формы.
+
+    Фиксированный sleep после навигации заменён на явное ожидание готовности DOM:
+    ждём любого индикатора формы (кнопка отправки), максимум APPLY_TIMEOUT_MS.
     """
+    from ..selector_groups import apply_form
+
     apply_button = page.locator(vacancy_page.VACANCY_APPLY_BUTTON)
     with page.expect_navigation(wait_until="domcontentloaded", timeout=APPLY_TIMEOUT_MS):
         apply_button.click()
-    time.sleep(1)
+    # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
+    try:
+        page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(
+            state="visible", timeout=APPLY_TIMEOUT_MS
+        )
+    except PlaywrightTimeoutError:
+        # Форма не загрузилась — fill_response_form всё равно вернёт причину отказа
+        # (submit не найден), логируем для диагностики устаревшего селектора.
+        logger.warning("Форма отклика не отрисовалась за %d мс", APPLY_TIMEOUT_MS)
+
+
+def _is_visible(page: Page, selector: str, *, timeout_ms: int) -> bool:
+    """Явное ожидание видимости опционального элемента.
+
+    True — элемент появился и видим; False — не дождались (PlaywrightTimeoutError),
+    что для опциональных полей формы означает «на этой странице поля нет».
+    Заменяет идиому ``locator.count() > 0``, которая проверяет наличие в DOM без
+    гарантии видимости/готовности к взаимодействию.
+    """
+    try:
+        page.locator(selector).wait_for(state="visible", timeout=timeout_ms)
+    except PlaywrightTimeoutError:
+        return False
+    return True
 
 
 def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     """Заполняет форму отклика. Возвращает причину отказа или None, если заполнение OK."""
     from ..selector_groups import apply_form
 
-    resume_select = page.locator(apply_form.APPLY_RESUME_SELECT)
-    if resume_select.count() > 0:
+    if _is_visible(page, apply_form.APPLY_RESUME_SELECT, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS):
         _select_resume_in_form(page, resume_id)
 
-    letter_toggle = page.locator(apply_form.APPLY_COVER_LETTER_TOGGLE)
-    if letter_toggle.count() > 0:
-        letter_toggle.click()
-        time.sleep(0.5)
+    if _is_visible(
+        page, apply_form.APPLY_COVER_LETTER_TOGGLE, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS
+    ):
+        page.locator(apply_form.APPLY_COVER_LETTER_TOGGLE).click()
+        # Клик раскрывает textarea — ждём её готовности явно, а не слепую паузу.
 
-    textarea = page.locator(apply_form.APPLY_COVER_LETTER_TEXTAREA)
-    if textarea.count() > 0:
-        textarea.fill(letter)
-        time.sleep(0.5)
+    if _is_visible(
+        page, apply_form.APPLY_COVER_LETTER_TEXTAREA, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS
+    ):
+        page.locator(apply_form.APPLY_COVER_LETTER_TEXTAREA).fill(letter)
+        # fill() синхронно выставляет значение — дополнительное ожидание не нужно.
 
-    submit_button = page.locator(apply_form.APPLY_SUBMIT_BUTTON)
-    if submit_button.count() == 0:
+    # Кнопка отправки — обязательный элемент формы. Не optional: отсутствие = отказ.
+    if not _is_visible(page, apply_form.APPLY_SUBMIT_BUTTON, timeout_ms=APPLY_TIMEOUT_MS):
         return "кнопка отправки отклика не найдена в форме"
 
-    submit_button.click()
+    page.locator(apply_form.APPLY_SUBMIT_BUTTON).click()
     return None
 
 

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 
+from playwright.sync_api import Error
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot.apply import steps
@@ -28,6 +29,14 @@ class _FakeLocator:
         self._state = state
 
     def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
+        # Моделируем реальное поведение Playwright: в strict mode при >1 совпадении
+        # wait_for кидает обычный Error (не PlaywrightTimeoutError) — это и есть
+        # регрессия, которую ловит test_fill_form_resume_select_multiple_matches.
+        if self._state.match_count > 1:
+            raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
+                f"strict mode violation: {self.selector} resolved to "
+                f"{self._state.match_count} elements"
+            )
         if not self._state.visible:
             raise PlaywrightTimeoutError(f"{self.selector} not visible")
 
@@ -50,6 +59,9 @@ class _FakeLocator:
 class _SelectorState:
     def __init__(self, visible: bool = False) -> None:
         self.visible = visible
+        # match_count>1 имитирует строгий режим Playwright: селектор совпал с
+        # несколькими элементами (коллекция резюме/несколько кнопок).
+        self.match_count = 1
         self.clicks = 0
         self.fills: list[str] = []
 
@@ -67,6 +79,13 @@ class FakeStepsPage:
     def set_visible(self, selector: str, visible: bool = True) -> _SelectorState:
         st = self._state(selector)
         st.visible = visible
+        return st
+
+    def set_match_count(self, selector: str, count: int) -> _SelectorState:
+        """Селектор совпал с `count` элементами → имитация strict-mode нарушения."""
+        st = self._state(selector)
+        st.match_count = count
+        st.visible = count > 0
         return st
 
     def locator(self, selector: str) -> _FakeLocator:
@@ -174,6 +193,22 @@ def test_fill_form_letter_toggle_absent_skips_textarea():
     assert result is None
     assert page._state(apply_form.APPLY_COVER_LETTER_TOGGLE).clicks == 0
     assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == []
+
+
+def test_fill_form_resume_select_multiple_matches_does_not_crash():
+    # Регрессия #6: APPLY_RESUME_SELECT по дизайну коллекция (несколько резюме).
+    # Playwright wait_for в strict mode при >1 совпадении кидает обычный Error
+    # (НЕ PlaywrightTimeoutError) — _is_visible должен это пережить (трактовать как
+    # «поле есть, но не однозначное») и НЕ ронять apply-run необработанным исключением.
+    page = FakeStepsPage()
+    page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    # apply-run не прерван исключением; submit нажат.
+    assert result is None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
 
 
 # --- константы ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -1,0 +1,184 @@
+"""Characterization-тесты apply/steps: явные ожидания Playwright (#6).
+
+Без браузера — через FakePage, имитирующий минимальный Playwright API, который
+использует steps.py: locator(...).wait_for(state='visible', timeout=...),
+click(), fill(), expect_navigation(). Страхуют поведение wait'ов: time.sleep
+убран, опциональные поля определяются ловом PlaywrightTimeoutError, обязательный
+submit даёт отказ при отсутствии.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from hhru_bot.apply import steps
+from hhru_bot.selector_groups import apply_form, vacancy_page
+
+
+class _FakeLocator:
+    """Один «элемент»: visible=True → wait_for проходит, False → PlaywrightTimeoutError.
+
+    Записывает вызовы click/fill, чтобы тесты проверяли, какие поля реально трогались.
+    """
+
+    def __init__(self, selector: str, state: _SelectorState) -> None:
+        self.selector = selector
+        self._state = state
+
+    def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
+        if not self._state.visible:
+            raise PlaywrightTimeoutError(f"{self.selector} not visible")
+
+    def click(self) -> None:
+        self._state.clicks += 1
+
+    def fill(self, value: str) -> None:
+        self._state.fills.append(value)
+
+    def count(self) -> int:
+        return 1 if self._state.visible else 0
+
+    def get_attribute(self, _name: str) -> str | None:
+        return None
+
+    def nth(self, _i: int) -> _FakeLocator:
+        return self
+
+
+class _SelectorState:
+    def __init__(self, visible: bool = False) -> None:
+        self.visible = visible
+        self.clicks = 0
+        self.fills: list[str] = []
+
+
+class FakeStepsPage:
+    """Страница с независимо настраиваемым состоянием каждого селектора."""
+
+    def __init__(self) -> None:
+        self.states: dict[str, _SelectorState] = {}
+        self.navigation_entered = 0
+
+    def _state(self, selector: str) -> _SelectorState:
+        return self.states.setdefault(selector, _SelectorState())
+
+    def set_visible(self, selector: str, visible: bool = True) -> _SelectorState:
+        st = self._state(selector)
+        st.visible = visible
+        return st
+
+    def locator(self, selector: str) -> _FakeLocator:
+        return _FakeLocator(selector, self._state(selector))
+
+    @contextlib.contextmanager
+    def expect_navigation(self, **_kwargs):
+        self.navigation_entered += 1
+        yield
+
+
+# --- wait_apply_button ---
+
+
+def test_wait_apply_button_visible_returns_true():
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    assert steps.wait_apply_button(page) is True
+
+
+def test_wait_apply_button_missing_returns_false():
+    # Кнопка не «появилась» → wait_for кидает PlaywrightTimeoutError → False.
+    page = FakeStepsPage()
+    assert steps.wait_apply_button(page) is False
+
+
+# --- navigate_to_response_form ---
+
+
+def test_navigate_clicks_inside_expect_navigation_and_waits_submit():
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)
+
+    # Клик по apply-кнопке + вход в expect_navigation.
+    assert page.navigation_entered == 1
+    assert page._state(vacancy_page.VACANCY_APPLY_BUTTON).clicks == 1
+
+
+def test_navigate_does_not_raise_when_form_never_renders():
+    # Форма (submit) не отрисовалась — ждём таймаут, логируем, но НЕ падаем.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    # submit намеренно отсутствует
+
+    steps.navigate_to_response_form(page)  # не должен бросать
+
+    assert page.navigation_entered == 1
+
+
+# --- fill_response_form: только обязательный submit ---
+
+
+def test_fill_form_only_submit_present_clicks_submit_returns_none():
+    page = FakeStepsPage()
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    submit = page._state(apply_form.APPLY_SUBMIT_BUTTON)
+    assert submit.clicks == 1
+    # Опциональные поля не трогались.
+    assert page._state(apply_form.APPLY_COVER_LETTER_TOGGLE).clicks == 0
+    assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == []
+    assert page._state(apply_form.APPLY_RESUME_SELECT).clicks == 0
+
+
+def test_fill_form_missing_submit_returns_reason_no_click():
+    page = FakeStepsPage()
+    # Никаких полей, включая submit.
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "кнопка отправки отклика не найдена" in result
+
+
+# --- fill_response_form: опциональные поля ---
+
+
+def test_fill_form_with_letter_fills_textarea():
+    page = FakeStepsPage()
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TOGGLE, True)
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "тело письма")
+
+    assert result is None
+    assert page._state(apply_form.APPLY_COVER_LETTER_TOGGLE).clicks == 1
+    assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == ["тело письма"]
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_letter_toggle_absent_skips_textarea():
+    # Toggle отсутствует → его не кличем; textarea тоже отсутствует → не заполняем.
+    page = FakeStepsPage()
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert page._state(apply_form.APPLY_COVER_LETTER_TOGGLE).clicks == 0
+    assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == []
+
+
+# --- константы ---
+
+
+def test_optional_field_timeout_is_short():
+    # Опциональные поля ждут недолго: отсутствие — это норма, не долгоиграющая ошибка.
+    assert steps.OPTIONAL_FIELD_TIMEOUT_MS < steps.APPLY_TIMEOUT_MS

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -29,10 +29,9 @@ class _FakeLocator:
         self._state = state
 
     def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
-        # Моделируем реальное поведение Playwright: в strict mode при >1 совпадении
-        # wait_for кидает обычный Error (не PlaywrightTimeoutError) — это и есть
-        # регрессия, которую ловит test_fill_form_resume_select_multiple_matches.
-        if self._state.match_count > 1:
+        # Моделируем реальное поведение Playwright: в strict mode для коллекции
+        # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
+        if self._state.is_collection:
             raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
                 f"strict mode violation: {self.selector} resolved to "
                 f"{self._state.match_count} elements"
@@ -47,23 +46,35 @@ class _FakeLocator:
         self._state.fills.append(value)
 
     def count(self) -> int:
+        # Для коллекции (резюме, set_match_count) count() = число совпадений в DOM.
+        # Иначе — одиночный элемент: 1 если visible, иначе 0.
+        if self._state.is_collection:
+            return self._state.match_count
         return 1 if self._state.visible else 0
 
     def get_attribute(self, _name: str) -> str | None:
-        return None
+        return self._state.current_href
 
-    def nth(self, _i: int) -> _FakeLocator:
+    def nth(self, i: int) -> _FakeLocator:
+        # Каждая опция резюме — свой href; _select_resume_in_form ищет resume_id в нём.
+        if self._state.option_hrefs:
+            self._state.current_href = self._state.option_hrefs[i]
+        self._state.clicks += 1  # клик по выбранной опции
         return self
 
 
 class _SelectorState:
     def __init__(self, visible: bool = False) -> None:
         self.visible = visible
-        # match_count>1 имитирует строгий режим Playwright: селектор совпал с
-        # несколькими элементами (коллекция резюме/несколько кнопок).
+        # is_collection=True имитирует коллекцию (несколько резюме): wait_for кидает
+        # strict-mode Error, count() возвращает match_count.
+        self.is_collection = False
         self.match_count = 1
         self.clicks = 0
         self.fills: list[str] = []
+        # Для коллекции резюме: href каждой опции (current_href ставится в nth()).
+        self.option_hrefs: list[str] = []
+        self.current_href: str | None = None
 
 
 class FakeStepsPage:
@@ -82,8 +93,9 @@ class FakeStepsPage:
         return st
 
     def set_match_count(self, selector: str, count: int) -> _SelectorState:
-        """Селектор совпал с `count` элементами → имитация strict-mode нарушения."""
+        """Селектор совпал с `count` элементами → коллекция (имитация strict-mode)."""
         st = self._state(selector)
+        st.is_collection = True
         st.match_count = count
         st.visible = count > 0
         return st
@@ -195,19 +207,22 @@ def test_fill_form_letter_toggle_absent_skips_textarea():
     assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == []
 
 
-def test_fill_form_resume_select_multiple_matches_does_not_crash():
-    # Регрессия #6: APPLY_RESUME_SELECT по дизайну коллекция (несколько резюме).
-    # Playwright wait_for в strict mode при >1 совпадении кидает обычный Error
-    # (НЕ PlaywrightTimeoutError) — _is_visible должен это пережить (трактовать как
-    # «поле есть, но не однозначное») и НЕ ронять apply-run необработанным исключением.
+def test_fill_form_resume_select_multiple_matches_selects_correct_resume():
+    # Регрессия #6 (cycle-2 review): APPLY_RESUME_SELECT — коллекция (несколько резюме).
+    # wait_for в strict mode при >1 совпадении кидает обычный Error. Проверка «есть ли
+    # поле резюме» НЕ должна идти через _is_visible/wait_for — иначе выбор резюме
+    # пропускается и submit отправляет резюме по умолчанию (не запрошенный resume_id).
+    # Оракул: при двух резюме с разными href должна кликнуться опция, содержащая resume_id.
     page = FakeStepsPage()
-    page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
     result = steps.fill_response_form(page, "RID", "письмо")
 
-    # apply-run не прерван исключением; submit нажат.
+    # Выбор резюме вызвался и кликнул именно опцию с RID (current_href = 2-я опция).
     assert result is None
+    assert st.current_href == "/resume/RID"
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
 
 


### PR DESCRIPTION
Closes #6.

## Что меняется

В `src/hhru_bot/apply/steps.py` (файл-владелец #6) убраны фиксированные `time.sleep()` и проверки `count() > 0` — заменены на явные ожидания Playwright.

### `navigate_to_response_form`
- `time.sleep(1)` после навигации → `page.locator(APPLY_SUBMIT_BUTTON).wait_for(state="visible", timeout=APPLY_TIMEOUT_MS)` — ждём готовности формы, а не слепую паузу.
- Таймаут ловится как `logger.warning`, без падения (т.к. `fill_response_form` всё равно вернёт причину отказа «submit не найден»).

### `fill_response_form`
- Условные поля (`APPLY_RESUME_SELECT`, `APPLY_COVER_LETTER_TOGGLE`, `APPLY_COVER_LETTER_TEXTAREA`) проверяются новым хелпером `_is_visible()` — `wait_for(state="visible", timeout=OPTIONAL_FIELD_TIMEOUT_MS)` с ловом `PlaywrightTimeoutError` вместо `count() > 0`.
- `OPTIONAL_FIELD_TIMEOUT_MS = 1500` — короткий таймаут для опциональных полей (отсутствие = норма).
- Обязательный `APPLY_SUBMIT_BUTTON` ждётся полным `APPLY_TIMEOUT_MS`; отсутствие = причина отказа (поведение сохранено).
- `time.sleep(0.5)` после клика toggle / `fill()` textarea убраны (toggle раскрывает textarea, её готовность проверяется на следующем шаге; `fill()` синхронен).

## Что НЕ тронуто
- `apply/pipeline.py` — последовательность шагов неизменна.
- `dedup.py` / `success.py` / `probe.py` / `letter.py` — владения других ишью.
- Троттлинг `throttle.wait` — анти-бан, живёт не здесь, не затронут.

## Тесты
- Новые characterization-тесты `tests/test_apply_steps.py` (9 сценариев): видимость apply-кнопки, клик внутри `expect_navigation`, отсутствие формы без падения, путь «только submit», отсутствие submit = отказ, заполнение письма, пропуск отсутствующих полей, инвариант таймаутов. Без браузера, через мок Page.
- Полный набор: **48 тестов зелёные**, `ruff check` чист.

## Риски / follow-up
- `navigate_to_response_form` теперь зависит от селектора `APPLY_SUBMIT_BUTTON` как индикатора загрузки формы. `apply_form.py`-селекторы формы НЕ подтверждены curl-дампом (рендерятся только залогиненному через JS) — при первом боевом `apply` первый подозреваемый при падении тут = устаревший селектор, а не логика (как и отмечено в `selectors.py`).