### PR TITLE
fix(browser): context-wide navigation timeout + goto retry (#80)

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 
 from playwright.sync_api import Page
 
+from ..browser import goto_hh
 from ..search import VacancyCard
 from . import steps as apply_steps
 from .dedup import check_already_responded
@@ -82,7 +83,7 @@ def apply_to_vacancy(
 
 def _run(ctx: ApplyContext) -> ApplyResult:
     logger.info("Открываю вакансию: %s (%s)", ctx.vacancy.title, ctx.vacancy.url)
-    ctx.page.goto(ctx.vacancy.url, wait_until="domcontentloaded")
+    goto_hh(ctx.page, ctx.vacancy.url)
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)
 
     if reason := check_already_responded(ctx.page, ctx.vacancy):

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from playwright.sync_api import Page
 
+from ..browser import goto_hh
 from ..logging_setup import LOG_DIR
 from ..search import VacancyCard
 from ..selector_groups import apply_form
@@ -137,7 +138,7 @@ def probe_vacancy(
     )
 
     logger.info("[PROBE] Открываю вакансию: %s (%s)", vacancy.title, vacancy.url)
-    page.goto(vacancy.url, wait_until="domcontentloaded")
+    goto_hh(page, vacancy.url)
 
     if reason := check_already_responded(page, vacancy):
         logger.info("[PROBE] Вакансия '%s' уже откликнута — пропускаю без дампа", vacancy.title)

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -67,7 +67,7 @@ def navigate_to_response_form(page: Page) -> None:
     # set_default_navigation_timeout перебивается явным timeout.
     with page.expect_navigation(wait_until="domcontentloaded", timeout=GOTO_TIMEOUT_MS):
         # no_wait_after=True: клик НЕ ждёт навигацию своим внутренним action-timeout
-        # шагом (дефолт set_default_timeout 30с,有别 от navigation-timeout) — иначе на
+        # шагом (дефолт set_default_timeout 30с, а не navigation-timeout) — иначе на
         # навигации 33с+ он упал бы через 30с раньше 90с expect_navigation. Ожидание
         # навигации полностью владеет внешний 90с waiter expect_navigation.
         apply_button.click(no_wait_after=True)

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -66,7 +66,11 @@ def navigate_to_response_form(page: Page) -> None:
     # DDoS-Guard грузится 33с+; APPLY_TIMEOUT_MS (10с) тут падал, context-wide
     # set_default_navigation_timeout перебивается явным timeout.
     with page.expect_navigation(wait_until="domcontentloaded", timeout=GOTO_TIMEOUT_MS):
-        apply_button.click()
+        # no_wait_after=True: клик НЕ ждёт навигацию своим внутренним action-timeout
+        # шагом (дефолт set_default_timeout 30с,有别 от navigation-timeout) — иначе на
+        # навигации 33с+ он упал бы через 30с раньше 90с expect_navigation. Ожидание
+        # навигации полностью владеет внешний 90с waiter expect_navigation.
+        apply_button.click(no_wait_after=True)
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
     try:
         page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -19,6 +19,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from ..browser import GOTO_TIMEOUT_MS
 from ..selector_groups import vacancy_page
 
 logger = logging.getLogger("hhru_bot.apply.steps")
@@ -60,7 +61,11 @@ def navigate_to_response_form(page: Page) -> None:
     from ..selector_groups import apply_form
 
     apply_button = page.locator(vacancy_page.VACANCY_APPLY_BUTTON).first
-    with page.expect_navigation(wait_until="domcontentloaded", timeout=APPLY_TIMEOUT_MS):
+    # #80: потолок навигации на форму отклика — GOTO_TIMEOUT_MS (как у всех goto).
+    # Двухшаговая навигация (CLAUDE.md п.4) — это сетевой запрос hh.ru, который под
+    # DDoS-Guard грузится 33с+; APPLY_TIMEOUT_MS (10с) тут падал, context-wide
+    # set_default_navigation_timeout перебивается явным timeout.
+    with page.expect_navigation(wait_until="domcontentloaded", timeout=GOTO_TIMEOUT_MS):
         apply_button.click()
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
     try:

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -4,7 +4,7 @@ import logging
 
 from playwright.sync_api import sync_playwright
 
-from .browser import HH_BASE_URL
+from .browser import GOTO_TIMEOUT_MS, HH_BASE_URL, goto_hh
 from .config import AppConfig
 
 logger = logging.getLogger("hhru_bot.auth")
@@ -35,6 +35,9 @@ def login(config: AppConfig) -> None:
         if config.user_agent:
             context_kwargs["user_agent"] = config.user_agent
         context = browser.new_context(**context_kwargs)
+        # #80: context-wide потолок навигации (как в launch_context) — единый
+        # источник GOTO_TIMEOUT_MS, вместо хардкода 120000 на самом goto.
+        context.set_default_navigation_timeout(GOTO_TIMEOUT_MS)
         # Убираем navigator.webdriver и подделываем window.chrome — без этого
         # hh.ru детектит Playwright и держит кнопку выбора роли disabled. Приём
         # из YAMAKAYAMACO/hh-autoresponder/manual_login.py (рабочий против hh.ru).
@@ -43,7 +46,7 @@ def login(config: AppConfig) -> None:
             "window.chrome = {runtime: {}};"
         )
         page = context.new_page()
