### PR TITLE
fix(search): regex ЗП-fallback по тексту без тегов (#78)

### DIFF
--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -279,21 +279,33 @@ def _salary_value_in_range(raw: str) -> bool:
     return any(_SALARY_MIN <= _strip_digits(n) <= _SALARY_MAX for n in numbers)
 
 
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
 def extract_salary_text_from_html(html: str) -> str | None:
     """Извлекает текст ЗП из HTML карточки regex'ом (fallback, issue #73).
 
     Когда data-qa селектор vacancy-serp__vacancy-compensation не находит
     элемент (hh.ru перешёл на magritte-разметку), пробуем найти ЗП по
-    текстовому паттерну в HTML карточки. Фильтруем по валидному диапазону,
+    текстовому паттерну в карточке. Фильтруем по валидному диапазону,
     чтобы отсечь ложные срабатывания ("3000 отзывов" и пр.).
+
+    Важно: regex применяется к ТЕКСТУ БЕЗ ТЕГОВ, а не к сырой HTML (#78).
+    hh.ru (magritte) разбивает ЗП по spans: ``<span>150</span><span> </span>
+    <span>000</span><span> </span><span>₽</span>`` — теги внутри числа и
+    whitespace-only спаны (разделитель разрядов) разрывают «digits+валюта
+    подряд», и регексп по сырой HTML не срабатывает. Удаляем теги в пустую
+    строку и нормализуем пробелы — получаем «150 000 ₽», точно как
+    ``card.inner_text()``, и число снова матчится единым фрагментом.
     """
-    match = _SALARY_PATTERN.search(html)
+    text = _TAG_RE.sub("", html)
+    match = _SALARY_PATTERN.search(text)
     if not match:
         return None
-    text = re.sub(r"<[^>]+>", "", match.group(0))
-    if not _salary_value_in_range(text):
+    salary_text = " ".join(match.group(0).split())
+    if not _salary_value_in_range(salary_text):
         return None
-    return text
+    return salary_text
 
 
 def _optional_text(card, selector: str) -> str | None:

--- a/tests/fixtures/vacancy_card_salary_usd.html
+++ b/tests/fixtures/vacancy_card_salary_usd.html
@@ -1,5 +1,7 @@
 <!--
-  HTML-фикстура: ЗП в USD, формат "от N".
+  HTML-фикстура живой карточки вакансии hh.ru (magritte-разметка, 2025).
+  ЗП в USD, формат "от N". magritte разбивает по spans (#78): «от», число,
+  разделитель, валюта — отдельные span.
 -->
 <div data-qa="vacancy-serp__vacancy" class="magritte-card-serp-item__main">
   <div class="magritte-serp-item__header">
@@ -12,7 +14,9 @@
     <span data-qa="vacancy-serp__vacancy-date">3 дня назад</span>
   </div>
   <div class="magritte-serp-item__salary">
-    <span class="magritte-text">от 3 000 $</span>
+    <span class="magritte-text__tg3gq5">
+      <span>от</span><span> </span><span>3</span><span> </span><span>000</span><span> </span><span>$</span>
+    </span>
   </div>
   <div class="magritte-serp-item__meta">
     <span>Удалённо</span>

--- a/tests/fixtures/vacancy_card_with_salary.html
+++ b/tests/fixtures/vacancy_card_with_salary.html
@@ -5,7 +5,11 @@
   Ключевое отличие от curl-дампа: блок ЗП рендерится в элементе
   БЕЗ data-qa (или с другим data-qa), поэтому селектор
   vacancy-serp__vacancy-compensation его не находит.
-  Зарплата присутствует как текст в потомках карточки.
+
+  magritte-особенность (#78): ЗП разбита по отдельным <span> — отдельный
+  спан на число, на разделитель разрядов (пробел как отдельный узел/спан),
+  на валюту. Регексп по СЫРОЙ HTML здесь НЕ сматчит «digits+валюта подряд»
+  (теги разрывают матч) — должен применяться к тексту без тегов.
 -->
 <div data-qa="vacancy-serp__vacancy" class="magritte-card-serp-item__main">
   <div class="magritte-serp-item__header">
@@ -17,9 +21,11 @@
     <span data-qa="vacancy-serp__vacancy-employer" class="magritte-link">ООО Ромашка</span>
     <span data-qa="vacancy-serp__vacancy-date">вчера</span>
   </div>
-  <!-- ЗП в magritte-разметке: нет data-qa, класс компенсации отсутствует -->
+  <!-- ЗП в magritte: каждый фрагмент в своём span -->
   <div class="magritte-serp-item__salary">
-    <span class="magritte-text">150 000–200 000 руб.</span>
+    <span class="magritte-text__tg3gq5">
+      <span>150</span><span> </span><span>000</span><span>–</span><span>200</span><span> </span><span>000</span><span> </span><span>₽</span>
+    </span>
   </div>
   <!-- Метаданные -->
   <div class="magritte-serp-item__meta">

--- a/tests/test_search_salary_extract.py
+++ b/tests/test_search_salary_extract.py
@@ -29,7 +29,8 @@ def test_extract_salary_from_card_with_salary():
     text = extract_salary_text_from_html(html)
     assert text is not None
     assert "150" in text
-    assert "руб" in text
+    # Валюта рублей в magritte-разметке -- символ ₽ или слово «руб».
+    assert "₽" in text or "руб" in text
 
 
 def test_extract_salary_from_card_no_salary_returns_none():
@@ -123,6 +124,33 @@ def test_extract_salary_strips_html_tags():
     result = parse_salary(text)
     assert result is not None
     assert result.raw == text
+
+
+def test_extract_salary_split_across_spans():
+    """Регрессия #78: magritte разбивает ЗП по spans.
+
+    Живая разметка hh.ru: «<span>150</span><span> </span><span>000</span>
+    <span>₽</span>» — теги внутри числа разрывают матч «digits+валюта подряд»,
+    и регексп по СЫРОЙ HTML даёт None. Фикс: regex применяется к тексту без
+    тегов. До фикса этот тест падал (salary=NULL у всех вакансий).
+    """
+    html = (
+        '<div class="magritte-serp-item__salary">'
+        '<span class="magritte-text__tg3gq5">'
+        "<span>150</span><span> </span><span>000</span>"
+        "<span>–</span>"
+        "<span>200</span><span> </span><span>000</span>"
+        "<span> </span><span>₽</span>"
+        "</span></div>"
+    )
+    text = extract_salary_text_from_html(html)
+    assert text is not None
+    assert "<span" not in text
+    result = parse_salary(text)
+    assert result is not None
+    assert result.salary_from == 150000
+    assert result.salary_to == 200000
+    assert result.currency == "RUB"
 
 
 def test_extract_salary_boundary_min():


### PR DESCRIPTION
## Что

Регрессия #75 на живых magritte-карточках: `extract_salary_text_from_html`
искал `_SALARY_PATTERN` по **сырой HTML**, но hh.ru разбивает ЗП по spans —
`<span>150</span><span> </span><span>000</span><span>₽</span>`. Теги и
whitespace-only спаны внутри числа разрывают «digits+валюта подряд»,
регексп не срабатывает, и `salary_from`/`salary_to = NULL` у **всех**
вакансий. Это ломает #66 (рынок-доход) и #74 (ML-скоринг по salary).

## Как чиним

`_SALARY_PATTERN.search` применяется к тексту **без тегов** вместо сырой HTML:
теги удаляются в пустую строку (`re.sub(r"<[^>]+>", "", html)`), затем
whitespace нормализуется. Результат — `150 000–200 000 ₽`, эквивалент
`card.inner_text()`. После этого число снова матчится единым фрагментом.

## Изменения

- `search.py`: теги вырезаются ДО регекспа; `_TAG_RE` в модульную константу;
  `match.group(0)` нормализует пробелы перед возвратом.
- фикстуры `vacancy_card_with_salary.html` / `vacancy_card_salary_usd.html`
  обновлены под живую magritte-разметку (ЗП разбита по spans, RUB/USD).
- `test_extract_salary_split_across_spans` — регрессионный тест бага #78
  (до фикса: `salary is None`).

## Проверки

- `ruff check` + `ruff format --check` — чисто.
- `pytest` — 478 тестов зелёные.
- End-to-end smoke (путь данных без браузера):
  magritte-фикстура → `extract_salary_text_from_html` → `parse_salary` →
  `upsert_vacancy_seen` → `SELECT ... WHERE salary_to IS NOT NULL`
  → `('12345678', 150000, 200000, 'RUB')`.
- Регресс: вакансия без ЗП → `None` (сохранено).

## Риски / follow-ups

- Фикс чисто в логике извлечения; селекторы и парсинг `SalaryInfo` не тронуты.
- Боевой `search --dry-run` на hh.ru требует интерактивного логина — не запускал;
  цепочка проверена программно на живой magritte-разметке из дампа.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)