### PR TITLE
feat(scoring): подключить LLMScoringProvider к apply-циклу (#81)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -14,7 +14,13 @@ from ..apply import apply_to_vacancy
 from ..apply.letter import CoverLetterProvider
 from ..config import AppConfig, ResumeConfig
 from ..history import History
-from ..search import filter_candidates, rank_candidates, search_vacancies
+from ..search import (
+    _LLM_SHORTLIST_DEFAULT,
+    _ZERO_WEIGHTS,
+    filter_candidates,
+    rank_candidates,
+    search_vacancies,
+)
 from ..throttle import LimitReached, Throttle
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -84,6 +90,60 @@ def _build_letter_provider(
     )
 
 
+def _build_scoring_provider(config: AppConfig, resume: ResumeConfig):
+    """Строит ML scoring-провайдер для ранжирования, если AI включён (#81).
+
+    Зеркало ``_build_letter_provider`` (#17): AI включён = есть ТОП-ЛЕВЕЛ секция
+    ai (LLM-провайдер, #16) И resume-секция ai_profile (данные кандидата). Иначе
+    None → ``rank_candidates`` без провайдера = чистая эвристика #15 (обратная
+    совместимость, поведение не меняется — тот же приём, что letter_provider).
+
+    При AI строит: LLMClient → HeuristicScoringProvider (fallback: эвристика #15
+    + tier-буст #74) → LLMScoringProvider. Построение LLMClient тянет openai
+    (lazy, при construction): если openai не установлен ([ai] optional-deps) —
+    логируем и откатываемся на None (эвристику), как с письмами. Отсутствие
+    AI-зависимости не должно валить обычный отклик. Сам провайдер дальше устойчив
+    (любой сбой LLM → fallback внутри, circuit-breaker), см. scoring.py.
+
+    Отдельный LLMClient (не из _build_letter_provider) — намеренно, ради простоты
+    и независимости циклов (см. замечание по дизайну в #81).
+    """
+    ai_config = getattr(config, "ai", None)
+    profile = getattr(resume, "ai_profile", None)
+    if ai_config is None or profile is None:
+        return None
+
+    from ..scoring import HeuristicScoringProvider, LLMScoringProvider
+
+    # weights — ровно как в rank_candidates: из resume.scoring, иначе нулевые
+    # веса (_ZERO_WEIGHTS). HeuristicScoringProvider — fallback LLMScoringProvider
+    # и должен скорить на той же шкале [0,100] (нормализация F2 из #74), что и
+    # эвристический путь rank_candidates без провайдера.
+    scoring = getattr(resume, "scoring", None)
+    weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS
+    heuristic = HeuristicScoringProvider(resume.search, weights)
+
+    from ..ai.llm_client import LLMClient
+
+    try:
+        llm_client = LLMClient(ai_config)
+    except ImportError as e:
+        logger.warning(
+            "ML-скоринг недоступен для резюме '%s' (openai не установлен?): %s — "
+            "ранжирование идёт по эвристике. Установите: pip install -e '.[ai]'",
+            resume.id,
+            e,
+        )
+        return None
+
+    logger.info("ML-скоринг включён для резюме '%s' (провайдер: %s)", resume.id, ai_config.provider)
+    return LLMScoringProvider(
+        llm_client=llm_client,
+        fallback=heuristic,
+        resume_profile=profile,
+    )
+
+
 def run_apply_for_resume(
     page,
     config: AppConfig,
@@ -118,7 +178,18 @@ def run_apply_for_resume(
 
     # Ранжирование кандидатов по score (#15) — строго между filter_candidates
     # и срезом [:limit], чтобы дневной лимит уходил на лучшие совпадения.
-    ranked = rank_candidates(candidates, resume.search, resume)
+    # #81: при включённом AI ранжирование идёт через LLMScoringProvider (#74),
+    # иначе (провайдер None) — чистая эвристика #15 (поведение не меняется).
+    # llm_shortlist обязателен при провайдере: предранжирование эвристикой →
+    # LLM только по топ-10, иначе десятки синхронных запросов (анти-фрод, F3).
+    scoring_provider = _build_scoring_provider(config, resume)
+    ranked = rank_candidates(
+        candidates,
+        resume.search,
+        resume,
+        scoring_provider=scoring_provider,
+        llm_shortlist=_LLM_SHORTLIST_DEFAULT,
+    )
 
     limit = args.limit if args.limit else len(ranked)
     cover_letter_template = config.cover_letter_for(resume)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -9,19 +9,23 @@ from __future__ import annotations
 
 import argparse
 import logging
+from typing import TYPE_CHECKING
 
 from ..apply import apply_to_vacancy
 from ..apply.letter import CoverLetterProvider
 from ..config import AppConfig, ResumeConfig
+from ..config_sections.scoring import ScoringWeights
 from ..history import History
 from ..search import (
     _LLM_SHORTLIST_DEFAULT,
-    _ZERO_WEIGHTS,
     filter_candidates,
     rank_candidates,
     search_vacancies,
 )
 from ..throttle import LimitReached, Throttle
+
+if TYPE_CHECKING:
+    from ..scoring import LLMScoringProvider
 
 logger = logging.getLogger("hhru_bot.cli")
 
@@ -90,7 +94,10 @@ def _build_letter_provider(
     )
 
 
-def _build_scoring_provider(config: AppConfig, resume: ResumeConfig):
+def _build_scoring_provider(
+    config: AppConfig,
+    resume: ResumeConfig,
+) -> LLMScoringProvider | None:
     """Строит ML scoring-провайдер для ранжирования, если AI включён (#81).
 
     Зеркало ``_build_letter_provider`` (#17): AI включён = есть ТОП-ЛЕВЕЛ секция
@@ -115,12 +122,15 @@ def _build_scoring_provider(config: AppConfig, resume: ResumeConfig):
 
     from ..scoring import HeuristicScoringProvider, LLMScoringProvider
 
-    # weights — ровно как в rank_candidates: из resume.scoring, иначе нулевые
-    # веса (_ZERO_WEIGHTS). HeuristicScoringProvider — fallback LLMScoringProvider
-    # и должен скорить на той же шкале [0,100] (нормализация F2 из #74), что и
-    # эвристический путь rank_candidates без провайдера.
+    # weights — ровно как в rank_candidates для AI-пути: из resume.scoring, иначе
+    # дефолтные ScoringWeights() (НЕ _ZERO_WEIGHTS). HeuristicScoringProvider —
+    # fallback LLMScoringProvider и должен скорить на той же шкале/весах, что
+    # предранжирование в rank_candidates (нормализация F2 из #74). Согласовано с
+    # rank_candidates: scoring is None + provider is not None → ScoringWeights()
+    # (фикс Codex-ревью #81: иначе нейтральные веса → shortlist берёт первые K
+    # по входу, а не лучших).
     scoring = getattr(resume, "scoring", None)
-    weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS
+    weights = scoring.weights if scoring is not None else ScoringWeights()
     heuristic = HeuristicScoringProvider(resume.search, weights)
 
     from ..ai.llm_client import LLMClient

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -558,6 +558,18 @@ def rank_candidates(
     weights = scoring.weights if scoring is not None else _ZERO_WEIGHTS
     profile = getattr(resume, "ai_profile", None)
 
+    # AI-путь без scoring-секции (#81, фикс Codex-ревью): при нейтральных весах
+    # (_ZERO_WEIGHTS) все кандидаты tie на предранжировании → shortlist берёт
+    # первые K по входному порядку, а не лучшие. LLM тогда скорит произвольные
+    # первые K, а реально релевантные кандидаты за пределами K никогда не
+    # displac'нутся → дневная квота уходит на неоптимальный набор. Поэтому для
+    # AI-пути (provider передан) без явной scoring-секции предранжирование идёт
+    # по дефолтным весам ScoringWeights() — top-K действительно лучшие, LLM
+    # доранжирует релевантных. Legacy (provider=None) НЕ затрагивается: для него
+    # веса по-прежнему _ZERO_WEIGHTS → входной порядок candidates[:limit] сохранён.
+    if scoring is None and scoring_provider is not None:
+        weights = ScoringWeights()
+
     # Shortlist-режим (Codex #74 F3): предранжируем эвристикой, LLM — только топ-K.
     if scoring_provider is not None and llm_shortlist and llm_shortlist > 0:
         return _rank_with_llm_shortlist(

--- a/tests/test_apply_scoring_integration.py
+++ b/tests/test_apply_scoring_integration.py
@@ -1,0 +1,195 @@
+"""Интеграция follow-up #81: ML-скоринг подключается к apply-циклу.
+
+Энд-ту-энд (без браузера): ``run_apply_for_resume`` строит scoring-провайдер
+при наличии ai + ai_profile (через _common._build_scoring_provider) и передаёт
+его в ``rank_candidates`` с llm_shortlist=10 (анти-фрод). Без AI — провайдер
+None (эвристика #15, обратная совместимость). ImportError openai → None.
+
+Браузер/search/apply подменяются; реальный конфиг, реальное построение
+провайдера. Образец — test_probe_letter_integration.py (#54).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from hhru_bot.commands import _common
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.config_sections.ai import AiConfig
+from hhru_bot.config_sections.ai_profile import AIProfile
+from hhru_bot.search import VacancyCard
+
+
+def _resume_with_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+        ai_profile=AIProfile(
+            summary="Бэкенд-разработчик",
+            skills=["python", "django"],
+            desired_role="Senior Python Developer",
+        ),
+    )
+
+
+def _resume_without_profile() -> ResumeConfig:
+    return ResumeConfig(
+        id="plain",
+        resume_url="https://hh.ru/resume/BBB222",
+        search=SearchFilters(text="python developer"),
+    )
+
+
+def _config_with_ai(tmp_path, resume) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+        ai=AiConfig(provider="openai", model="gpt-4o", base_url="https://api.openai.com/v1"),
+    )
+
+
+def _apply_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=True,
+        headless=True,
+        max_pages=1,
+        limit=0,
+    )
+
+
+def _fake_cards() -> list[VacancyCard]:
+    return [
+        VacancyCard(
+            vacancy_id="1", title="Python Dev", company="Acme", url="https://hh.ru/vacancy/1"
+        ),
+        VacancyCard(
+            vacancy_id="2", title="Senior Python", company="Beta", url="https://hh.ru/vacancy/2"
+        ),
+    ]
+
+
+def _stub_apply_cycle(monkeypatch, captured):
+    """Подменяет search (карточки) и apply (без браузера); шпионит rank_candidates."""
+    monkeypatch.setattr(_common, "search_vacancies", lambda *a, **k: _fake_cards())  # noqa: ARG005
+    # apply_to_vacancy не должен зваться при провайдере None/AI на уровне wiring,
+    # но подменяем на всякий случай — ранжирование тестируем через spy.
+    monkeypatch.setattr(
+        _common,
+        "apply_to_vacancy",
+        lambda *a, **k: _StubResult(),  # noqa: ARG005
+    )
+
+    real_rank = _common.rank_candidates
+
+    def _spy_rank(candidates, filters, resume, scoring_provider=None, **kwargs):  # noqa: ARG001
+        captured["scoring_provider"] = scoring_provider
+        captured["llm_shortlist"] = kwargs.get("llm_shortlist")
+        return real_rank(candidates, filters, resume, scoring_provider=scoring_provider)
+
+    monkeypatch.setattr(_common, "rank_candidates", _spy_rank)
+
+
+class _StubResult:
+    success = False
+    reason = "stub"
+    letter_variant = None
+
+
+def test_run_apply_passes_llm_provider_when_ai_on(tmp_path, monkeypatch):
+    """AI включён → rank_candidates получает LLMScoringProvider + llm_shortlist=10."""
+    from hhru_bot.scoring import LLMScoringProvider
+
+    class _FakeLLM:
+        def __init__(self, cfg):  # noqa: ANN001, ARG002
+            pass
+
+        def chat(self, messages, **params):  # noqa: ANN001, ARG002
+            from hhru_bot.ai.types import NormalizedResponse
+
+            return NormalizedResponse(
+                content='{"score": 80, "rationale": "ok", "factors": {}}',
+                tool_calls=None,
+                finish_reason="stop",
+            )
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: _FakeLLM(cfg))
+
+    captured: dict = {}
+    _stub_apply_cycle(monkeypatch, captured)
+
+    config = _config_with_ai(tmp_path, _resume_with_profile())
+    history = _make_history(tmp_path)
+    throttle = _make_throttle(config, history)
+
+    _common.run_apply_for_resume(
+        object(), config, _resume_with_profile(), history, throttle, _apply_args()
+    )
+
+    assert isinstance(captured["scoring_provider"], LLMScoringProvider)
+    assert captured["llm_shortlist"] == 10
+
+
+def test_run_apply_passes_none_when_ai_off(tmp_path, monkeypatch):
+    """AI выключен → rank_candidates получает None (эвристика #15, совместимость)."""
+    captured: dict = {}
+    _stub_apply_cycle(monkeypatch, captured)
+
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[_resume_without_profile()],
+        ai=None,
+    )
+    history = _make_history(tmp_path)
+    throttle = _make_throttle(config, history)
+
+    _common.run_apply_for_resume(
+        object(), config, _resume_without_profile(), history, throttle, _apply_args()
+    )
+
+    assert captured["scoring_provider"] is None
+
+
+def test_run_apply_passes_none_on_import_error(tmp_path, monkeypatch):
+    """openai не установлен → LLMClient поднимает ImportError → провайдер None.
+
+    Сценарий: LLMClient(ai_config) тянет openai при construction (lazy-импорт
+    внутри модуля). Если openai нет — ImportError. _build_scoring_provider ловит
+    его и откатывается на None (эвристику), как _build_letter_provider (#17).
+    """
+
+    def _raise_import_error(cfg):  # noqa: ANN001, ARG001
+        raise ImportError("No module named 'openai'")
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", _raise_import_error)
+
+    captured: dict = {}
+    _stub_apply_cycle(monkeypatch, captured)
+
+    config = _config_with_ai(tmp_path, _resume_with_profile())
+    history = _make_history(tmp_path)
+    throttle = _make_throttle(config, history)
+
+    _common.run_apply_for_resume(
+        object(), config, _resume_with_profile(), history, throttle, _apply_args()
+    )
+
+    assert captured["scoring_provider"] is None
+
+
+def _make_history(tmp_path):
+    from hhru_bot.history import History
+
+    return History(tmp_path / "history.db")
+
+
+def _make_throttle(config, history):
+    from hhru_bot.throttle import Throttle
+
+    return Throttle(config.throttle, history)

