### PR TITLE
test(probe): fix #35 — _FakeLocator.wait_for принимает state (красный main)

### DIFF
--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -26,7 +26,7 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 


### PR DESCRIPTION
## Что

БЛОКЕР, красный `main`: 3 теста в `tests/test_apply_probe.py` падали с `TypeError`.

## Причина

Интеграционный баг между двумя вмердженными PR:
- **#29 (#6, steps)** — `src/hhru_bot/apply/steps.py:58` вызывает `page.locator(...).wait_for(state="visible", timeout=APPLY_TIMEOUT_MS)` (валидный Playwright API).
- **#30 (#8, probe)** — мок `_FakeLocator.wait_for` в `tests/test_apply_probe.py:29` принимал только `timeout` и не принимал `state` → `TypeError` на kwargs.

## Фикс

Одна строка: добавлен необязательный параметр `state` в сигнатуру мока (значение мок игнорирует, `noqa: ARG002` сохранён).

**Код (`steps.py`) не тронут** — `wait_for(state="visible")` корректен, баг был только в отставшем моке.

## Diff

```diff
-    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
```

## Тесты

- `pytest tests/test_apply_probe.py` — **5 passed** (3 ранее падавших — зелёные).
- `pytest -q` (весь набор) — зелёный (99 тестов), `main` снова зелёный.
- `ruff check .` — All checks passed.
- `ruff format --check .` — 56 files already formatted.

## Риски

Нет. Правка только тестового мока, прод-код не изменён.

Closes #35.