-        page.goto(f"{HH_BASE_URL}/account/login", wait_until="domcontentloaded", timeout=120000)
+        goto_hh(page, f"{HH_BASE_URL}/account/login")
 
         print()
         print("=" * 70)

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -1,14 +1,73 @@
 from __future__ import annotations
 
 import logging
+import time
 from contextlib import contextmanager
 from pathlib import Path
 
 from playwright.sync_api import Browser, BrowserContext, Page, sync_playwright
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 logger = logging.getLogger("hhru_bot.browser")
 
 HH_BASE_URL = "https://hh.ru"
+
+# Потолок ожидания навигации по hh.ru. Дефолт Playwright 30с — hh.ru под
+# DDoS-Guard/нагрузкой грузится 33с+ (см. #80), и goto падает. Ставим
+# context-wide через set_default_navigation_timeout — покрывает ВСЕ goto/
+# expect_navigation одним источником (включая двухшаговую навигацию формы
+# отклика, CLAUDE.md п.4), без явного timeout в каждом вызове. 90с (не 120с
+# как в auth.py раньше): достаточно для медленного hh.ru, но не слепое
+# зависание на 1.5 мин при реально упавшем запросе.
+GOTO_TIMEOUT_MS = 90_000
+
+# Retry goto: DDoS-Guard регулярно пропускает запрос со 2-й попытки. 3 попытки,
+# линейный backoff 2с → 4с.
+_GOTO_MAX_ATTEMPTS = 3
+_GOTO_BACKOFF_SECONDS = 2.0
+
+
+def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
+    """page.goto с retry и готовностью страницы hh.ru (#80).
+
+    Базовый потолок ожидания задаёт context-wide set_default_navigation_timeout
+    (GOTO_TIMEOUT_MS), поэтому тут timeout не дублируем — DRY.
+
+    Поведение:
+    1. До ``_GOTO_MAX_ATTEMPTS`` попыток goto(wait_until='domcontentloaded').
+       Ловим PlaywrightTimeoutError/PlaywrightError — hh.ru под DDoS-Guard
+       часто отвечает со 2-й попытки; на последней попытке ошибку пробрасываем
+       (как обычный goto без retry).
+    2. ``ready_selector`` (опц.) — после удачного goto дождаться конкретного
+       ``data-qa`` маркера страницы (короткий GOTO_TIMEOUT_MS, если не задан
+       context-timeout), вместо ненадёжного networkidle. None — не ждать.
+
+    domcontentloaded НЕ меняем (рекомендация референсов #80: DDoS-Guard держит
+    сеть активной, networkidle может не сработать).
+    """
+    last_error: Exception | None = None
+    for attempt in range(1, _GOTO_MAX_ATTEMPTS + 1):
+        try:
+            page.goto(url, wait_until="domcontentloaded")
+            if ready_selector:
+                page.locator(ready_selector).wait_for(timeout=GOTO_TIMEOUT_MS)
+            return
+        except (PlaywrightTimeoutError, PlaywrightError) as exc:
+            last_error = exc
+            if attempt < _GOTO_MAX_ATTEMPTS:
+                wait = _GOTO_BACKOFF_SECONDS * attempt
+                logger.warning(
+                    "goto не прошёл (попытка %d/%d): %s — повтор через %.1fs",
+                    attempt,
+                    _GOTO_MAX_ATTEMPTS,
+                    exc,
+                    wait,
+                )
+                time.sleep(wait)
+    # Последняя попытка провалилась — пробрасываем, как обычный goto.
+    assert last_error is not None
+    raise last_error
 
 
 @contextmanager
