### PR TITLE
feat(letter): рандомизация шаблонов {a|b|c} (#86)

### DIFF
--- a/src/hhru_bot/ai/letters.py
+++ b/src/hhru_bot/ai/letters.py
@@ -30,6 +30,7 @@ from ..apply.letter import (
     CoverLetterProvider,
     LetterOutcome,
     _format_template,
+    _resolve_alternatives,
 )
 from ..search import VacancyCard
 
@@ -109,6 +110,10 @@ def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[
     vacancy-description) требует доп. захода на страницу (троттлинг) и живёт в
     Этапе 4; здесь v1 обходимся карточкой, чтобы не плодить лишних запросов к
     hh.ru (анти-фрод: меньше запросов — ниже риск детекта).
+
+    #86: поля профиля (summary/skills/highlights/desired_role) могут содержать
+    альтернативы {a|b|c} — рандомизируем их (_resolve_alternatives), чтобы
+    промпт (и, значит, генерируемое письмо) варьировался между запусками.
     """
     system = (
         "Ты помогаешь писать короткие сопроводительные письма для отклика на "
@@ -118,14 +123,19 @@ def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[
 
     lines = [f"Вакансия: {vacancy.title}.", f"Компания: {vacancy.company or 'не указана'}."]
     if profile is not None:
-        if profile.summary:
-            lines.append(f"О кандидате: {profile.summary}.")
-        if profile.skills:
-            lines.append("Ключевые навыки: " + ", ".join(profile.skills) + ".")
-        if profile.highlights:
-            lines.append("Достижения: " + "; ".join(profile.highlights) + ".")
-        if profile.desired_role:
-            lines.append(f"Желаемая роль: {profile.desired_role}.")
+        # Рандомизация {a|b|c} в каждом поле профиля — до подстановки в промпт.
+        summary = _resolve_alternatives(profile.summary)
+        skills = [_resolve_alternatives(s) for s in profile.skills]
+        highlights = [_resolve_alternatives(h) for h in profile.highlights]
+        desired_role = _resolve_alternatives(profile.desired_role)
+        if summary:
+            lines.append(f"О кандидате: {summary}.")
+        if skills:
+            lines.append("Ключевые навыки: " + ", ".join(skills) + ".")
+        if highlights:
+            lines.append("Достижения: " + "; ".join(highlights) + ".")
+        if desired_role:
+            lines.append(f"Желаемая роль: {desired_role}.")
         if profile.tone == "friendly":
             lines.append("Тон: дружелюбный, но профессиональный.")
         else:

--- a/src/hhru_bot/apply/letter.py
+++ b/src/hhru_bot/apply/letter.py
@@ -14,10 +14,19 @@ apply.py НЕ знает, статичный провайдер или LLM: ед
 LetterOutcome.variant — A/B-признак для истории (actions.letter_variant):
 'template' (статичный шаблон) / 'ai' (LLM-генерация) / 'ai_fallback' (LLM не
 сработал, откатились на шаблон).
+
+#86: рандомизация альтернатив ``{a|b|c}`` → ``random.choice`` (``_resolve_
+alternatives``). Применяется в ``_format_template`` ДО плейсхолдеров — значит,
+работает сразу для статичного шаблона, для AI-fallback-шаблона (тоже через
+``_format_template``) и для AI-промпта (``ai/letters._build_prompt`` применяет
+``_resolve_alternatives`` к полям профиля). Одиночный плейсхолдер ``{vacancy_
+title}`` без ``|`` не матчится и остаётся для ``.format``.
 """
 
 from __future__ import annotations
 
+import random
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -79,8 +88,29 @@ class TemplateCoverLetterProvider:
         )
 
 
