### PR TITLE
fix(apply): .first на VACANCY_APPLY_BUTTON — strict mode на живой странице

### DIFF
--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -32,7 +32,7 @@ OPTIONAL_FIELD_TIMEOUT_MS = 1_500
 def wait_apply_button(page: Page) -> bool:
     """Ждёт появления кнопки отклика на странице вакансии. False — не дождались."""
     try:
-        page.locator(vacancy_page.VACANCY_APPLY_BUTTON).wait_for(timeout=APPLY_TIMEOUT_MS)
+        page.locator(vacancy_page.VACANCY_APPLY_BUTTON).first.wait_for(timeout=APPLY_TIMEOUT_MS)
     except PlaywrightTimeoutError:
         return False
     return True
@@ -50,7 +50,7 @@ def navigate_to_response_form(page: Page) -> None:
     """
     from ..selector_groups import apply_form
 
-    apply_button = page.locator(vacancy_page.VACANCY_APPLY_BUTTON)
+    apply_button = page.locator(vacancy_page.VACANCY_APPLY_BUTTON).first
     with page.expect_navigation(wait_until="domcontentloaded", timeout=APPLY_TIMEOUT_MS):
         apply_button.click()
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -12,6 +12,10 @@ from hhru_bot.search import VacancyCard
 
 
 class _FakeLocator:
+    @property
+    def first(self):
+        return self
+
     def __init__(self, present: bool = False, attrs: dict[str, str] | None = None):
         self._present = present
         self._attrs = attrs or {}

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -17,6 +17,10 @@ from hhru_bot.search import VacancyCard
 class _FakeLocator:
     """Локатор с отслеживанием click() — критично для проверки атомарности."""
 
+    @property
+    def first(self):
+        return self
+
     def __init__(self, present: bool = False, attrs: dict[str, str] | None = None):
         self._present = present
         self._attrs = attrs or {}

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -24,6 +24,10 @@ class _FakeLocator:
     Записывает вызовы click/fill, чтобы тесты проверяли, какие поля реально трогались.
     """
 
+    @property
+    def first(self):
+        return self
+
     def __init__(self, selector: str, state: _SelectorState) -> None:
         self.selector = selector
         self._state = state

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -22,6 +22,10 @@ class _FakeLocator:
     превысит appear_after (моделирует асинхронный рендер сигнала после submit).
     """
 
+    @property
+    def first(self):
+        return self
+
     def __init__(
         self,
         *,

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -36,6 +36,10 @@ def _resume() -> ResumeConfig:
 class _FakeLocator:
     """Минимальный Playwright-locator для apply-pipeline в dry-run."""
 
+    @property
+    def first(self):
+        return self
+
     def __init__(self, present: bool = False):
         self._present = present
 


### PR DESCRIPTION
Найдено через probe-дамп (#10): на живой странице вакансии hh.ru [data-qa='vacancy-response-link-top'] рендерится 3 раза → Playwright strict mode violation на wait_for/click. Фикс: .first (верхняя кнопка отклика). Моки _FakeLocator в 5 test-файлах получили свойство first. Все тесты зелёные.