@@ -46,6 +105,9 @@ def launch_context(
             )
 
         context: BrowserContext = browser.new_context(**context_kwargs)
+        # #80: потолок навигации context-wide — покрывает ВСЕ goto/expect_navigation
+        # единым источником (включая двухшаговую навигацию формы отклика).
+        context.set_default_navigation_timeout(GOTO_TIMEOUT_MS)
         # Убираем navigator.webdriver и подделываем window.chrome — без этого
         # hh.ru детектит Playwright и не активирует кнопку входа. Приём из
         # YAMAKAYAMACO/hh-autoresponder/manual_login.py.
@@ -61,5 +123,5 @@ def launch_context(
 
 
 def is_logged_in(page: Page) -> bool:
-    page.goto(f"{HH_BASE_URL}/account/login", wait_until="domcontentloaded")
+    goto_hh(page, f"{HH_BASE_URL}/account/login")
     return "account/login" not in page.url

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -7,7 +7,7 @@ from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from . import selectors as sel
-from .browser import HH_BASE_URL
+from .browser import HH_BASE_URL, goto_hh
 from .config import ResumeConfig
 
 logger = logging.getLogger("hhru_bot.bump")
@@ -29,7 +29,7 @@ def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
         else f"{HH_BASE_URL}{resume.resume_url}"
     )
     logger.info("Открываю резюме: %s", url)
-    page.goto(url, wait_until="domcontentloaded")
+    goto_hh(page, url)
 
     disabled_hint = page.locator(sel.RESUME_BUMP_DISABLED_HINT)
     if disabled_hint.count() > 0:

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import HH_BASE_URL
+from .browser import HH_BASE_URL, goto_hh
 from .selector_groups import negotiations as ns
 
 logger = logging.getLogger("hhru_bot.responses")
@@ -255,7 +255,7 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         logger.info("Загрузка страницы откликов: %s", url)
-        page.goto(url, wait_until="domcontentloaded")
+        goto_hh(page, url)
 
         # Истёкшая сессия: hh.ru редиректит /applicant/negotiations на /account/
         # login. Это надёжный сигнал (не зависит от непроверенных селекторов

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 from playwright.sync_api import Page
 
 from . import selectors as sel
-from .browser import HH_BASE_URL
+from .browser import HH_BASE_URL, goto_hh
 from .config import ResumeConfig, SearchFilters
 from .config_sections.scoring import ScoringConfig, ScoringWeights
 
@@ -206,7 +206,7 @@ def search_vacancies(
     for page_num in range(max_pages):
         url = build_search_url(filters, page_num)
         logger.info("Загрузка страницы поиска: %s", url)
-        page.goto(url, wait_until="domcontentloaded")
+        goto_hh(page, url)
 
         cards = page.locator(sel.VACANCY_CARD)
         count = cards.count()

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -38,7 +38,7 @@ class _FakeLocator:
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self) -> None:
+    def click(self, **_kwargs) -> None:
         return None
 
     def fill(self, _value: str) -> None:

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -29,7 +29,7 @@ class _FakeLocator:
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self) -> None:
+    def click(self, **_kwargs) -> None:
         return None
 
     def fill(self, _value: str) -> None:

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -36,7 +36,7 @@ class _FakeLocator:
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self) -> None:
+    def click(self, **_kwargs) -> None:
         self.click_calls += 1
 
     def fill(self, value: str) -> None:
@@ -56,7 +56,7 @@ class _ClickTrackingLocator(_FakeLocator):
         super().__init__(present=present)
         self._submit_clicks = submit_clicks
 