+# Рандомизация альтернатив {a|b|c} (#86): матчит {вариант1|вариант2|...} —
+# обязателен хотя бы один '|', альтернативы могут быть пустыми ({a||c} → иногда
+# пусто). Внутри группы не допускаются фигурные скобки (вложенность не нужна).
+# Одиночный плейсхолдер {vacancy_title} (без '|') не матчится — остаётся для .format.
+_ALTERNATIVES_RE = re.compile(r"\{([^{}]*\|[^{}]*)\}")
+
+
+def _resolve_alternatives(text: str) -> str:
+    """Заменяет каждую группу ``{a|b|c}`` на один случайный вариант (random.choice).
+
+    Применяется ДО плейсхолдеров ``{vacancy_title}``/``{company_name}``: так
+    одиночный плейсхолдер (без ``|``) не матчится этим регекспом и доходит до
+    ``.format`` нетронутым. Снижает шаблонность писём — анти-фрод + AI-детекторы
+    (HIGH-идея №2 из #84, паттерн s3rgeym ``rand_text()``). random без seed:
+    каждый рендер — разный вывод.
+    """
+    return _ALTERNATIVES_RE.sub(lambda m: random.choice(m.group(1).split("|")), text)
+
+
 def _format_template(template: str, vacancy: VacancyCard) -> str:
-    return template.format(vacancy_title=vacancy.title, company_name=vacancy.company)
+    return _resolve_alternatives(template).format(
+        vacancy_title=vacancy.title, company_name=vacancy.company
+    )
 
 
 def render_cover_letter(

--- a/tests/test_letter_randomize.py
+++ b/tests/test_letter_randomize.py
@@ -1,0 +1,164 @@
+"""Рандомизация шаблонов писём {a|b|c} (#86).
+
+Синтаксис ``{вариант1|вариант2|вариант3}`` → при каждом рендере один случайный
+вариант (``random.choice``). Применяется ДО плейсхолдеров ``{vacancy_title}``/
+``{company_name}``, чтобы они не путались с альтернативами (одиночный плейсхолдер
+без ``|`` не матчится и остаётся как есть — обратная совместимость).
+
+ТДД-контракты #86:
+  - ``{a|b|c}`` → ровно один из вариантов a/b/c.
+  - ``{vacancy_title}`` без ``|`` НЕ трогается (регресс плейсхолдеров).
+  - ``{Привет|Здравствуйте}`` + ``{vacancy_title}`` вместе — приветствие
+    подставлено, title подставлен.
+  - Пустая альтернатива (``{a||c}``) → один из вариантов, включая пустую строку.
+  - Работает и для AI-fallback (через тот же шаблон), и для AI-промпта
+    (если в AI-profile-поле есть ``{a|b|c}``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hhru_bot.ai.types import NormalizedResponse
+from hhru_bot.apply.letter import (
+    TemplateCoverLetterProvider,
+    _format_template,
+    render_cover_letter,
+)
+from hhru_bot.search import VacancyCard
+
+_GREETINGS = ["Привет", "Здравствуйте", "Добрый день"]
+
+
+def _card(title: str = "Dev", company: str = "Acme") -> VacancyCard:
+    return VacancyCard(vacancy_id="1", title=title, company=company, url="https://hh.ru/vacancy/1")
+
+
+# --- ядро рандомизации ---
+
+
+@pytest.mark.parametrize("choice_index", [0, 1, 2])
+def test_alternatives_pick_one_of_options(choice_index):
+    # Зафиксированный выбор → точно предсказуемый вариант из трёх.
+    template = "{Привет|Здравствуйте|Добрый день}!"
+    picked = _GREETINGS[choice_index]
+    with patch("hhru_bot.apply.letter.random.choice", return_value=picked):
+        assert _format_template(template, _card()) == f"{picked}!"
+
+
+def test_alternatives_eventually_yield_different_results():
+    # Без фикстуры — за много рендеров должны встретиться все варианты (random,
+    # но на 60 попытках по 3 вариантам это надёжно). Это и есть «разный вывод».
+    template = "{a|b|c}"
+    seen = {_format_template(template, _card()) for _ in range(60)}
+    assert seen == {"a", "b", "c"}
+
+
+def test_placeholder_without_pipe_is_not_randomized():
+    # {vacancy_title} без | — регресс плейсхолдера, не альтернатива.
+    rendered = _format_template("Вакансия: {vacancy_title}", _card("Python Dev", "Acme"))
+    assert rendered == "Вакансия: Python Dev"
+
+
+def test_alternatives_combined_with_placeholder():
+    # {Привет|Здравствуйте}, меня заинтересовала {vacancy_title}
+    template = "{Привет|Здравствуйте}, меня заинтересовала {vacancy_title}"
+    with patch("hhru_bot.apply.letter.random.choice", return_value="Здравствуйте"):
+        rendered = _format_template(template, _card("Python Dev", "Acme"))
+    assert rendered == "Здравствуйте, меня заинтересовала Python Dev"
+
+
+def test_two_alternative_groups_both_resolved():
+    template = "{Привет|Здравствуйте}! Пишу по {вакансии|позиции} {vacancy_title}"
+    with patch("hhru_bot.apply.letter.random.choice", side_effect=["Привет", "позиции"]):
+        rendered = _format_template(template, _card("Dev", "Acme"))
+    assert rendered == "Привет! Пишу по позиции Dev"
+
+
+def test_empty_alternative_is_allowed():
+    # {a||c} — средняя пустая альтернатива валидна, может выпасть пустая строка.
+    with patch("hhru_bot.apply.letter.random.choice", return_value=""):
+        assert _format_template("X{a||c}Y", _card()) == "XY"
+
+
+def test_single_option_inside_braces_not_matched():
+    # {vacancy_title} — единственный «вариант» без |, не матчится как альтернатива,
+    # random.choice не вызывается.
+    with patch("hhru_bot.apply.letter.random.choice") as mock_choice:
+        rendered = _format_template("Привет, {company_name}", _card("Dev", "Acme"))
+    assert rendered == "Привет, Acme"
+    mock_choice.assert_not_called()
+
+
+# --- публичный API: render_cover_letter и TemplateCoverLetterProvider ---
+
+
+def test_render_cover_letter_randomizes_alternatives():
+    template = "{Привет|Здравствуйте}, {company_name}!"
+    with patch("hhru_bot.apply.letter.random.choice", return_value="Здравствуйте"):
+        assert render_cover_letter(template, _card("Dev", "Acme")) == "Здравствуйте, Acme!"
+
+
+def test_template_provider_randomizes_alternatives():
+    provider = TemplateCoverLetterProvider("{Привет|Здравствуйте} {vacancy_title}")
+    with patch("hhru_bot.apply.letter.random.choice", return_value="Привет"):
+        outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.text == "Привет Dev"
+    assert outcome.variant == "template"
+
+
+# --- AI: рандомизация в fallback-шаблоне и в промпте из AI-profile ---
+
+
+class _FailingLLM:
+    """Мок LLMClient, бросающий при chat (сбой AI → fallback на шаблон)."""
+
+    def chat(self, messages, **params):  # noqa: ARG002
+        raise ConnectionError("LLM недоступен")
+
+
+class _CapturingLLM:
+    """Мок LLMClient: запоминает user-сообщение промпта, возвращает непустой контент."""
+
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def chat(self, messages, **params):  # noqa: ARG002
+        self.prompts.append(messages[1]["content"])
+        return NormalizedResponse(content="AI письмо", tool_calls=None, finish_reason="stop")
+
+
+def test_ai_fallback_template_is_randomized():
+    from hhru_bot.ai.letters import AICoverLetterProvider
+
+    provider = AICoverLetterProvider(
+        llm_client=_FailingLLM(),
+        resume_profile=None,
+        fallback_template="{Привет|Здравствуйте}, {company_name}!",
+    )
+    with patch("hhru_bot.apply.letter.random.choice", return_value="Здравствуйте"):
+        outcome = provider.render(_card("Dev", "Acme"), resume_profile=None)
+    assert outcome.variant == "ai_fallback"
+    assert outcome.text == "Здравствуйте, Acme!"
+
+
+def test_ai_prompt_randomizes_alternatives_from_profile_summary():
+    # Если в AI-profile.summary есть {a|b|c}, рандомизация применяется и к
+    # тексту, который уходит в промпт (п.3 ишью: работает и для AI-промпта).
+    from hhru_bot.ai.letters import AICoverLetterProvider
+    from hhru_bot.config_sections.ai_profile import AIProfile
+
+    llm = _CapturingLLM()
+    profile = AIProfile(summary="{Опытный|Сеньорный} бэкенд-разработчик", skills=["python"])
+    provider = AICoverLetterProvider(llm_client=llm, resume_profile=profile)
+
+    with patch("hhru_bot.apply.letter.random.choice", return_value="Сеньорный"):
+        provider.render(_card("Dev", "Acme"), resume_profile=None)
+
+    assert llm.prompts, "промпт не был собран"
+    prompt = llm.prompts[0]
+    assert "Сеньорный бэкенд-разработчик" in prompt
+    # Ни одной неразрешённой альтернативы в промпте не осталось.
+    assert "{" not in prompt and "|" not in prompt

--- a/tests/test_letter_randomize.py
+++ b/tests/test_letter_randomize.py
@@ -83,6 +83,20 @@ def test_empty_alternative_is_allowed():
         assert _format_template("X{a||c}Y", _card()) == "XY"
 
 
+def test_braces_inside_alternative_do_not_match():
+    # Класс [^{}] запрещает {/} внутри группы альтернатив. Поэтому {a|{x}}
+    # (вложенность) внешней группой НЕ матчится — random.choice не вызывается и
+    # текст возвращается _resolve_alternatives нетронутым. Этот инвариант
+    # критичен: он гарантирует, что выбранная альтернатива никогда не содержит
+    # {x}, а значит последующий .format(...) не получит KeyError от случайной
+    # скобки внутри варианта (внутри валидной {a|b} группы скобок быть не может).
+    from hhru_bot.apply.letter import _resolve_alternatives
+
+    with patch("hhru_bot.apply.letter.random.choice") as mock_choice:
+        assert _resolve_alternatives("pre {a|{x}} post") == "pre {a|{x}} post"
+    mock_choice.assert_not_called()
+
+
 def test_single_option_inside_braces_not_matched():
     # {vacancy_title} — единственный «вариант» без |, не матчится как альтернатива,
     # random.choice не вызывается.


### PR DESCRIPTION
## Что

Рандомизация шаблонов сопроводительных писём: `{вариант1|вариант2|вариант3}` → `random.choice` при каждом рендере. Снижает шаблонность писём — анти-фрод hh.ru + AI-детекторы (HIGH-идея №2 из #84, паттерн s3rgeym `rand_text()`).

## Как

Ядро — `_resolve_alternatives` в `apply/letter.py` (регексп `\{([^{}]*\|[^{}]*)\}` → `random.choice(split('|'))`), применяется в `_format_template` **до** плейсхолдеров `{vacancy_title}`/`{company_name}`. Поэтому одиночный плейсхолдер без `|` не матчится и доходит до `.format` нетронутым — полная обратная совместимость.

Одна точка `_format_template` покрывает сразу три сценария:
- статичный шаблон (`TemplateCoverLetterProvider` / `render_cover_letter`)
- AI-fallback-шаблон (`AICoverLetterProvider._fallback`)
- AI-промпт: `_build_prompt` применяет `_resolve_alternatives` к полям профиля (`summary`/`skills`/`highlights`/`desired_role`) — п.3 ишью

Регексп требует минимум один `|`; альтернативы могут быть пустыми (`{a||c}` → иногда пусто). Вложенность `{..{..}..}` не поддерживается (не нужна).

## Критерии готовности #86
- [x] `"{Привет|Здравствуйте|Добрый день}, меня заинтересовала {vacancy_title}"` → приветствие + реальный title
- [x] `{vacancy_title}`/`{company_name}` работают как раньше (регресс)
- [x] Ноль эмодзи
- [x] ruff + pytest зелёные
- [x] gen_cli_docs без изменений (новая команда не добавлялась)
- [x] Зона `apply/letter.py` (+ `ai/letters.py` для промпта per п.3); `search.py`/`history.py`/`scoring.py`/`commands/search.py` не тронуты

## Тесты
- 13 новых в `tests/test_letter_randomize.py` (ТДД): фиксированный выбор через `mock random.choice` + статистический «все варианты за 60 попыток», пустая альтернатива, комбинация с плейсхолдером, AI-fallback и AI-промпт.
- Регресс: **522 pytest** зелёные, `ruff check` + `ruff format --check` чисты.

## Риски / follow-up
- `random` без seed — каждый рендер разный (намеренно, см. ишью).
- Если в шаблоне окажется литерал `{текст с |}`, не задуманный как альтернатива, он разрешится как alternatives-group. Для писём маловероятно; не регрессия (старый `.format` тоже падал бы на нестандартных `{}`).

Closes #86