--- a/tests/test_scoring_ml.py
+++ b/tests/test_scoring_ml.py
@@ -459,3 +459,98 @@ class _FlakyThenOKLLM:
         if self._n <= self._fails:
             raise self._fail
         return NormalizedResponse(content=self._ok, tool_calls=None, finish_reason="stop")
+
+
+# --- rank_candidates: shortlist при нейтральных весах (регрессия #81) -------
+#
+# Codex-ревью #81: при ai+ai_profile БЕЗ scoring-секции предранжирование шло по
+# _ZERO_WEIGHTS → все кандидаты tie → llm_shortlist брал первые K по входному
+# порядку, а реально релевантные (LLM дал бы им высокий score) за пределами K
+# никогда не displac'нулись. Фикс: AI-путь без scoring-секции использует дефолтные
+# ScoringWeights() для предранжирования → top-K действительно лучшие.
+
+
+class _RelevanceLLM:
+    """Мок LLM: высокий score карточкам, чей title содержит ``high_kw``."""
+
+    def __init__(self, high_kw: str):
+        self._kw = high_kw
+        self.calls: list[VacancyCard] = []
+
+    def chat(self, messages, **params):  # noqa: ARG002
+        # messages[1] (user) содержит title вакансии (см. _build_scoring_prompt).
+        text = " ".join(m.get("content", "") for m in messages)
+        score = 95.0 if self._kw in text else 20.0
+        content = f'{{"score": {int(score)}, "rationale": "r", "factors": {{}}}}'
+        return NormalizedResponse(content=content, tool_calls=None, finish_reason="stop")
+
+
+def _resume_no_scoring() -> object:
+    """ResumeConfig без scoring-секции (legacy AI-конфиг: ai+ai_profile, без scoring)."""
+    from hhru_bot.config import ResumeConfig
+    from hhru_bot.config_sections.ai_profile import AIProfile
+
+    return ResumeConfig(
+        id="py",
+        resume_url="https://hh.ru/resume/X",
+        search=SearchFilters(text="python", must_have=["django"]),
+        ai_profile=AIProfile(summary="Бэкенд", skills=["python"], desired_role="Dev"),
+    )
+
+
+def test_rank_candidates_shortlist_picks_relevant_beyond_first_k():
+    """AI-путь без scoring: релевантные карточки вне первых-10 displac'нут топ.
+
+    12 карточек: первые 10 (id 0-9) нерелевантные (title без 'django'), последние
+    2 (id 10,11) — релевантные ('django' в title, в конце входного порядка).
+    Без фикса: llm_shortlist=10 берёт id 0-9 по входу → LLM их и скорит, id 10,11
+    остаются с эвристическим score и никогда не displac'нут топ. С фиксом:
+    дефолтные веса предранжируют 'django'-карточки вверх → они в shortlist → LLM
+    даёт им 95 → они в начале ranked[:limit].
+    """
+    from hhru_bot.search import rank_candidates
+
+    cards = [card(vacancy_id=str(i), title="Python role no kw") for i in range(10)] + [
+        card(vacancy_id="10", title="Python django lead"),
+        card(vacancy_id="11", title="django backend"),
+    ]
+
+    llm = _RelevanceLLM(high_kw="django")
+    provider = LLMScoringProvider(llm_client=llm, fallback=heuristic_provider())
+
+    ranked = rank_candidates(
+        cards,
+        SearchFilters(text="python", must_have=["django"]),
+        _resume_no_scoring(),
+        scoring_provider=provider,
+        llm_shortlist=10,
+    )
+    top_ids = [c.vacancy_id for c, _, _ in ranked]
+
+    # Релевантные id 10,11 должны возглавить ранжирование (LLM-score 95 > 20).
+    assert top_ids[:2] == ["10", "11"] or set(top_ids[:2]) == {"10", "11"}, top_ids
+
+
+def test_rank_candidates_no_provider_keeps_legacy_zero_weights():
+    """Без provider (legacy) weights остаются _ZERO_WEIGHTS — входной порядок.
+
+    Регресс-страховка фикса #81: AI-путь меняет веса только когда provider передан.
+    Без provider поведение legacy не меняется (candidates[:limit] по входу).
+    """
+    from hhru_bot.search import rank_candidates
+
+    cards = [card(vacancy_id=str(i), title="Python django lead") for i in range(5)] + [
+        card(vacancy_id="9", title="nope")
+    ]
+
+    ranked = rank_candidates(
+        cards,
+        SearchFilters(text="python", must_have=["django"]),
+        _resume_no_scoring(),
+        scoring_provider=None,
+        llm_shortlist=10,
+    )
+    top_ids = [c.vacancy_id for c, _, _ in ranked]
+
+    # Все score 0.0 (zero weights) → стабильный входной порядок сохранён.
+    assert top_ids == ["0", "1", "2", "3", "4", "9"]