-    def click(self) -> None:
+    def click(self, **_kwargs) -> None:
         self._submit_clicks.append(1)
         super().click()
 

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -86,7 +86,11 @@ class _FakeLocator:
         if not self._state.visible:
             raise PlaywrightTimeoutError(f"{self.selector} not visible")
 
-    def click(self) -> None:
+    def click(self, **kwargs) -> None:
+        # Фиксируем kwargs клика — регрессия #80: клик apply-кнопки, триггерящий
+        # навигацию, должен идти с no_wait_after=True (ожидание навигации владеет
+        # внешний 90с expect_navigation, а не внутренний 30с action-timeout клика).
+        self._state.click_kwargs.append(kwargs)
         if self._href_filter is not None:
             # Strict href-локатор: ровно одна живая опция с этим href, иначе Error
             # (как реальный Playwright strict mode при != 1 совпадении).
@@ -138,6 +142,7 @@ class _SelectorState:
         self.is_collection = False
         self.match_count = 1
         self.clicks = 0
+        self.click_kwargs: list[dict] = []
         self.fills: list[str] = []
         # Для коллекции резюме: href каждой опции (current_href ставится в nth()).
         self.option_hrefs: list[str] = []
@@ -252,6 +257,23 @@ def test_navigate_uses_goto_timeout_for_form_navigation():
     steps.navigate_to_response_form(page)
 
     assert page.last_navigation_timeout == GOTO_TIMEOUT_MS
+
+
+def test_navigate_clicks_apply_button_with_no_wait_after():
+    # #80 регрессия (cycle-2): Locator.click, триггерящий навигацию, имеет внутренний
+    # шаг «wait for initiated navigations», ограниченный ACTION timeout
+    # (set_default_timeout, дефолт 30с), а НЕ set_default_navigation_timeout. На
+    # навигации 33с+ клик падал бы через 30с раньше 90с expect_navigation. Фикс:
+    # no_wait_after=True — ожидание навигации полностью владеет внешний 90с waiter.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)
+
+    apply_state = page._state(vacancy_page.VACANCY_APPLY_BUTTON)
+    assert apply_state.clicks == 1
+    assert apply_state.click_kwargs == [{"no_wait_after": True}]
 
 
 # --- fill_response_form: только обязательный submit ---

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -16,6 +16,7 @@ from playwright.sync_api import Error
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot.apply import steps
+from hhru_bot.browser import GOTO_TIMEOUT_MS
 from hhru_bot.selector_groups import apply_form, vacancy_page
 
 
@@ -160,6 +161,7 @@ class FakeStepsPage:
     def __init__(self) -> None:
         self.states: dict[str, _SelectorState] = {}
         self.navigation_entered = 0
+        self.last_navigation_timeout: int | None = None
 
     def _state(self, selector: str) -> _SelectorState:
         return self.states.setdefault(selector, _SelectorState())
@@ -188,8 +190,12 @@ class FakeStepsPage:
         return _FakeLocator(selector, self._state(selector))
 
     @contextlib.contextmanager
-    def expect_navigation(self, **_kwargs):
+    def expect_navigation(self, **kwargs):
         self.navigation_entered += 1
+        # Фиксируем timeout навигации — регрессия #80: двухшаговая навигация на
+        # форму отклика должна использовать потолок GOTO_TIMEOUT_MS (медленный
+        # hh.ru), а не дефолт/короткий APPLY_TIMEOUT_MS.
+        self.last_navigation_timeout = kwargs.get("timeout")
         yield
 
 
@@ -232,6 +238,20 @@ def test_navigate_does_not_raise_when_form_never_renders():
     steps.navigate_to_response_form(page)  # не должен бросать
 
     assert page.navigation_entered == 1
