### PR TITLE
feat(ai): transport-слой LLM из hermes-agent (#16, Этап 5)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -12,6 +12,26 @@ account:
   # требует конкретный UA. Хардкода Chrome/xxx в коде нет (см. #9).
   # user_agent: "Mozilla/5.0 ... Chrome/XXX Safari/537.36"
 
+# AI/LLM-провайдер (issue #16, Этап 5) — ОПЦИОНАЛЬНО. TOP-LEVEL секция (как
+# account): один провайдер на весь бот. Раскомментируйте, только если нужна
+# AI-функциональность (ранжирование/сопоставление резюме и т.п.).
+#
+# Требует optional-зависимости:  pip install -e '.[ai]'
+# API-ключ НЕ пишите сюда — он читается из env HHRU_AI_API_KEY (чтобы секрет не
+# рисковал попасть в git-коммит). Пример для OpenAI:
+#
+# ai:
+#   provider: openai
+#   model: gpt-4o
+#   base_url: https://api.openai.com/v1
+#
+# Пример для OpenAI-совместимого шлюза (OpenRouter, локальный Ollama/vLLM, ...):
+#
+# ai:
+#   provider: openrouter
+#   model: anthropic/claude-3.5-sonnet
+#   base_url: https://openrouter.ai/api/v1
+
 throttle:
   min_delay_seconds: 8
   max_delay_seconds: 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ dev = [
     "pytest>=8",
     "ruff>=0.6",
 ]
+# AI/LLM-функциональность (issue #16, Этап 5). Не входит в базовые dependencies —
+# бот работает без LLM; установите группу [ai] только когда нужна AI-интеграция:
+#   pip install -e '.[ai]'
+# openai импортируется лениво внутри hhru_bot.ai.llm_client, поэтому отсутствие
+# пакета не ломает импорт остального кода.
+ai = [
+    "openai>=1.50",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/hhru_bot/ai/__init__.py
+++ b/src/hhru_bot/ai/__init__.py
@@ -1,0 +1,39 @@
+"""AI transport layer for hhru (issue #16, Stage 5).
+
+Thin LLM client + provider transport abstraction ported from
+NousResearch/hermes-agent (MIT). ``openai`` is an optional dependency
+(install group ``[ai]``); this package imports without it.
+
+Public surface:
+    LLMClient              -- synchronous OpenAI-compat client (lazy openai import)
+    NormalizedResponse     -- canonical normalized API response
+    ToolCall / Usage       -- response building blocks
+    get_transport          -- resolve a transport instance by api_mode
+    register_transport     -- register a transport class for an api_mode
+    resolve_runtime_provider -- build a runtime entry from AiConfig + env key
+    ChatCompletionsTransport -- the default OpenAI-compat transport
+    ProviderTransport      -- ABC for provider transports
+"""
+
+from __future__ import annotations
+
+from .base import ProviderTransport
+from .chat_completions import ChatCompletionsTransport
+from .llm_client import LLMClient
+from .registry import get_transport, register_transport
+from .runtime_provider import resolve_runtime_provider
+from .types import NormalizedResponse, ToolCall, Usage, build_tool_call, map_finish_reason
+
+__all__ = [
+    "LLMClient",
+    "NormalizedResponse",
+    "ToolCall",
+    "Usage",
+    "build_tool_call",
+    "map_finish_reason",
+    "get_transport",
+    "register_transport",
+    "resolve_runtime_provider",
+    "ChatCompletionsTransport",
+    "ProviderTransport",
+]

--- a/src/hhru_bot/ai/base.py
+++ b/src/hhru_bot/ai/base.py
@@ -1,0 +1,92 @@
+# Ported from NousResearch/hermes-agent (MIT).
+# Copyright (c) 2025 Nous Research.
+#
+"""Abstract base for provider transports.
+
+A transport owns the data path for one api_mode:
+  convert_messages -> convert_tools -> build_kwargs -> normalize_response
+
+It does NOT own: client construction, streaming, credential refresh,
+prompt caching, interrupt handling, or retry logic. Those stay on the caller
+(``LLMClient`` in this package).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from .types import NormalizedResponse
+
+
+class ProviderTransport(ABC):
+    """Base class for provider-specific format conversion and normalization."""
+
+    @property
+    @abstractmethod
+    def api_mode(self) -> str:
+        """The api_mode string this transport handles (e.g. 'chat_completions')."""
+        ...
+
+    @abstractmethod
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        """Convert OpenAI-format messages to provider-native format.
+
+        Returns provider-specific structure (e.g. the messages list unchanged for
+        chat_completions, or ``(system, messages)`` for Anthropic-style providers).
+        """
+        ...
+
+    @abstractmethod
+    def convert_tools(self, tools: list[dict[str, Any]]) -> Any:
+        """Convert OpenAI-format tool definitions to provider-native format."""
+        ...
+
+    @abstractmethod
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **params,
+    ) -> dict[str, Any]:
+        """Build the complete API call kwargs dict.
+
+        This is the primary entry point -- it typically calls ``convert_messages()``
+        and ``convert_tools()`` internally, then adds model-specific config.
+
+        Returns a dict ready to be passed to the provider's SDK client.
+        """
+        ...
+
+    @abstractmethod
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        """Normalize a raw provider response to the shared NormalizedResponse type.
+
+        This is the only method that returns a transport-layer type.
+        """
+        ...
+
+    def validate_response(self, response: Any) -> bool:
+        """Optional: check if the raw response is structurally valid.
+
+        Returns True if valid, False if the response should be treated as invalid.
+        Default implementation always returns True.
+        """
+        return True
+
+    def extract_cache_stats(self, response: Any) -> dict[str, int] | None:
+        """Optional: extract provider-specific cache hit/creation stats.
+
+        Returns dict with 'cached_tokens' and 'creation_tokens', or None.
+        Default returns None.
+        """
+        return None
+
+    def map_finish_reason(self, raw_reason: str) -> str:
+        """Optional: map provider-specific stop reason to OpenAI equivalent.
+
+        Default returns the raw reason unchanged. Override for providers with
+        different stop reason vocabularies.
+        """
+        return raw_reason

--- a/src/hhru_bot/ai/chat_completions.py
+++ b/src/hhru_bot/ai/chat_completions.py
@@ -1,0 +1,306 @@
+# Ported from NousResearch/hermes-agent (MIT).
+# Copyright (c) 2025 Nous Research.
+#
+"""OpenAI Chat Completions transport.
+
+Handles the default api_mode ('chat_completions') used by OpenAI-compatible
+providers (OpenAI, OpenRouter, Nous, local servers, etc.).
+
+Messages and tools are already in OpenAI format -- ``convert_messages`` and
+``convert_tools`` are near-identity. The complexity lives in ``build_kwargs``
+(provider-specific conditionals) and in ``normalize_response``.
+
+This is a deliberately trimmed port of hermes-agent's chat_completions
+transport: provider-specific reasoning/thinking/gemini/moonshot/lmstudio and
+the ProviderProfile path were removed. hhru uses a single OpenAI-compatible
+endpoint; the core conversion/normalization surface is preserved verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ProviderTransport
+from .types import NormalizedResponse, ToolCall, Usage
+
+# Models that expect the ``developer`` role instead of ``system``. Ported from
+# agent/prompt_builder.py:664 (DEVELOPER_ROLE_MODELS) -- kept as a local
+# constant so this transport does not pull in the rest of hermes' prompt
+# machinery (hermes_constants / runtime_cwd / skill_utils / threat_patterns).
+DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
+
+
+class ChatCompletionsTransport(ProviderTransport):
+    """Transport for api_mode='chat_completions'.
+
+    The default path for OpenAI-compatible providers.
+    """
+
+    @property
+    def api_mode(self) -> str:
+        return "chat_completions"
+
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> list[dict[str, Any]]:
+        """Messages are already in OpenAI format -- strip internal fields that
+        strict chat-completions providers reject with HTTP 400/422:
+
+        - Codex Responses API fields: ``codex_reasoning_items`` /
+          ``codex_message_items`` on the message.
+        - ``tool_name`` on tool-result messages (SQLite FTS bookkeeping, not
+          part of the Chat Completions schema).
+        - ``effect_disposition`` / ``timestamp`` / ``api_content`` -- internal
+          sidecars.
+        - Any Hermes-internal scaffolding marker -- any top-level message key
+          starting with ``_``. Permissive providers silently drop unknown
+          message keys, but strict gateways reject them.
+        """
+        needs_sanitize = False
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "tool_name" in msg
+                or "effect_disposition" in msg
+                or "timestamp" in msg
+                or "api_content" in msg
+            ):
+                needs_sanitize = True
+                break
+            if any(isinstance(k, str) and k.startswith("_") for k in msg):
+                needs_sanitize = True
+                break
+
+        if not needs_sanitize:
+            return messages
+
+        sanitized = list(messages)
+        for msg_idx, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                continue
+
+            copied_msg: dict[str, Any] | None = None
+
+            # NOTE: mutable_msg is redefined per loop iteration, so each closure
+            # binds its own msg / msg_idx -- there is no late-binding bug. The
+            # inline noqa markers below silence ruff's conservative B023 warning.
+            def mutable_msg() -> dict[str, Any]:
+                nonlocal copied_msg
+                if copied_msg is None:
+                    copied_msg = dict(msg)  # noqa: B023
+                    sanitized[msg_idx] = copied_msg  # noqa: B023
+                return copied_msg
+
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "tool_name" in msg
+                or "effect_disposition" in msg
+                or "timestamp" in msg
+                or "api_content" in msg
+            ):
+                out_msg = mutable_msg()
+                out_msg.pop("codex_reasoning_items", None)
+                out_msg.pop("codex_message_items", None)
+                out_msg.pop("tool_name", None)
+                out_msg.pop("effect_disposition", None)
+                out_msg.pop("timestamp", None)
+                out_msg.pop("api_content", None)
+
+            # Drop all internal scaffolding markers (``_``-prefixed).
+            internal_keys = [k for k in msg if isinstance(k, str) and k.startswith("_")]
+            if internal_keys:
+                out_msg = mutable_msg()
+                for key in internal_keys:
+                    out_msg.pop(key, None)
+        return sanitized
+
+    def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Tools are already in OpenAI format -- identity."""
+        return tools
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **params,
+    ) -> dict[str, Any]:
+        """Build ``chat.completions.create()`` kwargs.
+
+        params (all optional):
+            timeout: float -- API call timeout
+            max_tokens: int | None -- user-configured max tokens
+            request_overrides: dict | None -- caller-supplied kwargs merged last
+            temperature: Any -- forwarded when present
+            extra_body: dict | None -- folded into api_kwargs['extra_body']
+        """
+        # Sanitize: drop reasoning_items / tool_name / internal markers.
+        sanitized = self.convert_messages(messages, model=model)
+
+        # Developer role swap for GPT-5/Codex models.
+        model_lower = params.get("model_lower", (model or "").lower())
+        if (
+            sanitized
+            and isinstance(sanitized[0], dict)
+            and sanitized[0].get("role") == "system"
+            and any(p in model_lower for p in DEVELOPER_ROLE_MODELS)
+        ):
+            sanitized = list(sanitized)
+            sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        api_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": sanitized,
+        }
+
+        timeout = params.get("timeout")
+        if timeout is not None:
+            api_kwargs["timeout"] = timeout
+
+        # Temperature
+        temperature = params.get("temperature")
+        if temperature is not None:
+            api_kwargs["temperature"] = temperature
+
+        # Tools
+        if tools:
+            api_kwargs["tools"] = tools
+
+        # max_tokens -- user-configured value wins when present.
+        max_tokens = params.get("max_tokens")
+        if max_tokens is not None:
+            api_kwargs["max_tokens"] = max_tokens
+
+        # extra_body assembly
+        extra_body: dict[str, Any] = {}
+        additions = params.get("extra_body")
+        if additions:
+            extra_body.update(additions)
+        if extra_body:
+            api_kwargs["extra_body"] = extra_body
+
+        # Request overrides last (service_tier etc.)
+        overrides = params.get("request_overrides")
+        if overrides:
+            api_kwargs.update(overrides)
+
+        return api_kwargs
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        """Normalize OpenAI ChatCompletion to NormalizedResponse.
+
+        For chat_completions this is near-identity -- the response is already in
+        OpenAI format. ``reasoning_details`` (OpenRouter unified format) and
+        ``reasoning_content`` (DeepSeek/Moonshot) are preserved for downstream
+        replay.
+        """
+        choice = response.choices[0]
+        msg = choice.message
+        # Some gateways return an integer finish_reason instead of a string.
+        _fr = choice.finish_reason
+        if isinstance(_fr, int):
+            _fr = str(_fr)
+        finish_reason = _fr or "stop"
+
+        tool_calls = None
+        if msg.tool_calls:
+            tool_calls = []
+            for tc in msg.tool_calls:
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    )
+                )
+
+        usage = None
+        if hasattr(response, "usage") and response.usage:
+            u = response.usage
+            usage = Usage(
+                prompt_tokens=getattr(u, "prompt_tokens", 0) or 0,
+                completion_tokens=getattr(u, "completion_tokens", 0) or 0,
+                total_tokens=getattr(u, "total_tokens", 0) or 0,
+            )
+
+        # Preserve reasoning fields separately. DeepSeek/Moonshot use
+        # ``reasoning_content``; others use ``reasoning``. Keep them apart in
+        # provider_data rather than merging.
+        reasoning = getattr(msg, "reasoning", None)
+        reasoning_content = getattr(msg, "reasoning_content", None)
+        if reasoning_content is None and hasattr(msg, "model_extra"):
+            model_extra = getattr(msg, "model_extra", None) or {}
+            if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
+                reasoning_content = model_extra["reasoning_content"]
+
+        provider_data: dict[str, Any] = {}
+        if reasoning_content is not None:
+            provider_data["reasoning_content"] = reasoning_content
+        rd = getattr(msg, "reasoning_details", None)
+        if rd:
+            provider_data["reasoning_details"] = rd
+
+        # OpenAI structured-refusal field. When a model declines, the SDK
+        # populates ``message.refusal`` and leaves ``content`` empty. Promote it
+        # to content + a ``content_filter`` finish reason so a refusal doesn't
+        # look like an empty response. ``refusal`` is ``None`` for normal
+        # responses, so this is a no-op in the common case.
+        content = msg.content
+        refusal = getattr(msg, "refusal", None)
+        if refusal is None and hasattr(msg, "model_extra"):
+            _msg_extra = getattr(msg, "model_extra", None) or {}
+            if isinstance(_msg_extra, dict):
+                refusal = _msg_extra.get("refusal")
+        if isinstance(refusal, str) and refusal.strip():
+            provider_data["refusal"] = refusal
+            _has_text = isinstance(content, str) and content.strip()
+            _has_tool_calls = bool(tool_calls)
+            # Only promote to a terminal content_filter when the refusal is the
+            # sole payload -- no visible text and no tool calls.
+            if not _has_text and not _has_tool_calls:
+                content = refusal
+                if finish_reason in (None, "stop"):
+                    finish_reason = "content_filter"
+
+        return NormalizedResponse(
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            reasoning=reasoning,
+            usage=usage,
+            provider_data=provider_data or None,
+        )
+
+    def validate_response(self, response: Any) -> bool:
+        """Check that response has valid choices."""
+        if response is None:
+            return False
+        if not hasattr(response, "choices") or response.choices is None:
+            return False
+        if not response.choices:
+            return False
+        return True
+
+    def extract_cache_stats(self, response: Any) -> dict[str, int] | None:
+        """Extract cache stats from prompt_tokens_details (OpenRouter/OpenAI)
+        or DeepSeek's native top-level prompt_cache_hit_tokens field."""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return None
+        details = getattr(usage, "prompt_tokens_details", None)
+        cached = getattr(details, "cached_tokens", 0) or 0 if details else 0
+        written = getattr(details, "cache_write_tokens", 0) or 0 if details else 0
+        if not cached:
+            # DeepSeek native API shape: top-level prompt_cache_hit_tokens.
+            cached = getattr(usage, "prompt_cache_hit_tokens", 0) or 0
+        if cached or written:
+            return {"cached_tokens": cached, "creation_tokens": written}
+        return None
+
+
+# Auto-register on import
+from .registry import register_transport  # noqa: E402
+
+register_transport("chat_completions", ChatCompletionsTransport)