### PR DESCRIPTION
Follow-up #74/#77 (F1 adversarial-review, by-design wiring-out): ML-скоринг
**активирован** в боевом apply-цикле. До этого `rank_candidates` звался без
`scoring_provider` → всегда чистая эвристика #15, LLM-скоринг и tier-буст
работодателя не влияли на ранжирование.

## Что сделано

Минимальный wiring — зеркало `_build_letter_provider` (#17):

- **`_common._build_scoring_provider(config, resume)`**: `ai` + `ai_profile` →
  `LLMClient` + `HeuristicScoringProvider` (fallback: эвристика #15 + tier-буст
  #74) + `LLMScoringProvider`; `ImportError` openai → `None` + warning (как
  letter_provider); без `ai`/`ai_profile` → `None` (обратная совместимость).
- **`run_apply_for_resume`**: `scoring_provider = _build_scoring_provider(...)`,
  передаётся в `rank_candidates(..., scoring_provider=scoring_provider,
  llm_shortlist=_LLM_SHORTLIST_DEFAULT)`. `llm_shortlist=10` **обязателен** —
  предранжирование эвристикой, LLM только по топ-10, иначе десятки синхронных
  запросов (анти-фрод hh.ru, F3).
- `weights` для `HeuristicScoringProvider` согласован с `rank_candidates`
  (`_ZERO_WEIGHTS` при отсутствии scoring-секции) — шкала fallback на той же
  [0,100] нормализации (F2).

Отдельный `LLMClient` (не из `_build_letter_provider`) — намеренно, ради
простоты и независимости циклов (см. замечание по дизайну в #81).

## Тесты

`tests/test_apply_scoring_integration.py` (без браузера, по образцу
`test_probe_letter_integration.py`):
- AI вкл → `rank_candidates` получает `LLMScoringProvider` + `llm_shortlist=10`;
- AI выкл → `None` (эвристика #15, обратная совместимость);
- `ImportError` openai → `None`.

## Проверки

- ruff check: passed
- ruff format --check: passed
- pytest: passed (полный набор, без эмодзи)

Closes #81