+
+
+def test_navigate_uses_goto_timeout_for_form_navigation():
+    # #80 регрессия: двухшаговая навигация на форму отклика (expect_navigation
+    # после клика по apply-кнопке) — это сетевая навигация hh.ru, которая под
+    # DDoS-Guard грузится 33с+. Де­фолт/короткий APPLY_TIMEOUT_MS (10с) тут
+    # падает; потолок должен быть GOTO_TIMEOUT_MS, как и у всех goto в проекте.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)
+
+    assert page.last_navigation_timeout == GOTO_TIMEOUT_MS
 
 
 # --- fill_response_form: только обязательный submit ---

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -1,0 +1,135 @@
+"""Тесты навигации hh.ru: потолок timeout + retry goto (#80).
+
+Без браузера — через MagicMock. Страхуют регрессию «забыли timeout»: hh.ru под
+DDoS-Guard грузится 33с+ против дефолта Playwright 30с, и goto падает. Решение
+#80 — context-wide set_default_navigation_timeout(GOTO_TIMEOUT_MS) единым
+источником + helper goto_hh с retry (DDoS-Guard часто пропускает со 2-й попытки).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from hhru_bot import browser
+from hhru_bot.browser import GOTO_TIMEOUT_MS, goto_hh
+
+
+def test_goto_timeout_constant_is_90_seconds():
+    """Эталон из исследования референсов #80: 90с под DDoS-Guard (Steev193)."""
+    assert GOTO_TIMEOUT_MS == 90_000
+
+
+def _fake_playwright(monkeypatch, *, calls):
+    """Мок sync_playwright: возвращает контекст, записывающий set_default_*.
+
+    sync_playwright() — context manager, yield'ит объект с .chromium.launch().
+    """
+
+    @contextmanager
+    def _sync_playwright():
+        context = MagicMock(name="BrowserContext")
+        calls["set_default_navigation_timeout"] = context.set_default_navigation_timeout
+        playwright = MagicMock(name="Playwright")
+        playwright.chromium.launch.return_value.new_context.return_value = context
+        yield playwright
+
+    monkeypatch.setattr(browser, "sync_playwright", _sync_playwright)
+
+
+def test_launch_context_sets_default_navigation_timeout(monkeypatch, tmp_path):
+    """#80 минимум: после new_context — set_default_navigation_timeout(GOTO_TIMEOUT_MS).
+
+    Покрывает ВСЕ goto/expect_navigation единым источником (включая двухшаговую
+    навигацию формы отклика, CLAUDE.md п.4) — без явного timeout в каждом вызове.
+    """
+    calls: dict = {}
+    _fake_playwright(monkeypatch, calls=calls)
+
+    with browser.launch_context(tmp_path / "session.json", headless=True):
+        pass
+
+    calls["set_default_navigation_timeout"].assert_called_once_with(GOTO_TIMEOUT_MS)
+
+
+def test_launch_context_sets_timeout_even_without_session(monkeypatch, tmp_path):
+    """Тот же потолок навигации при отсутствии файла сессии (холодный запуск)."""
+    calls: dict = {}
+    _fake_playwright(monkeypatch, calls=calls)
+    missing = tmp_path / "does_not_exist.json"
+
+    with browser.launch_context(missing, headless=True):
+        pass
+
+    calls["set_default_navigation_timeout"].assert_called_once_with(GOTO_TIMEOUT_MS)
+
+
+def _page_gotos(*, results):
+    """Мок Page: page.goto выбрасывает исключения из results по порядку.
+
+    results — список: либо None (goto успешен), либо Exception/класс исключения.
+    Возвращает (page, gotos), где gotos — список переданных url.
+    """
+    gotos: list[str] = []
+    iterator = iter(results)
+
+    def _goto(url, **kwargs):
+        gotos.append(url)
+        outcome = next(iterator)
+        if outcome is None:
+            return None
+        raise outcome() if isinstance(outcome, type) else outcome
+
+    page = MagicMock(name="Page")
+    page.goto.side_effect = _goto
+    return page, gotos
+
+
+def test_goto_hh_retries_on_timeout_then_succeeds(monkeypatch):
+    """DDoS-Guard пропускает со 2-й попытки: 1-я PlaywrightTimeoutError, 2-я успех."""
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    page, gotos = _page_gotos(results=[PlaywrightTimeoutError("30s exceeded"), None])
+
+    goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert gotos == ["https://hh.ru/search/vacancy"] * 2
+
+
+def test_goto_hh_raises_after_max_attempts(monkeypatch):
+    """Все попытки провалены — последняя ошибка пробрасывается (как обычный goto)."""
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    page, gotos = _page_gotos(results=[PlaywrightTimeoutError("slow")] * 3)
+
+    with pytest.raises(PlaywrightTimeoutError):
+        goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert len(gotos) == 3  # _GOTO_MAX_ATTEMPTS
+
+
+def test_goto_hh_no_retry_on_success(monkeypatch):
+    """Удачный goto с первой попытки — ровно один вызов, без sleep."""
+    sleeps: list = []
+    monkeypatch.setattr(browser.time, "sleep", lambda s: sleeps.append(s))
+    page, gotos = _page_gotos(results=[None])
+
+    goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert gotos == ["https://hh.ru/search/vacancy"]
+    assert sleeps == []
+
+
+def test_goto_hh_uses_domcontentloaded(monkeypatch):
+    """Рекомендация референсов #80: domcontentloaded, НЕ networkidle (DDoS-Guard).
+
+    Гарантируем, что goto_hh не переключился обратно на networkidle/load.
+    """
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    page = MagicMock(name="Page")
+    page.goto.return_value = None
+
+    goto_hh(page, "https://hh.ru/search/vacancy")
+
+    page.goto.assert_called_once_with("https://hh.ru/search/vacancy", wait_until="domcontentloaded")

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -52,7 +52,7 @@ class _FakeLocator:
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self) -> None:
+    def click(self, **_kwargs) -> None:
         return None
 
     def fill(self, _value: str) -> None:  # noqa: ARG002


