### PR TITLE
feat(probe): AI-письмо в probe-дампе (#54)

### DIFF
--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -33,7 +33,7 @@ from ..search import VacancyCard
 from ..selector_groups import apply_form
 from . import steps as apply_steps
 from .dedup import check_already_responded
-from .letter import render_cover_letter
+from .letter import CoverLetterProvider, render_cover_letter
 
 logger = logging.getLogger("hhru_bot.apply.probe")
 
@@ -116,12 +116,18 @@ def probe_vacancy(
     resume_id: str,
     cover_letter_template: str,
     logs_dir: Path | None = None,
+    letter_provider: CoverLetterProvider | None = None,
 ) -> ProbeResult:
     """Probe одной вакансии: дойти до формы, заполнить письмо, сдампить, НЕ отправлять.
 
     Шаги: открыть вакансию → проверка «уже откликались» → ждать кнопку отклика →
     навигация на форму → заполнить письмо → дамп screenshot+HTML → стоп.
     submit никогда не кликается.
+
+    #17 (follow-up #54): если передан letter_provider — письмо рендерится им
+    (AI под вакансию, виден в дампе формы), иначе — статичный .format (обратная
+    совместимость). Атомарность probe при этом не меняется: провайдер только
+    генерирует текст письма, submit не трогается. Аналогично pipeline._run.
     """
     ctx_dir = ProbeContext(
         vacancy_id=vacancy.vacancy_id,
@@ -143,7 +149,14 @@ def probe_vacancy(
     apply_steps.navigate_to_response_form(page)
     logger.info("[PROBE] Дошёл до формы отклика, заполняю письмо (без отправки)")
 
-    letter = render_cover_letter(cover_letter_template, vacancy)
+    # #17 (follow-up #54): письмо через провайдер, если он задан (AI под вакансию),
+    # иначе статичный .format. Провайдер сам падает на шаблон при сбое LLM —
+    # исключений не ждём (см. ai/letters.py). Атомарность probe не нарушается:
+    # провайдер только генерирует текст, submit не кликается.
+    if letter_provider is not None:
+        letter = letter_provider.render(vacancy).text
+    else:
+        letter = render_cover_letter(cover_letter_template, vacancy)
     _fill_cover_letter_only(page, resume_id, letter)
 
     dump_paths = dump_probe_snapshot(page, ctx_dir)

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from ._common import add_common_args, resolve_resumes
+from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 
 def register(subparsers) -> None:
@@ -77,6 +77,10 @@ def run(args: argparse.Namespace) -> None:
         sys.exit(1)
     resume = resumes[0]
     cover_letter_template = config.cover_letter_for(resume)
+    # #17 (follow-up #54): AI-письмо в probe-дампе. Провайдер строится по тому же
+    # правилу, что и в apply (ai + ai_profile); None → статичный шаблон. Атомарность
+    # probe не страдает: провайдер только генерирует текст письма, submit не кликается.
+    letter_provider = _build_letter_provider(config, resume, cover_letter_template)
 
     print(f"=== probe для резюме: {resume.id} ===")
     print(f"Целевая вакансия: {vacancy.url}")
@@ -88,6 +92,7 @@ def run(args: argparse.Namespace) -> None:
             vacancy,
             resume_id=resume.id,
             cover_letter_template=cover_letter_template,
+            letter_provider=letter_provider,
         )
 
     if result.success:

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -218,3 +218,78 @@ def test_probe_dedup_step_is_passthrough(tmp_path: Path):
     assert result.success is True
     assert page.screenshot_calls >= 1
     assert page.content_calls >= 1
+
+
+# --- #17 (follow-up #54): AI-письмо в probe-дампе через letter_provider ---
+
+
+class _SpyProvider:
+    """Мок CoverLetterProvider для probe: фиксирует render-вызовы, возвращает
+    заданный текст/variant. Не должен знать про textarea/submit — только генерация.
+    """
+
+    def __init__(self, text: str, variant: str = "ai"):
+        self._text = text
+        self._variant = variant
+        self.render_calls: list[VacancyCard] = []
+
+    def render(self, vacancy, resume_profile=None):  # noqa: ARG002
+        from hhru_bot.apply.letter import LetterOutcome
+
+        self.render_calls.append(vacancy)
+        return LetterOutcome(text=self._text, variant=self._variant)
+
+
+def test_probe_uses_letter_provider_text(tmp_path: Path):
+    # Провайдер задан → textarea заполняется текстом от провайдера (AI под вакансию),
+    # а НЕ статичным шаблоном. Главный контракт follow-up #54.
+    page = FakeProbePage(textarea=True)
+    provider = _SpyProvider(text="AI-письмо под Dev от Acme", variant="ai")
+
+    probe_vacancy(
+        page,
+        _vacancy(),
+        resume_id="RID",
+        cover_letter_template="Здравствуйте, {company_name}",
+        logs_dir=tmp_path,
+        letter_provider=provider,
+    )
+
+    assert provider.render_calls == [_vacancy()]
+    assert page._textarea_locator is not None
+    assert page._textarea_locator.fill_calls == ["AI-письмо под Dev от Acme"]
+
+
+def test_probe_provider_does_not_click_submit(tmp_path: Path):
+    # Атомарность probe сохраняется и с провайдером: submit не кликается.
+    page = FakeProbePage(apply_button=True, textarea=True, submit=True)
+    provider = _SpyProvider(text="AI письмо")
+
+    probe_vacancy(
+        page,
+        _vacancy(),
+        resume_id="RID",
+        cover_letter_template="Здравствуйте, {company_name}",
+        logs_dir=tmp_path,
+        letter_provider=provider,
+    )
+
+    assert page.submit_clicks == []
+
+
+def test_probe_without_provider_uses_template(tmp_path: Path):
+    # Характеризация обратной совместимости: без провайдера — статичный .format
+    # (текст от шаблона, а не от провайдера).
+    page = FakeProbePage(textarea=True)
+
+    probe_vacancy(
+        page,
+        _vacancy(),
+        resume_id="RID",
+        cover_letter_template="Здравствуйте, {company_name}",
+        logs_dir=tmp_path,
+        letter_provider=None,
+    )
+
+    assert page._textarea_locator is not None
+    assert page._textarea_locator.fill_calls == ["Здравствуйте, Acme"]

--- a/tests/test_probe_letter_integration.py
+++ b/tests/test_probe_letter_integration.py
@@ -175,4 +175,4 @@ def test_probe_command_no_resume_exits(tmp_path, monkeypatch, capsys):
 
     assert excinfo.value.code == 1
     err = capsys.readouterr().err
-    assert "не выбрано резюме" in err.lower() or "резюме" in err.lower()
+    assert "не выбрано резюме" in err.lower()

--- a/tests/test_probe_letter_integration.py
+++ b/tests/test_probe_letter_integration.py
@@ -1,0 +1,178 @@
+"""Интеграция follow-up #54: AI-письмо прокидывается в probe-команду.
+
+Энд-ту-энд (без браузера): команда ``probe`` строит AI-провайдер при наличии
+ai + ai_profile (через _common._build_letter_provider) и передаёт его в
+probe_vacancy. Без AI — провайдер None (статичный шаблон). Браузер и сам
+probe_vacancy подменяются; реальный конфиг, реальное построение провайдера.
+
+Критерий готовности #54: ``probe --vacancy-id N`` с включённым AI показывает
+в дампе формы письмо от LLM. Здесь это проверяется на уровне проброса
+провайдера в probe_vacancy (текст письма/дамп тестируются в test_apply_probe).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hhru_bot.commands import probe as probe_cmd
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.config_sections.ai import AiConfig
+from hhru_bot.config_sections.ai_profile import AIProfile
+
+
+class _CtxStub:
+    """Заглушка браузерного контекста: context manager + new_page()->None."""
+
+    def __enter__(self):  # noqa: ANN204
+        return self
+
+    def __exit__(self, *_exc):  # noqa: ANN204
+        return False
+
+    def new_page(self):  # noqa: ANN204
+        return None
+
+
+def _resume_with_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+        ai_profile=AIProfile(
+            summary="Бэкенд-разработчик",
+            skills=["python", "django"],
+            desired_role="Senior Python Developer",
+        ),
+    )
+
+
+def _resume_without_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="plain",
+        resume_url="https://hh.ru/resume/BBB222",
+        search=SearchFilters(text="python developer"),
+    )
+
+
+def _config_with_ai(tmp_path, resume) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+        ai=AiConfig(provider="openai", model="gpt-4o", base_url="https://api.openai.com/v1"),
+    )
+
+
+def _probe_args(resume_id: str | None) -> argparse.Namespace:
+    return argparse.Namespace(
+        config=None,
+        resume=resume_id,
+        headless=True,
+        vacancy_id="42",
+        vacancy_url=None,
+    )
+
+
+def test_probe_command_passes_ai_provider_to_probe_vacancy(tmp_path, monkeypatch):
+    """AI включён → probe_vacancy получает не-None AICoverLetterProvider."""
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    class _FakeLLM:
+        def chat(self, messages, **params):  # noqa: ARG002
+            from hhru_bot.ai.types import NormalizedResponse
+
+            return NormalizedResponse(content="AI письмо", tool_calls=None, finish_reason="stop")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: _FakeLLM())
+    # launch_context/probe_vacancy/load_config_or_exit — лениво импортируются
+    # внутри run(), поэтому патчим их в модулях-источниках (имя резолвится
+    # из источника в момент вызова).
+    monkeypatch.setattr(
+        "hhru_bot.browser.launch_context",
+        lambda *a, **k: _CtxStub(),  # noqa: ARG005
+    )
+
+    captured: dict = {}
+
+    def _spy_probe_vacancy(page, vacancy, resume_id, cover_letter_template, **kwargs):  # noqa: ARG001
+        captured["letter_provider"] = kwargs.get("letter_provider")
+        # Возвращаем провал, чтобы не идти в реальный дамп.
+        from hhru_bot.apply.probe import ProbeResult
+        from hhru_bot.search import VacancyCard
+
+        return ProbeResult(
+            VacancyCard(vacancy_id="42", title="t", company="c", url="https://hh.ru/vacancy/42"),
+            False,
+            "stub",
+        )
+
+    monkeypatch.setattr("hhru_bot.apply.probe.probe_vacancy", _spy_probe_vacancy)
+
+    config = _config_with_ai(tmp_path, _resume_with_profile())
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _cfg: config)
+
+    probe_cmd.run(_probe_args("python"))
+
+    provider = captured["letter_provider"]
+    assert provider is not None
+    assert isinstance(provider, AICoverLetterProvider)
+
+
+def test_probe_command_passes_none_provider_without_ai(tmp_path, monkeypatch):
+    """AI выключен → probe_vacancy получает None (статичный шаблон)."""
+    monkeypatch.setattr(
+        "hhru_bot.browser.launch_context",
+        lambda *a, **k: _CtxStub(),  # noqa: ARG005
+    )
+
+    captured: dict = {}
+
+    def _spy_probe_vacancy(page, vacancy, resume_id, cover_letter_template, **kwargs):  # noqa: ARG001
+        captured["letter_provider"] = kwargs.get("letter_provider")
+        from hhru_bot.apply.probe import ProbeResult
+        from hhru_bot.search import VacancyCard
+
+        return ProbeResult(
+            VacancyCard(vacancy_id="42", title="t", company="c", url="https://hh.ru/vacancy/42"),
+            False,
+            "stub",
+        )
+
+    monkeypatch.setattr("hhru_bot.apply.probe.probe_vacancy", _spy_probe_vacancy)
+
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[_resume_without_profile()],
+        ai=None,
+    )
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _cfg: config)
+
+    probe_cmd.run(_probe_args("plain"))
+
+    assert captured["letter_provider"] is None
+
+
+def test_probe_command_no_resume_exits(tmp_path, monkeypatch, capsys):
+    """Без --resume команда probe завершается с ошибкой (нет резюме для дампа)."""
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="x",
+        resumes=[],
+        ai=None,
+    )
+
+    # load_config возвращает конфиг без резюме; resolve_resumes → [].
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _cfg: config)
+
+    with pytest.raises(SystemExit) as excinfo:
+        probe_cmd.run(_probe_args(None))
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "не выбрано резюме" in err.lower() or "резюме" in err.lower()


### PR DESCRIPTION
Follow-up к #17 (PR #52). Часть эпика #1, Этап 5.

## Проблема

#17 требует «при включённом AI письмо генерируется под вакансию любым сконфигурированным LLM (виден в probe-дампе)». Но PR #52 не пробросил `letter_provider` в probe-путь: `apply/probe.py` и `commands/probe.py` звали `render_cover_letter(...)` без провайдера → probe-дамп всегда показывал статичный шаблон, даже когда AI включён. PR #52 умышленно не трогал probe (явное ограничение оркестратора) — это отдельный follow-up #54.

## Что сделано

- `apply/probe.py`: `probe_vacancy(...)` принимает опц. `letter_provider`. В точке рендера письма — если провайдер задан, `provider.render(vacancy).text` (AI под вакансию), иначе старый `render_cover_letter(template, vacancy)` (обратная совместимость). Аналогично `pipeline._run`/`apply_to_vacancy` из #17.
- `commands/probe.py`: строит провайдер через `_common._build_letter_provider(config, resume, cover_letter_template)` (то же правило, что и apply: `ai` + `ai_profile`; `None` без секции/профиля/openai) и передаёт в `probe_vacancy`.

Атомарность probe сохранена: провайдер только генерирует текст письма, `submit_button.click()` НИКОГДА не вызывается.

## Критерий готовности #54

`hhru-bot probe --vacancy-id N` с включённым AI (секция `ai` + `ai_profile`) показывает в дампе формы письмо, сгенерированное LLM, а не статичный шаблон.

## Тесты

- `test_apply_probe.py`: probe с провайдером заполняет textarea текстом от LLM; submit не кликается при провайдере (атомарность); без провайдера — статичный `.format` (характеризация).
- `test_probe_letter_integration.py` (новый): команда `probe` энд-ту-энд прокидывает `AICoverLetterProvider` в `probe_vacancy` при AI и `None` без AI; без `--resume` завершается с кодом 1.
- Весь набор: **426 passed**, `ruff check` + `ruff format --check` зелёные. README (`gen_cli_docs.py`) без изменений — сигнатура команды не поменялась.

## Риски / follow-up

- Поведение без AI не изменилось (провайдер `None` → статичный шаблон) — обратно совместимо.
- Сам AI-провайдер (`AICoverLetterProvider`) уже устойчив к сбоям LLM (fallback на шаблон без исключения), поведение probe при сбое AI идентично apply.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)