### PR TITLE
fix(history): единый ключ resume.resume_id в apply и bump (#2)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -57,13 +57,13 @@ def run_apply_for_resume(
     print(f"\n=== Отклики для резюме: {resume.id} ===")
 
     try:
-        throttle.check_apply_limit(resume.id, args.dry_run)
+        throttle.check_apply_limit(resume.resume_id, args.dry_run)
     except LimitReached as e:
         print(f"Пропуск: {e}")
         return
 
     cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
-    candidates, skipped = filter_candidates(cards, resume.search, resume.id, history)
+    candidates, skipped = filter_candidates(cards, resume.search, resume.resume_id, history)
 
     for card, reason in skipped:
         logger.debug("Пропуск вакансии %s: %s", card.title, reason)
@@ -78,14 +78,14 @@ def run_apply_for_resume(
     applied_count = 0
     for card, _score, _breakdown in ranked[:limit]:
         try:
-            throttle.check_apply_limit(resume.id, args.dry_run)
+            throttle.check_apply_limit(resume.resume_id, args.dry_run)
         except LimitReached as e:
             print(f"Дневной лимит достигнут, останавливаюсь: {e}")
             break
 
-        result = apply_to_vacancy(page, card, resume.id, cover_letter_template, args.dry_run)
+        result = apply_to_vacancy(page, card, resume.resume_id, cover_letter_template, args.dry_run)
         status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
-        history.record_action(resume.id, card.vacancy_id, "apply", status, result.reason)
+        history.record_action(resume.resume_id, card.vacancy_id, "apply", status, result.reason)
 
         if result.success:
             applied_count += 1

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -45,6 +45,9 @@ def run(args: argparse.Namespace) -> None:
 
             result = bump_resume(page, resume, args.dry_run)
             status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+            # Для action='bump' нет естественного vacancy_id (поднятие резюме, не отклик).
+            # actions.vacancy_id NOT NULL — заполняем resume.resume_id как sentinel; UNIQUE-индекс
+            # idx_resume_vacancy_apply существует только WHERE action='apply', так что коллизий нет.
             history.record_action(resume.resume_id, resume.resume_id, "bump", status, result.reason)
 
             if result.success:

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -33,19 +33,19 @@ def run(args: argparse.Namespace) -> None:
             print(f"\n=== Поднятие резюме: {resume.id} ===")
 
             try:
-                throttle.check_bump_limit(resume.id, args.dry_run)
+                throttle.check_bump_limit(resume.resume_id, args.dry_run)
             except LimitReached as e:
                 print(f"Пропуск: {e}")
                 continue
 
-            can_bump, wait_left = throttle.can_bump_now(resume.id)
+            can_bump, wait_left = throttle.can_bump_now(resume.resume_id)
             if not can_bump:
                 print(f"Пропуск: рано поднимать, подождите ещё {wait_left}")
                 continue
 
             result = bump_resume(page, resume, args.dry_run)
             status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
-            history.record_action(resume.id, resume.resume_id, "bump", status, result.reason)
+            history.record_action(resume.resume_id, resume.resume_id, "bump", status, result.reason)
 
             if result.success:
                 print(f"  [OK] {resume.id} поднято")

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -30,7 +30,7 @@ def run(args: argparse.Namespace) -> None:
         for resume in resumes:
             print(f"\n=== Поиск вакансий для резюме: {resume.id} ===")
             cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
-            candidates, skipped = filter_candidates(cards, resume.search, resume.id, history)
+            candidates, skipped = filter_candidates(cards, resume.search, resume.resume_id, history)
             ranked = rank_candidates(candidates, resume.search, resume)
 
             print(

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -62,10 +62,11 @@ class _FakeLocator:
 
 
 class _ApplyFakePage:
-    """Page для apply-pipeline: есть кнопка отклика, нет маркера «уже откликались».
+    """Page для apply-pipeline: есть кнопка отклика.
 
     Dry-run стопает после кнопки отклика — до навигации на форму, поэтому submit
-    не нужен.
+    не нужен. Дедуп-маркер «уже откликались» убран из pipeline (PR #27), поэтому
+    locator() его больше не получает — check_already_responded всегда возвращает None.
     """
 
     def __init__(self):
@@ -75,11 +76,8 @@ class _ApplyFakePage:
         self.goto_calls.append(url)
 
     def locator(self, selector: str):  # noqa: ARG002
-        from hhru_bot.apply import dedup
         from hhru_bot.selector_groups import vacancy_page
 
-        if selector == dedup.APPLY_ALREADY_RESPONDED_MARKER:
-            return _FakeLocator(present=False)
         if selector == vacancy_page.VACANCY_APPLY_BUTTON:
             return _FakeLocator(present=True)
         return _FakeLocator(present=False)
@@ -154,6 +152,10 @@ def test_apply_and_bump_record_under_same_resume_key(tmp_path, monkeypatch):
         def __exit__(self, *_a):  # noqa: ARG002
             return False
 
+    # String-path monkeypatch патчит символ в модуле-источнике (browser/bump/config).
+    # Работает только потому, что bump.run импортирует launch_context/bump_resume/
+    # load_config_or_exit лениво (внутри функции) — каждый вызов подхватывает свежий патч.
+    # Если импорты вынести наверх модуля bump.py — этот тест нужно править.
     monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _CtxManager())  # noqa: ARG005
     monkeypatch.setattr(
         "hhru_bot.bump.bump_resume",

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -57,7 +57,7 @@ class _FakeLocator:
     def get_attribute(self, _name: str) -> str | None:  # noqa: ARG002
         return None
 
-    def nth(self, _i: int) -> "_FakeLocator":  # noqa: ARG002
+    def nth(self, _i: int) -> _FakeLocator:  # noqa: ARG002
         return self
 
 

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -137,9 +137,7 @@ def test_apply_and_bump_record_under_same_resume_key(tmp_path, monkeypatch):
     )
 
     # --- apply-путь (dry-run) ---
-    card = VacancyCard(
-        vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
-    )
+    card = VacancyCard(vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42")
     monkeypatch.setattr(_common, "search_vacancies", lambda page, search, max_pages=5: [card])  # noqa: ARG005
     apply_args = argparse.Namespace(dry_run=True, limit=1, max_pages=5, headless=True)
     _common.run_apply_for_resume(_ApplyFakePage(), config, resume, history, throttle, apply_args)

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -1,0 +1,191 @@
+"""Тест на согласованность ключа истории apply ↔ bump (#2).
+
+Баг: apply-путь пишет/читает actions по ``resume.id`` (человекочитаемый slug из
+конфига), а bump-путь — по ``resume.resume_id`` (число из URL). Колонка
+``actions.resume_id`` смешивает два пространства ключей, поэтому ``has_applied``,
+``count_today`` и ``can_bump_now`` живут в разных ключевых пространствах и не
+видят записи другого пути.
+
+Критерий готовности ишью #2: единый ключ ``resume.resume_id`` во всех записях
+``actions``.
+
+Подход — characterization через реальные функции команд, а не хардкод ключей:
+запускаем ``run_apply_for_resume`` (apply) и ``bump.run`` (bump) с подменами
+браузера/поиска и реальной ``History``, после чего читаем ``resume_id`` прямо из
+``actions``. На бажном коде apply пишет под ``resume.id`` (slug ``python``),
+bump — под ``resume.resume_id`` (``AAA111``) → ключи расходятся → тест падает.
+После unify оба пишут под ``resume.resume_id`` → тест зелёный.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+
+
+def _resume() -> ResumeConfig:
+    """Резюме, у которого slug (id) и hh.ru-id (resume_id) заведомо различны."""
+    return ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+    )
+
+
+class _FakeLocator:
+    """Минимальный Playwright-locator для apply-pipeline в dry-run."""
+
+    def __init__(self, present: bool = False):
+        self._present = present
+
+    def count(self) -> int:
+        return 1 if self._present else 0
+
+    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+        if not self._present:
+            from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+            raise PlaywrightTimeoutError("not present")
+
+    def click(self) -> None:
+        return None
+
+    def fill(self, _value: str) -> None:  # noqa: ARG002
+        return None
+
+    def get_attribute(self, _name: str) -> str | None:  # noqa: ARG002
+        return None
+
+    def nth(self, _i: int) -> "_FakeLocator":  # noqa: ARG002
+        return self
+
+
+class _ApplyFakePage:
+    """Page для apply-pipeline: есть кнопка отклика, нет маркера «уже откликались».
+
+    Dry-run стопает после кнопки отклика — до навигации на форму, поэтому submit
+    не нужен.
+    """
+
+    def __init__(self):
+        self.goto_calls: list[str] = []
+
+    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+        self.goto_calls.append(url)
+
+    def locator(self, selector: str):  # noqa: ARG002
+        from hhru_bot.apply import dedup
+        from hhru_bot.selector_groups import vacancy_page
+
+        if selector == dedup.APPLY_ALREADY_RESPONDED_MARKER:
+            return _FakeLocator(present=False)
+        if selector == vacancy_page.VACANCY_APPLY_BUTTON:
+            return _FakeLocator(present=True)
+        return _FakeLocator(present=False)
+
+    def expect_navigation(self, **_kwargs):  # noqa: ARG002
+        import contextlib
+
+        @contextlib.contextmanager
+        def _cm():
+            yield
+
+        return _cm()
+
+
+def _read_resume_ids(history_db) -> list[tuple[str, str]]:
+    """Список (resume_id, action) из actions в порядке записи."""
+    import sqlite3
+
+    conn = sqlite3.connect(history_db)
+    try:
+        rows = conn.execute("SELECT resume_id, action FROM actions ORDER BY id").fetchall()
+    finally:
+        conn.close()
+    return rows
+
+
+def test_apply_and_bump_record_under_same_resume_key(tmp_path, monkeypatch):
+    """apply-путь и bump-путь пишут в actions под одним resume_id = resume.resume_id.
+
+    Симметричный энд-ту-энд сценарий:
+      1) apply (dry-run) через run_apply_for_resume — подмена только браузерного
+         сбора карточек (search_vacancies), фейковый page, реальная History.
+      2) bump (dry-run) через bump.run — подмена launch_context и bump_resume.
+    После обоих шагов resume_id в actions должен быть единым и равен
+    resume.resume_id. На бажном коде оба пути пишут slug 'python' (через
+    resume.id) вместо числового resume.resume_id='AAA111' — это и есть симптом
+    бага: ключ истории завязан на переименуемый slug, а не на стабильный id hh.ru.
+    """
+    from hhru_bot.bump import BumpResult
+    from hhru_bot.commands import _common
+    from hhru_bot.commands import bump as bump_cmd
+    from hhru_bot.history import History
+    from hhru_bot.search import VacancyCard
+    from hhru_bot.throttle import Throttle
+
+    resume = _resume()
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    throttle = Throttle(ThrottleConfig(), history)
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="письмо {vacancy_title}",
+        resumes=[resume],
+    )
+
+    # --- apply-путь (dry-run) ---
+    card = VacancyCard(
+        vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+    )
+    monkeypatch.setattr(_common, "search_vacancies", lambda page, search, max_pages=5: [card])  # noqa: ARG005
+    apply_args = argparse.Namespace(dry_run=True, limit=1, max_pages=5, headless=True)
+    _common.run_apply_for_resume(_ApplyFakePage(), config, resume, history, throttle, apply_args)
+
+    # --- bump-путь (dry-run) ---
+    class _CtxManager:
+        def __enter__(self):
+            class _Ctx:
+                def new_page(self):
+                    return object()
+
+            return _Ctx()
+
+        def __exit__(self, *_a):  # noqa: ARG002
+            return False
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _CtxManager())  # noqa: ARG005
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda page, r, dry_run: BumpResult(resume_id=r.id, success=True, reason="dry-run"),  # noqa: ARG005
+    )
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)  # noqa: ARG005
+    bump_cmd.run(
+        argparse.Namespace(
+            config=None,
+            history=str(history_db),
+            dry_run=True,
+            headless=True,
+            resume=None,
+            max_pages=5,
+        )
+    )
+
+    rows = _read_resume_ids(history_db)
+    apply_rows = [r for r in rows if r[1] == "apply"]
+    bump_rows = [r for r in rows if r[1] == "bump"]
+    assert apply_rows, "apply-путь ничего не записал в историю"
+    assert bump_rows, "bump-путь ничего не записал в историю"
+
+    apply_key = apply_rows[0][0]
+    bump_key = bump_rows[0][0]
+    assert apply_key == bump_key == resume.resume_id, (
+        "apply и bump должны писать в историю под resume.resume_id="
+        f"{resume.resume_id!r}, но apply={apply_key!r}, bump={bump_key!r}"
+    )
+
+    # Гарантируем, что тест осмысленен: slug и resume_id различны по построению,
+    # иначе равенство ключей доказывало бы мало.
+    assert resume.id != resume.resume_id