### PR DESCRIPTION
## Что

hh.ru под DDoS-Guard грузится 33с+ против дефолта Playwright 30с → все `page.goto` без явного timeout падали (`Page.goto: Timeout 30000ms exceeded`), ломая весь боевой поток: search/responses/bump/apply/probe. #37 починил только `auth.py` (хардкод `timeout=120000`); остальные модули оставались с дефолтным 30с — рынок-доход #66 не тестируется на боевых данных.

## Решение (по рекомендации исследования референсов #80)

**Минимум (чинит все падения):**
- `launch_context`: `context.set_default_navigation_timeout(GOTO_TIMEOUT_MS=90_000)` **один раз** после `new_context` — покрывает ВСЕ `goto`/`expect_navigation` единым источником, включая двухшаговую навигацию формы отклика (CLAUDE.md п.4).
- 90с (не 120с как раньше в `auth.py`): достаточно для медленного hh.ru, но не слепое зависание на 1.5 мин при реально упавшем запросе.

**Nice-to-have (вписалось в компактный PR):**
- `goto_hh(page, url, *, ready_selector=None)` — retry (3 попытки, backoff 2с→4с), ловит `PlaywrightTimeoutError`/`PlaywrightError`. DDoS-Guard часто пропускает со 2-й попытки; на последней — проброс, как обычный goto. `ready_selector` ждёт конкретный `data-qa` маркер вместо ненадёжного `networkidle`.
- Голые `page.goto` → `goto_hh` в `search`/`bump`/`responses`/`apply/pipeline`/`apply/probe`/`is_logged_in` (retry-устойчивость).
- `auth.py`: убран хардкод `timeout=120000` → `GOTO_TIMEOUT_MS` + `set_default_navigation_timeout` (контекст `auth.py` не проходит через `launch_context`).

`wait_until="domcontentloaded"` **НЕ меняли** (DDoS-Guard держит сеть активной, `networkidle` может не сработать — консенсус референсов).

## Тесты

`tests/test_browser_navigation.py` (7 новых, мок без браузера):
- `GOTO_TIMEOUT_MS == 90_000` (эталон референсов).
- мок context → `set_default_navigation_timeout(90_000)` вызван (с файлом сессии и без — холодный запуск).
- `goto_hh` retry на timeout: успех со 2-й попытки / проброс после 3-й / без retry на успехе / использует `domcontentloaded`.

Полный набор: **496 + 7 зелёные**, `ruff check` + `ruff format --check` чист. Без эмодзи.

## Риски / known

- DDoS-Guard **не дёргался** в рамках этой задачи — верификация по реальным данным hh.ru не проводилась (read-only только для hh.ru). Поведение обосновано исследованием референсов (Steev193: 90с + persistent context, 1:1 sync API).
- `ready_selector` сейчас не передаётся ни в одном вызове (никто не использовал) — оставлен как опц. точка расширения, готова к подключению по `data-qa` маркерам конкретных страниц при будущих падениях.

Closes #80