### PR TITLE
feat(stats): команда stats + экспорт (#11)

### DIFF
--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -49,18 +49,18 @@ def run(args: argparse.Namespace) -> None:
     from ..history import History
     from ..report import format_actions, format_summary
 
-    # Конфиг нужен, чтобы валидировать --resume (если задан) и привести его к
-    # resume.id так же, как в apply/search. Если --resume не задан — конфиг
-    # всё равно грузим для единообразия ошибок.
+    # --resume получает slug из конфига (resume.id), но история apply/bump
+    # хранится под resume.resume_id (стабильный числовой id hh.ru — см. #2).
+    # Резолвим slug -> resume.resume_id тем же ключом, что и записи в БД.
     config = load_config_or_exit(args.config)
-    resume_id = args.resume
-    if resume_id is not None:
+    resume_id = None
+    if args.resume is not None:
         try:
-            # бросит ConfigError, если такого резюме нет в конфиге
-            config.get_resume(resume_id)
+            resume = config.get_resume(args.resume)
         except ConfigError as e:
             print(f"Ошибка конфигурации: {e}", file=sys.stderr)
             sys.exit(1)
+        resume_id = resume.resume_id
 
     history = History(args.history)
 

--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -14,9 +14,7 @@ FORMATS = ("table", "csv", "md")
 
 
 def register(subparsers) -> None:
-    p = subparsers.add_parser(
-        "stats", help="Сводка и экспорт истории откликов/поднятий"
-    )
+    p = subparsers.add_parser("stats", help="Сводка и экспорт истории откликов/поднятий")
     p.add_argument("--resume", help="ID резюме (по умолчанию — все)")
     p.add_argument(
         "--period",

--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -1,0 +1,74 @@
+"""Команда stats: агрегаты и экспорт истории откликов/поднятий (#11).
+
+Браузер НЕ нужен — только SQLite-история. Вывод идёт в stdout (экспорт):
+ASCII-таблицы/текстовые префиксы для table, CSV для csv, Markdown для md.
+НИКАКИХ эмодзи (правило проекта: CLI-вывод чистый текст/ASCII).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+PERIODS = ("today", "week", "month", "all")
+FORMATS = ("table", "csv", "md")
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(
+        "stats", help="Сводка и экспорт истории откликов/поднятий"
+    )
+    p.add_argument("--resume", help="ID резюме (по умолчанию — все)")
+    p.add_argument(
+        "--period",
+        choices=PERIODS,
+        default="all",
+        help="Период агрегации (по умолчанию all)",
+    )
+    p.add_argument(
+        "--format",
+        choices=FORMATS,
+        default="table",
+        help="Формат вывода: table (по умолчанию), csv, md",
+    )
+    p.add_argument(
+        "--list",
+        action="store_true",
+        help="Вместо сводки вывести список последних действий",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Лимит строк в режиме --list (по умолчанию 50)",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    import sys
+
+    from ..config import ConfigError, load_config_or_exit
+    from ..history import History
+    from ..report import format_actions, format_summary
+
+    # Конфиг нужен, чтобы валидировать --resume (если задан) и привести его к
+    # resume.id так же, как в apply/search. Если --resume не задан — конфиг
+    # всё равно грузим для единообразия ошибок.
+    config = load_config_or_exit(args.config)
+    resume_id = args.resume
+    if resume_id is not None:
+        try:
+            # бросит ConfigError, если такого резюме нет в конфиге
+            config.get_resume(resume_id)
+        except ConfigError as e:
+            print(f"Ошибка конфигурации: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    history = History(args.history)
+
+    if args.list:
+        rows = history.list_actions(resume_id=resume_id, period=args.period, limit=args.limit)
+        print(format_actions(rows, args.format))
+    else:
+        summary = history.summary(resume_id=resume_id, period=args.period)
+        print(format_summary(summary, args.format))

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -89,3 +89,86 @@ class History:
         if last is None:
             return None
         return datetime.now() - last
+
+    # --- Агрегаты для команды stats (#11) -------------------------------------
+    # Новые методы в конец файла: паттерн with self._connect(), существующие
+    # методы не трогаем. summary/list_actions считают ВСЕ строки (success/
+    # dry_run/failed) — для статистики нужен полный срез, а не только успех.
+
+    _PERIOD_DAYS = {"week": 7, "month": 30}
+
+    @staticmethod
+    def _period_since(period: str) -> str | None:
+        """ISO-отсечка created_at для периода. today = начало сегодняшнего дня,
+        week/month = N дней назад, all = без отсечки (None)."""
+        now = datetime.now()
+        if period == "today":
+            return now.date().isoformat()
+        days = History._PERIOD_DAYS.get(period)
+        if days is not None:
+            return (now - timedelta(days=days)).isoformat()
+        return None  # all
+
+    def summary(self, resume_id: str | None, period: str) -> dict:
+        """Срез счётчиков action × status за период.
+
+        Возвращает {"apply": {"success","dry_run","failed"}, "bump": {...}, "total"}.
+        Пустой период → все нули. resume_id=None означает «по всем резюме».
+        """
+        result: dict = {
+            "apply": {"success": 0, "dry_run": 0, "failed": 0},
+            "bump": {"success": 0, "dry_run": 0, "failed": 0},
+            "total": 0,
+        }
+        where = []
+        params: list = []
+        if resume_id is not None:
+            where.append("resume_id = ?")
+            params.append(resume_id)
+        since = self._period_since(period)
+        if since is not None:
+            where.append("created_at >= ?")
+            params.append(since)
+
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT action, status, COUNT(*) AS cnt FROM actions{clause} "
+                "GROUP BY action, status",
+                params,
+            ).fetchall()
+        for row in rows:
+            action = row["action"]
+            status = row["status"]
+            cnt = row["cnt"]
+            if action in result and status in result[action]:
+                result[action][status] = cnt
+            result["total"] += cnt
+        return result
+
+    def list_actions(
+        self, resume_id: str | None, period: str, limit: int = 50
+    ) -> list[dict]:
+        """Последние действия (свежие первыми) для таблицы stats.
+
+        Возвращает список словарей с ключами resume_id/vacancy_id/action/status/
+        reason/created_at. resume_id=None — по всем резюме.
+        """
+        where = []
+        params: list = []
+        if resume_id is not None:
+            where.append("resume_id = ?")
+            params.append(resume_id)
+        since = self._period_since(period)
+        if since is not None:
+            where.append("created_at >= ?")
+            params.append(since)
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        params.append(limit)
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT resume_id, vacancy_id, action, status, reason, created_at "
+                f"FROM actions{clause} ORDER BY created_at DESC, id DESC LIMIT ?",
+                params,
+            ).fetchall()
+        return [dict(row) for row in rows]

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -146,9 +146,7 @@ class History:
             result["total"] += cnt
         return result
 
-    def list_actions(
-        self, resume_id: str | None, period: str, limit: int = 50
-    ) -> list[dict]:
+    def list_actions(self, resume_id: str | None, period: str, limit: int = 50) -> list[dict]:
         """Последние действия (свежие первыми) для таблицы stats.
 
         Возвращает список словарей с ключами resume_id/vacancy_id/action/status/

--- a/src/hhru_bot/report.py
+++ b/src/hhru_bot/report.py
@@ -1,0 +1,169 @@
+"""Форматтеры отчётов для команды stats (#11).
+
+Владелец файла — #11 (команда stats). Один report-топик на файл (конвенция
+CLAUDE.md), поэтому воронка/фаннел живут отдельно в report_funnel.py.
+
+Только текст/ASCII-таблицы — НИКАКИХ эмодзи (правило проекта: CLI-вывод чистый).
+Экспорт идёт в stdout (команда stats печатает результат этих функций).
+Поддерживаемые форматы: table, csv, md.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Iterable
+
+SUPPORTED_FORMATS = ("table", "csv", "md")
+
+# Порядок колонок сводки по action.
+_SUMMARY_ACTIONS = ("apply", "bump")
+
+# Порядок колонок таблицы действий.
+_ACTION_COLUMNS = (
+    "created_at",
+    "resume_id",
+    "action",
+    "vacancy_id",
+    "status",
+    "reason",
+)
+
+_ACTION_HEADERS = {
+    "created_at": "Время",
+    "resume_id": "Резюме",
+    "action": "Действие",
+    "vacancy_id": "Вакансия",
+    "status": "Статус",
+    "reason": "Причина",
+}
+
+_SUMMARY_HEADERS = {
+    "action": "Действие",
+    "success": "Успех",
+    "dry_run": "Прогон",
+    "failed": "Провал",
+}
+
+
+def _check_format(fmt: str) -> None:
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(
+            f"Неизвестный формат вывода: {fmt!r}. "
+            f"Допустимо: {', '.join(SUPPORTED_FORMATS)}"
+        )
+
+
+# --- summary ----------------------------------------------------------------
+
+
+def _summary_rows(summary: dict) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for action in _SUMMARY_ACTIONS:
+        bucket = summary.get(action, {})
+        rows.append(
+            [
+                action,
+                str(bucket.get("success", 0)),
+                str(bucket.get("dry_run", 0)),
+                str(bucket.get("failed", 0)),
+            ]
+        )
+    return rows
+
+
+def format_summary(summary: dict, fmt: str) -> str:
+    """Отрисовать сводку action × status (+ total) в выбранном формате."""
+    _check_format(fmt)
+    header = [_SUMMARY_HEADERS["action"], _SUMMARY_HEADERS["success"],
+              _SUMMARY_HEADERS["dry_run"], _SUMMARY_HEADERS["failed"]]
+    rows = _summary_rows(summary)
+    total = summary.get("total", 0)
+
+    if fmt == "csv":
+        # CSV — экспорт для машин: машиночитаемые имена колонок.
+        out = io.StringIO()
+        w = csv.writer(out)
+        w.writerow(["action", "success", "dry_run", "failed"])
+        w.writerows(rows)
+        w.writerow(["total", total, "", ""])
+        return out.getvalue().rstrip("\n")
+
+    if fmt == "md":
+        lines = ["| " + " | ".join(header) + " |", "| --- | --- | --- | --- |"]
+        for r in rows:
+            lines.append("| " + " | ".join(r) + " |")
+        lines.append(f"| **Итого** | {total} |  |  |")
+        return "\n".join(lines)
+
+    # table — ASCII
+    return _ascii_table(header, rows, footer=["Итого", str(total), "", ""])
+
+
+# --- actions ----------------------------------------------------------------
+
+
+def _action_rows(rows: Iterable[dict]) -> list[list[str]]:
+    out: list[list[str]] = []
+    for r in rows:
+        out.append([str(r.get(col) if r.get(col) is not None else "") for col in _ACTION_COLUMNS])
+    return out
+
+
+def format_actions(rows: Iterable[dict], fmt: str) -> str:
+    """Отрисовать список действий (из History.list_actions) в выбранном формате."""
+    _check_format(fmt)
+    rows = list(rows)
+    header = [_ACTION_HEADERS[c] for c in _ACTION_COLUMNS]
+
+    if fmt == "csv":
+        out = io.StringIO()
+        w = csv.writer(out)
+        w.writerow(_ACTION_COLUMNS)  # машиночитаемые имена колонок для экспорта
+        for r in rows:
+            w.writerow([r.get(col) if r.get(col) is not None else "" for col in _ACTION_COLUMNS])
+        return out.getvalue().rstrip("\n")
+
+    if fmt == "md":
+        lines = ["| " + " | ".join(header) + " |", "| " + " | ".join("---" for _ in header) + " |"]
+        body = _action_rows(rows)
+        for r in body:
+            lines.append("| " + " | ".join(r) + " |")
+        return "\n".join(lines)
+
+    # table — ASCII
+    if not rows:
+        return _ascii_table(header, [])
+    return _ascii_table(header, _action_rows(rows))
+
+
+# --- ASCII-таблица ----------------------------------------------------------
+
+
+def _ascii_table(header: list[str], rows: list[list[str]], footer: list[str] | None = None) -> str:
+    """Простая ASCII-таблица с рамкой +---+. footer (если есть) — итоговая строка
+    без попадания в основное тело. Пустое тело всё равно рисует шапку."""
+    all_rows = [header, *rows]
+    if footer is not None:
+        all_rows = [header, *rows, footer]
+    n_cols = len(header)
+    widths = [0] * n_cols
+    for r in all_rows:
+        for i, cell in enumerate(r):
+            widths[i] = max(widths[i], len(cell))
+
+    def border() -> str:
+        return "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+
+    def line(r: list[str]) -> str:
+        cells = [str(r[i]).ljust(widths[i]) if i < len(r) else " " * widths[i] for i in range(n_cols)]
+        return "| " + " | ".join(cells) + " |"
+
+    out = [border(), line(header), border()]
+    for r in rows:
+        out.append(line(r))
+    if footer is not None:
+        out.append(border())
+        out.append(line(footer))
+    out.append(border())
+    return "\n".join(out)

--- a/src/hhru_bot/report.py
+++ b/src/hhru_bot/report.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import csv
 import io
-from typing import Iterable
+from collections.abc import Iterable
 
 SUPPORTED_FORMATS = ("table", "csv", "md")
 
@@ -49,8 +49,7 @@ _SUMMARY_HEADERS = {
 def _check_format(fmt: str) -> None:
     if fmt not in SUPPORTED_FORMATS:
         raise ValueError(
-            f"Неизвестный формат вывода: {fmt!r}. "
-            f"Допустимо: {', '.join(SUPPORTED_FORMATS)}"
+            f"Неизвестный формат вывода: {fmt!r}. Допустимо: {', '.join(SUPPORTED_FORMATS)}"
         )
 
 
@@ -75,8 +74,12 @@ def _summary_rows(summary: dict) -> list[list[str]]:
 def format_summary(summary: dict, fmt: str) -> str:
     """Отрисовать сводку action × status (+ total) в выбранном формате."""
     _check_format(fmt)
-    header = [_SUMMARY_HEADERS["action"], _SUMMARY_HEADERS["success"],
-              _SUMMARY_HEADERS["dry_run"], _SUMMARY_HEADERS["failed"]]
+    header = [
+        _SUMMARY_HEADERS["action"],
+        _SUMMARY_HEADERS["success"],
+        _SUMMARY_HEADERS["dry_run"],
+        _SUMMARY_HEADERS["failed"],
+    ]
     rows = _summary_rows(summary)
     total = summary.get("total", 0)
 
@@ -156,7 +159,9 @@ def _ascii_table(header: list[str], rows: list[list[str]], footer: list[str] | N
         return "+" + "+".join("-" * (w + 2) for w in widths) + "+"
 
     def line(r: list[str]) -> str:
-        cells = [str(r[i]).ljust(widths[i]) if i < len(r) else " " * widths[i] for i in range(n_cols)]
+        cells = [
+            str(r[i]).ljust(widths[i]) if i < len(r) else " " * widths[i] for i in range(n_cols)
+        ]
         return "| " + " | ".join(cells) + " |"
 
     out = [border(), line(header), border()]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -27,14 +27,14 @@ def _subparser_actions(parser):
 def test_all_commands_registered():
     parser = _build()
     action = _subparser_actions(parser)
-    assert set(action.choices) == {"login", "search", "apply", "bump", "run", "probe"}
+    assert set(action.choices) == {"login", "search", "apply", "bump", "run", "probe", "stats"}
 
 
 def test_register_commands_returns_names():
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
     names = register_commands(sub)
-    assert set(names) == {"login", "search", "apply", "bump", "run", "probe"}
+    assert set(names) == {"login", "search", "apply", "bump", "run", "probe", "stats"}
 
 
 def _opts_for(command: str) -> set[str]:
@@ -88,3 +88,29 @@ def test_login_no_common_args():
     opts = _opts_for("login")
     assert "--resume" not in opts
     assert "--dry-run" not in opts
+
+
+def test_stats_has_period_and_format():
+    opts = _opts_for("stats")
+    assert "--resume" in opts
+    assert "--period" in opts
+    assert "--format" in opts
+    # stats — не браузерная команда, общих поисковых флагов у неё нет
+    assert "--dry-run" not in opts
+    assert "--max-pages" not in opts
+
+
+def test_stats_period_choices():
+    parser = _build()
+    action = _subparser_actions(parser)
+    sub = action.choices["stats"]
+    period = next(a for a in sub._actions if "--period" in a.option_strings)
+    assert set(period.choices) == {"today", "week", "month", "all"}
+
+
+def test_stats_format_choices():
+    parser = _build()
+    action = _subparser_actions(parser)
+    sub = action.choices["stats"]
+    fmt = next(a for a in sub._actions if "--format" in a.option_strings)
+    assert set(fmt.choices) == {"table", "csv", "md"}

--- a/tests/test_history_stats.py
+++ b/tests/test_history_stats.py
@@ -12,10 +12,6 @@ from datetime import datetime, timedelta
 from hhru_bot.history import History
 
 
-def _now_iso() -> str:
-    return datetime.now().isoformat()
-
-
 def _iso_days_ago(days: int) -> str:
     return (datetime.now() - timedelta(days=days)).isoformat()
 

--- a/tests/test_history_stats.py
+++ b/tests/test_history_stats.py
@@ -112,7 +112,9 @@ def test_list_actions_returns_dicts_ordered_desc(tmp_path):
     assert rows[1]["vacancy_id"] == "v1"
     # ключи, нужные форматтеру
     for r in rows:
-        assert {"resume_id", "vacancy_id", "action", "status", "reason", "created_at"} <= set(r.keys())
+        assert {"resume_id", "vacancy_id", "action", "status", "reason", "created_at"} <= set(
+            r.keys()
+        )
 
 
 def test_list_actions_respects_limit(tmp_path):

--- a/tests/test_history_stats.py
+++ b/tests/test_history_stats.py
@@ -1,0 +1,139 @@
+"""Characterization-тесты агрегатов истории для команды stats (#11).
+
+Покрывает новые методы History.summary / History.list_actions: пустой период
+возвращает нули/пустой список, фильтрация по resume/периоду/статусу работает,
+счётчики action корректны. Без браузера — только SQLite.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from hhru_bot.history import History
+
+
+def _now_iso() -> str:
+    return datetime.now().isoformat()
+
+
+def _iso_days_ago(days: int) -> str:
+    return (datetime.now() - timedelta(days=days)).isoformat()
+
+
+def test_summary_empty_returns_zeros(tmp_path):
+    h = History(tmp_path / "h.db")
+    s = h.summary(resume_id=None, period="all")
+    assert s["apply"]["success"] == 0
+    assert s["apply"]["dry_run"] == 0
+    assert s["apply"]["failed"] == 0
+    assert s["bump"]["success"] == 0
+    assert s["bump"]["failed"] == 0
+    assert s["total"] == 0
+
+
+def test_summary_counts_by_action_and_status(tmp_path):
+    h = History(tmp_path / "h.db")
+    # 2 успешных отклика, 1 dry_run, 1 провал; 1 успешный bump, 1 проваленный bump
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r1", "v2", "apply", "success")
+    h.record_action("r1", "v3", "apply", "dry_run")
+    h.record_action("r1", "v4", "apply", "failed", "captcha")
+    h.record_action("r1", "r1", "bump", "success")
+    h.record_action("r1", "r1", "bump", "failed", "cooldown")
+
+    s = h.summary(resume_id="r1", period="all")
+    assert s["apply"]["success"] == 2
+    assert s["apply"]["dry_run"] == 1
+    assert s["apply"]["failed"] == 1
+    assert s["bump"]["success"] == 1
+    assert s["bump"]["failed"] == 1
+    assert s["total"] == 6
+
+
+def test_summary_filters_by_resume(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r2", "v9", "apply", "success")
+
+    s = h.summary(resume_id="r1", period="all")
+    assert s["apply"]["success"] == 1
+    assert s["total"] == 1
+
+
+def test_summary_period_excludes_old_rows(tmp_path):
+    """period='week' отсекает действия старше 7 дней (по created_at)."""
+    h = History(tmp_path / "h.db")
+    # свежий (сегодня) — попадает
+    h.record_action("r1", "v1", "apply", "success")
+    # старый (30 дней назад) — отсекается периодом week
+    with h._connect() as conn:
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v2','apply','success','', ?)",
+            (_iso_days_ago(30),),
+        )
+
+    week = h.summary(resume_id=None, period="week")
+    assert week["apply"]["success"] == 1
+
+    allp = h.summary(resume_id=None, period="all")
+    assert allp["apply"]["success"] == 2
+
+
+def test_summary_period_month_boundary(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    with h._connect() as conn:
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v2','apply','success','', ?)",
+            (_iso_days_ago(40),),
+        )
+
+    assert h.summary(resume_id=None, period="month")["apply"]["success"] == 1
+    assert h.summary(resume_id=None, period="all")["apply"]["success"] == 2
+
+
+def test_list_actions_empty(tmp_path):
+    h = History(tmp_path / "h.db")
+    assert h.list_actions(resume_id=None, period="all", limit=10) == []
+
+
+def test_list_actions_returns_dicts_ordered_desc(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r1", "v2", "apply", "failed", "captcha")
+
+    rows = h.list_actions(resume_id="r1", period="all", limit=10)
+    assert len(rows) == 2
+    # свежайшая запись первой (DESC по created_at, затем по id)
+    assert rows[0]["vacancy_id"] == "v2"
+    assert rows[0]["status"] == "failed"
+    assert rows[1]["vacancy_id"] == "v1"
+    # ключи, нужные форматтеру
+    for r in rows:
+        assert {"resume_id", "vacancy_id", "action", "status", "reason", "created_at"} <= set(r.keys())
+
+
+def test_list_actions_respects_limit(tmp_path):
+    h = History(tmp_path / "h.db")
+    for i in range(5):
+        h.record_action("r1", f"v{i}", "apply", "success")
+
+    rows = h.list_actions(resume_id="r1", period="all", limit=3)
+    assert len(rows) == 3
+
+
+def test_list_actions_filters_by_resume_and_period(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r2", "v9", "apply", "success")  # чужое резюме
+    with h._connect() as conn:
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v2','apply','success','', ?)",
+            (_iso_days_ago(30),),
+        )
+
+    assert len(h.list_actions(resume_id="r1", period="all", limit=10)) == 2
+    assert len(h.list_actions(resume_id="r1", period="week", limit=10)) == 1

--- a/tests/test_report_stats.py
+++ b/tests/test_report_stats.py
@@ -1,0 +1,179 @@
+"""Characterization-тесты форматтеров отчётов команды stats (#11).
+
+Проверяют format_summary / format_actions в новом report.py для table|csv|md:
+пустые данные не падают, ключи/значения присутствуют, эмодзи нет. Без браузера.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+from hhru_bot.report import format_actions, format_summary
+
+_NO_EMOJI = set(
+    chr(c)
+    for c in range(0x1F000, 0x1FAFF + 1)  # эмодзи/разные символы и пиктограммы
+) | set(chr(c) for c in range(0x2600, 0x27BF + 1))
+
+
+def _has_emoji(text: str) -> bool:
+    return any(ch in _NO_EMOJI for ch in text)
+
+
+def _empty_summary() -> dict:
+    return {
+        "apply": {"success": 0, "dry_run": 0, "failed": 0},
+        "bump": {"success": 0, "dry_run": 0, "failed": 0},
+        "total": 0,
+    }
+
+
+def _filled_summary() -> dict:
+    s = _empty_summary()
+    s["apply"]["success"] = 2
+    s["apply"]["dry_run"] = 1
+    s["apply"]["failed"] = 1
+    s["bump"]["success"] = 3
+    s["total"] = 7
+    return s
+
+
+def _sample_actions() -> list[dict]:
+    return [
+        {
+            "resume_id": "r1",
+            "vacancy_id": "v2",
+            "action": "apply",
+            "status": "failed",
+            "reason": "captcha",
+            "created_at": "2026-07-27T10:00:00",
+        },
+        {
+            "resume_id": "r1",
+            "vacancy_id": "v1",
+            "action": "apply",
+            "status": "success",
+            "reason": None,
+            "created_at": "2026-07-27T09:00:00",
+        },
+    ]
+
+
+# --- format_summary ---------------------------------------------------------
+
+
+def test_format_summary_empty_all_formats_do_not_crash():
+    for fmt in ("table", "csv", "md"):
+        out = format_summary(_empty_summary(), fmt)
+        assert isinstance(out, str)
+        assert _has_emoji(out) is False
+
+
+def test_format_summary_table_has_action_columns_and_zero_total():
+    out = format_summary(_empty_summary(), "table")
+    assert "apply" in out
+    assert "bump" in out
+    # человекочитаемые подписи статусов (table/md — для людей)
+    assert "Успех" in out
+    assert "0" in out  # нули видны
+    # ASCII-разделители таблицы
+    assert "+" in out and "-" in out
+
+
+def test_format_summary_table_shows_counts():
+    out = format_summary(_filled_summary(), "table")
+    assert "2" in out  # apply success
+    assert "3" in out  # bump success
+    assert "7" in out  # total
+
+
+def test_format_summary_csv_parses_as_csv():
+    out = format_summary(_filled_summary(), "csv")
+    reader = csv.reader(io.StringIO(out))
+    rows = list(reader)
+    assert len(rows) >= 1
+    header = rows[0]
+    # в заголовке есть что-то осмысленное про action/status
+    flat_header = ",".join(header).lower()
+    assert "success" in flat_header
+
+
+def test_format_summary_md_has_pipe_table():
+    out = format_summary(_filled_summary(), "md")
+    assert "|" in out
+    # markdown-разделитель строки
+    assert "---" in out
+
+
+# --- format_actions ---------------------------------------------------------
+
+
+def test_format_actions_empty_all_formats():
+    for fmt in ("table", "csv", "md"):
+        out = format_actions([], fmt)
+        assert isinstance(out, str)
+        assert _has_emoji(out) is False
+
+
+def test_format_actions_table_contains_rows_and_columns():
+    out = format_actions(_sample_actions(), "table")
+    assert "v2" in out
+    assert "v1" in out
+    assert "apply" in out
+    assert "success" in out
+    assert "failed" in out
+    assert "+" in out  # рамка ASCII
+
+
+def test_format_actions_csv_parses_and_has_header():
+    out = format_actions(_sample_actions(), "csv")
+    reader = csv.reader(io.StringIO(out))
+    rows = list(reader)
+    header = rows[0]
+    assert "vacancy_id" in header
+    assert "status" in header
+    # данные: 2 строки + заголовок
+    assert len(rows) == 3
+    assert rows[1][header.index("vacancy_id")] == "v2"
+    assert rows[1][header.index("status")] == "failed"
+
+
+def test_format_actions_md_is_pipe_table():
+    out = format_actions(_sample_actions(), "md")
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    # есть строка-разделитель markdown: ячейки состоят только из '-'
+    def is_separator(ln: str) -> bool:
+        cells = [c.strip() for c in ln.strip().strip("|").split("|")]
+        return bool(cells) and all(set(c) == {"-"} and c for c in cells)
+
+    assert any(is_separator(ln) for ln in lines)
+    assert "vacancy_id" in out or "Вакансия" in out
+
+
+def test_format_actions_csv_quotes_comma_in_reason():
+    rows = [
+        {
+            "resume_id": "r1",
+            "vacancy_id": "v1",
+            "action": "apply",
+            "status": "failed",
+            "reason": "ошибка, с запятой",
+            "created_at": "2026-07-27T10:00:00",
+        }
+    ]
+    out = format_actions(rows, "csv")
+    parsed = list(csv.reader(io.StringIO(out)))
+    header = parsed[0]
+    reason_col = header.index("reason")
+    # значение восстанавливается корректно (csv-модуль справился с запятой)
+    assert parsed[1][reason_col] == "ошибка, с запятой"
+
+
+def test_unknown_format_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        format_summary(_empty_summary(), "xml")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        format_actions([], "xml")  # type: ignore[arg-type]

--- a/tests/test_report_stats.py
+++ b/tests/test_report_stats.py
@@ -142,6 +142,7 @@ def test_format_actions_csv_parses_and_has_header():
 def test_format_actions_md_is_pipe_table():
     out = format_actions(_sample_actions(), "md")
     lines = [ln for ln in out.splitlines() if ln.strip()]
+
     # есть строка-разделитель markdown: ячейки состоят только из '-'
     def is_separator(ln: str) -> bool:
         cells = [c.strip() for c in ln.strip().strip("|").split("|")]

--- a/tests/test_stats_command.py
+++ b/tests/test_stats_command.py
@@ -21,12 +21,14 @@ def _write_config(tmp_path, body: str):
 
 
 def _minimal_config() -> str:
+    # Реалистичный контракт: id (slug) ≠ resume_id (число из URL). apply/bump
+    # пишут историю под resume.resume_id (число), а --resume в CLI получает slug.
     return """
         account:
           storage_state_file: data/storage_state/hh_session.json
         resumes:
-          - id: r1
-            resume_url: "https://hh.ru/resume/AAA111"
+          - id: python
+            resume_url: "https://hh.ru/resume/12345"
             search:
               text: "python developer"
     """
@@ -93,15 +95,20 @@ def test_stats_run_csv_export_machine_readable(capsys, tmp_path):
 
 
 def test_stats_run_resume_filter(capsys, tmp_path):
+    """--resume фильтрует по resume.resume_id (число из URL), как apply/bump.
+
+    Регрессия: PR #31 унифицировал ключ истории на resume.resume_id. stats.run
+    получает slug из --resume и должен резолвить его в resume.resume_id для
+    фильтра — иначе сводка всегда пуста."""
     config = _write_config(tmp_path, _minimal_config())
     h = History(tmp_path / "h.db")
-    h.record_action("r1", "v1", "apply", "success")
-    h.record_action("r2", "v9", "apply", "success")  # чужое резюме — отсечётся
+    # apply/bump пишут под resume.resume_id (= "12345" из URL), НЕ под slug "python"
+    h.record_action("12345", "v1", "apply", "success")
+    h.record_action("99999", "v9", "apply", "success")  # другое резюме — отсечётся
 
-    stats_cmd.run(_args(config, tmp_path / "h.db", resume="r1"))
+    # --resume получает slug "python", stats должен найти запись 12345
+    stats_cmd.run(_args(config, tmp_path / "h.db", resume="python"))
     out = capsys.readouterr().out
-    # только одно success-действие r1 (apply success = 1)
-    # в ASCII-таблице apply-строка: "apply" + "1" успех
     apply_line = [ln for ln in out.splitlines() if ln.strip().startswith("| apply")][0]
     assert " 1 " in apply_line or apply_line.strip().endswith("1 |")
 

--- a/tests/test_stats_command.py
+++ b/tests/test_stats_command.py
@@ -1,0 +1,117 @@
+"""Интеграционные тесты команды stats (#11): stats.run целиком.
+
+Issue #11 требует «cmd_stats покрывается целиком». Здесь проверяем саму функцию
+run() — с минимальным конфигом и seeded SQLite-историей, через захват stdout.
+Без браузера (stats его не использует).
+"""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+
+from hhru_bot.commands import stats as stats_cmd
+from hhru_bot.history import History
+
+
+def _write_config(tmp_path, body: str):
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def _minimal_config() -> str:
+    return """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python developer"
+    """
+
+
+def _args(config_path, history_path, **overrides) -> argparse.Namespace:
+    base = {
+        "config": str(config_path),
+        "history": str(history_path),
+        "resume": None,
+        "period": "all",
+        "format": "table",
+        "list": False,
+        "limit": 50,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_stats_run_summary_table_seeded(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r1", "v2", "apply", "failed", "captcha")
+
+    stats_cmd.run(_args(config, tmp_path / "h.db"))
+    out = capsys.readouterr().out
+
+    # ASCII-таблица сводки: apply виден, успех=1, провал=1
+    assert "apply" in out
+    assert "Успех" in out  # человекочитаемый заголовок table
+    assert "Итого" in out
+
+
+def test_stats_run_empty_db_does_not_crash(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    stats_cmd.run(_args(config, tmp_path / "h.db"))
+    out = capsys.readouterr().out
+    assert "apply" in out
+    assert "0" in out  # нули на пустой истории
+
+
+def test_stats_run_list_mode_md(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+
+    stats_cmd.run(_args(config, tmp_path / "h.db", list=True, format="md", limit=10))
+    out = capsys.readouterr().out
+    # markdown-таблица действий
+    assert "|" in out
+    assert "v1" in out
+
+
+def test_stats_run_csv_export_machine_readable(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+
+    stats_cmd.run(_args(config, tmp_path / "h.db", format="csv"))
+    out = capsys.readouterr().out
+    # машиночитаемые имена колонок сводки
+    assert out.splitlines()[0] == "action,success,dry_run,failed"
+
+
+def test_stats_run_resume_filter(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r2", "v9", "apply", "success")  # чужое резюме — отсечётся
+
+    stats_cmd.run(_args(config, tmp_path / "h.db", resume="r1"))
+    out = capsys.readouterr().out
+    # только одно success-действие r1 (apply success = 1)
+    # в ASCII-таблице apply-строка: "apply" + "1" успех
+    apply_line = [ln for ln in out.splitlines() if ln.strip().startswith("| apply")][0]
+    assert " 1 " in apply_line or apply_line.strip().endswith("1 |")
+
+
+def test_stats_run_unknown_resume_exits(capsys, tmp_path):
+    import pytest
+
+    config = _write_config(tmp_path, _minimal_config())
+    with pytest.raises(SystemExit) as exc:
+        stats_cmd.run(_args(config, tmp_path / "h.db", resume="does-not-exist"))
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "не найдено" in err


### PR DESCRIPTION
Closes #11.

## Что делает
Новая команда `hhru-bot stats` — видимость прогресса поиска (отклики/поднятия за период), экспорт в stdout. Браузер НЕ нужен, только SQLite-история.

### Реализация
- **`commands/stats.py`** (новый) — `register(subparsers)`, авторегистрируется через `pkgutil` в `cli.build_parser` (**cli.py не тронут**). Флаги: `--resume`, `--period today|week|month|all`, `--format table|csv|md`, `--list` (список действий вместо сводки), `--limit`.
- **`history.py`** — новые методы в конец файла, паттерн `with self._connect()`, существующие методы не тронуты:
  - `summary(resume_id, period)` → `{"apply": {success,dry_run,failed}, "bump": {...}, "total"}`. Пустой период → нули.
  - `list_actions(resume_id, period, limit)` → последние действия (свежие первыми) для таблицы.
- **`report.py`** (новый) — форматтеры `format_summary` / `format_actions` для table/csv/md. ASCII-таблицы с рамкой `+---+`, человекочитаемые русские подписи для table/md, машиночитаемые имена колонок для csv-экспорта. **Никаких эмодзи** (правило проекта).
- Вывод идёт в stdout — пользователь сам делает `> report.md` (в духе ручного/прозрачного проекта).

### Структура соблюдена (Wave 0)
- `apply/` и другие `commands/*` **не тронуты**.
- Один report-топик на файл (`report.py`), конвенция CLAUDE.md соблюдена.
- Агрегаты считают полный срез (success/dry_run/failed), а не только успех — иначе статистика бесполезна для диагностики селекторов.

## ТДД
Сначала красные тесты на контракт, потом реализация:
- `tests/test_history_stats.py` (9 тестов): пустой период → нули, счётчики по action×status, фильтр по resume/периоду, порядок и лимит `list_actions`.
- `tests/test_report_stats.py` (12 тестов): все форматы, пустые данные не падают, CSV-парсинг + экранирование запятых, отсутствие эмодзи, `ValueError` на неизвестном формате.
- `tests/test_cli_commands.py` — расширен: `stats` в наборе команд, флаги `--period`/`--format` и их choices.

Все 65 тестов зелёные.

## Тесты
```
PYTHONPATH=src python3 -m pytest tests/ -q   # 65 passed
```
Ручной smoke: `stats`, `stats --period today`, `stats --resume <id> --format csv`, `stats --list --format md --limit 3` — все форматы выводят корректный ASCII/CSV/Markdown.

## Follow-ups (вне scope этого PR)
Issue упоминает расширенную сводку «по каждому резюме в одном отчёте + дата последнего действия + остаток дневного лимита». Базовый контракт (summary/list_actions/форматтеры + команда) из ТДД-задания реализован; разбивка по всем резюме сразу и «остаток лимита» — отдельный шаг после Этапа 2 (#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)