### PR TITLE
feat(ai): AI-генерация сопроводительных писем с fallback на шаблон (#17)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -76,6 +76,19 @@ resumes:
         nice_to_have: 1.0     # буст за каждое nice_to_have-совпадение
         exclude_keyword: -3.0 # штраф за стоп-слово в title
         text_match: 1.0       # буст × доля совпавших токенов filters.text
+    # Опционально (issue #17): профиль кандидата для AI-генерации писем под
+    # конкретную вакансию. Включает AI ТОЛЬКО ВМЕСТЕ с топ-левел секцией ai
+    # (см. выше): нет ai или нет ai_profile → отклик идёт со статичным шаблоном
+    # cover_letter (поведение не меняется). При сбое LLM письмо откатывается на
+    # шаблон автоматически (variant 'ai_fallback' пишется в историю для A/B).
+    # ai_profile:
+    #   summary: "Бэкенд-разработчик с фокусом на высоконагруженные сервисы"
+    #   skills: ["python", "django", "postgresql", "docker"]
+    #   highlights:
+    #     - "Поднял throughput API в 3 раза"
+    #     - "Выстроил CI/CD с нуля"
+    #   desired_role: "Senior Python Developer"
+    #   tone: formal   # formal | friendly (по умолчанию formal)
     cover_letter: null
 
   - id: "resume-name-2"

--- a/src/hhru_bot/ai/letters.py
+++ b/src/hhru_bot/ai/letters.py
@@ -1,0 +1,138 @@
+"""AI-генерация сопроводительного письма под вакансию (#17).
+
+Использует реальный transport-слой LLM из #16 (PR #48, слит в main):
+``LLMClient(ai_config).chat(messages, **params) -> NormalizedResponse``.
+Контракт: ``NormalizedResponse.content: str | None`` — контент МОЖЕТ прийти
+None (timeout / content_filter / length без текста). Поэтому None-контент
+обрабатывается как точка fallback на статичный шаблон — это и есть «fallback
+на шаблон» из заголовка #17. None НЕ считается успехом.
+
+``openai`` НЕ нужен для импорта этого модуля — LLMClient импортируется из
+``hhru_bot.ai`` (он сам лениво тянет openai только в момент вызова chat()).
+Базовая установка hhru-bot без группы [ai] всё ещё импортирует letters.py;
+ошибка ImportError всплывёт только при реальной попытке построить LLMClient
+без openai — и это ответственность вызывающей стороны (commands), не letters.
+
+Главный инвариант: любая ошибка AI (исключение, None-контент, пустой текст)
+→ fallback на статичный шаблон БЕЗ исключения. Сбой генерации письма не
+должен валить отклик целиком (иначе автоматизация hh.ru теряет заявку из-за
+временной недоступности LLM).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..apply.letter import (
+    VARIANT_AI,
+    VARIANT_AI_FALLBACK,
+    CoverLetterProvider,
+    LetterOutcome,
+    _format_template,
+)
+from ..search import VacancyCard
+
+if TYPE_CHECKING:
+    from ..config_sections.ai_profile import AIProfile
+    from . import LLMClient
+
+logger = logging.getLogger("hhru_bot.ai.letters")
+
+
+class AICoverLetterProvider(CoverLetterProvider):
+    """Генерация письма через LLM (#16), с устойчивым fallback на шаблон.
+
+    llm_client — готовый ``LLMClient`` (построен в commands из AppConfig.ai).
+    fallback_template — статичный шаблон с плейсхолдерами {vacancy_title}/
+    {company_name}, на который откатываемся при любом сбое AI (исключение,
+    None-контент, пустой текст). resume_profile — данные кандидата для
+    релевантного промпта; None → генерация по вакансии без профиля.
+    """
+
+    def __init__(
+        self,
+        llm_client: LLMClient,
+        resume_profile: AIProfile | None = None,
+        fallback_template: str = "",
+        *,
+        temperature: float = 0.7,
+    ):
+        self._llm = llm_client
+        self._profile = resume_profile
+        self._fallback_template = fallback_template
+        self._temperature = temperature
+
+    def render(
+        self,
+        vacancy: VacancyCard,
+        resume_profile: AIProfile | None = None,
+    ) -> LetterOutcome:
+        profile = resume_profile or self._profile
+        messages = _build_prompt(vacancy, profile)
+        try:
+            response = self._llm.chat(messages, temperature=self._temperature)
+        except Exception as e:  # noqa: BLE001 — намеренно широкий: любой сбой AI → fallback
+            logger.warning(
+                "AI letter generation failed for '%s': %s — fallback to template",
+                vacancy.title,
+                e,
+            )
+            return self._fallback(vacancy)
+
+        # content может быть None (timeout / content_filter / length без текста).
+        # None и пустой/только-пробелы текст → fallback, НЕ успех.
+        content = response.content if response is not None else None
+        letter = (content or "").strip()
+        if not letter:
+            logger.warning(
+                "AI returned empty letter for '%s' (finish_reason=%s) — fallback to template",
+                vacancy.title,
+                getattr(response, "finish_reason", "?"),
+            )
+            return self._fallback(vacancy)
+
+        return LetterOutcome(text=letter, variant=VARIANT_AI)
+
+    def _fallback(self, vacancy: VacancyCard) -> LetterOutcome:
+        return LetterOutcome(
+            text=_format_template(self._fallback_template, vacancy),
+            variant=VARIANT_AI_FALLBACK,
+        )
+
+
+def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[str, str]]:
+    """Собирает chat-completion сообщения: системная инструкция + контекст.
+
+    Контекст вакансии берём из VacancyCard (title/company) — подтверждённые
+    данные со страницы поиска. Полный текст вакансии (data-qa
+    vacancy-description) требует доп. захода на страницу (троттлинг) и живёт в
+    Этапе 4; здесь v1 обходимся карточкой, чтобы не плодить лишних запросов к
+    hh.ru (анти-фрод: меньше запросов — ниже риск детекта).
+    """
+    system = (
+        "Ты помогаешь писать короткие сопроводительные письма для отклика на "
+        "вакансии на hh.ru. Пиши на русском, вежливо, без воды и без выдуманных "
+        "фактов о кандидате. Только текст письма, без пояснений и без темы."
+    )
+
+    lines = [f"Вакансия: {vacancy.title}.", f"Компания: {vacancy.company or 'не указана'}."]
+    if profile is not None:
+        if profile.summary:
+            lines.append(f"О кандидате: {profile.summary}.")
+        if profile.skills:
+            lines.append("Ключевые навыки: " + ", ".join(profile.skills) + ".")
+        if profile.highlights:
+            lines.append("Достижения: " + "; ".join(profile.highlights) + ".")
+        if profile.desired_role:
+            lines.append(f"Желаемая роль: {profile.desired_role}.")
+        if profile.tone == "friendly":
+            lines.append("Тон: дружелюбный, но профессиональный.")
+        else:
+            lines.append("Тон: формальный.")
+    lines.append("Напиши сопроводительное письмо под эту вакансию.")
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "\n".join(lines)},
+    ]

--- a/src/hhru_bot/apply/letter.py
+++ b/src/hhru_bot/apply/letter.py
@@ -1,12 +1,103 @@
-"""Сопроводительное письмо. #17 расширит выбор провайдера (шаблон/AI) здесь.
+"""Сопроводительное письмо: абстракция провайдера + дефолт-реализация (#17).
 
-Владелец: #17. pipeline и другие шаги этот файл не трогают.
+Владелец: #17. pipeline и другие шаги этот файл не трогают — кроме минимальной
+прокидки опц. letter_provider через ApplyContext (см. pipeline.py).
+
+Абстракция CoverLetterProvider.render(vacancy, resume_profile) -> LetterOutcome
+подключается ровно в точке render_cover_letter (pipeline._run). Дефолтная
+реализация — текущий .format(...) как офлайн-fallback (полная обратная
+совместимость). AI-реализация — в ai/letters.py, использует LLMClient из #16.
+
+apply.py НЕ знает, статичный провайдер или LLM: единственная точка — передача
+опц. provider в render_cover_letter. provider=None → старый .format.
+
+LetterOutcome.variant — A/B-признак для истории (actions.letter_variant):
+'template' (статичный шаблон) / 'ai' (LLM-генерация) / 'ai_fallback' (LLM не
+сработал, откатились на шаблон).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
 from ..search import VacancyCard
 
+if TYPE_CHECKING:
+    from ..config_sections.ai_profile import AIProfile
 
-def render_cover_letter(template: str, vacancy: VacancyCard) -> str:
+
+# Варианты письма для A/B-среза (срез конверсии, Этап 3).
+VARIANT_TEMPLATE = "template"  # статичный .format (дефолт/офлайн)
+VARIANT_AI = "ai"  # LLM сгенерировал письмо
+VARIANT_AI_FALLBACK = "ai_fallback"  # LLM не сработал → откатились на шаблон
+
+
+@dataclass(frozen=True)
+class LetterOutcome:
+    """Результат генерации письма: текст + вариант (для A/B-истории)."""
+
+    text: str
+    variant: str
+
+
+@runtime_checkable
+class CoverLetterProvider(Protocol):
+    """Генератор сопроводительного письма под вакансию.
+
+    render должен быть устойчив: любая ошибка AI-провайдера обязана
+    обрабатываться внутри (fallback на шаблон), НЕ пробрасываться наверх —
+    сбой генерации письма не должен валить отклик целиком.
+    """
+
+    def render(
+        self,
+        vacancy: VacancyCard,
+        resume_profile: AIProfile | None = None,
+    ) -> LetterOutcome: ...
+
+
+class TemplateCoverLetterProvider:
+    """Дефолтный провайдер: статичный шаблон с плейсхолдерами .format.
+
+    Офлайн-fallback. Полная обратная совместимость со старым render_cover_letter —
+    тот же .format(vacancy_title=..., company_name=...). resume_profile
+    игнорируется (шаблон не персонализируется).
+    """
+
+    def __init__(self, template: str):
+        self._template = template
+
+    def render(
+        self,
+        vacancy: VacancyCard,
+        resume_profile: AIProfile | None = None,  # noqa: ARG002
+    ) -> LetterOutcome:
+        return LetterOutcome(
+            text=_format_template(self._template, vacancy),
+            variant=VARIANT_TEMPLATE,
+        )
+
+
+def _format_template(template: str, vacancy: VacancyCard) -> str:
     return template.format(vacancy_title=vacancy.title, company_name=vacancy.company)
+
+
+def render_cover_letter(
+    template: str,
+    vacancy: VacancyCard,
+    provider: CoverLetterProvider | None = None,
+) -> str:
+    """Рендерит письмо. Единственная точка подключения провайдера (#17).
+
+    provider=None (по умолчанию) → статичный .format (характеризация, обратная
+    совместимость — поведение не меняется). provider задан → делегирует ему;
+    AI-провайдер сам отвечает за fallback, поэтому исключения не ждём.
+
+    Возвращает только текст письма. variant нужен истории — вызывающая сторона
+    (pipeline) берёт его отдельно через provider.render(...).variant, когда
+    провайдер задан; без провайдера вариант всегда 'template'.
+    """
+    if provider is None:
+        return _format_template(template, vacancy)
+    return provider.render(vacancy).text

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -19,7 +19,7 @@ from playwright.sync_api import Page
 from ..search import VacancyCard
 from . import steps as apply_steps
 from .dedup import check_already_responded
-from .letter import render_cover_letter
+from .letter import VARIANT_TEMPLATE, CoverLetterProvider, render_cover_letter
 from .probe import NOOP_PROBE, ProbeHook
 from .success import wait_success_confirmation
 
@@ -31,6 +31,9 @@ class ApplyResult:
     vacancy: VacancyCard
     success: bool
     reason: str = ""
+    # A/B-вариант письма (#17): 'template' / 'ai' / 'ai_fallback'. Для записи в
+    # history.actions.letter_variant. По умолчанию 'template' (без AI-провайдера).
+    letter_variant: str = VARIANT_TEMPLATE
 
 
 @dataclass
@@ -43,12 +46,17 @@ class ApplyContext:
     cover_letter_template: str
     dry_run: bool
     probe: ProbeHook = field(default_factory=lambda: NOOP_PROBE)
+    # #17: провайдер письма (шаблон/AI). None → статичный .format (обратная
+    # совместимость). Провайдер сам отвечает за fallback, исключений не кидает.
+    letter_provider: CoverLetterProvider | None = None
+    # Заполняется в _run после рендера письма — итоговый variant для ApplyResult.
+    letter_variant: str = VARIANT_TEMPLATE
 
     def fail(self, reason: str) -> ApplyResult:
-        return ApplyResult(self.vacancy, False, reason)
+        return ApplyResult(self.vacancy, False, reason, letter_variant=self.letter_variant)
 
     def ok(self, reason: str) -> ApplyResult:
-        return ApplyResult(self.vacancy, True, reason)
+        return ApplyResult(self.vacancy, True, reason, letter_variant=self.letter_variant)
 
 
 def apply_to_vacancy(
@@ -58,6 +66,7 @@ def apply_to_vacancy(
     cover_letter_template: str,
     dry_run: bool,
     probe: ProbeHook | None = None,
+    letter_provider: CoverLetterProvider | None = None,
 ) -> ApplyResult:
     ctx = ApplyContext(
         page=page,
@@ -66,6 +75,7 @@ def apply_to_vacancy(
         cover_letter_template=cover_letter_template,
         dry_run=dry_run,
         probe=probe or NOOP_PROBE,
+        letter_provider=letter_provider,
     )
     return _run(ctx)
 
@@ -81,7 +91,16 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     if not apply_steps.wait_apply_button(ctx.page):
         return ctx.fail("кнопка отклика не найдена на странице")
 
-    letter = render_cover_letter(ctx.cover_letter_template, ctx.vacancy)
+    # #17: рендер письма через провайдер, если он задан (AI/шаблон). Провайдер
+    # сам падает на шаблон при сбое — исключений не ждём. variant фиксируем в
+    # контексте, чтобы ApplyResult понёс его в history (A/B-срез, Этап 3).
+    if ctx.letter_provider is not None:
+        outcome = ctx.letter_provider.render(ctx.vacancy)
+        letter = outcome.text
+        ctx.letter_variant = outcome.variant
+    else:
+        letter = render_cover_letter(ctx.cover_letter_template, ctx.vacancy)
+        ctx.letter_variant = VARIANT_TEMPLATE
 
     if ctx.dry_run:
         logger.info("[DRY-RUN] Откликнулся бы на '%s' с письмом:\n%s", ctx.vacancy.title, letter)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -11,6 +11,7 @@ import argparse
 import logging
 
 from ..apply import apply_to_vacancy
+from ..apply.letter import CoverLetterProvider
 from ..config import AppConfig, ResumeConfig
 from ..history import History
 from ..search import filter_candidates, rank_candidates, search_vacancies
@@ -40,6 +41,49 @@ def resumes_from_args(config: AppConfig, args: argparse.Namespace) -> list[Resum
     return resolve_resumes(config, [args.resume] if args.resume else None)
 
 
+def _build_letter_provider(
+    config: AppConfig,
+    resume: ResumeConfig,
+    cover_letter_template: str,
+) -> CoverLetterProvider | None:
+    """Строит AI-провайдер писем, если AI включён (#17).
+
+    AI включён = есть ТОП-ЛЕВЕЛ секция ai (LLM-провайдер, #16) И resume-секция
+    ai_profile (данные кандидата). Иначе None → статичный .format (обратная
+    совместимость, дефолт).
+
+    Построение LLMClient тянет openai (lazy, но при construction). Если openai
+    не установлен ([ai] optional-deps) — логируем и откатываемся на шаблон:
+    отсутствие AI-зависимости не должно валить обычный отклик. Сам провайдер
+    дальше устойчив (любой сбой LLM → fallback внутри), см. ai/letters.py.
+    """
+    ai_config = getattr(config, "ai", None)
+    profile = getattr(resume, "ai_profile", None)
+    if ai_config is None or profile is None:
+        return None
+
+    from ..ai.letters import AICoverLetterProvider
+    from ..ai.llm_client import LLMClient
+
+    try:
+        llm_client = LLMClient(ai_config)
+    except ImportError as e:
+        logger.warning(
+            "AI-письма недоступны для резюме '%s' (openai не установлен?): %s — "
+            "используется статичный шаблон. Установите: pip install -e '.[ai]'",
+            resume.id,
+            e,
+        )
+        return None
+
+    logger.info("AI-письма включены для резюме '%s' (провайдер: %s)", resume.id, ai_config.provider)
+    return AICoverLetterProvider(
+        llm_client=llm_client,
+        resume_profile=profile,
+        fallback_template=cover_letter_template,
+    )
+
+
 def run_apply_for_resume(
     page,
     config: AppConfig,
@@ -53,6 +97,10 @@ def run_apply_for_resume(
     Перенесено дословно из cli._apply_for_resume. Принципы CLAUDE.md сохранены:
     дедупликация и стоп-листы через filter_candidates (history-based),
     дневной лимит проверяется перед каждым откликом, throttle.wait между откликами.
+
+    #17: если включён AI (секция ai + ai_profile) — отклик идёт через
+    CoverLetterProvider; иначе (провайдер None) — статичный шаблон, поведение
+    не меняется. letter_variant пишется в history для A/B-среза (Этап 3).
     """
     print(f"\n=== Отклики для резюме: {resume.id} ===")
 
@@ -74,6 +122,7 @@ def run_apply_for_resume(
 
     limit = args.limit if args.limit else len(ranked)
     cover_letter_template = config.cover_letter_for(resume)
+    letter_provider = _build_letter_provider(config, resume, cover_letter_template)
 
     applied_count = 0
     for card, _score, _breakdown in ranked[:limit]:
@@ -83,9 +132,23 @@ def run_apply_for_resume(
             print(f"Дневной лимит достигнут, останавливаюсь: {e}")
             break
 
-        result = apply_to_vacancy(page, card, resume.resume_id, cover_letter_template, args.dry_run)
+        result = apply_to_vacancy(
+            page,
+            card,
+            resume.resume_id,
+            cover_letter_template,
+            args.dry_run,
+            letter_provider=letter_provider,
+        )
         status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
-        history.record_action(resume.resume_id, card.vacancy_id, "apply", status, result.reason)
+        history.record_action(
+            resume.resume_id,
+            card.vacancy_id,
+            "apply",
+            status,
+            result.reason,
+            letter_variant=result.letter_variant,
+        )
 
         if result.success:
             applied_count += 1

--- a/src/hhru_bot/config_sections/__init__.py
+++ b/src/hhru_bot/config_sections/__init__.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 # Импорт регистрирует парсеры; порядок не важен.
-from . import account, scoring, search  # noqa: F401
+from . import account, ai_profile, scoring, search  # noqa: F401
 from ._registry import get, names, register
 from .account import parse_account
 

--- a/src/hhru_bot/config_sections/ai_profile.py
+++ b/src/hhru_bot/config_sections/ai_profile.py
@@ -1,0 +1,77 @@
+"""Парсер опциональной resume-секции ai_profile -> AIProfile (issue #17).
+
+Профиль кандидата для AI-генерации сопроводительных писем: чем подробнее
+заполнен, тем релевантнее письмо под вакансию. Секция опциональна: при
+отсутствии load_config оставит ResumeConfig.ai_profile = None (обратная
+совместимость — apply использует статичный шаблон, AI не включается).
+
+Поля:
+  - summary / profile: короткое описание себя (строка).
+  - skills: список ключевых навыков.
+  - highlights: список достижений/ярких фактов.
+  - desired_role: желаемая роль (строка).
+  - tone: тон письма ('formal' | 'friendly'), по умолчанию 'formal'.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..config import ConfigError
+from ._registry import register
+
+# Допустимые значения тона. Неизвестное -> ConfigError (явный контракт), а не
+# молчаливый пропуск: пользователь мог опечататься и получить не тот тон.
+_VALID_TONES = ("formal", "friendly")
+
+
+@dataclass
+class AIProfile:
+    """Профиль кандидата для AI-генерации писем. Все поля опциональны."""
+
+    summary: str = ""
+    skills: list[str] = field(default_factory=list)
+    highlights: list[str] = field(default_factory=list)
+    desired_role: str = ""
+    tone: str = "formal"
+
+
+def _require_str(raw, key: str, context: str) -> str:
+    value = raw.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ConfigError(f"Поле '{key}' в '{context}' должно быть строкой, получено: {value!r}")
+    return value
+
+
+def _require_str_list(raw, key: str, context: str) -> list[str]:
+    value = raw.get(key, [])
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        raise ConfigError(f"Поле '{key}' в '{context}' должно быть списком строк")
+    return value
+
+
+@register("ai_profile")
+def parse_ai_profile(raw, context: str) -> AIProfile | None:
+    """raw — подсекция ai_profile (может быть None/отсутствовать)."""
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением")
+
+    tone = _require_str(raw, "tone", context).strip() or "formal"
+    if tone not in _VALID_TONES:
+        raise ConfigError(
+            f"Поле 'tone' в '{context}' должно быть одним из {_VALID_TONES}, получено: {tone!r}"
+        )
+
+    return AIProfile(
+        summary=_require_str(raw, "summary", context),
+        skills=_require_str_list(raw, "skills", context),
+        highlights=_require_str_list(raw, "highlights", context),
+        desired_role=_require_str(raw, "desired_role", context),
+        tone=tone,
+    )

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -82,9 +82,18 @@ class History:
             conn.close()
 
     def _init_schema(self):
-        """Создаёт все таблицы (CREATE IF NOT EXISTS). Идемпотентно."""
+        """Создаёт все таблицы (CREATE IF NOT EXISTS). Идемпотентно.
+
+        CAVEAT (#51): CREATE TABLE IF NOT EXISTS НЕ добавляет колонку в уже
+        существующую таблицу. Новые колонки в существующих таблицах добавляем
+        через ALTER TABLE ADD COLUMN под идемпотентной обёрткой PRAGMA
+        table_info (добавляем только если колонки ещё нет — иначе повторный
+        запуск упадёт на 'duplicate column'). Это безопаснее пересоздания БД:
+        не теряем историю откликов.
+        """
         with self._connect() as conn:
             conn.executescript(SCHEMA)
+            _ensure_column(conn, "actions", "letter_variant", "TEXT")
 
     def has_applied(self, resume_id: str, vacancy_id: str) -> bool:
         with self._connect() as conn:
@@ -106,14 +115,24 @@ class History:
         action: str,
         status: str,
         reason: str | None = None,
+        letter_variant: str | None = None,
     ) -> None:
         with self._connect() as conn:
             conn.execute(
                 """
-                INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO actions
+                    (resume_id, vacancy_id, action, status, reason, letter_variant, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (resume_id, vacancy_id, action, status, reason, datetime.now().isoformat()),
+                (
+                    resume_id,
+                    vacancy_id,
+                    action,
+                    status,
+                    reason,
+                    letter_variant,
+                    datetime.now().isoformat(),
+                ),
             )
 
     def count_today(self, resume_id: str, action: str) -> int:
@@ -525,3 +544,17 @@ class History:
             "dead": dead,
             "dead_rate": self._pct(dead, total_sent),
         }
+
+
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl_type: str) -> None:
+    """Идемпотентно добавляет колонку в существующую таблицу через ALTER TABLE.
+
+    CREATE TABLE IF NOT EXISTS не добавляет колонку в уже созданную таблицу
+    (#51 caveat). Эта функция проверяет наличие колонки через PRAGMA table_info
+    и добавляет ALTER TABLE ADD COLUMN только если её нет — иначе повторный
+    запуск History упал бы на 'duplicate column name'. Используется в
+    _init_schema ПОСЛЕ executescript(SCHEMA).
+    """
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if column not in existing:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}")

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -554,7 +554,19 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl_type: 
     и добавляет ALTER TABLE ADD COLUMN только если её нет — иначе повторный
     запуск History упал бы на 'duplicate column name'. Используется в
     _init_schema ПОСЛЕ executescript(SCHEMA).
+
+    table/column/ddl_type интерполируются в DDL напрямую — это безопасно:
+    значения caller-controlled (строковые литералы в коде истории), не ввод
+    пользователя. Если хелпер когда-нибудь примет данные из конфига —
+    потребуется валидация идентификатора.
     """
+    # Нет таблицы → нечего дополнять (executescript(SCHEMA) должен был её
+    # создать; если нет — это баг выше по потоку, не здесь).
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    if not exists:
+        return
     existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
     if column not in existing:
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}")

--- a/tests/test_apply_letter.py
+++ b/tests/test_apply_letter.py
@@ -1,16 +1,35 @@
-"""Characterization-тесты чистой логики сопроводительного письма (apply.py).
+"""Сопроводительное письмо: дефолт-провайдер (characterization) + #17.
 
-Поведение render_cover_letter не должно измениться после декомпозиции apply.
+#17 вводит абстракцию CoverLetterProvider: render(vacancy, resume_profile)
+возвращает LetterOutcome(text, variant). Дефолтная реализация — текущий
+.format (офлайн-fallback, полная обратная совместимость). AI-реализация —
+в ai/letters.py, тестится тут через мок LLMClient (реальный транспорт из #16).
+
+ТДД-контракты #17:
+  - AI-успех (content непустой) → письмо под вакансию, variant='ai'.
+  - AI None-контент (timeout/content_filter) → fallback БЕЗ исключения, 'ai_fallback'.
+  - AI-ошибка (исключение из chat) → fallback БЕЗ исключения, 'ai_fallback'.
+  - AI пустой ответ → fallback, 'ai_fallback'.
+  - дефолт-провайдер (.format) → variant='template', поведение как прежде.
 """
 
 from __future__ import annotations
 
+from hhru_bot.ai.types import NormalizedResponse
 from hhru_bot.apply import render_cover_letter
+from hhru_bot.apply.letter import (
+    CoverLetterProvider,
+    LetterOutcome,
+    TemplateCoverLetterProvider,
+)
 from hhru_bot.search import VacancyCard
 
 
 def _card(title: str, company: str) -> VacancyCard:
     return VacancyCard(vacancy_id="1", title=title, company=company, url="https://hh.ru/vacancy/1")
+
+
+# --- characterization: render_cover_letter не изменился (#17 не ломает API) ---
 
 
 def test_render_cover_letter_substitutes_placeholders():
@@ -28,3 +47,132 @@ def test_render_cover_letter_multiline_example():
     assert render_cover_letter(template, _card("DevOps", "Z")) == (
         "Здравствуйте!\nВакансия: DevOps"
     )
+
+
+# --- дефолт-провайдер: текущий .format как офлайн-fallback (#17) ---
+
+
+def test_template_provider_substitutes_placeholders():
+    provider = TemplateCoverLetterProvider("Письмо для {vacancy_title} / {company_name}")
+    outcome = provider.render(_card("Python Dev", "Acme"), resume_profile=None)
+    assert outcome.text == "Письмо для Python Dev / Acme"
+    assert outcome.variant == "template"
+
+
+def test_template_provider_works_without_resume_profile():
+    # resume_profile опционален для дефолтного провайдера — он не использует его.
+    provider = TemplateCoverLetterProvider("Привет, {company_name}")
+    outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "template"
+
+
+# --- AI-провайдер через мок LLMClient (#16 контракт: chat()->NormalizedResponse) ---
+
+
+class _RecordingLLM:
+    """Мок LLMClient.chat(messages, **params) -> NormalizedResponse.
+
+    Имитирует реальный транспорт #16: возвращает NormalizedResponse с заданным
+    content (может быть None), записывает вызовы для проверок промпта.
+    """
+
+    def __init__(self, content: str | None, finish_reason: str = "stop"):
+        self._content = content
+        self._finish_reason = finish_reason
+        self.calls: list[tuple[list[dict], dict]] = []
+
+    def chat(self, messages, **params):
+        self.calls.append((messages, params))
+        return NormalizedResponse(
+            content=self._content, tool_calls=None, finish_reason=self._finish_reason
+        )
+
+
+class _FailingLLM:
+    """Мок LLMClient, бросающий при chat (сетевая ошибка/таймаут/timeout SDK)."""
+
+    def __init__(self, exc: Exception):
+        self.exc = exc
+
+    def chat(self, messages, **params):  # noqa: ARG002
+        raise self.exc
+
+
+def test_ai_provider_success_personalized_letter():
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    llm = _RecordingLLM("Здравствуйте! Мой опыт в Python идеально подходит для Python Dev.")
+    provider = AICoverLetterProvider(llm_client=llm, resume_profile=None)
+    outcome = provider.render(_card("Python Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "ai"
+    assert "Python" in outcome.text
+    # LLM реально вызывался, промпт содержал контекст вакансии.
+    assert llm.calls, "LLM не был вызван"
+    prompt = str(llm.calls[0][0])
+    assert "Python Dev" in prompt or "Acme" in prompt
+
+
+def test_ai_provider_none_content_falls_back_to_template():
+    # content=None (timeout/content_filter/length без текста) → fallback, НЕ успех.
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    provider = AICoverLetterProvider(
+        llm_client=_RecordingLLM(None, finish_reason="content_filter"),
+        resume_profile=None,
+        fallback_template="Здравствуйте, {company_name}!",
+    )
+    outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "ai_fallback"
+    assert outcome.text == "Здравствуйте, Acme!"
+
+
+def test_ai_provider_exception_falls_back_without_raising():
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    provider = AICoverLetterProvider(
+        llm_client=_FailingLLM(ConnectionError("LLM недоступен")),
+        resume_profile=None,
+        fallback_template="Здравствуйте, {company_name}!",
+    )
+    outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "ai_fallback"
+    assert outcome.text == "Здравствуйте, Acme!"
+
+
+def test_ai_provider_empty_response_falls_back_to_template():
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    provider = AICoverLetterProvider(
+        llm_client=_RecordingLLM("   "),  # пустой/только-пробелы content
+        resume_profile=None,
+        fallback_template="Шаблон: {vacancy_title}",
+    )
+    outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "ai_fallback"
+    assert outcome.text == "Шаблон: Dev"
+
+
+# --- render_cover_letter делегирует провайдеру, если он передан (#17) ---
+
+
+def test_render_cover_letter_uses_provider_when_given():
+    # Единственная точка подключения (pipeline._run): если провайдер передан,
+    # render_cover_letter делегирует ему; без провайдера — старый .format.
+    class _SpyProvider(CoverLetterProvider):
+        def __init__(self):
+            self.called = False
+
+        def render(self, vacancy, resume_profile=None):  # noqa: ARG002
+            self.called = True
+            return LetterOutcome(text="from-spy", variant="ai")
+
+    spy = _SpyProvider()
+    result = render_cover_letter("ignored template", _card("X", "Y"), provider=spy)
+    assert result == "from-spy"
+    assert spy.called
+
+
+def test_render_cover_letter_template_when_no_provider():
+    # provider=None (по умолчанию) → старое поведение .format.
+    result = render_cover_letter("Hi {company_name}", _card("X", "Acme"))
+    assert result == "Hi Acme"

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -1,0 +1,255 @@
+"""Интеграция #17: провайдер писем прокидывается через run_apply_for_resume.
+
+Энд-ту-энд (без браузера): _build_letter_provider строит AI-провайдер при
+наличии ai + ai_profile; letter_variant доходит до history. Без AI — None
+(статичный шаблон), variant='template'. Подмена только браузерного сбора
+карточек и LLM-вызова; реальная History, реальный pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+from hhru_bot.ai.types import NormalizedResponse
+from hhru_bot.commands import _common
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.config_sections.ai import AiConfig
+from hhru_bot.config_sections.ai_profile import AIProfile
+from hhru_bot.history import History
+from hhru_bot.search import VacancyCard
+from hhru_bot.throttle import Throttle
+
+
+class _FakeLocator:
+    @property
+    def first(self):
+        return self
+
+    def __init__(self, present: bool = False):
+        self._present = present
+
+    def count(self) -> int:
+        return 1 if self._present else 0
+
+    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+        if not self._present:
+            from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+            raise PlaywrightTimeoutError("not present")
+
+    def click(self) -> None:
+        return None
+
+    def fill(self, _value: str) -> None:
+        return None
+
+    def get_attribute(self, _name: str) -> str | None:  # noqa: ARG002
+        return None
+
+    def nth(self, _i: int) -> _FakeLocator:  # noqa: ARG002
+        return self
+
+
+class _ApplyFakePage:
+    """Page для apply-pipeline в dry-run: есть кнопка отклика, до формы не доходим."""
+
+    def __init__(self):
+        self.goto_calls: list[str] = []
+
+    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+        self.goto_calls.append(url)
+
+    def locator(self, selector: str):  # noqa: ARG002
+        from hhru_bot.selector_groups import vacancy_page
+
+        if selector == vacancy_page.VACANCY_APPLY_BUTTON:
+            return _FakeLocator(present=True)
+        return _FakeLocator(present=False)
+
+    def expect_navigation(self, **_kwargs):  # noqa: ARG002
+        import contextlib
+
+        @contextlib.contextmanager
+        def _cm():
+            yield
+
+        return _cm()
+
+
+def _resume_with_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+        ai_profile=AIProfile(
+            summary="Бэкенд-разработчик",
+            skills=["python", "django"],
+            desired_role="Senior Python Developer",
+        ),
+    )
+
+
+def _resume_without_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="plain",
+        resume_url="https://hh.ru/resume/BBB222",
+        search=SearchFilters(text="python developer"),
+    )
+
+
+def _config_with_ai(tmp_path, resume) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+        ai=AiConfig(provider="openai", model="gpt-4o", base_url="https://api.openai.com/v1"),
+    )
+
+
+def _apply_args() -> argparse.Namespace:
+    return argparse.Namespace(dry_run=True, limit=1, max_pages=5, headless=True)
+
+
+def _read_letter_variants(history_db) -> list[str | None]:
+    conn = sqlite3.connect(history_db)
+    try:
+        return [r[0] for r in conn.execute("SELECT letter_variant FROM actions ORDER BY id")]
+    finally:
+        conn.close()
+
+
+# --- _build_letter_provider: AI включён/выключен ---
+
+
+def test_build_letter_provider_returns_ai_when_ai_and_profile_present(tmp_path, monkeypatch):
+    # Подменяем LLMClient, чтобы не тянуть реальный openai/сеть.
+    class _FakeLLM:
+        def chat(self, messages, **params):  # noqa: ARG002
+            return NormalizedResponse(content="AI письмо", tool_calls=None, finish_reason="stop")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: _FakeLLM())
+
+    config = _config_with_ai(tmp_path, _resume_with_profile())
+    provider = _common._build_letter_provider(config, config.resumes[0], "шаблон {vacancy_title}")
+    assert provider is not None
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    assert isinstance(provider, AICoverLetterProvider)
+
+
+def test_build_letter_provider_none_without_ai_config(tmp_path):
+    # Нет секции ai (top-level) → None, даже если есть ai_profile.
+    resume = _resume_with_profile()
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="x",
+        resumes=[resume],
+        ai=None,
+    )
+    assert _common._build_letter_provider(config, resume, "x") is None
+
+
+def test_build_letter_provider_none_without_profile(tmp_path):
+    # Есть ai, но нет ai_profile → None (нет данных кандидата для промпта).
+    resume = _resume_without_profile()
+    config = _config_with_ai(tmp_path, resume)
+    assert _common._build_letter_provider(config, resume, "x") is None
+
+
+def test_build_letter_provider_none_when_openai_missing(tmp_path, monkeypatch):
+    # [ai] не установлен → LLMClient бросает ImportError → None (молчаливый
+    # fallback на шаблон, обычный отклик не падает).
+    def _boom(_cfg):
+        raise ImportError("openai SDK is required")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", _boom)
+    config = _config_with_ai(tmp_path, _resume_with_profile())
+    assert _common._build_letter_provider(config, config.resumes[0], "x") is None
+
+
+# --- letter_variant доходит до history через run_apply_for_resume ---
+
+
+def test_apply_writes_ai_variant_to_history(tmp_path, monkeypatch):
+    # AI включён и срабатывает → variant='ai' в actions.
+    class _FakeLLM:
+        def chat(self, messages, **params):  # noqa: ARG002
+            return NormalizedResponse(content="AI письмо", tool_calls=None, finish_reason="stop")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: _FakeLLM())
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.search_vacancies",
+        lambda page, search, max_pages=5: [  # noqa: ARG005
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+
+    resume = _resume_with_profile()
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    throttle = Throttle(ThrottleConfig(), history)
+    config = _config_with_ai(tmp_path, resume)
+
+    _common.run_apply_for_resume(_ApplyFakePage(), config, resume, history, throttle, _apply_args())
+
+    assert _read_letter_variants(history_db) == ["ai"]
+
+
+def test_apply_writes_template_variant_without_ai(tmp_path, monkeypatch):
+    # AI выключен → статичный шаблон, variant='template'.
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.search_vacancies",
+        lambda page, search, max_pages=5: [  # noqa: ARG005
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+
+    resume = _resume_without_profile()
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    throttle = Throttle(ThrottleConfig(), history)
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+        ai=None,
+    )
+
+    _common.run_apply_for_resume(_ApplyFakePage(), config, resume, history, throttle, _apply_args())
+
+    assert _read_letter_variants(history_db) == ["template"]
+
+
+def test_apply_writes_ai_fallback_variant_when_llm_fails(tmp_path, monkeypatch):
+    # LLM падает в рантайме → провайдер откатывается на шаблон, variant='ai_fallback'.
+    class _FailingLLM:
+        def chat(self, messages, **params):  # noqa: ARG002
+            raise ConnectionError("LLM недоступен")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: _FailingLLM())
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.search_vacancies",
+        lambda page, search, max_pages=5: [  # noqa: ARG005
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+
+    resume = _resume_with_profile()
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    throttle = Throttle(ThrottleConfig(), history)
+    config = _config_with_ai(tmp_path, resume)
+
+    _common.run_apply_for_resume(_ApplyFakePage(), config, resume, history, throttle, _apply_args())
+
+    assert _read_letter_variants(history_db) == ["ai_fallback"]

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -130,3 +130,50 @@ def test_apply_probe_hook_invoked_noop_default():
     page = FakePage(apply_button=True)
     apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True, probe=Spy())  # type: ignore[arg-type]
     assert "vacancy_loaded" in calls
+
+
+# --- #17: провайдер письма в pipeline ---
+
+
+def test_apply_uses_letter_provider_when_given():
+    # Прямая pipeline-интеграция: apply_to_vacancy(letter_provider=...) рендерит
+    # письмо через провайдер (а не статичный .format), и ApplyResult несёт его
+    # variant. Это точка подключения #17, отдельная от _common.run_apply_for_resume.
+    from hhru_bot.apply.letter import LetterOutcome
+
+    class _SpyProvider:
+        def __init__(self):
+            self.rendered_with = None
+
+        def render(self, vacancy, resume_profile=None):  # noqa: ARG002
+            self.rendered_with = vacancy.title
+            return LetterOutcome(text="ai-letter-text", variant="ai")
+
+    spy = _SpyProvider()
+    page = FakePage(apply_button=True)
+    result = apply_to_vacancy(
+        page, _vacancy(), "RID", "IGNORED-TEMPLATE", dry_run=True, letter_provider=spy
+    )
+    assert result.success is True
+    assert spy.rendered_with == "Dev"  # провайдер получил вакансию
+    assert result.letter_variant == "ai"
+
+
+def test_apply_letter_variant_template_without_provider():
+    # Без провайдера variant остаётся 'template' (обратная совместимость).
+    page = FakePage(apply_button=True)
+    result = apply_to_vacancy(
+        page, _vacancy(), "RID", "Hi {company_name}", dry_run=True, letter_provider=None
+    )
+    assert result.success is True
+    assert result.letter_variant == "template"
+
+
+def test_apply_letter_variant_preserved_on_fail():
+    # fail() после рендера письма несёт variant провайдера (например, кнопка
+    # отклика отсутствует — но это до рендера; проверяем путь с провайдером
+    # и кнопкой нет → variant дефолт template, т.к. письмо не генерилось).
+    page = FakePage(apply_button=False)
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True, letter_provider=None)
+    assert result.success is False
+    assert result.letter_variant == "template"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from hhru_bot.config import ConfigError, ResumeConfig, SearchFilters, load_config
+from hhru_bot.config_sections.ai_profile import AIProfile
 
 
 def _write_config(tmp_path, body: str):
@@ -344,3 +345,126 @@ def test_session_secret_gitignored_for_legacy_config_value(tmp_path):
         f"{config.storage_state_file}. Defence-in-depth .gitignore нужен "
         "(**/storage_state/*.json)."
     )
+
+
+# --- ai_profile: опциональная resume-секция для AI-писем (#17) ---
+
+
+def test_load_config_ai_profile_none_when_absent(tmp_path):
+    # Без секции ai_profile → ResumeConfig.ai_profile = None (AI выключен).
+    config = load_config(_write_config(tmp_path, _minimal_config()))
+    assert config.resumes[0].ai_profile is None
+
+
+def test_load_config_ai_profile_full(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AI100"
+            search:
+              text: "python developer"
+            ai_profile:
+              summary: "Бэкенд-разработчик"
+              skills: ["python", "django"]
+              highlights: ["Поднял throughput в 3 раза"]
+              desired_role: "Senior Python Developer"
+              tone: friendly
+        """,
+    )
+    config = load_config(path)
+    profile: AIProfile = config.resumes[0].ai_profile  # type: ignore[assignment]
+    assert profile is not None
+    assert profile.summary == "Бэкенд-разработчик"
+    assert profile.skills == ["python", "django"]
+    assert profile.highlights == ["Поднял throughput в 3 раза"]
+    assert profile.desired_role == "Senior Python Developer"
+    assert profile.tone == "friendly"
+
+
+def test_load_config_ai_profile_defaults_partial(tmp_path):
+    # Поля опциональны по отдельности: задан только один — остальные дефолты.
+    # Консистентно с scoring: пустая {} трактуется как отсутствие секции (None).
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AI200"
+            search:
+              text: "x"
+            ai_profile:
+              summary: "Краткое описание"
+        """,
+    )
+    profile: AIProfile = load_config(path).resumes[0].ai_profile  # type: ignore[assignment]
+    assert profile is not None
+    assert profile.summary == "Краткое описание"
+    assert profile.skills == []
+    assert profile.highlights == []
+    assert profile.desired_role == ""
+    assert profile.tone == "formal"
+
+
+def test_load_config_ai_profile_empty_dict_is_none(tmp_path):
+    # Пустая секция ai_profile: {} трактуется как отсутствие (None) —
+    # консистентно с поведением parse_scoring для scoring: {}.
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AI250"
+            search:
+              text: "x"
+            ai_profile: {}
+        """,
+    )
+    assert load_config(path).resumes[0].ai_profile is None
+
+
+def test_load_config_ai_profile_invalid_tone(tmp_path):
+    # Неизвестный tone → ConfigError (явный контракт, не молчаливый пропуск).
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AI300"
+            search:
+              text: "x"
+            ai_profile:
+              tone: casual
+        """,
+    )
+    with pytest.raises(ConfigError, match="tone"):
+        load_config(path)
+
+
+def test_load_config_ai_profile_skills_wrong_type(tmp_path):
+    # skills не список строк → ConfigError.
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AI400"
+            search:
+              text: "x"
+            ai_profile:
+              skills: "python"
+        """,
+    )
+    with pytest.raises(ConfigError, match="skills"):
+        load_config(path)

--- a/tests/test_history_schema.py
+++ b/tests/test_history_schema.py
@@ -1,0 +1,114 @@
+"""Схема SQLite + letter_variant (#17): идемпотентность DDL и ALTER-колонки.
+
+Миграций в проекте нет (#50/#51): схема — константа SCHEMA в history.py,
+CREATE TABLE IF NOT EXISTS применяется _init_schema. CAVEAT #51: IF NOT EXISTS
+не добавляет колонку в существующую таблицу, поэтому letter_variant (#17)
+добавляется через ALTER TABLE ADD COLUMN под идемпотентной обёрткой
+PRAGMA table_info. Эти тесты страхуют инварианты схемы.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from hhru_bot.history import SCHEMA, History
+
+
+def test_schema_creates_actions_table():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "actions" in tables
+    finally:
+        conn.close()
+
+
+def test_schema_is_idempotent():
+    # IF NOT EXISTS: повторное executescript той же схемы не падает.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.executescript(SCHEMA)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "actions" in tables
+    finally:
+        conn.close()
+
+
+def test_unique_index_prevents_duplicate_success_apply():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','success','','2026-01-01')"
+        )
+        # второй success-apply на ту же (resume_id, vacancy_id) должен нарушить UNIQUE-индекс
+        try:
+            conn.execute(
+                "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+                "VALUES ('r1','v1','apply','success','','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("ожидалась IntegrityError от UNIQUE-индекса")
+    finally:
+        conn.close()
+
+
+def test_history_creates_letter_variant_column(tmp_path):
+    # #17: History._init_schema добавляет actions.letter_variant (ALTER под обёрткой).
+    History(tmp_path / "h.db")
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(actions)")}
+    finally:
+        conn.close()
+    assert "letter_variant" in cols
+
+
+def test_letter_variant_added_idempotently_on_reopen(tmp_path):
+    # CAVEAT #51: повторное открытие той же БД не падает на 'duplicate column'.
+    History(tmp_path / "h.db")
+    History(tmp_path / "h.db")  # второй History на тот же файл — не должно упасть
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(actions)")}
+    finally:
+        conn.close()
+    assert "letter_variant" in cols
+
+
+def test_record_action_persists_letter_variant(tmp_path):
+    # ТДД-контракт #17: letter_variant пишется в историю.
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success", reason="success", letter_variant="ai")
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        row = conn.execute("SELECT letter_variant FROM actions WHERE action='apply'").fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "ai"
+
+
+def test_record_action_letter_variant_defaults_to_none(tmp_path):
+    # backward compatible: callers без letter_variant (bump и пр.) пишут NULL.
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v2", "bump", "success", reason="bumped")
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        row = conn.execute("SELECT letter_variant FROM actions WHERE action='bump'").fetchone()
+    finally:
+        conn.close()
+    assert row[0] is None
+
+
+def test_history_works_after_schema_creation(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "dry_run")
+    assert h.has_applied("r1", "v1")
+    # повторное открытие того же файла не падает и данные на месте
+    h2 = History(tmp_path / "h.db")
+    assert h2.has_applied("r1", "v1")


### PR DESCRIPTION
Этап 5, issue #17. Персонализация сопроводительного письма под вакансию через LLM (#16) с устойчивым откатом на статичный шаблон при любом сбое AI.

## Что делает
- Абстракция `CoverLetterProvider.render(vacancy, resume_profile) -> LetterOutcome(text, variant)` в `apply/letter.py`. Дефолтная реализация `TemplateCoverLetterProvider` = текущий `.format` (офлайн-fallback, обратная совместимость).
- AI-реализация `AICoverLetterProvider` в новом `ai/letters.py`: поверх реального `LLMClient` из #16 (`chat()->NormalizedResponse`, `.content: str | None`). **None-контент (timeout/content_filter/length), пустой ответ и любое исключение → fallback на шаблон без поднятия исключения** (`variant='ai_fallback'`). Промпт строится из `VacancyCard` + `ai_profile`; полный текст вакансии (`vacancy-description`) сознательно оставлен на Этап 4 (доп. заход = доп. пауза, анти-фрод).
- Парсер `ai_profile` (новый `config_sections/ai_profile.py`, `@register('ai_profile')`): `summary/skills/highlights/desired_role/tone`. Секция опциональна, `{}` трактуется как отсутствие (консистентно с `scoring`).
- AI включается **только** при наличии одновременно top-level секции `ai` (#16) И resume-секции `ai_profile`; иначе — статичный шаблон. `LLMClient` без `openai` ([ai] не установлен) → молчаливый `None`.
- `letter_variant` ('template'/'ai'/'ai_fallback') пишется в `history.actions` для A/B-среза конверсии (Этап 3).

## Ключевые решения
- **Прокидывание провайдера** — опц. `letter_provider` в `ApplyContext` + `apply_to_vacancy` (дефолт `None` = старое поведение). `pipeline.py` правка минимальна и обратна: последовательность шагов не тронута, лишь точка `render_cover_letter` делегирует провайдеру. Это единственный путь до единственной точки подключения (`render_cover_letter`) при запрете ломать оркестрацию.
- **Колонка `letter_variant`** — через `ALTER TABLE actions ADD COLUMN` под идемпотентной обёрткой `PRAGMA table_info` в `_init_schema` (caveat из #51: `CREATE TABLE IF NOT EXISTS` колонку в существующей таблице не добавит). Безопаснее пересоздания БД — история откликов не теряется. Запись в ту же строку apply-действия (новая таблица не заводилась).
- **`complete()`→`chat()`**: стартовал до мерджа #16/#48 с выдуманным интерфейсом; после rebase на свежий main переписан под реальный контракт `LLMClient.chat()->NormalizedResponse`, None-контент = fallback (как уточнил оркестратор).

## Тесты
- `test_apply_letter.py`: provider + fallback через мок `LLMClient` (успех→`ai`; None-контент/пусто/исключение→`ai_fallback` без поднятия исключения); characterization `render_cover_letter` не сломан.
- `test_apply_letter_integration.py`: энд-ту-энд `_build_letter_provider` (AI вкл/выкл/нет openai) и `letter_variant`→`history` (`ai`/`template`/`ai_fallback`) через `run_apply_for_resume`.
- `test_config.py`: парсинг `ai_profile` (full/частичный/пустой→None/невалидный tone/типы).
- `test_history_schema.py`: `letter_variant` колонка, идемпотентность на повторном открытии БД.

259 тестов зелёные, `ruff check` + `ruff format --check` чистые.

## Не затронуто
search.py, responses.py, apply/steps.py, apply/success.py, apply/probe.py, apply/dedup.py, selector_groups/. ai-config / `LLMClient` / `AppConfig.ai` / `[ai]` optional-deps — из #16.

## Известные риски / follow-up
- Промпт v1 не использует полный текст вакансии (только карточку) — сознательно, до Этапа 4 (парсинг `vacancy-description` + доп. троттлинг).
- Читателя A/B-среза (отчёт конверсии по письмам) нет — заведётся в Этапе 3.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)