### PR TITLE
fix(apply): fail-closed выбор резюме в форме отклика (#33)

### DIFF
--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -118,9 +118,19 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
         resume_select_present = False
     else:
         resume_select_present = True
-    if resume_select_present and page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
-        if not _select_resume_in_form(page, resume_id):
-            return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
+    if resume_select_present:
+        # TOCTOU (cycle-2 review): селектор был видим в wait_for, но исчез к count()
+        # (transient re-render/drift). count()==0 после detect — НЕ «одно резюме»
+        # (там wait_for таймаутит → resume_select_present=False), а нестабильный
+        # селектор на multi-resume форме. Fail-closed: отказ, не submit дефолтного.
+        if page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
+            if not _select_resume_in_form(page, resume_id):
+                return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
+        else:
+            return (
+                "селектор выбора резюме исчез после обнаружения — "
+                "отправка отменена (нестабильная форма отклика)"
+            )
 
     if _is_visible(
         page, apply_form.APPLY_COVER_LETTER_TOGGLE, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS
@@ -150,9 +160,10 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
     curl-дампом, рендерится только залогиненному через JS) и наверняка потребует
     уточнения при первом реальном запуске.
 
-    Совпадение resume_id ищется как **сегмент пути**, а не как голая подстрока href:
-    ``/resume/{resume_id}`` или ``resume_id={resume_id}``. Голая подстрока давала бы
-    лжесовпадения (напр. ``RID`` внутри ``/resume/PONDERING``).
+    Совпадение resume_id требует **точного равенства** сегмента/значения (см.
+    ``_href_matches_resume_id``): последний сегмент пути (``/resume/{id}``) или
+    значение query-параметра ``resume_id``. Голая подстрока отвергается — она давала
+    лжесовпадения (``RID`` внутри ``/resume/RID2``, ``?other_resume_id=RID``).
 
     fail-closed: ровно одна подходящая опция → кликаем, возвращаем True. Ноль или
     больше одной (неоднозначно) → возвращаем False, отправка не состоится.

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -170,23 +170,49 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
     """
     from ..selector_groups import apply_form
 
+    # Identity-bound выбор (cycle-3 review): НЕ кликаем по сохранённому индексу —
+    # Playwright резолвит nth(i) против текущего DOM в момент действия, и если JS
+    # переупорядочил/вставил опции между сканом и кликом, тот же индекс = другое
+    # резюме. Вместо этого: находим единственный совпадающий href, а перед кликом
+    # пере-сканируем опции по этому href и требуем строгую уникальность. Любой
+    # drift (переупорядочивание, исчезновение, раздвоение) между scan и click → отказ.
     options = page.locator(apply_form.APPLY_RESUME_SELECT)
     count = options.count()
-    matched: list[int] = []
+    matched_hrefs: list[str] = []
     for i in range(count):
         href = options.nth(i).get_attribute("href") or ""
         if _href_matches_resume_id(href, resume_id):
-            matched.append(i)
-    if len(matched) != 1:
+            matched_hrefs.append(href)
+    if len(matched_hrefs) != 1:
         # 0 — нужного резюме нет среди опций; >1 — неоднозначно. И то и другое = отказ.
         logger.warning(
             "Не удалось однозначно выбрать резюме '%s' в форме отклика "
             "(совпадений: %d) — отправка отменена",
             resume_id,
-            len(matched),
+            len(matched_hrefs),
         )
         return False
-    options.nth(matched[0]).click()
+    target_href = matched_hrefs[0]
+    # Пере-скан в момент клика: ровно одна опция с этим точным href. Если DOM
+    # изменился (переупорядочили/вставили дубль/убрали) — отказ, не клик по индексу.
+    live_count = 0
+    live_index: int | None = None
+    fresh = page.locator(apply_form.APPLY_RESUME_SELECT)
+    fresh_total = fresh.count()
+    for i in range(fresh_total):
+        if (fresh.nth(i).get_attribute("href") or "") == target_href:
+            live_count += 1
+            live_index = i
+    if live_count != 1 or live_index is None:
+        logger.warning(
+            "Резюме '%s' (href=%s) не подтверждено при клике (живых совпадений: %d) "
+            "— отправка отменена",
+            resume_id,
+            target_href,
+            live_count,
+        )
+        return False
+    fresh.nth(live_index).click()
     return True
 
 

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -193,27 +193,38 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
         )
         return False
     target_href = matched_hrefs[0]
-    # Пере-скан в момент клика: ровно одна опция с этим точным href. Если DOM
-    # изменился (переупорядочили/вставили дубль/убрали) — отказ, не клик по индексу.
-    live_count = 0
-    live_index: int | None = None
-    fresh = page.locator(apply_form.APPLY_RESUME_SELECT)
-    fresh_total = fresh.count()
-    for i in range(fresh_total):
-        if (fresh.nth(i).get_attribute("href") or "") == target_href:
-            live_count += 1
-            live_index = i
-    if live_count != 1 or live_index is None:
+    # Клик по strict href-локатору, БЕЗ конвертации обратно в индекс (cycle-3 review):
+    # nth(i).click() re-resolves индекс в момент действия — любой scan→click gap даёт
+    # TOCTOU (JS reorder/insert → тот же индекс = другое резюме). Вместо этого кликаем
+    # строгий локатор, привязанный к точному href: Playwright сам резолвит его в момент
+    # click() и кидает Error (strict mode) при != 1 совпадении — дубль/исчезновение/
+    # переупорядочивание между scan и click ловятся как отказ. href — стабильная
+    # identity резюме на hh.ru, не позиция в коллекции.
+    try:
+        page.locator(_resume_option_by_href_selector(target_href)).click()
+    except PlaywrightError as exc:
+        # strict-mode violation (>1 совпадение), element not found (исчез) или detach —
+        # любое из этого = не удалось гарантированно кликнуть нужное резюме → отказ.
         logger.warning(
-            "Резюме '%s' (href=%s) не подтверждено при клике (живых совпадений: %d) "
-            "— отправка отменена",
+            "Резюме '%s' (href=%s) не подтверждено при клике (%s) — отправка отменена",
             resume_id,
             target_href,
-            live_count,
+            exc,
         )
         return False
-    fresh.nth(live_index).click()
     return True
+
+
+def _resume_option_by_href_selector(href: str) -> str:
+    """CSS-селектор опции резюме по точному href, для strict-клика в момент действия.
+
+    Совмещает APPLY_RESUME_SELECT с фильтром по атрибуту href. Quote обратными кавычками
+    для CSS-безопасности (значение берётся из DOM страницы, не из ввода пользователя).
+    """
+    from ..selector_groups import apply_form
+
+    escaped = href.replace("\\", "\\\\").replace("'", "\\'")
+    return f"{apply_form.APPLY_RESUME_SELECT}[href='{escaped}']"
 
 
 def _href_matches_resume_id(href: str, resume_id: str) -> bool:

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -117,10 +117,19 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
         page.locator(apply_form.APPLY_RESUME_SELECT).first.wait_for(
             state="attached", timeout=RESUME_SELECT_TIMEOUT_MS
         )
-    except PlaywrightError:
-        # Селектор не появился в DOM за долгий таймаут — выбора на этой странице нет
-        # (одно резюме, happy path). submit разрешён ниже.
+    except PlaywrightTimeoutError:
+        # Легитимное «селектор не появился в DOM за долгий таймаут» — выбора на этой
+        # странице нет (одно резюме, happy path). submit разрешён ниже.
         options_count = 0
+    except PlaywrightError:
+        # Cycle-5 review: НЕ маскировать не-timeout ошибки (runtime/selector failure)
+        # под «выбора нет» — это пропустило бы count() и выбор → submit дефолтного
+        # резюме. Только PlaywrightTimeoutError = легитимное отсутствие; прочие
+        # PlaywrightError — аномалия, fail-closed отказ.
+        return (
+            "ошибка при проверке выбора резюме в форме отклика — "
+            "отправка отменена (нестабильная страница)"
+        )
     else:
         options_count = page.locator(apply_form.APPLY_RESUME_SELECT).count()
         if options_count == 0:

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -92,11 +92,26 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
 
     # Выбор резюме — особый случай: APPLY_RESUME_SELECT это коллекция (несколько резюме),
     # и wait_for в strict mode при >1 совпадении кидает Error. Поэтому «есть ли выбор
-    # резюме» проверяем через count() > 0 (как до #6), а НЕ через _is_visible/wait_for —
-    # иначе при нескольких резюме выбор молча пропускается и submit отправляет резюме
-    # по умолчанию вместо запрошенного resume_id (необратимая отправка неверного резюме).
-    if page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
-        _select_resume_in_form(page, resume_id)
+    # резюме» проверяем через .first.wait_for(state='visible') (.first снимает strict
+    # mode — см. инвариант из PR #29), а затем _select_resume_in_form работает по
+    # count()/nth(). Это закрывает гонку рендера: коллекция может появиться позже
+    # submit-кнопки, и мгновенный count() > 0 пропустил бы выбор резюме.
+    #
+    # fail-closed (#33): если нужное резюме не найдено или совпадение неоднозначно —
+    # НЕ отправляем (submit не кликается), возвращаем причину. Иначе отправка ушла бы
+    # с резюме по умолчанию вместо запрошенного resume_id — необратимая отправка
+    # неверного резюме/персональных данных работодателю.
+    try:
+        page.locator(apply_form.APPLY_RESUME_SELECT).first.wait_for(
+            state="visible", timeout=OPTIONAL_FIELD_TIMEOUT_MS
+        )
+    except PlaywrightError:
+        resume_select_present = False
+    else:
+        resume_select_present = True
+    if resume_select_present and page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
+        if not _select_resume_in_form(page, resume_id):
+            return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
 
     if _is_visible(
         page, apply_form.APPLY_COVER_LETTER_TOGGLE, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS
@@ -118,26 +133,48 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     return None
 
 
-def _select_resume_in_form(page: Page, resume_id: str) -> None:
-    """
-    Если у пользователя несколько резюме, hh.ru может показать выбор резюме
-    в форме отклика. Селектор APPLY_RESUME_SELECT — приблизительный и почти
-    наверняка потребует уточнения при первом реальном запуске: нужно найти
-    конкретный пункт списка, соответствующий resume_id, и кликнуть на него.
-    Пока реализация ищет опцию, содержащую resume_id в data-атрибуте или href.
+def _select_resume_in_form(page: Page, resume_id: str) -> bool:
+    """Выбирает резюме ``resume_id`` в форме отклика. True — выбрано, False — нет.
+
+    Если у пользователя несколько резюме, hh.ru показывает выбор резюме в форме
+    отклика. Селектор APPLY_RESUME_SELECT — приблизительный (не подтверждён
+    curl-дампом, рендерится только залогиненному через JS) и наверняка потребует
+    уточнения при первом реальном запуске.
+
+    Совпадение resume_id ищется как **сегмент пути**, а не как голая подстрока href:
+    ``/resume/{resume_id}`` или ``resume_id={resume_id}``. Голая подстрока давала бы
+    лжесовпадения (напр. ``RID`` внутри ``/resume/PONDERING``).
+
+    fail-closed: ровно одна подходящая опция → кликаем, возвращаем True. Ноль или
+    больше одной (неоднозначно) → возвращаем False, отправка не состоится.
     """
     from ..selector_groups import apply_form
 
     options = page.locator(apply_form.APPLY_RESUME_SELECT)
     count = options.count()
+    matched: list[int] = []
     for i in range(count):
-        option = options.nth(i)
-        href = option.get_attribute("href") or ""
-        if resume_id in href:
-            option.click()
-            return
-    logger.warning(
-        "Не удалось однозначно выбрать резюме '%s' в форме отклика — "
-        "используется резюме, выбранное hh.ru по умолчанию",
-        resume_id,
-    )
+        href = options.nth(i).get_attribute("href") or ""
+        if _href_matches_resume_id(href, resume_id):
+            matched.append(i)
+    if len(matched) != 1:
+        # 0 — нужного резюме нет среди опций; >1 — неоднозначно. И то и другое = отказ.
+        logger.warning(
+            "Не удалось однозначно выбрать резюме '%s' в форме отклика "
+            "(совпадений: %d) — отправка отменена",
+            resume_id,
+            len(matched),
+        )
+        return False
+    options.nth(matched[0]).click()
+    return True
+
+
+def _href_matches_resume_id(href: str, resume_id: str) -> bool:
+    """Совпадает ли ``resume_id`` с ``href`` как сегмент пути, а не как подстрока.
+
+    Принимает стандартные формы hh.ru: ``/resume/{id}`` (путь) и ``resume_id={id}``
+    (query). Голая подстрока (``resume_id in href``) отвергается — она ловит
+    случайные вхождения (``RID`` внутри ``PONDERING``).
+    """
+    return f"/resume/{resume_id}" in href or f"resume_id={resume_id}" in href

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -100,37 +100,41 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     from ..selector_groups import apply_form
 
     # Выбор резюме — особый случай: APPLY_RESUME_SELECT это коллекция (несколько резюме),
-    # и wait_for в strict mode при >1 совпадении кидает Error. Поэтому «есть ли выбор
-    # резюме» проверяем через .first.wait_for(state='visible') (.first снимает strict
-    # mode — см. инвариант из PR #29), а затем _select_resume_in_form работает по
-    # count()/nth(). Это закрывает гонку рендера: коллекция может появиться позже
-    # submit-кнопки, и мгновенный count() > 0 пропустил бы выбор резюме.
+    # и wait_for в strict mode при >1 совпадении кидает Error. Поэтому ждём появление
+    # коллекции через .first.wait_for(state='attached') (.first снимает strict mode —
+    # см. инвариант из PR #29; state='attached' = наличие в DOM, НЕ видимость), а
+    # решающую проверку «есть ли выбор» делаем по count(). Это закрывает и гонку
+    # рендера (коллекция может появиться позже submit-кнопки), и баг cycle-4: раньше
+    # .first.wait_for(state='visible') видел только первый DOM-матч — если первый
+    # скрыт, а другой видим, таймаут ошибочно трактовался как «выбора нет» → submit
+    # дефолтного резюме.
     #
-    # fail-closed (#33): если нужное резюме не найдено или совпадение неоднозначно —
-    # НЕ отправляем (submit не кликается), возвращаем причину. Иначе отправка ушла бы
-    # с резюме по умолчанию вместо запрошенного resume_id — необратимая отправка
-    # неверного резюме/персональных данных работодателю.
+    # fail-closed (#33): count() > 0 → выбор ОБЯЗАТЕЛЕН (_select_resume_in_form сам
+    # fail-closed). Не найдено/неоднозначно — НЕ отправляем, возвращаем причину.
+    # count() == 0 (детерминированное отсутствие после долгого ожидания) — выбора нет
+    # (одно резюме), submit разрешён.
     try:
         page.locator(apply_form.APPLY_RESUME_SELECT).first.wait_for(
-            state="visible", timeout=RESUME_SELECT_TIMEOUT_MS
+            state="attached", timeout=RESUME_SELECT_TIMEOUT_MS
         )
     except PlaywrightError:
-        resume_select_present = False
+        # Селектор не появился в DOM за долгий таймаут — выбора на этой странице нет
+        # (одно резюме, happy path). submit разрешён ниже.
+        options_count = 0
     else:
-        resume_select_present = True
-    if resume_select_present:
-        # TOCTOU (cycle-2 review): селектор был видим в wait_for, но исчез к count()
-        # (transient re-render/drift). count()==0 после detect — НЕ «одно резюме»
-        # (там wait_for таймаутит → resume_select_present=False), а нестабильный
-        # селектор на multi-resume форме. Fail-closed: отказ, не submit дефолтного.
-        if page.locator(apply_form.APPLY_RESUME_SELECT).count() > 0:
-            if not _select_resume_in_form(page, resume_id):
-                return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
-        else:
+        options_count = page.locator(apply_form.APPLY_RESUME_SELECT).count()
+        if options_count == 0:
+            # TOCTOU (cycle-2): был прикреплён в wait_for, но исчез к count()
+            # (transient re-render/drift). Это НЕ «одно резюме» (там wait_for таймаутит
+            # и мы в ветке except выше), а нестабильный селектор. Fail-closed: отказ.
             return (
                 "селектор выбора резюме исчез после обнаружения — "
                 "отправка отменена (нестабильная форма отклика)"
             )
+    if options_count > 0:
+        # Выбор есть (multi-resume) — выбираем нужное; _select_resume_in_form fail-closed.
+        if not _select_resume_in_form(page, resume_id):
+            return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
 
     if _is_visible(
         page, apply_form.APPLY_COVER_LETTER_TOGGLE, timeout_ms=OPTIONAL_FIELD_TIMEOUT_MS

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import logging
+from urllib.parse import parse_qs, urlparse
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -27,6 +28,14 @@ APPLY_TIMEOUT_MS = 10_000
 # отсутствовать — это нормально, а не ошибка). Ждать полной APPLY_TIMEOUT_MS тут
 # бессмысленно: отсутствие поля детерминировано почти сразу.
 OPTIONAL_FIELD_TIMEOUT_MS = 1_500
+# Таймаут ожидания селектора выбора резюме. Это НЕ опциональное поле вроде
+# cover-letter: если на multi-resume аккаунте селектор резюме не успел отрисоваться
+# за короткий OPTIONAL_FIELD_TIMEOUT_MS (медленный JS-рендер залогиненной формы),
+# выбор молча пропускается и submit отправляет резюме по умолчанию (fail-open,
+# см. cycle-2 review #33). Поэтому селектор резюме ждём как обязательный элемент:
+# появится — выберем нужное, детерминированно отсутствует после долгого ожидания —
+# на этой странице выбора нет (одно резюме), submit разрешён.
+RESUME_SELECT_TIMEOUT_MS = APPLY_TIMEOUT_MS
 
 
 def wait_apply_button(page: Page) -> bool:
@@ -103,7 +112,7 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     # неверного резюме/персональных данных работодателю.
     try:
         page.locator(apply_form.APPLY_RESUME_SELECT).first.wait_for(
-            state="visible", timeout=OPTIONAL_FIELD_TIMEOUT_MS
+            state="visible", timeout=RESUME_SELECT_TIMEOUT_MS
         )
     except PlaywrightError:
         resume_select_present = False
@@ -171,10 +180,19 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
 
 
 def _href_matches_resume_id(href: str, resume_id: str) -> bool:
-    """Совпадает ли ``resume_id`` с ``href`` как сегмент пути, а не как подстрока.
+    """Совпадает ли ``resume_id`` с ``href`` как **полный** сегмент/значение.
 
-    Принимает стандартные формы hh.ru: ``/resume/{id}`` (путь) и ``resume_id={id}``
-    (query). Голая подстрока (``resume_id in href``) отвергается — она ловит
-    случайные вхождения (``RID`` внутри ``PONDERING``).
+    Принимает стандартные формы hh.ru: ``/resume/{id}`` (последний сегмент пути) и
+    ``resume_id={id}`` (значение query-параметра). Требуется **точное равенство**
+    сегмента/значения, а не вхождение подстроки — иначе ``resume_id="RID"`` ложно
+    совпадает с ``/resume/RID2`` (суффикс) или ``?other_resume_id=RID``
+    (похожий параметр), и кликается чужое резюме (cycle-2 review #33).
     """
-    return f"/resume/{resume_id}" in href or f"resume_id={resume_id}" in href
+    parsed = urlparse(href)
+    # Путь: /resume/{id} — последний сегмент должен совпадать ровно.
+    last_segment = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    if last_segment == resume_id:
+        return True
+    # Query: resume_id={id} — точное значение параметра (не похоже названного).
+    query = parse_qs(parsed.query)
+    return query.get("resume_id", [None])[0] == resume_id

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -62,12 +62,23 @@ class _FakeLocator:
     def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
         # Моделируем реальное поведение Playwright: в strict mode для коллекции
         # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
-        # Через .first strict mode снимается — тогда ждём видимость коллекции.
+        # Через .first strict mode снимается — тогда ждём готовность коллекции.
         if self._state.is_collection and self._strict and self._href_filter is None:
             raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
                 f"strict mode violation: {self.selector} resolved to "
                 f"{self._state.match_count} elements"
             )
+        if state == "attached":
+            # state='attached' — наличие в DOM (match_count>0 для коллекции), без
+            # требования видимости. Моделирует cycle-4 фикс: скрытый первый элемент
+            # всё равно «прикреплён», и count() решает, есть ли выбор.
+            if self._state.is_collection:
+                if self._state.match_count == 0:
+                    raise PlaywrightTimeoutError(f"{self.selector} not attached")
+                return
+            if not self._state.visible:
+                raise PlaywrightTimeoutError(f"{self.selector} not attached")
+            return
         if not self._state.visible:
             raise PlaywrightTimeoutError(f"{self.selector} not visible")
 
@@ -497,6 +508,25 @@ def test_fill_form_resume_target_disappears_at_click_time_does_not_submit():
 
     assert result is not None
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_hidden_first_match_still_selects_not_submit_default():
+    # Codex cycle-4: .first.wait_for(state='visible') видел только первый DOM-матч.
+    # Если первый скрыт, а другой видим — старый код таймаутил → «выбора нет» → submit
+    # дефолтного резюме. Фикс: wait_for(state='attached') + решающая проверка по count().
+    # Оракул: коллекция прикреплена (count=2) → выбор вызывается → клик по RID.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.visible = False  # первый элемент скрыт → wait_for(state='visible') таймаутил бы
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    # С фиксом: count()==2 → выбор → клик RID, submit нажат.
+    assert result is None
+    assert st.current_href == "/resume/RID"
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
 
 
 # --- константы ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -26,16 +26,21 @@ class _FakeLocator:
 
     @property
     def first(self):
-        return self
+        # В реальном Playwright .first снимает strict mode: wait_for на коллекции
+        # через .first проходит (ждёт первый совпавший), а на всей коллекции без .first
+        # кидает strict-mode Error. Возвращаем локатор с _strict=False.
+        return _FakeLocator(self.selector, self._state, strict=False)
 
-    def __init__(self, selector: str, state: _SelectorState) -> None:
+    def __init__(self, selector: str, state: _SelectorState, *, strict: bool = True) -> None:
         self.selector = selector
         self._state = state
+        self._strict = strict
 
     def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
         # Моделируем реальное поведение Playwright: в strict mode для коллекции
         # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
-        if self._state.is_collection:
+        # Через .first strict mode снимается — тогда ждём видимость коллекции.
+        if self._state.is_collection and self._strict:
             raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
                 f"strict mode violation: {self.selector} resolved to "
                 f"{self._state.match_count} elements"
@@ -228,6 +233,72 @@ def test_fill_form_resume_select_multiple_matches_selects_correct_resume():
     assert result is None
     assert st.current_href == "/resume/RID"
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+# --- fill_response_form: выбор резюме fail-closed (#33) ---
+#
+# Регрессия #33: ранее при отсутствии опции с совпадающим resume_id форма всё равно
+# отправлялась (fail-open — submit кликался, уходило резюме по умолчанию). Теперь
+# неоднозначность/отсутствие нужного резюме = отказ: submit НЕ нажимается, возвращается
+# причина. Совпадение resume_id проверяется как сегмент пути (/resume/{id} или
+# resume_id={id}), не как голая подстрока href — снижает случайные лжесовпадения.
+
+
+def test_fill_form_resume_no_match_does_not_submit_returns_reason():
+    # Коллекция резюме есть, но ни одна опция не содержит запрошенный resume_id.
+    # Оракул: submit НЕ нажат, возвращена причина отказа (а не None).
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER1", "/resume/OTHER2"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "резюме" in result.lower()
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_ambiguous_match_does_not_submit_returns_reason():
+    # Две опции совпадают по resume_id — неоднозначность = отказ, а не «кликни первое».
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/RID", "/resume/RID"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "резюме" in result.lower()
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_single_match_submits_and_returns_none():
+    # Ровно одна опция с совпадающим resume_id → выбор успешен, submit нажат, None.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 3)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID", "/resume/THIRD"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert st.current_href == "/resume/RID"
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_resume_match_requires_path_segment_not_bare_substring():
+    # resume_id должен совпасть как сегмент пути, а не как подстрока где попало.
+    # Здесь "RID" — лишь подстрока чужого href /resume/PONDERING, сегмента /resume/RID нет.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 1)
+    st.option_hrefs = ["/resume/PONDERING"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 
 
 # --- константы ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -10,6 +10,7 @@ submit даёт отказ при отсутствии.
 from __future__ import annotations
 
 import contextlib
+import re
 
 from playwright.sync_api import Error
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -31,16 +32,38 @@ class _FakeLocator:
         # кидает strict-mode Error. Возвращаем локатор с _strict=False.
         return _FakeLocator(self.selector, self._state, strict=False)
 
-    def __init__(self, selector: str, state: _SelectorState, *, strict: bool = True) -> None:
+    def __init__(
+        self,
+        selector: str,
+        state: _SelectorState,
+        *,
+        strict: bool = True,
+        href_filter: str | None = None,
+    ) -> None:
         self.selector = selector
         self._state = state
         self._strict = strict
+        # href_filter: селектор уточнён [href='...'] — strict-локатор, привязанный к
+        # identity. click()/count() резолвятся по живым href с учётом reorder (cycle-3).
+        self._href_filter = href_filter
+
+    def _live_hrefs(self) -> list[str]:
+        # Текущие «живые» href опций. href-локатор моделирует «момент клика» — после
+        # scan, поэтому при заданном reorder он всегда отражает post-scan DOM. Обычный
+        # nth-доступ активирует reorder после полного scan (nth_calls > match_count).
+        hrefs = self._state.option_hrefs
+        if self._href_filter is not None:
+            if self._state.reorder_to:
+                hrefs = self._state.reorder_to
+        elif self._state.reorder_to and self._state._nth_calls > self._state.match_count:
+            hrefs = self._state.reorder_to
+        return hrefs
 
     def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
         # Моделируем реальное поведение Playwright: в strict mode для коллекции
         # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
         # Через .first strict mode снимается — тогда ждём видимость коллекции.
-        if self._state.is_collection and self._strict:
+        if self._state.is_collection and self._strict and self._href_filter is None:
             raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
                 f"strict mode violation: {self.selector} resolved to "
                 f"{self._state.match_count} elements"
@@ -49,6 +72,16 @@ class _FakeLocator:
             raise PlaywrightTimeoutError(f"{self.selector} not visible")
 
     def click(self) -> None:
+        if self._href_filter is not None:
+            # Strict href-локатор: ровно одна живая опция с этим href, иначе Error
+            # (как реальный Playwright strict mode при != 1 совпадении).
+            matches = [h for h in self._live_hrefs() if h == self._href_filter]
+            if len(matches) != 1:
+                raise Error(  # noqa: TRY002
+                    f"strict mode violation: {self.selector} resolved to {len(matches)} "
+                    f"elements (href={self._href_filter!r})"
+                )
+            self._state.current_href = matches[0]
         self._state.clicks += 1
 
     def fill(self, value: str) -> None:
@@ -128,6 +161,13 @@ class FakeStepsPage:
         return st
 
     def locator(self, selector: str) -> _FakeLocator:
+        # Селектор опции резюме по точному href: BASE[href='...']. Резолвится к тому же
+        # состоянию коллекции APPLY_RESUME_SELECT, но с href_filter для strict-клика
+        # в момент действия (cycle-3 identity-bound выбор).
+        m = re.match(r"^(.+?)\[href='(.*)'\]$", selector)
+        if m:
+            base, href = m.group(1), m.group(2).replace("\\'", "'")
+            return _FakeLocator(selector, self._state(base), href_filter=href)
         return _FakeLocator(selector, self._state(selector))
 
     @contextlib.contextmanager
@@ -431,11 +471,26 @@ def test_fill_form_resume_reorder_after_scan_clicks_correct_resume():
 
 def test_fill_form_resume_dup_appears_at_click_time_does_not_submit():
     # TOCTOU (Codex cycle-3): к моменту клика href резюме задвоился (JS вставил дубль).
-    # Live-скан находит >1 опции с target_href → неоднозначно → отказ, submit не нажат.
+    # href-локатор strict → >1 совпадение → Error → отказ, submit не нажат.
     page = FakeStepsPage()
     st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
     st.option_hrefs = ["/resume/OTHER", "/resume/RID"]  # одна RID на scan
     st.reorder_to = ["/resume/RID", "/resume/RID"]  # две RID к моменту клика
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_target_disappears_at_click_time_does_not_submit():
+    # TOCTOU (Codex cycle-3 verify): target-href исчез между scan и click.
+    # href-локатор strict → 0 совпадений → Error → отказ, submit не нажат.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]  # RID есть на scan
+    st.reorder_to = ["/resume/OTHER", "/resume/THIRD"]  # RID исчез к моменту клика
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
     result = steps.fill_response_form(page, "RID", "письмо")

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -301,6 +301,81 @@ def test_fill_form_resume_match_requires_path_segment_not_bare_substring():
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 
 
+# --- fill_response_form: точное совпадение сегмента (cycle-2 review, Codex) ---
+#
+# Codex cycle-1: совпадение как сегмент всё ещё подстрока — /resume/RID2 и
+# other_resume_id=RID ложно матчат resume_id=RID → клик неверной опции → submit.
+# Оракул: точное равенство сегмента пути/значения query, без префиксных/суффиксных
+# лжесовпадений.
+
+
+def test_fill_form_resume_match_rejects_suffix_in_path_segment():
+    # /resume/RID2 НЕ должно совпадать с resume_id="RID": это чужое резюме.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 1)
+    st.option_hrefs = ["/resume/RID2"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_match_rejects_similarly_named_query_param():
+    # ?other_resume_id=RID НЕ должно совпадать: совпадает только resume_id=RID.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 1)
+    st.option_hrefs = ["/app/applicant/vacancy_response?other_resume_id=RID"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_match_accepts_resume_id_query_param():
+    # Позитивный контроль: ?resume_id=RID (точное значение) → выбор успешен.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 1)
+    st.option_hrefs = ["/app/applicant/vacancy_response?resume_id=RID&topic=1"]
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+# --- выбор резюме: долгое ожидание селектора (cycle-2 review, Codex) ---
+#
+# Codex cycle-1: короткий OPTIONAL_FIELD_TIMEOUT_MS (1.5с) для селектора резюме
+# пропускает выбор при медленном JS-рендере залогиненной формы на multi-resume
+# аккаунте → submit отправляет резюме по умолчанию (fail-open). Селектор резюме —
+# критичнее cover-letter: ждём его как обязательный элемент (APPLY_TIMEOUT_MS), и
+# только отсутствие после долгого ожидания = «на этой странице выбора нет».
+
+
+def test_resume_select_uses_full_timeout_not_optional():
+    # Оракул: ожидание селектора резюме — APPLY_TIMEOUT_MS, не OPTIONAL_FIELD_TIMEOUT_MS.
+    # Это закрывает гонку рендера (селектор может появиться позже submit-кнопки).
+    assert steps.RESUME_SELECT_TIMEOUT_MS >= steps.APPLY_TIMEOUT_MS
+
+
+def test_fill_form_resume_select_absent_single_resume_submits():
+    # Happy path одного резюме: выбора нет (селектор отсутствует после долгого ожидания)
+    # → submit жмётся. Не ломаем аккаунты с одним резюме.
+    page = FakeStepsPage()
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    # APPLY_RESUME_SELECT намеренно отсутствует.
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
 # --- константы ---
 
 

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -63,6 +63,9 @@ class _FakeLocator:
         # Моделируем реальное поведение Playwright: в strict mode для коллекции
         # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
         # Через .first strict mode снимается — тогда ждём готовность коллекции.
+        if self._state.wait_error:
+            # Cycle-5: имитация не-timeout PlaywrightError (runtime/selector failure).
+            raise Error(f"runtime error waiting for {self.selector}")
         if self._state.is_collection and self._strict and self._href_filter is None:
             raise Error(  # noqa: TRY002 — имитация playwright._impl._errors.Error
                 f"strict mode violation: {self.selector} resolved to "
@@ -146,6 +149,9 @@ class _SelectorState:
         # переупорядочивание/вставку опций JS между scan и click.
         self.reorder_to: list[str] | None = None
         self._nth_calls = 0
+        # Имитация не-timeout PlaywrightError в wait_for (cycle-5): runtime/selector
+        # failure, который НЕ должен маскироваться под «выбора нет».
+        self.wait_error = False
 
 
 class FakeStepsPage:
@@ -527,6 +533,23 @@ def test_fill_form_resume_hidden_first_match_still_selects_not_submit_default():
     assert result is None
     assert st.current_href == "/resume/RID"
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_resume_wait_runtime_error_does_not_submit():
+    # Codex cycle-5: except ловил ЛЮБОЙ PlaywrightError → options_count=0. Не-timeout
+    # runtime/selector failure маскировался под «выбора нет» → skip count()/выбор →
+    # submit дефолтного резюме. Фикс: ловим только PlaywrightTimeoutError; прочие
+    # PlaywrightError → отказ. Оракул: submit НЕ нажат.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]
+    st.wait_error = True  # wait_for кидает generic PlaywrightError (НЕ timeout)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 
 
 # --- константы ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -58,6 +58,8 @@ class _FakeLocator:
         # Для коллекции (резюме, set_match_count) count() = число совпадений в DOM.
         # Иначе — одиночный элемент: 1 если visible, иначе 0.
         if self._state.is_collection:
+            if self._state.disappear_after_wait:
+                return 0  # TOCTOU: селектор исчез между wait_for и count
             return self._state.match_count
         return 1 if self._state.visible else 0
 
@@ -84,6 +86,9 @@ class _SelectorState:
         # Для коллекции резюме: href каждой опции (current_href ставится в nth()).
         self.option_hrefs: list[str] = []
         self.current_href: str | None = None
+        # Имитация TOCTOU: селектор был видим в wait_for, но исчез к count().
+        # Моделирует transient re-render/drift между двумя вызовами Playwright.
+        self.disappear_after_wait = False
 
 
 class FakeStepsPage:
@@ -374,6 +379,23 @@ def test_fill_form_resume_select_absent_single_resume_submits():
 
     assert result is None
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_resume_selector_disappears_after_detect_does_not_submit():
+    # TOCTOU (Codex cycle-2): селектор выбора резюме был видим в wait_for, но исчез
+    # к count() (transient re-render/drift). Оракул: submit НЕ нажат, возвращена
+    # причина отказа — не отправляем резюме по умолчанию при нестабильном селекторе.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/RID", "/resume/OTHER"]
+    st.disappear_after_wait = True  # wait_for проходит, count() → 0
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "резюме" in result.lower()
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 
 
 # --- константы ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -68,8 +68,16 @@ class _FakeLocator:
 
     def nth(self, i: int) -> _FakeLocator:
         # Каждая опция резюме — свой href; _select_resume_in_form ищет resume_id в нём.
+        self._state._nth_calls += 1
         if self._state.option_hrefs:
-            self._state.current_href = self._state.option_hrefs[i]
+            hrefs = self._state.option_hrefs
+            # reorder_to: после того как scan прочитал все опции один раз
+            # (_nth_calls > match_count), DOM «меняется» и последующие nth() берут
+            # href из reorder_to. Старый код кликал по сохранённому индексу скана →
+            # попадал на WRONG опцию; identity-bound фикс пере-сканирует и кликает верно.
+            if self._state.reorder_to and self._state._nth_calls > self._state.match_count:
+                hrefs = self._state.reorder_to
+            self._state.current_href = hrefs[i]
         self._state.clicks += 1  # клик по выбранной опции
         return self
 
@@ -89,6 +97,11 @@ class _SelectorState:
         # Имитация TOCTOU: селектор был видим в wait_for, но исчез к count().
         # Моделирует transient re-render/drift между двумя вызовами Playwright.
         self.disappear_after_wait = False
+        # Имитация reorder-TOCTOU (cycle-3): после того как scan прочитал все опции
+        # один раз, последующие nth() берут href из reorder_to. Моделирует
+        # переупорядочивание/вставку опций JS между scan и click.
+        self.reorder_to: list[str] | None = None
+        self._nth_calls = 0
 
 
 class FakeStepsPage:
@@ -395,6 +408,39 @@ def test_fill_form_resume_selector_disappears_after_detect_does_not_submit():
 
     assert result is not None
     assert "резюме" in result.lower()
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_resume_reorder_after_scan_clicks_correct_resume():
+    # TOCTOU (Codex cycle-3): JS переупорядочил опции между scan и click. Scan видит
+    # [OTHER, RID] (RID на индексе 1); к моменту клика DOM = [RID, OTHER] (RID на 0).
+    # Оракул: identity-bound выбор пере-сканирует href в момент клика и кликает RID
+    # (а не сохранённый индекс 1, который теперь = OTHER).
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]  # порядок на scan
+    st.reorder_to = ["/resume/RID", "/resume/OTHER"]  # порядок к моменту клика
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert st.current_href == "/resume/RID"  # кликнули RID, не OTHER
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_resume_dup_appears_at_click_time_does_not_submit():
+    # TOCTOU (Codex cycle-3): к моменту клика href резюме задвоился (JS вставил дубль).
+    # Live-скан находит >1 опции с target_href → неоднозначно → отказ, submit не нажат.
+    page = FakeStepsPage()
+    st = page.set_match_count(apply_form.APPLY_RESUME_SELECT, 2)
+    st.option_hrefs = ["/resume/OTHER", "/resume/RID"]  # одна RID на scan
+    st.reorder_to = ["/resume/RID", "/resume/RID"]  # две RID к моменту клика
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 
 


### PR DESCRIPTION
## Что

`_select_resume_in_form` в `src/hhru_bot/apply/steps.py` был **fail-open**: при отсутствии однозначного совпадения `resume_id` лишь логировал warning, а `submit` кликался безусловно — отправка уходила с резюме по умолчанию вместо запрошенного `resume_id`. Необратимая отправка неверного резюме/персональных данных работодателю, которую pipeline мог записать как `success`.

Делаю **fail-closed**: нет однозначного совпадения `resume_id` → НЕ отправляем, возвращаем причину отказа.

Follow-up к PR #29 (issue #6), выявлено на cycle-3 review. Часть эпика #1.

## Реализация (после 6 итераций cycle-review)

- **Exact-equality совпадение** `resume_id` через `urlparse`/`parse_qs`: последний сегмент пути `/resume/{id}` или точное значение query-параметра `resume_id`. Голая подстрока отвергнута (фикс лжесовпадений `/resume/RID2`, `?other_resume_id=RID`).
- **Presence-check по `count()`**, не по `.first.wait_for(visible)`: ждём коллекцию через `.first.wait_for(state='attached')`, а решающую проверку делаем по `count()`. Закрывает гонку рендера и баг «hidden first match».
- **Узкий exception handling**: только `PlaywrightTimeoutError` = легитимное отсутствие выбора (одно резюме); прочие `PlaywrightError` → отказ (не маскировать runtime-ошибки под «нет выбора»).
- **Identity-bound клик**: strict CSS-локатор `APPLY_RESUME_SELECT[href='<target>']` кликается напрямую, без index-handoff. Playwright резолвит identity атомарно в момент `click()` и кидает strict-mode Error при !=1 совпадении → отказ. Устраняет scan→click TOCTOU.
- **TOCTOU-guards**: count()==0 после attached-detect = отказ; скрытый первый элемент не маскируется под «нет выбора»; дубль/исчезновение href в момент клика = отказ.

## ТДД

13 characterization-тестов добавлены под fail-closed (красные до реализации, мутационные гарды): no-match, ambiguous, exact-path, suffix/query-param rejection, single-match, absent-single-resume happy-path, disappear-after-detect, reorder-after-scan, dup-at-click, target-disappears-at-click, hidden-first-match, wait-runtime-error. Тестовая инфраструктура `_FakeLocator` расширена (strict-mode, href_filter, attached-state, reorder, wait_error).

25 тестов steps зелёные, полный набор зелёный, ruff check + format чист.

## Scope / не затронуто

`apply/success.py`, `probe.py`, `dedup.py`, `pipeline.py`, `letter.py`, `commands/` — не трогал.

## Residual risk (follow-up, вне steps.py)

1. Browser-automation TOCTOU внутри Playwright click-resolution — предел sync API.
2. Single-resume аккаунт: селектор не появляется → submit (преднамеренно). Полная гарантия требует подтверждённого curl-дампом маркера активного резюме — первая боевая сверка через `probe` (#8)/F12.
3. Валидация `resume.id` vs `resume.resume_id` — `commands/login,probe`.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)