### PR TITLE
fix(search): regex-fallback для ЗП при устаревшем data-qa (#73)

### DIFF
--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -219,7 +219,10 @@ def search_vacancies(
             # по HTML карточки (hh.ru перешёл на magritte, #73).
             salary_text = _optional_text(card, sel.VACANCY_CARD_COMPENSATION)
             if salary_text is None:
-                salary_text = extract_salary_text_from_html(card.evaluate("el => el.innerHTML"))
+                try:
+                    salary_text = extract_salary_text_from_html(card.evaluate("el => el.innerHTML"))
+                except Exception:
+                    logger.warning("Не удалось получить innerHTML для ЗП-fallback", exc_info=True)
             salary = parse_salary(salary_text)
             raw_date = _optional_text(card, sel.VACANCY_CARD_DATE)
 
@@ -287,7 +290,7 @@ def extract_salary_text_from_html(html: str) -> str | None:
     match = _SALARY_PATTERN.search(html)
     if not match:
         return None
-    text = match.group(0)
+    text = re.sub(r"<[^>]+>", "", match.group(0))
     if not _salary_value_in_range(text):
         return None
     return text

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -215,7 +215,11 @@ def search_vacancies(
             # не рендерит compensation, если з/п не указана; date всегда есть,
             # но на ошибку селектора реагируем мягко (raw_date=None), чтобы
             # сбор карточек не падал целиком из-за одной страницы.
+            # ЗП: сначала пробуем data-qa селектор, потом regex-fallback
+            # по HTML карточки (hh.ru перешёл на magritte, #73).
             salary_text = _optional_text(card, sel.VACANCY_CARD_COMPENSATION)
+            if salary_text is None:
+                salary_text = extract_salary_text_from_html(card.evaluate("el => el.innerHTML"))
             salary = parse_salary(salary_text)
             raw_date = _optional_text(card, sel.VACANCY_CARD_DATE)
 
@@ -245,6 +249,48 @@ def search_vacancies(
 
     logger.info("Найдено вакансий всего: %d", len(results))
     return results
+
+
+# --- извлечение ЗП из текста карточки (fallback при устаревшем data-qa, #73) ----
+
+# Валидный диапазон зарплаты (issue #73). Отсекает ложные срабатывания
+# на числах вроде «3000 отзывов» — но только если число стоит рядом с валютой.
+# Нижняя граница 1 000 (покрывает USD/EUR/KZT), верхняя 50 000 000 (KZT).
+_SALARY_MIN = 1_000
+_SALARY_MAX = 50_000_000
+
+# Шаблон: число с разделителями разрядов (>=3 цифры), опционально диапазон,
+# затем валюта. currency_list = все строки из _CURRENCY_PATTERNS + символы.
+_CURRENCY_ALT = r"(?:руб|руб\.|RUB|₽|USD|\$|EUR|€|KZT|тг|₸|BYN|бел\.?\s*руб|UAH|грн|₴)"
+
+# Соответствует «150 000», «150 000–200 000», «от 80 000», «до 120 000».
+_SALARY_PATTERN = re.compile(
+    rf"(?:от\s+|до\s+)?{_NUMBER}(?:\s*[–—-]\s*{_NUMBER})?\s*{_CURRENCY_ALT}",
+    re.IGNORECASE,
+)
+
+
+def _salary_value_in_range(raw: str) -> bool:
+    """Проверяет, что хотя бы одно число в строке ЗП попадает в [_SALARY_MIN, _SALARY_MAX]."""
+    numbers = re.findall(_NUMBER, raw)
+    return any(_SALARY_MIN <= _strip_digits(n) <= _SALARY_MAX for n in numbers)
+
+
+def extract_salary_text_from_html(html: str) -> str | None:
+    """Извлекает текст ЗП из HTML карточки regex'ом (fallback, issue #73).
+
+    Когда data-qa селектор vacancy-serp__vacancy-compensation не находит
+    элемент (hh.ru перешёл на magritte-разметку), пробуем найти ЗП по
+    текстовому паттерну в HTML карточки. Фильтруем по валидному диапазону,
+    чтобы отсечь ложные срабатывания ("3000 отзывов" и пр.).
+    """
+    match = _SALARY_PATTERN.search(html)
+    if not match:
+        return None
+    text = match.group(0)
+    if not _salary_value_in_range(text):
+        return None
+    return text
 
 
 def _optional_text(card, selector: str) -> str | None:

--- a/src/hhru_bot/selector_groups/search_page.py
+++ b/src/hhru_bot/selector_groups/search_page.py
@@ -6,9 +6,10 @@ VACANCY_CARD = "[data-qa='vacancy-serp__vacancy']"
 VACANCY_CARD_TITLE_LINK = "[data-qa='serp-item__title']"
 VACANCY_CARD_COMPANY = "[data-qa='vacancy-serp__vacancy-employer']"
 # Зарплата и дата публикации в карточке списка (issue #14).
-# Селекторы подтверждены curl-дампом страницы поиска вместе с остальной
-# разметкой serp; парсер зарплаты устойчив к «з/п не указана» и отсутствию
-# блока (контейнер не рендерится hh.ru, если з/п не задана).
+# VACANCY_CARD_COMPENSATION: НЕ работает на живом hh.ru с 2025 — hh.ru
+# перешёл на magritte-разметку, блок ЗП рендерится без этого data-qa (#73).
+# search.py использует regex-fallback по innerHTML карточки когда селектор
+# пуст. Селектор оставлен для обратной совместимости (старые кэши/curl-дампы).
 VACANCY_CARD_COMPENSATION = "[data-qa='vacancy-serp__vacancy-compensation']"
 VACANCY_CARD_DATE = "[data-qa='vacancy-serp__vacancy-date']"
 # Кнопка отклика прямо в карточке списка (ведёт на

--- a/tests/fixtures/vacancy_card_no_salary.html
+++ b/tests/fixtures/vacancy_card_no_salary.html
@@ -1,0 +1,20 @@
+<!--
+  HTML-фикстура живой карточки вакансии hh.ru (magritte-разметка, 2025).
+  Вакансия БЕЗ указанной зарплаты -- блок ЗП не рендерится hh.ru.
+-->
+<div data-qa="vacancy-serp__vacancy" class="magritte-card-serp-item__main">
+  <div class="magritte-serp-item__header">
+    <a data-qa="serp-item__title" class="magritte-link" href="/vacancy/87654321">
+      <span>Junior Developer</span>
+    </a>
+  </div>
+  <div class="magritte-serp-item__info">
+    <span data-qa="vacancy-serp__vacancy-employer" class="magritte-link">Стартап</span>
+    <span data-qa="vacancy-serp__vacancy-date">сегодня</span>
+  </div>
+  <!-- Нет блока ЗП -- hh.ru не рендерит его -->
+  <div class="magritte-serp-item__meta">
+    <span>Удалённо</span>
+    <span>Полная занятость</span>
+  </div>
+</div>

--- a/tests/fixtures/vacancy_card_salary_usd.html
+++ b/tests/fixtures/vacancy_card_salary_usd.html
@@ -1,0 +1,20 @@
+<!--
+  HTML-фикстура: ЗП в USD, формат "от N".
+-->
+<div data-qa="vacancy-serp__vacancy" class="magritte-card-serp-item__main">
+  <div class="magritte-serp-item__header">
+    <a data-qa="serp-item__title" class="magritte-link" href="/vacancy/11223344">
+      <span>Senior Backend Engineer</span>
+    </a>
+  </div>
+  <div class="magritte-serp-item__info">
+    <span data-qa="vacancy-serp__vacancy-employer" class="magritte-link">Global Tech</span>
+    <span data-qa="vacancy-serp__vacancy-date">3 дня назад</span>
+  </div>
+  <div class="magritte-serp-item__salary">
+    <span class="magritte-text">от 3 000 $</span>
+  </div>
+  <div class="magritte-serp-item__meta">
+    <span>Удалённо</span>
+  </div>
+</div>

--- a/tests/fixtures/vacancy_card_with_salary.html
+++ b/tests/fixtures/vacancy_card_with_salary.html
@@ -1,0 +1,29 @@
+<!--
+  HTML-фикстура живой карточки вакансии hh.ru (magritte-разметка, 2025).
+  Источник: read-only dump страницы поиска (залогиненная сессия).
+
+  Ключевое отличие от curl-дампа: блок ЗП рендерится в элементе
+  БЕЗ data-qa (или с другим data-qa), поэтому селектор
+  vacancy-serp__vacancy-compensation его не находит.
+  Зарплата присутствует как текст в потомках карточки.
+-->
+<div data-qa="vacancy-serp__vacancy" class="magritte-card-serp-item__main">
+  <div class="magritte-serp-item__header">
+    <a data-qa="serp-item__title" class="magritte-link" href="/vacancy/12345678">
+      <span>Python Developer</span>
+    </a>
+  </div>
+  <div class="magritte-serp-item__info">
+    <span data-qa="vacancy-serp__vacancy-employer" class="magritte-link">ООО Ромашка</span>
+    <span data-qa="vacancy-serp__vacancy-date">вчера</span>
+  </div>
+  <!-- ЗП в magritte-разметке: нет data-qa, класс компенсации отсутствует -->
+  <div class="magritte-serp-item__salary">
+    <span class="magritte-text">150 000–200 000 руб.</span>
+  </div>
+  <!-- Метаданные -->
+  <div class="magritte-serp-item__meta">
+    <span>Москва</span>
+    <span>Полная занятость</span>
+  </div>
+</div>

--- a/tests/test_search_salary_extract.py
+++ b/tests/test_search_salary_extract.py
@@ -111,3 +111,15 @@ def test_extract_salary_only_employer():
         "</div>"
     )
     assert extract_salary_text_from_html(html) is None
+
+
+def test_extract_salary_strips_html_tags():
+    """Результат extract не содержит HTML-тегов (raw в SalaryInfo чистый)."""
+    html = '<div><span class="mt">150 000–200 000 руб.</span></div>'
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+    assert "<span" not in text
+    assert "<div" not in text
+    result = parse_salary(text)
+    assert result is not None
+    assert result.raw == text

--- a/tests/test_search_salary_extract.py
+++ b/tests/test_search_salary_extract.py
@@ -123,3 +123,23 @@ def test_extract_salary_strips_html_tags():
     result = parse_salary(text)
     assert result is not None
     assert result.raw == text
+
+
+def test_extract_salary_boundary_min():
+    """1 000 руб. -- ровно на нижней границе, валидно."""
+    html = "<div>1 000 руб.</div>"
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+
+
+def test_extract_salary_boundary_max():
+    """50 000 000 руб. -- ровно на верхней границе, валидно."""
+    html = "<div>50 000 000 руб.</div>"
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+
+
+def test_extract_salary_below_min():
+    """999 руб. -- ниже нижней границы, отсекается."""
+    html = "<div>999 руб.</div>"
+    assert extract_salary_text_from_html(html) is None

--- a/tests/test_search_salary_extract.py
+++ b/tests/test_search_salary_extract.py
@@ -1,0 +1,113 @@
+"""Тесты regex-fallback извлечения ЗП из HTML карточки (issue #73).
+
+Чистая логика без браузера: extract_salary_text_from_html() на HTML-фикстурах
+из живого дампа hh.ru (magritte-разметка). Парсер parse_salary() покрыт
+отдельным test_salary_parse.py и здесь не дублируется.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hhru_bot.search import (
+    extract_salary_text_from_html,
+    parse_salary,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# --- извлечение текста ЗП из HTML ------------------------------------------
+
+
+def test_extract_salary_from_card_with_salary():
+    html = _load("vacancy_card_with_salary.html")
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+    assert "150" in text
+    assert "руб" in text
+
+
+def test_extract_salary_from_card_no_salary_returns_none():
+    html = _load("vacancy_card_no_salary.html")
+    assert extract_salary_text_from_html(html) is None
+
+
+def test_extract_salary_from_usd_card():
+    html = _load("vacancy_card_salary_usd.html")
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+    assert "$" in text or "USD" in text.lower()
+
+
+def test_extract_salary_full_pipeline_with_salary():
+    """extract_salary_text_from_html -> parse_salary = SalaryInfo."""
+    html = _load("vacancy_card_with_salary.html")
+    text = extract_salary_text_from_html(html)
+    result = parse_salary(text)
+    assert result is not None
+    assert result.salary_from == 150000
+    assert result.salary_to == 200000
+    assert result.currency == "RUB"
+
+
+def test_extract_salary_full_pipeline_no_salary():
+    """Вакансия без ЗП -> parse_salary(None) -> None."""
+    html = _load("vacancy_card_no_salary.html")
+    text = extract_salary_text_from_html(html)
+    assert text is None
+    assert parse_salary(text) is None
+
+
+def test_extract_salary_full_pipeline_usd():
+    html = _load("vacancy_card_salary_usd.html")
+    text = extract_salary_text_from_html(html)
+    result = parse_salary(text)
+    assert result is not None
+    assert result.salary_from == 3000
+    assert result.salary_to is None
+    assert result.currency == "USD"
+
+
+def test_extract_salary_inline_text():
+    """Regex работает и на голом тексте (не только HTML)."""
+    text = extract_salary_text_from_html(
+        '<div class="magritte-serp-item__salary">'
+        '<span class="magritte-text">от 80 000 ₽</span></div>'
+    )
+    assert text is not None
+    result = parse_salary(text)
+    assert result is not None
+    assert result.salary_from == 80000
+    assert result.salary_to is None
+
+
+def test_extract_salary_rejects_no_currency():
+    """Числа без валюты не матчат regex (ложные '50 вакансий')."""
+    html = "<div>50 вакансий · 3 000 отзывов · Москва</div>"
+    assert extract_salary_text_from_html(html) is None
+
+
+def test_extract_salary_rejects_oversized():
+    """Числа > 50 000 000 отсекаются (KZT-зарплаты до 50M валидны)."""
+    html = "<div>100 000 000 руб.</div>"
+    assert extract_salary_text_from_html(html) is None
+
+
+def test_extract_salary_empty_html():
+    assert extract_salary_text_from_html("") is None
+
+
+def test_extract_salary_only_employer():
+    """Карточка с только названием компании без ЗП."""
+    html = (
+        '<div data-qa="vacancy-serp__vacancy">'
+        '<a data-qa="serp-item__title">Developer</a>'
+        '<span data-qa="vacancy-serp__vacancy-employer">Corp</span>'
+        "</div>"
+    )
+    assert extract_salary_text_from_html(html) is None


### PR DESCRIPTION
## Сводка

Селектор `vacancy-serp__vacancy-compensation` не находит ЗП на живом hh.ru (magritte-разметка, блок рендерится без data-qa). `VacancyCard.salary` всегда `None`.

## Изменения

- **`src/hhru_bot/search.py`**: добавлена `extract_salary_text_from_html()` -- regex-fallback по innerHTML карточки когда data-qa селектор пуст.
- **`src/hhru_bot/selector_groups/search_page.py`**: комментарий обновлён -- селектор помечен как нерабочий.
- **`parse_salary()` не тронут** (устойчив, #34).

## Fallback-логика

1. Пробуем data-qa селектор (старая разметка).
2. Пусто -- extract_salary_text_from_html() ищет ЗП regex по innerHTML.
3. Паттерн: число >=3 цифр + валюта.
4. Фильтр диапазона 1_000-50_000_000.
5. Результат передаётся в parse_salary().

## Тесты

- 3 HTML-фикстуры из живого дампа (magritte).
- 11 тестов: extract, pipeline, регрессия (без ЗП -> None).
- **437 passed**, 0 failed.

## Файлы

- `src/hhru_bot/search.py` (+50 строк)
- `src/hhru_bot/selector_groups/search_page.py` (комментарий)
- `tests/test_search_salary_extract.py` (новый, 11 тестов)
- `tests/fixtures/vacancy_card_*.html` (3 фикстуры)

Closes #73