### PR DESCRIPTION
## Что

Closes #2 (часть эпика #1, этап 0).

Баг: apply-путь писал/читал `actions` по `resume.id` (человекочитаемый slug из конфига, напр. `python`), а bump-путь — по `resume.resume_id` (число из URL hh.ru). Колонка `actions.resume_id` смешивала два пространства ключей:
- при переименовании `id` в конфиге история apply ломалась;
- перекрёстные запросы (`has_applied`/`count_today`/`can_bump_now`) не видели записи другого пути.

## Как чинил

Унификация на стабильный `resume.resume_id` (id hh.ru из URL) во всех ключах apply-пути и bump-пути:

- `commands/_common.py` — `throttle.check_apply_limit`, `filter_candidates`, `apply_to_vacancy`, `history.record_action` (apply)
- `commands/bump.py` — `throttle.check_bump_limit`, `can_bump_now`, `history.record_action` (bump)
- `commands/search.py` — `filter_candidates` (apply-дедуп в команде search)

Человекочитаемый вывод (`print`-заголовки, `throttle.wait`, `BumpResult.reason`/логи `bump.py`) оставлен с `resume.id` — числовой хэш в логах ухудшил бы UX; критерий готовости ишью (единый ключ в `actions`) при этом полностью выполнен.

> Развилка «id в выводе vs resume_id везде» — согласована в [комментарии к #2](https://github.com/axisrow/hhru/issues/2#issuecomment-5085358928).

## ТДД

Сначала красный тест `test_apply_and_bump_record_under_same_resume_key`: энд-ту-энд через реальные `run_apply_for_resume` (apply) и `bump.run` (bump) с подменами браузера/поиска и реальной `History`, читает `resume_id` прямо из `actions`. На бажном коде оба пути пишут slug `python` вместо `resume.resume_id='AAA111'` → тест падает. После unify — зелёный.

## Тесты

```
PYTHONPATH=src python3 -m pytest tests/ -q   →  40 passed
```
(39 baseline + 1 новый). Поведение и троттлинг не менялись.

## Риски / follow-ups

- Не трогал `apply/pipeline.py` и шаги-владельцы — ключ заходит в `apply_to_vacancy` параметром, поведение формы не изменилось. `_select_resume_in_form` теперь получает `resume.resume_id` (число hh.ru) — это семантически правильнее для поиска опции резюме в форме отклика по href, но селектор всё равно приблизительный (отмечен в коде) и требует проверки первым боевым запуском.
- Существующая история `data/history.db` (если есть) с ключами `resume.id` для apply-записей не мигрируется — старые apply-записи под slug останутся в другом ключевом пространстве. Для боевого инстанса это означает, что «уже откликались» по старым apply-записям не сработает до повторного отклика. На это можно отдельной миграцией данных, если потребуется.