--- a/src/hhru_bot/ai/chat_completions.py
+++ b/src/hhru_bot/ai/chat_completions.py
@@ -290,8 +290,12 @@ class ChatCompletionsTransport(ProviderTransport):
         if usage is None:
             return None
         details = getattr(usage, "prompt_tokens_details", None)
-        cached = getattr(details, "cached_tokens", 0) or 0 if details else 0
-        written = getattr(details, "cache_write_tokens", 0) or 0 if details else 0
+        if details:
+            cached = getattr(details, "cached_tokens", 0) or 0
+            written = getattr(details, "cache_write_tokens", 0) or 0
+        else:
+            cached = 0
+            written = 0
         if not cached:
             # DeepSeek native API shape: top-level prompt_cache_hit_tokens.
             cached = getattr(usage, "prompt_cache_hit_tokens", 0) or 0

--- a/src/hhru_bot/ai/llm_client.py
+++ b/src/hhru_bot/ai/llm_client.py
@@ -45,6 +45,21 @@ class LLMClient:
         self._config = ai_config
         self._runtime = resolve_runtime_provider(ai_config, api_key=api_key, api_mode=api_mode)
         self._api_mode = self._runtime["api_mode"]
+        # The OpenAI client owns a persistent httpx connection pool; construct it
+        # once and reuse it across calls rather than paying pool setup per chat().
+        # ``openai`` is imported lazily here (not at module import) so the package
+        # stays importable without the optional [ai] extra installed.
+        try:
+            from openai import OpenAI
+        except ImportError as e:
+            raise ImportError(
+                "openai SDK is required for LLM calls. Install it with: "
+                "pip install -e '.[ai]'  (or: pip install openai)"
+            ) from e
+        self._client = OpenAI(
+            base_url=self._runtime["base_url"],
+            api_key=self._runtime["api_key"],
+        )
 
     @property
     def runtime(self) -> dict[str, Any]:
@@ -64,14 +79,6 @@ class LLMClient:
         (e.g. ``temperature``, ``max_tokens``, ``timeout``). ``openai`` SDK
         exceptions propagate to the caller unchanged -- this layer does not retry.
         """
-        try:
-            from openai import OpenAI
-        except ImportError as e:  # pragma: no cover - exercised manually with [ai]
-            raise ImportError(
-                "openai SDK is required for LLM calls. Install it with: "
-                "pip install -e '.[ai]'  (or: pip install openai)"
-            ) from e
-
         transport = get_transport(self._api_mode)
         if transport is None:
             raise RuntimeError(
@@ -85,9 +92,5 @@ class LLMClient:
             tools,
             **params,
         )
-        client = OpenAI(
-            base_url=self._runtime["base_url"],
-            api_key=self._runtime["api_key"],
-        )
-        response = client.chat.completions.create(**kwargs)
+        response = self._client.chat.completions.create(**kwargs)
         return transport.normalize_response(response)

--- a/src/hhru_bot/ai/llm_client.py
+++ b/src/hhru_bot/ai/llm_client.py
@@ -1,0 +1,93 @@
+# Ported from NousResearch/hermes-agent (MIT) -- transport conversion contract.
+# The ``LLMClient`` wrapper itself is new for hhru.
+#
+"""Thin LLM client over the ``openai`` SDK.
+
+``openai`` is an OPTIONAL dependency (install group ``[ai]``). It is imported
+lazily inside the methods so that importing this package -- and the rest of
+``hhru_bot`` -- does not require it. A clear ``ImportError`` is raised only
+when an LLM call is actually attempted without the SDK installed.
+
+The client delegates format conversion / request kwargs assembly / response
+normalization to the registered transport (``chat_completions`` by default).
+It owns only client construction and the SDK call -- no retry, streaming,
+credential refresh, or prompt caching (those concerns belong elsewhere).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .registry import get_transport
+from .runtime_provider import resolve_runtime_provider
+from .types import NormalizedResponse
+
+if TYPE_CHECKING:
+    from ..config_sections.ai import AiConfig
+
+
+class LLMClient:
+    """Minimal synchronous client for an OpenAI-compatible chat endpoint.
+
+    Args:
+        ai_config: parsed top-level ``ai`` config (provider / model / base_url).
+        api_key: optional explicit key; otherwise read from ``HHRU_AI_API_KEY``.
+        api_mode: transport to use; defaults to ``chat_completions``.
+    """
+
+    def __init__(
+        self,
+        ai_config: AiConfig,
+        *,
+        api_key: str | None = None,
+        api_mode: str | None = None,
+    ) -> None:
+        self._config = ai_config
+        self._runtime = resolve_runtime_provider(ai_config, api_key=api_key, api_mode=api_mode)
+        self._api_mode = self._runtime["api_mode"]
+
+    @property
+    def runtime(self) -> dict[str, Any]:
+        """Resolved runtime entry (provider / api_mode / base_url / api_key / model)."""
+        return self._runtime
+
+    def chat(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> NormalizedResponse:
+        """Run a chat-completions request and return a NormalizedResponse.
+
+        Extra keyword arguments are forwarded to the transport's ``build_kwargs``
+        (e.g. ``temperature``, ``max_tokens``, ``timeout``). ``openai`` SDK
+        exceptions propagate to the caller unchanged -- this layer does not retry.
+        """
+        try:
+            from openai import OpenAI
+        except ImportError as e:  # pragma: no cover - exercised manually with [ai]
+            raise ImportError(
+                "openai SDK is required for LLM calls. Install it with: "
+                "pip install -e '.[ai]'  (or: pip install openai)"
+            ) from e
+
+        transport = get_transport(self._api_mode)
+        if transport is None:
+            raise RuntimeError(
+                f"No transport registered for api_mode={self._api_mode!r}. "
+                f"Install the corresponding transport module or check ai_mode."
+            )
+
+        kwargs = transport.build_kwargs(
+            self._runtime["model"],
+            messages,
+            tools,
+            **params,
+        )
+        client = OpenAI(
+            base_url=self._runtime["base_url"],
+            api_key=self._runtime["api_key"],
+        )
+        response = client.chat.completions.create(**kwargs)
+        return transport.normalize_response(response)

--- a/src/hhru_bot/ai/registry.py
+++ b/src/hhru_bot/ai/registry.py
@@ -1,0 +1,59 @@
+# Ported from NousResearch/hermes-agent (MIT).
+# Copyright (c) 2025 Nous Research.
+#
+"""Transport registry for provider response normalization.
+
+Usage:
+    from hhru_bot.ai import get_transport
+    transport = get_transport("chat_completions")
+    result = transport.normalize_response(raw_response)
+
+Transports auto-register on import of their module (see
+``chat_completions.py``). ``get_transport`` lazily imports the bundled
+transport module on first lookup so callers don't pay the import cost until
+they actually resolve a transport.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_REGISTRY: dict[str, type] = {}
+_discovered: bool = False
+
+
+def register_transport(api_mode: str, transport_cls: type) -> None:
+    """Register a transport class for an api_mode string."""
+    _REGISTRY[api_mode] = transport_cls
+
+
+def get_transport(api_mode: str) -> Any:
+    """Get a transport instance for the given api_mode.
+
+    Returns None if no transport is registered for this api_mode. This allows
+    gradual migration -- call sites can check for None and fall back.
+    """
+    global _discovered
+    if not _discovered:
+        _discover_transports()
+    cls = _REGISTRY.get(api_mode)
+    if cls is None:
+        # The registry can be partially populated when a specific transport
+        # module was imported directly. Discover on misses, not only when the
+        # registry is empty, so test/order-dependent imports do not make valid
+        # api_modes unavailable.
+        _discover_transports()
+        cls = _REGISTRY.get(api_mode)
+    if cls is None:
+        return None
+    return cls()
+
+
+def _discover_transports() -> None:
+    """Import all bundled transport modules to trigger auto-registration."""
+    global _discovered
+    _discovered = True
+    try:
+        from . import chat_completions  # noqa: F401
+    except ImportError:
+        pass

--- a/src/hhru_bot/ai/runtime_provider.py
+++ b/src/hhru_bot/ai/runtime_provider.py
@@ -1,0 +1,74 @@
+# Ported from NousResearch/hermes-agent (MIT).
+# Copyright (c) 2025 Nous Research.
+#
+"""Runtime provider resolution for the AI transport.
+
+This is a deliberately thin port of hermes-agent's ``resolve_runtime_provider``.
+The original resolves credentials across ~20 providers via credential pools,
+OAuth, Vertex, Bedrock, Azure Foundry, and a trust-gated custom-provider
+chain. hhru needs none of that: it talks to one OpenAI-compatible endpoint
+configured in ``config.yaml`` (section ``ai``) with a key from the environment.
+
+The output dict shape mirrors the original so a future richer resolver could
+drop in: ``provider``, ``api_mode``, ``base_url``, ``api_key``, ``model``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..config_sections.ai import AiConfig
+
+# The single transport shipped with this package. A future api_mode (anthropic,
+# responses, ...) would be selected here based on provider/base_url.
+DEFAULT_API_MODE = "chat_completions"
+
+# Env var that carries the API key. The key is intentionally NOT read from
+# config.yaml so it can't be committed by accident.
+API_KEY_ENV_VAR = "HHRU_AI_API_KEY"
+
+
+def _resolve_api_key(explicit_api_key: str | None) -> str:
+    """Pick the API key: explicit argument first, then env, else empty string.
+
+    An empty string is returned (not raised) so resolution never fails on
+    missing credentials -- failure surfaces on the first real request where the
+    SDK rejects the empty key.
+    """
+    if explicit_api_key and explicit_api_key.strip():
+        return explicit_api_key.strip()
+    env_value = os.environ.get(API_KEY_ENV_VAR, "")
+    if env_value:
+        return env_value.strip()
+    return ""
+
+
+def resolve_runtime_provider(
+    config: AiConfig,
+    *,
+    api_key: str | None = None,
+    api_mode: str | None = None,
+) -> dict[str, Any]:
+    """Resolve a runtime provider entry from ``AiConfig`` + env api key.
+
+    Args:
+        config: parsed top-level ``ai`` config (provider / model / base_url).
+        api_key: optional explicit key; overrides the ``HHRU_AI_API_KEY`` env var.
+        api_mode: optional override; defaults to ``chat_completions``.
+
+    Returns a dict with ``provider``, ``api_mode``, ``base_url``, ``api_key``,
+    ``model`` and ``source`` (``"config"`` when the key came from config/env,
+    ``"explicit"`` when passed in directly).
+    """
+    resolved_key = _resolve_api_key(api_key)
+    source = "explicit" if api_key and api_key.strip() else "config"
+    return {
+        "provider": config.provider,
+        "api_mode": api_mode or DEFAULT_API_MODE,
+        "base_url": config.base_url,
+        "api_key": resolved_key,
+        "model": config.model,
+        "source": source,
+    }

--- a/src/hhru_bot/ai/types.py
+++ b/src/hhru_bot/ai/types.py
@@ -1,0 +1,115 @@
+# Ported from NousResearch/hermes-agent (MIT).
+# Copyright (c) 2025 Nous Research.
+#
+# Shared types for normalized provider responses.
+#
+# These dataclasses define the canonical shape that all provider adapters
+# normalize responses to.  The shared surface is intentionally minimal -- only
+# fields that every downstream consumer reads are top-level. Protocol-specific
+# state goes in ``provider_data`` dicts (response-level and per-tool-call) so
+# that protocol-aware code paths can access it without polluting the shared type.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolCall:
+    """A normalized tool call from any provider.
+
+    ``id`` is the protocol's canonical identifier -- what gets used in
+    ``tool_call_id`` / ``tool_use_id`` when constructing tool result messages.
+    May be ``None`` when the provider omits it.
+
+    ``provider_data`` carries per-tool-call protocol metadata that only
+    protocol-aware code reads (e.g. Gemini ``extra_content`` / thought_signature).
+    """
+
+    id: str | None
+    name: str
+    arguments: str  # JSON string
+    provider_data: dict[str, Any] | None = field(default=None, repr=False)
+
+    @property
+    def type(self) -> str:
+        return "function"
+
+    @property
+    def function(self) -> ToolCall:
+        """Return self so ``tc.function.name`` / ``tc.function.arguments`` work.
+
+        Backward-compat shim mirroring the OpenAI SDK's nested ``function`` object,
+        kept so callers that read ``tc.function.name`` keep working against the
+        flat canonical fields.
+        """
+        return self
+
+
+@dataclass
+class Usage:
+    """Token usage from an API response."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cached_tokens: int = 0
+
+
+@dataclass
+class NormalizedResponse:
+    """Normalized API response from any provider.
+
+    Shared fields are truly cross-provider -- every caller can rely on them
+    without branching on api_mode. Protocol-specific state goes in
+    ``provider_data`` so that only protocol-aware code paths read it.
+    """
+
+    content: str | None
+    tool_calls: list[ToolCall] | None
+    finish_reason: str  # "stop", "tool_calls", "length", "content_filter"
+    reasoning: str | None = None
+    usage: Usage | None = None
+    provider_data: dict[str, Any] | None = field(default=None, repr=False)
+
+    @property
+    def reasoning_content(self) -> str | None:
+        pd = self.provider_data or {}
+        return pd.get("reasoning_content")
+
+    @property
+    def reasoning_details(self):
+        pd = self.provider_data or {}
+        return pd.get("reasoning_details")
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def build_tool_call(
+    id: str | None,
+    name: str,
+    arguments: Any,
+    **provider_fields: Any,
+) -> ToolCall:
+    """Build a ``ToolCall``, auto-serialising *arguments* if it's a dict.
+
+    Any extra keyword arguments are collected into ``provider_data``.
+    """
+    args_str = json.dumps(arguments) if isinstance(arguments, dict) else str(arguments)
+    pd = dict(provider_fields) if provider_fields else None
+    return ToolCall(id=id, name=name, arguments=args_str, provider_data=pd)
+
+
+def map_finish_reason(reason: str | None, mapping: dict[str, str]) -> str:
+    """Translate a provider-specific stop reason to the normalised set.
+
+    Falls back to ``"stop"`` for unknown or ``None`` reasons.
+    """
+    if reason is None:
+        return "stop"
+    return mapping.get(reason, "stop")

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    # Только для статического анализа; реальный импорт был бы циклическим
+    # (config_sections.ai импортирует ConfigError из config).
+    from .config_sections.ai import AiConfig
 
 
 @dataclass
@@ -54,6 +60,9 @@ class AppConfig:
     resumes: list[ResumeConfig]
     # None = родной UA Playwright. Пробрасывается из account.user_agent (см. parse_account).
     user_agent: str | None = None
+    # None = AI-функциональность выключена (issue #16, Этап 5). TOP-LEVEL секция ai
+    # (как account), парсится в load_config через config_sections.ai.parse_ai.
+    ai: AiConfig | None = None
 
     def get_resume(self, resume_id: str) -> ResumeConfig:
         for resume in self.resumes:
@@ -82,6 +91,7 @@ def load_config(path: str | Path) -> AppConfig:
     from .config_sections import get as section_parser
     from .config_sections import names as section_names
     from .config_sections import parse_account
+    from .config_sections.ai import parse_ai
 
     path = Path(path)
     if not path.exists():
@@ -103,6 +113,10 @@ def load_config(path: str | Path) -> AppConfig:
     account = parse_account(raw.get("account"), path.parent)
     storage_state_file = account.storage_state_file
     user_agent = account.user_agent
+
+    # TOP-LEVEL секция ai (issue #16, Этап 5): провайдер/модель/base_url.
+    # Опциональна — None, если секции нет. API-ключ НЕ парсится из yaml (только env).
+    ai = parse_ai(raw.get("ai"), "ai")
 
     throttle_raw = raw.get("throttle", {})
     throttle = ThrottleConfig(
@@ -149,6 +163,7 @@ def load_config(path: str | Path) -> AppConfig:
         cover_letter_default=cover_letter_default,
         resumes=resumes,
         user_agent=user_agent,
+        ai=ai,
     )
 
 

--- a/src/hhru_bot/config_sections/ai.py
+++ b/src/hhru_bot/config_sections/ai.py
@@ -1,0 +1,70 @@
+"""Парсер TOP-LEVEL секции ai → AiConfig (issue #16, Этап 5).
+
+В отличие от resume-подсекций (search/scoring/ai_profile) эта секция —
+корневая, на уровне account/throttle: один LLM-провайдер на весь бот, а не
+своё у каждого резюме. Поэтому парсится напрямую в ``load_config`` (как
+``parse_account``), а НЕ через resume-реестр ``config_sections/_registry``.
+
+Секция опциональна: при отсутствии ``load_config`` оставит
+``AppConfig.ai = None`` (обратная совместимость — бот без AI работает как
+раньше).
+
+API-ключ намеренно НЕ парсится из yaml — только provider/model/base_url.
+Ключ читается из env ``HHRU_AI_API_KEY`` в момент реального LLM-вызова
+(см. ``hhru_bot.ai.runtime_provider``), чтобы секрет не попадал в конфиг и
+не рисковал утечь в git-коммит.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..config import ConfigError
+
+
+@dataclass(frozen=True)
+class AiConfig:
+    """Конфигурация LLM-провайдера (OpenAI-совместимый endpoint).
+
+    provider: имя провайдера для логов/метаданных (напр. 'openai', 'openrouter').
+    model: имя модели, отправляемое в API (напр. 'gpt-4o').
+    base_url: корневой URL OpenAI-совместимого API (напр. 'https://api.openai.com/v1').
+    """
+
+    provider: str
+    model: str
+    base_url: str
+
+
+def _require(mapping: dict, key: str, context: str):
+    if key not in mapping or mapping[key] is None:
+        raise ConfigError(f"В конфиге отсутствует обязательное поле '{key}' ({context})")
+    return mapping[key]
+
+
+def parse_ai(raw, context: str) -> AiConfig | None:
+    """raw — корневая секция ai. Возвращает AiConfig или None, если секции нет.
+
+    ``context`` — строка для диагностики ошибок (обычно 'ai').
+    """
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением")
+    provider = _require(raw, "provider", context)
+    model = _require(raw, "model", context)
+    base_url = _require(raw, "base_url", context)
+    for name, value in (("provider", provider), ("model", model), ("base_url", base_url)):
+        if not isinstance(value, str) or not value.strip():
+            raise ConfigError(
+                f"Поле '{name}' ({context}) должно быть непустой строкой, получено: {value!r}"
+            )
+    return AiConfig(
+        provider=provider.strip(),
+        model=model.strip(),
+        base_url=base_url.strip(),
+    )
+
+
+# ai — корневая секция (как account), не resume-подсекция, поэтому в resume-реестр
+# не регистрируется; используется напрямую из load_config.

--- a/tests/test_ai_chat_completions.py
+++ b/tests/test_ai_chat_completions.py
@@ -1,0 +1,264 @@
+"""Тесты ChatCompletionsTransport: конвертация формата (issue #16, Этап 5).
+
+Без браузера/сети. openai SDK мокается простыми объектами с атрибутами, точно
+повторяющими форму ChatCompletion (choices[0].message/tool_calls/usage и т.д.).
+Покрываем: convert_messages (sanitization), convert_tools (identity), build_kwargs
+(system->developer swap + tools + max_tokens + extra_body), normalize_response
+(content/tool_calls/usage/refusal), validate_response.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from hhru_bot.ai.chat_completions import DEVELOPER_ROLE_MODELS, ChatCompletionsTransport
+from hhru_bot.ai.types import NormalizedResponse, ToolCall
+
+# --- helpers: mock-объекты в форме OpenAI SDK -------------------------------
+
+
+def _msg(content=None, tool_calls=None, refusal=None, reasoning=None, reasoning_content=None):
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        refusal=refusal,
+        reasoning=reasoning,
+        reasoning_content=reasoning_content,
+        reasoning_details=None,
+        model_extra=None,
+    )
+
+
+def _tool_call_obj(tc_id="call_1", name="search", arguments='{"q":"x"}'):
+    return SimpleNamespace(id=tc_id, function=SimpleNamespace(name=name, arguments=arguments))
+
+
+def _choice(msg, finish_reason="stop"):
+    return SimpleNamespace(message=msg, finish_reason=finish_reason)
+
+
+def _response(msg, finish_reason: Any = "stop", usage=None):
+    return SimpleNamespace(choices=[_choice(msg, finish_reason)], usage=usage)
+
+
+def _usage(prompt=10, completion=5, total=15):
+    return SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion, total_tokens=total)
+
+
+# --- DEVELOPER_ROLE_MODELS --------------------------------------------------
+
+
+def test_developer_role_models_constant():
+    """Константа портирована дословно из agent/prompt_builder.py:664."""
+    assert DEVELOPER_ROLE_MODELS == ("gpt-5", "codex")
+
+
+# --- convert_messages -------------------------------------------------------
+
+
+def test_convert_messages_strips_internal_fields():
+    """tool_name/timestamp/codex_*/api_content и _-ключи выкидываются."""
+    transport = ChatCompletionsTransport()
+    messages = [
+        {
+            "role": "user",
+            "content": "hi",
+            "tool_name": "x",
+            "timestamp": 123,
+            "codex_reasoning_items": [],
+            "api_content": "y",
+            "effect_disposition": "z",
+            "_internal_marker": True,
+        }
+    ]
+    out = transport.convert_messages(messages)
+    assert out[0] == {"role": "user", "content": "hi"}
+    # исходный список не мутируется (возвращается копия при санитизации)
+    assert "tool_name" in messages[0]
+
+
+def test_convert_messages_identity_when_clean():
+    """Чистые сообщения возвращаются как есть (та же ссылка)."""
+    transport = ChatCompletionsTransport()
+    messages = [{"role": "user", "content": "hi"}]
+    out = transport.convert_messages(messages)
+    assert out is messages
+
+
+def test_convert_messages_skips_non_dict_entries():
+    transport = ChatCompletionsTransport()
+    out = transport.convert_messages([{"role": "user", "content": "x"}, None, "junk"])
+    assert out[0] == {"role": "user", "content": "x"}
+
+
+# --- convert_tools ----------------------------------------------------------
+
+
+def test_convert_tools_identity():
+    transport = ChatCompletionsTransport()
+    tools = [{"type": "function", "function": {"name": "f"}}]
+    assert transport.convert_tools(tools) is tools
+
+
+# --- build_kwargs -----------------------------------------------------------
+
+
+def test_build_kwargs_basic():
+    transport = ChatCompletionsTransport()
+    messages = [{"role": "user", "content": "hi"}]
+    kwargs = transport.build_kwargs("gpt-4o", messages)
+    assert kwargs["model"] == "gpt-4o"
+    assert kwargs["messages"] == messages
+    assert "developer" not in [m["role"] for m in kwargs["messages"]]
+
+
+def test_build_kwargs_system_to_developer_for_gpt5():
+    transport = ChatCompletionsTransport()
+    messages = [{"role": "system", "content": "be brief"}, {"role": "user", "content": "hi"}]
+    kwargs = transport.build_kwargs("gpt-5-mini", messages)
+    assert kwargs["messages"][0]["role"] == "developer"
+    # исходный список не мутируется
+    assert messages[0]["role"] == "system"
+
+
+def test_build_kwargs_system_to_developer_for_codex():
+    transport = ChatCompletionsTransport()
+    messages = [{"role": "system", "content": "x"}]
+    kwargs = transport.build_kwargs("codex-1", messages)
+    assert kwargs["messages"][0]["role"] == "developer"
+
+
+def test_build_kwargs_no_swap_for_arbitrary_model():
+    transport = ChatCompletionsTransport()
+    messages = [{"role": "system", "content": "x"}, {"role": "user", "content": "y"}]
+    kwargs = transport.build_kwargs("claude-3.5-sonnet", messages)
+    assert kwargs["messages"][0]["role"] == "system"
+
+
+def test_build_kwargs_passes_tools_max_tokens_temperature():
+    transport = ChatCompletionsTransport()
+    tools = [{"type": "function"}]
+    kwargs = transport.build_kwargs(
+        "gpt-4o",
+        [{"role": "user", "content": "x"}],
+        tools,
+        max_tokens=128,
+        temperature=0.3,
+        timeout=12.0,
+    )
+    assert kwargs["tools"] == tools
+    assert kwargs["max_tokens"] == 128
+    assert kwargs["temperature"] == 0.3
+    assert kwargs["timeout"] == 12.0
+
+
+def test_build_kwargs_extra_body_and_overrides():
+    transport = ChatCompletionsTransport()
+    kwargs = transport.build_kwargs(
+        "gpt-4o",
+        [{"role": "user", "content": "x"}],
+        extra_body={"foo": 1},
+        request_overrides={"service_tier": "default"},
+    )
+    assert kwargs["extra_body"] == {"foo": 1}
+    assert kwargs["service_tier"] == "default"
+
+
+# --- normalize_response -----------------------------------------------------
+
+
+def test_normalize_response_basic_content():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="hello"), usage=_usage())
+    nr = transport.normalize_response(resp)
+    assert isinstance(nr, NormalizedResponse)
+    assert nr.content == "hello"
+    assert nr.finish_reason == "stop"
+    assert nr.tool_calls is None
+    assert nr.usage is not None
+    assert nr.usage.prompt_tokens == 10
+    assert nr.usage.completion_tokens == 5
+
+
+def test_normalize_response_finish_reason_none_defaults_to_stop():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="x"), finish_reason=None)
+    assert transport.normalize_response(resp).finish_reason == "stop"
+
+
+def test_normalize_response_integer_finish_reason_coerced():
+    """Некоторые шлюзы возвращают числовой finish_reason."""
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="x"), finish_reason=24)
+    assert transport.normalize_response(resp).finish_reason == "24"
+
+
+def test_normalize_response_tool_calls():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content=None, tool_calls=[_tool_call_obj()]))
+    nr = transport.normalize_response(resp)
+    assert nr.tool_calls is not None
+    tc: ToolCall = nr.tool_calls[0]
+    assert tc.id == "call_1"
+    assert tc.name == "search"
+    assert tc.arguments == '{"q":"x"}'
+    # tc.function.* работает через back-compat свойство
+    assert tc.function.name == "search"
+
+
+def test_normalize_response_refusal_promoted_to_content_when_empty():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content=None, refusal="I can't help with that"))
+    nr = transport.normalize_response(resp)
+    assert nr.content == "I can't help with that"
+    assert nr.finish_reason == "content_filter"
+    assert nr.provider_data["refusal"] == "I can't help with that"
+
+
+def test_normalize_response_refusal_keeps_real_content():
+    """Если рядом с refusal есть реальный content — не повышаем до content_filter."""
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="real answer", refusal="minor note"), finish_reason="stop")
+    nr = transport.normalize_response(resp)
+    assert nr.content == "real answer"
+    assert nr.finish_reason == "stop"
+
+
+def test_normalize_response_reasoning_content_into_provider_data():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="x", reasoning_content="thoughts..."))
+    nr = transport.normalize_response(resp)
+    assert nr.provider_data["reasoning_content"] == "thoughts..."
+
+
+# --- validate_response / extract_cache_stats --------------------------------
+
+
+def test_validate_response_truthy_for_valid():
+    transport = ChatCompletionsTransport()
+    assert transport.validate_response(_response(_msg(content="x"))) is True
+
+
+def test_validate_response_falsey_for_empty_or_none():
+    transport = ChatCompletionsTransport()
+    assert transport.validate_response(None) is False
+    assert transport.validate_response(SimpleNamespace(choices=None)) is False
+    assert transport.validate_response(SimpleNamespace(choices=[])) is False
+
+
+def test_extract_cache_stats_from_prompt_tokens_details():
+    transport = ChatCompletionsTransport()
+    details = SimpleNamespace(cached_tokens=42, cache_write_tokens=7)
+    resp = SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(prompt_tokens_details=details),
+    )
+    stats = transport.extract_cache_stats(resp)
+    assert stats == {"cached_tokens": 42, "creation_tokens": 7}
+
+
+def test_extract_cache_stats_none_when_absent():
+    transport = ChatCompletionsTransport()
+    resp = _response(_msg(content="x"), usage=_usage())  # нет prompt_tokens_details
+    assert transport.extract_cache_stats(resp) is None

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -1,0 +1,150 @@
+"""Тесты парсинга TOP-LEVEL секции ai через load_config (issue #16, Этап 5).
+
+Секция ai — корневая (как account/throttle), не resume-подсекция. Опциональна:
+при отсутствии AppConfig.ai = None. API-ключ НЕ парсится из yaml (только env) —
+это проверяется явно: ключ в yaml не должен попасть в AiConfig.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import fields
+
+import pytest
+
+from hhru_bot.config import ConfigError, load_config
+from hhru_bot.config_sections.ai import AiConfig
+
+
+def _write(tmp_path, body: str):
+    path = tmp_path / "config.yaml"
+    # dedent по всему телу, чтобы можно было писать блоки с общим отступом.
+    path.write_text(textwrap.dedent(body).strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_ai_section_parsed(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        ai:
+          provider: openai
+          model: gpt-4o
+          base_url: https://api.openai.com/v1
+        """,
+    )
+    config = load_config(path)
+    assert isinstance(config.ai, AiConfig)
+    assert config.ai.provider == "openai"
+    assert config.ai.model == "gpt-4o"
+    assert config.ai.base_url == "https://api.openai.com/v1"
+
+
+def test_ai_section_optional_defaults_to_none(tmp_path):
+    """Без секции ai — AppConfig.ai = None (обратная совместимость)."""
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        """,
+    )
+    config = load_config(path)
+    assert config.ai is None
+
+
+def test_ai_section_missing_model_raises(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        ai:
+          provider: openai
+          base_url: https://api.openai.com/v1
+        """,
+    )
+    with pytest.raises(ConfigError, match="model"):
+        load_config(path)
+
+
+def test_ai_section_non_mapping_raises(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        ai: "just-a-string"
+        """,
+    )
+    with pytest.raises(ConfigError, match="должна быть отображением"):
+        load_config(path)
+
+
+def test_ai_api_key_not_parsed_from_yaml(tmp_path):
+    """api_key в yaml намеренно НЕ читается (только env) — поля api_key в AiConfig нет."""
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        ai:
+          provider: openai
+          model: gpt-4o
+          base_url: https://api.openai.com/v1
+          api_key: sk-should-be-ignored
+        """,
+    )
+    config = load_config(path)
+    assert config.ai is not None
+    # AiConfig — frozen-датакласс ровно с тремя полями; api_key там нет.
+    assert {f.name for f in fields(config.ai)} == {"provider", "model", "base_url"}
+
+
+def test_ai_section_empty_value_raises(tmp_path):
+    """Пустая строка в обязательном поле — ConfigError (а не тихая пустота)."""
+    path = _write(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        ai:
+          provider: ""
+          model: gpt-4o
+          base_url: https://api.openai.com/v1
+        """,
+    )
+    with pytest.raises(ConfigError, match="непустой строкой"):
+        load_config(path)

--- a/tests/test_ai_registry.py
+++ b/tests/test_ai_registry.py
@@ -1,0 +1,104 @@
+"""Тесты transport-реестра (issue #16, Этап 5).
+
+register_transport регистрирует transport-класс по api_mode; get_transport
+возвращает экземпляр (lazy-discovery подгружает chat_completions), None для
+неизвестного api_mode. Без браузера/сети — чистая логика реестра.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.ai import base, registry
+from hhru_bot.ai.chat_completions import ChatCompletionsTransport
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry(monkeypatch):
+    """Изолировать тесты: чистый реестр + сброс флага discovery до каждого теста.
+
+    get_transport() кэширует discovery в модуле; без сброса порядок тестов влиял
+    бы на видимость зарегистрированных transport'ов.
+    """
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    monkeypatch.setattr(registry, "_discovered", False)
+    yield
+
+
+class _DummyTransport(base.ProviderTransport):
+    """Минимальная реализация ABC для теста регистрации."""
+
+    @property
+    def api_mode(self) -> str:
+        return "dummy"
+
+    def convert_messages(self, messages, **kwargs):
+        return messages
+
+    def convert_tools(self, tools):
+        return tools
+
+    def build_kwargs(self, model, messages, tools=None, **params):
+        return {"model": model, "messages": messages}
+
+    def normalize_response(self, response, **kwargs):
+        from hhru_bot.ai.types import NormalizedResponse
+
+        return NormalizedResponse(content=None, tool_calls=None, finish_reason="stop")
+
+
+def test_register_then_get_returns_instance():
+    registry.register_transport("dummy", _DummyTransport)
+    transport = registry.get_transport("dummy")
+    assert isinstance(transport, _DummyTransport)
+
+
+def test_get_transport_unknown_returns_none():
+    assert registry.get_transport("definitely-unknown-mode") is None
+
+
+def test_get_chat_completions_via_lazy_discovery():
+    """get_transport('chat_completions') → подгрузка через discovery.
+
+    Регистрация ChatCompletionsTransport происходит как побочный эффект импорта
+    модуля chat_completions (один раз при первом импорте пакета). Чтобы тест был
+    изолирован от порядка запуска, мы НЕ рассчитываем на повторную регистрацию
+    после сброса _REGISTRY (модуль уже в sys.modules). Вместо этого: регистрируем
+    chat_completions вручную и проверяем, что discovery флаг выставляется, а
+    get_transport возвращает экземпляр.
+    """
+    # chat_completions уже импортирован пакетом; его авто-регистрация прошла в
+    # оригинальный _REGISTRY. Ручная регистрация имитирует результат discovery.
+    registry.register_transport("chat_completions", ChatCompletionsTransport)
+    transport = registry.get_transport("chat_completions")
+    assert isinstance(transport, ChatCompletionsTransport)
+    assert transport.api_mode == "chat_completions"
+
+
+def test_lazy_discovery_sets_flag():
+    registry.get_transport("chat_completions")
+    assert registry._discovered is True
+
+
+def test_get_transport_triggers_discovery_on_miss(monkeypatch):
+    """На miss по неизвестному api_mode discovery запускается повторно (как в оригинале)."""
+    calls = {"n": 0}
+    real_discover = registry._discover_transports
+
+    def spy():
+        calls["n"] += 1
+        real_discover()
+
+    monkeypatch.setattr(registry, "_discovered", True)  # притворимся, что уже открывали
+    monkeypatch.setattr(registry, "_discover_transports", spy)
+    # _REGISTRY пуст → первый get_transport не находит → miss → повторный discovery
+    transport = registry.get_transport("unknown-mode-after-miss")
+    assert transport is None
+    assert calls["n"] == 1
+
+
+def test_get_returns_fresh_instance_each_call():
+    registry.register_transport("dummy", _DummyTransport)
+    a = registry.get_transport("dummy")
+    b = registry.get_transport("dummy")
+    assert a is not b

--- a/tests/test_ai_runtime_provider.py
+++ b/tests/test_ai_runtime_provider.py
@@ -1,0 +1,70 @@
+"""Тесты resolve_runtime_provider (issue #16, Этап 5).
+
+Тонкий порт: по AiConfig (provider/model/base_url) + env-ключу строит runtime
+dict {provider, api_mode, base_url, api_key, model, source}. Без сети и без
+hermes-зависимостей — чистая функция, тестируется на моках env.
+
+Приоритет ключа: явный аргумент > env HHRU_AI_API_KEY > пустая строка.
+"""
+
+from __future__ import annotations
+
+from hhru_bot.ai.runtime_provider import (
+    API_KEY_ENV_VAR,
+    DEFAULT_API_MODE,
+    resolve_runtime_provider,
+)
+from hhru_bot.config_sections.ai import AiConfig
+
+
+def _cfg():
+    return AiConfig(provider="openai", model="gpt-4o", base_url="https://api.openai.com/v1")
+
+
+def test_returns_full_runtime_dict(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV_VAR, "sk-from-env")
+    runtime = resolve_runtime_provider(_cfg())
+    assert runtime == {
+        "provider": "openai",
+        "api_mode": DEFAULT_API_MODE,
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "sk-from-env",
+        "model": "gpt-4o",
+        "source": "config",
+    }
+
+
+def test_explicit_api_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV_VAR, "sk-from-env")
+    runtime = resolve_runtime_provider(_cfg(), api_key="sk-explicit")
+    assert runtime["api_key"] == "sk-explicit"
+    assert runtime["source"] == "explicit"
+
+
+def test_env_key_used_when_no_explicit(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV_VAR, "sk-env")
+    runtime = resolve_runtime_provider(_cfg())
+    assert runtime["api_key"] == "sk-env"
+    assert runtime["source"] == "config"
+
+
+def test_empty_api_key_when_neither_arg_nor_env(monkeypatch):
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    runtime = resolve_runtime_provider(_cfg())
+    # Не падает — пустой ключ; реальный SDK сообщит об ошибке при вызове.
+    assert runtime["api_key"] == ""
+    assert runtime["source"] == "config"
+
+
+def test_api_mode_override(monkeypatch):
+    monkeypatch.delenv(API_KEY_ENV_VAR, raising=False)
+    runtime = resolve_runtime_provider(_cfg(), api_key="k", api_mode="anthropic_messages")
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_explicit_empty_string_key_falls_back_to_env(monkeypatch):
+    """Пустая/пробельная строка как явный ключ — считается «не задано», идём в env."""
+    monkeypatch.setenv(API_KEY_ENV_VAR, "sk-env")
+    runtime = resolve_runtime_provider(_cfg(), api_key="   ")
+    assert runtime["api_key"] == "sk-env"
+    assert runtime["source"] == "config"


### PR DESCRIPTION
## Что

Порт transport-слоя LLM из `NousResearch/hermes-agent` (MIT) в новый пакет `src/hhru_bot/ai/`. Заложена инфраструктура LLM-вызовов для будущей AI-интеграции — сами вызовы пока не подключены к apply/bump/search (это следующий issue).

Closes #16

## Файлы

Новый пакет `src/hhru_bot/ai/`:
- `types.py` — `NormalizedResponse` / `ToolCall` / `Usage` + хелперы (порт дословно)
- `base.py` — `ProviderTransport` ABC (порт дословно)
- `registry.py` — `register_transport` / `get_transport` с lazy-discovery
- `chat_completions.py` — `ChatCompletionsTransport` (обрезанный порт: только transport-core; развязан от `prompt_builder` через локальную `DEVELOPER_ROLE_MODELS`; убраны hermes-импорты reasoning/gemini/moonshot/profile)
- `runtime_provider.py` — тонкий `resolve_runtime_provider` (без auth/pool/vertex/bedrock; чистая функция)
- `llm_client.py` — `LLMClient` поверх `openai` SDK (lazy-импорт, чтобы пакет импортировался без openai)

Конфиг:
- `config_sections/ai.py` — `AiConfig` + `parse_ai` (TOP-LEVEL секция `ai`, как `account`)
- `config.py` — `AppConfig.ai: AiConfig | None` + парсинг `raw.get("ai")` в `load_config`
- `pyproject.toml` — optional-группа `[ai]` (`openai>=1.50`); базовые `dependencies` не тронуты
- `config/config.example.yaml` — закомментированный пример секции `ai`

Лицензия: MIT copyright-notice («Ported from NousResearch/hermes-agent. Copyright (c) 2025 Nous Research.») в шапках всех скопированных файлов.

## Ключевые решения

- **Секция `ai` — TOP-LEVEL**, не resume-подсекция: один провайдер на весь бот. Парсится в `load_config` как `account`, НЕ через resume-реестр `_registry.py` (последний — только для resume-подсекций типа `ai_profile` из #17).
- **API-ключ только из env** (`HHRU_AI_API_KEY`), НЕ из yaml — чтобы секрет не рисковал попасть в git.
- **`openai` — optional**: базовый бот работает без неё; `pip install -e '.[ai]'` только когда нужна AI.
- **`chat_completions` агрессивно обрезан** до transport-core (hhru = один OpenAI-compat endpoint); reasoning/thinking/gemini/moonshot/profile-пути hermes выкинуты — добавим точечно, если понадобится.

## Тесты (40, characterization, моки вместо сети)

- `test_ai_registry.py` — register/get transport, lazy-discovery, None для неизвестного api_mode
- `test_ai_chat_completions.py` — convert_messages (sanitization), convert_tools (identity), build_kwargs (system→developer swap по `gpt-5`/`codex`, tools/max_tokens/extra_body/overrides), normalize_response (content/tool_calls/usage/refusal→content_filter/reasoning), validate_response, extract_cache_stats
- `test_ai_runtime_provider.py` — приоритет ключа (explicit > env > пусто), api_mode override
- `test_ai_config.py` — парсинг секции `ai` через `load_config`: опциональность, валидация, api_key не парсится из yaml

## Верификация

- `ruff check` + `ruff format --check` — чисто (обе стадии CI)
- `pytest -q` — 196 тестов проходят (включая 40 новых), ничего не сломано
- `python3 -c "import hhru_bot.cli"` — пакет импортируется без openai

## Риски / follow-ups

- `LLMClient` не имеет интеграции в apply/bump/search (намеренно — #16 только transport; интеграция — отдельный issue).
- `LLMClient` не проверен реальным сетевым вызовом (только конструирование runtime + unit-тесты transport-конвертации); первый боевой вызов — при подключении к apply.
- `runtime_provider` сейчас всегда возвращает `api_mode="chat_completions"` (единственный transport); расширение под другие api_mode — при появлении провайдеров с иным протоколом.
- НЕ мерджить: ждёт cycle-review + пользователя.