### PR TITLE
feat(scoring): эвристический pre-LLM фильтр работодателя (#85)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -111,7 +111,13 @@ def run_apply_for_resume(
         return
 
     cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
-    candidates, skipped = filter_candidates(cards, resume.search, resume.resume_id, history)
+    # pre-LLM фильтр работодателя (#85): пороги из опц. секции scoring.prefilter.
+    # resume.scoring=None / prefilter=None / enabled=False → фильтр откл. (no-op
+    # внутри filter_candidates), обратная совместимость.
+    prefilter = getattr(getattr(resume, "scoring", None), "prefilter", None)
+    candidates, skipped = filter_candidates(
+        cards, resume.search, resume.resume_id, history, prefilter
+    )
 
     for card, reason in skipped:
         logger.debug("Пропуск вакансии %s: %s", card.title, reason)

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -98,7 +98,11 @@ def run(args: argparse.Namespace) -> None:
             # #66: запись собранных карточек в рынок (побочный эффект сбора) —
             # между search_vacancies и filter_candidates, не трогая отбор/скоринг.
             _record_seen(cards, resume.search.text, history)
-            candidates, skipped = filter_candidates(cards, resume.search, resume.resume_id, history)
+            # pre-LLM фильтр работодателя (#85): пороги из опц. scoring.prefilter.
+            prefilter = getattr(getattr(resume, "scoring", None), "prefilter", None)
+            candidates, skipped = filter_candidates(
+                cards, resume.search, resume.resume_id, history, prefilter
+            )
             ranked = rank_candidates(candidates, resume.search, resume)
 
             print(

--- a/src/hhru_bot/config_sections/scoring.py
+++ b/src/hhru_bot/config_sections/scoring.py
@@ -3,6 +3,13 @@
 Веса факторов ранжирования вакансий. Секция опциональна: при отсутствии
 load_config оставит ResumeConfig.scoring = None (обратная совместимость —
 rank_candidates тогда использует нейтральные дефолтные веса).
+
+Расширено issue #85: подсекция ``prefilter`` — пороги эвристического
+pre-LLM фильтра работодателя (отсев мусора ДО LLM-скоринга, 0 токенов).
+``prefilter`` опционален и по умолчанию ОТКЛЮЧЕН (полная обратная
+совместимость: без секции pre-фильтр не применяется — поведение не меняется).
+Включается флагом ``enabled: true``; пороги rating_min/reviews_min — мягкие
+дефолты, перевешиваемые конфигом (см. PrefilterConfig).
 """
 
 from __future__ import annotations
@@ -23,9 +30,36 @@ class ScoringWeights:
     text_match: float = 1.0
 
 
+# Дефолтные пороги pre-LLM фильтра работодателя (#85). Мягкие: отсекают только
+# «слепые отклики в пустоту» (неизвестная компания без рейтинга/отзывов и без
+# былого взаимодействия), не трогая всё, что выше. Десятки отзывов на hh.ru —
+# уже заметный работодатель; рейтинг 3.5 — средний+ (из 5), ниже — рискованно.
+_PREFILTER_DEFAULT_RATING_MIN = 3.5
+_PREFILTER_DEFAULT_REVIEWS_MIN = 10
+
+
+@dataclass(frozen=True)
+class PrefilterConfig:
+    """Пороги эвристического pre-LLM фильтра работодателя (#85).
+
+    ``enabled`` — флаг включения фильтра (по умолчанию False: opt-in, обратная
+    совместимость). ``rating_min`` — минимальный рейтинг (0-5) работодателя,
+    чтобы пройти фильтр «по рейтингу». ``reviews_min`` — минимальное число
+    отзывов. Карточка проходит pre-фильтр, если выполняется ЛЮБОЕ из: известная
+    компания (top_tech/big_corp), trusted-бейдж, rating>=rating_min,
+    reviews_count>=reviews_min, работодатель раньше приглашал/смотрел
+    (history.employer_interacted). Иначе отсекается как «low employer signal».
+    """
+
+    enabled: bool = False
+    rating_min: float = _PREFILTER_DEFAULT_RATING_MIN
+    reviews_min: int = _PREFILTER_DEFAULT_REVIEWS_MIN
+
+
 @dataclass(frozen=True)
 class ScoringConfig:
     weights: ScoringWeights = ScoringWeights()
+    prefilter: PrefilterConfig | None = None
 
 
 def _parse_weights(raw, context: str) -> ScoringWeights:
@@ -53,6 +87,38 @@ def _parse_weights(raw, context: str) -> ScoringWeights:
     return ScoringWeights(**weights)
 
 
+def _parse_prefilter(raw, context: str) -> PrefilterConfig | None:
+    """raw — подсекция prefilter (может быть None/отсутствовать → None).
+
+    None/пусто → фильтр отключен (обратная совместимость). ``enabled: true``
+    включает фильтр; пороги опциональны с мягкими дефолтами PrefilterConfig.
+    """
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением")
+
+    enabled = bool(raw.get("enabled", False))
+
+    rating_min = raw.get("rating_min", _PREFILTER_DEFAULT_RATING_MIN)
+    try:
+        rating_min = float(rating_min)
+    except (TypeError, ValueError) as e:
+        raise ConfigError(
+            f"Порог 'rating_min' в '{context}' должен быть числом, получено: {rating_min!r}"
+        ) from e
+
+    reviews_min = raw.get("reviews_min", _PREFILTER_DEFAULT_REVIEWS_MIN)
+    try:
+        reviews_min = int(reviews_min)
+    except (TypeError, ValueError) as e:
+        raise ConfigError(
+            f"Порог 'reviews_min' в '{context}' должен быть целым числом, получено: {reviews_min!r}"
+        ) from e
+
+    return PrefilterConfig(enabled=enabled, rating_min=rating_min, reviews_min=reviews_min)
+
+
 @register("scoring")
 def parse_scoring(raw, context: str) -> ScoringConfig | None:
     """raw — подсекция scoring (может быть None/отсутствовать)."""
@@ -60,4 +126,7 @@ def parse_scoring(raw, context: str) -> ScoringConfig | None:
         return None
     if not isinstance(raw, dict):
         raise ConfigError(f"Секция '{context}' должна быть отображением")
-    return ScoringConfig(weights=_parse_weights(raw.get("weights"), f"{context}.weights"))
+    return ScoringConfig(
+        weights=_parse_weights(raw.get("weights"), f"{context}.weights"),
+        prefilter=_parse_prefilter(raw.get("prefilter"), f"{context}.prefilter"),
+    )

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -650,6 +650,74 @@ class History:
             ).fetchall()
         return [dict(row) for row in rows]
 
+    # --- Pre-LLM фильтр работодателя (#85) -----------------------------------
+    # Новый метод в конец файла (паттерн with self._connect(), существующие
+    # не трогаем). employer_interacted — позитивный сигнал для эвристического
+    # pre-фильтра: работодатель УЖЕ проявлял интерес (приглашал/смотрел резюме),
+    # значит отклик по новой вакансии от него — высокая конверсия, не отсекаем.
+    # Источник — responses (#12, account-scope) + manual_offers (#13), JOIN по
+    # vacancy_id (точный матч) и/или employer (имя компании, account-scope).
+
+    def employer_interacted(
+        self,
+        vacancy_id: str | None = None,
+        employer: str | None = None,
+        resume_id: str | None = None,
+    ) -> bool:
+        """Был ли ранее интерес работодателя (приглашение/просмотр) — сигнал pre-фильтра (#85).
+
+        Account-scope (как responses #12): НЕ требует resume_id. Проверяет по
+        ``vacancy_id`` (точный матч — работодатель отвечал по ЭТОЙ вакансии) И/ИЛИ
+        по ``employer`` (имя компании — работодатель когда-то отвечал по ЛЮБОЙ из
+        своих вакансий). resume_id опционален и сужает manual_offers до резюме
+        (responses и так account-scope, resume_id в их ключ не входит — #12).
+
+        «Взаимодействие» = есть responses-строка с активным статусом работодателя
+        (read/response/invitation/discard/offer — любой ответ = резюме видели) ИЛИ
+        липкая ручная пометка оффера в manual_offers. Чистые вакансии без ответа
+        (нет строки в responses) → False. Возвращает True при первом совпадении.
+        """
+        if vacancy_id is None and employer is None:
+            return False
+
+        clauses = []
+        params: list = []
+        # responses: активный статус работодателя (любой ответ). read включаем —
+        # работодатель ПОСМОТРЕЛ резюме, это валидный сигнал интереса.
+        clauses.append("status IN ('read', 'response', 'invitation', 'discard', 'offer')")
+        if vacancy_id is not None:
+            clauses.append("vacancy_id = ?")
+            params.append(vacancy_id)
+        if employer is not None:
+            clauses.append("employer = ?")
+            params.append(employer)
+        responses_where = " AND ".join(clauses)
+
+        with self._connect() as conn:
+            row = conn.execute(
+                f"SELECT 1 FROM responses WHERE {responses_where} LIMIT 1",
+                params,
+            ).fetchone()
+            if row is not None:
+                return True
+
+            # manual_offers: липкая ручная пометка оффера. resume_id обязателен в
+            # таблице, но здесь опционален — без него учитываем все пометки.
+            offer_clauses = []
+            offer_params: list = []
+            if vacancy_id is not None:
+                offer_clauses.append("vacancy_id = ?")
+                offer_params.append(vacancy_id)
+            if resume_id is not None:
+                offer_clauses.append("resume_id = ?")
+                offer_params.append(resume_id)
+            offer_where = (" WHERE " + " AND ".join(offer_clauses)) if offer_clauses else ""
+            row = conn.execute(
+                f"SELECT 1 FROM manual_offers{offer_where} LIMIT 1",
+                offer_params,
+            ).fetchone()
+            return row is not None
+
     def market_salary_by_query(self) -> list[dict]:
         """Медиана зарплаты по поисковому запросу — сравнение сфер по доходу.
 

--- a/src/hhru_bot/scoring.py
+++ b/src/hhru_bot/scoring.py
@@ -312,6 +312,82 @@ class ScoringProvider(Protocol):
     ) -> ScoreOutcome: ...
 
 
+# --- эвристический pre-LLM фильтр работодателя (#85) -------------------------
+#
+# Отсекает «слепые отклики в пустоту» ДО LLM-скоринга (#74) — бесплатно, без
+# токенов. Чистая функция (тестируется без браузера). Решение: известная компания
+# (top_tech/big_corp), trusted-бейдж, рейтинг/отзывы выше порога ИЛИ работодатель
+# раньше приглашал/смотрел резюме → ОСТАВЛЯЕМ; неизвестная компания без всего →
+# отсекаем как «low employer signal». Пороги — PrefilterConfig (#85), opt-in:
+# по умолчанию фильтр ОТКЛЮЧЕН (обратная совместимость — без конфига ничего не
+# меняется). Переиспользует classify_employer/EmployerInfo (#74).
+
+# Причина отсева в filter_candidates (как «стоп-слово»/«уже откликались»).
+# Строго без эмодзи (CLI-принцип). Префикс [skip] добавляет вызывающая сторона.
+PREFILTER_SKIP_REASON = "low employer signal (no tier/rating/reviews/interaction)"
+
+
+def employer_passes_prefilter(card, history, resume_id, thresholds) -> tuple[bool, str]:
+    """Эвристический pre-LLM фильтр: стоит ли вообще откликаться (0 токенов, #85).
+
+    Чистая функция. Возвращает ``(passes, reason)``: reason пустой, если карточка
+    проходит; иначе — PREFILTER_SKIP_REASON (для лога filter_candidates). Вызывается
+    в ``filter_candidates`` ПОСЛЕ дедупликации/стоп-листов и ДО ``rank_candidates``
+    (который может звать LLM #74) — отсечённые карточки не доходят до LLM.
+
+    Логика (по убыванию силы сигнала): любое срабатывание → проходит; только
+    отсутствие ВСЕХ сигналов → отсев:
+      1. thresholds is None / not thresholds.enabled → проходит (фильтр отключен,
+         обратная совместимость). history=None тоже → проходит (нет данных о
+         взаимодействии — не можем его учесть, безопасно пропустить).
+      2. classify_employer (#74) → top_tech/big_corp: известная компания → проходит.
+         (mid/unknown — НЕ достаточно: mid это слабый буст в скоринге, не «имя».)
+      3. info.trusted (бейдж «надёжный работодатель» hh.ru) → проходит.
+      4. info.rating >= thresholds.rating_min → проходит.
+      5. info.reviews_count >= thresholds.reviews_min → проходит.
+      6. history.employer_interacted(vacancy_id, employer, resume_id) → проходит
+         (работодатель раньше приглашал/смотрел — сильнейший позитивный сигнал).
+      7. Иначе → отсев (PREFILTER_SKIP_REASON).
+
+    ``card.employer_info`` может быть None (hh.ru не отдал блоков) — тогда пункты
+    3-5 пропускаются, и решение опирается на tier по имени + взаимодействие.
+    """
+    # Фильтр отключен (нет конфига / enabled=False) или нет history — не отсекаем.
+    if thresholds is None or not getattr(thresholds, "enabled", False):
+        return True, ""
+    if history is None:
+        return True, ""
+
+    info = getattr(card, "employer_info", None)
+    tier = classify_employer(card.company, info)
+
+    # 2. Известная компания (top_tech/big_corp) — сильный сигнал имени.
+    if tier in (KnownCompanyTier.TOP_TECH, KnownCompanyTier.BIG_CORP):
+        return True, ""
+
+    if info is not None:
+        # 3. Бейдж «надёжный работодатель».
+        if info.trusted:
+            return True, ""
+        # 4. Рейтинг выше порога.
+        if info.rating is not None and info.rating >= thresholds.rating_min:
+            return True, ""
+        # 5. Отзывов выше порога (заметный работодатель).
+        if info.reviews_count is not None and info.reviews_count >= thresholds.reviews_min:
+            return True, ""
+
+    # 6. Работодатель раньше приглашал/смотрел резюме (account-scope #12).
+    if history.employer_interacted(
+        vacancy_id=getattr(card, "vacancy_id", None),
+        employer=card.company or None,
+        resume_id=resume_id,
+    ):
+        return True, ""
+
+    # 7. Никакого сигнала — отсев.
+    return False, PREFILTER_SKIP_REASON
+
+
 # --- эвристический провайдер (обёртка над #15 + tier-буст) -------------------
 #
 # Связывает classify_employer (#74 Этап 2) с эвристикой #15: поверх взвешенной

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -410,11 +410,23 @@ def filter_candidates(
     filters: SearchFilters,
     resume_id: str,
     history,
+    prefilter_thresholds=None,
 ) -> tuple[list[VacancyCard], list[tuple[VacancyCard, str]]]:
     """
     Разделяет карточки на (подходящие, исключённые с причиной).
-    Причины исключения: уже откликались ранее ИЛИ попадание в стоп-лист.
+    Причины исключения: уже откликались ранее, попадание в стоп-лист, ИЛИ
+    (опц.) непрохождение эвристического pre-LLM фильтра работодателя (#85).
+
+    prefilter_thresholds (issue #85): опциональный PrefilterConfig. Если передан
+    и enabled — после дедупа/стоп-листов применяется employer_passes_prefilter
+    (чистая функция из scoring): карточки без сигнала работодателя (неизвестная
+    компания, нет рейтинга/отзывов, не приглашал ранее) отсекаются ДО ранжирования
+    и LLM-скоринга (#74) — экономия токенов. None / enabled=False = фильтр откл.
+    (обратная совместимость, поведение не меняется). Применяется ПОСЛЕ дедупа/
+    стоп-листов: «уже откликались» и стоп-слова — более определённые причины.
     """
+    from .scoring import employer_passes_prefilter  # локальный импорт: цикл search<->scoring
+
     candidates: list[VacancyCard] = []
     skipped: list[tuple[VacancyCard, str]] = []
 
@@ -426,6 +438,15 @@ def filter_candidates(
         reason = _matches_exclusions(card, filters)
         if reason:
             skipped.append((card, reason))
+            continue
+
+        # Pre-LLM фильтр работодателя (#85): отсев «слепых откликов» ДО скоринга.
+        # None/disabled внутри функции = no-op (обратная совместимость).
+        passes, prefilter_reason = employer_passes_prefilter(
+            card, history, resume_id, prefilter_thresholds
+        )
+        if not passes:
+            skipped.append((card, prefilter_reason))
             continue
 
         candidates.append(card)

--- a/tests/test_scoring_prefilter.py
+++ b/tests/test_scoring_prefilter.py
@@ -1,0 +1,356 @@
+"""Тесты эвристического pre-LLM фильтра работодателя (issue #85).
+
+Чистая логика без браузера/LLM. Фильтр отсекает «слепые отклики в пустоту»
+ДО LLM-скоринга (#74) — 0 токенов. Покрывает:
+  - employer_passes_prefilter: disabled→pass (обратная совместимость),
+    top_tech/big_corp→pass, trusted→pass, rating/reviews≥порога→pass,
+    employer_interacted→pass, unknown+ничего→skip.
+  - history.employer_interacted: account-scope JOIN responses/manual_offers по
+    vacancy_id и employer.
+  - parse_scoring: prefilter отсутствует→None (откл.), enabled+пороги, не-число.
+  - filter_candidates: pre-фильтр применяется после дедупа/стоп-листов.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from hhru_bot.config import ConfigError, SearchFilters, load_config
+from hhru_bot.config_sections.scoring import PrefilterConfig, parse_scoring
+from hhru_bot.history import History
+from hhru_bot.scoring import (
+    PREFILTER_SKIP_REASON,
+    EmployerInfo,
+    employer_passes_prefilter,
+)
+from hhru_bot.search import VacancyCard, filter_candidates
+
+# --- хелперы ----------------------------------------------------------------
+
+
+def card(
+    vacancy_id: str = "1",
+    title: str = "Python Developer",
+    company: str = "ООО Ромашка",
+    employer_info: EmployerInfo | None = None,
+) -> VacancyCard:
+    return VacancyCard(
+        vacancy_id=vacancy_id,
+        title=title,
+        company=company,
+        url="https://hh.ru/vacancy/0",
+        employer_info=employer_info,
+    )
+
+
+class FakeHistory:
+    """История с заглушками has_applied и employer_interacted для чистых тестов."""
+
+    def __init__(self, applied: set | None = None, interacted: bool = False):
+        self._applied = applied or set()
+        self._interacted = interacted
+
+    def has_applied(self, resume_id: str, vacancy_id: str) -> bool:
+        return (resume_id, vacancy_id) in self._applied
+
+    def employer_interacted(self, vacancy_id=None, employer=None, resume_id=None) -> bool:
+        return self._interacted
+
+
+THRESHOLDS = PrefilterConfig(enabled=True, rating_min=3.5, reviews_min=10)
+
+
+# --- employer_passes_prefilter: обратная совместимость ----------------------
+
+
+def test_prefilter_disabled_when_thresholds_none():
+    """thresholds=None → фильтр откл., проходит ВСЁ (обратная совместимость)."""
+    passes, reason = employer_passes_prefilter(card(), FakeHistory(), "r1", None)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_disabled_when_not_enabled():
+    """enabled=False (дефолт) → проходит, даже неизвестная компания."""
+    disabled = PrefilterConfig(enabled=False)
+    passes, reason = employer_passes_prefilter(card(), FakeHistory(), "r1", disabled)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_passes_when_history_none():
+    """history=None → нет данных о взаимодействии, безопасно пропускаем."""
+    passes, reason = employer_passes_prefilter(card(), None, "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+# --- employer_passes_prefilter: позитивные сигналы --------------------------
+
+
+def test_prefilter_top_tech_passes():
+    """Известная компания (Яндекс = top_tech) проходит без rating/reviews."""
+    c = card(company="Яндекс", employer_info=None)
+    passes, reason = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_big_corp_passes():
+    """big_corp (МТС) проходит без rating/reviews."""
+    c = card(company="МТС", employer_info=None)
+    passes, reason = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_trusted_passes():
+    """trusted-бейдж hh.ru проходит даже без rating."""
+    c = card(company="Новая Компания", employer_info=EmployerInfo(trusted=True))
+    passes, reason = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_rating_at_threshold_passes():
+    """rating >= rating_min проходит (граница включается)."""
+    c = card(employer_info=EmployerInfo(rating=3.5))
+    passes, reason = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_reviews_at_threshold_passes():
+    """reviews_count >= reviews_min проходит (граница включается)."""
+    c = card(employer_info=EmployerInfo(reviews_count=10))
+    passes, reason = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+def test_prefilter_interaction_passes():
+    """Работодатель раньше приглашал/смотрел → проходит даже unknown."""
+    c = card(company="ООО Ромашка", employer_info=None)
+    passes, reason = employer_passes_prefilter(c, FakeHistory(interacted=True), "r1", THRESHOLDS)
+    assert passes is True
+    assert reason == ""
+
+
+# --- employer_passes_prefilter: отсев ---------------------------------------
+
+
+def test_prefilter_unknown_no_signal_skips():
+    """Неизвестная компания без rating/reviews/взаимодействия → отсев."""
+    c = card(company="ООО Ромашка", employer_info=None)
+    passes, reason = employer_passes_prefilter(c, FakeHistory(interacted=False), "r1", THRESHOLDS)
+    assert passes is False
+    assert reason == PREFILTER_SKIP_REASON
+
+
+def test_prefilter_low_rating_no_reviews_skips():
+    """rating ниже порога И reviews ниже порога → отсев (нет иного сигнала)."""
+    c = card(employer_info=EmployerInfo(rating=2.0, reviews_count=3))
+    passes, reason = employer_passes_prefilter(c, FakeHistory(interacted=False), "r1", THRESHOLDS)
+    assert passes is False
+
+
+def test_prefilter_employer_info_none_unknown_company_skips():
+    """employer_info=None + неизвестное имя → отсев (нет блоков hh.ru)."""
+    c = card(company="Совсем Неизвестно", employer_info=None)
+    passes, _ = employer_passes_prefilter(c, FakeHistory(), "r1", THRESHOLDS)
+    assert passes is False
+
+
+# --- history.employer_interacted (SQLite) -----------------------------------
+
+
+def test_employer_interacted_no_args_false(tmp_path):
+    h = History(tmp_path / "h.db")
+    assert h.employer_interacted() is False
+
+
+def test_employer_interacted_by_vacancy_id_true(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v1", "Acme", "invitation", "/chat/1")
+    assert h.employer_interacted(vacancy_id="v1") is True
+
+
+def test_employer_interacted_by_employer_name_true(tmp_path):
+    """Матч по имени компании: работодатель отвечал по ДРУГОЙ вакансии."""
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v_old", "Acme", "invitation", "/chat/1")
+    assert h.employer_interacted(employer="Acme") is True
+
+
+def test_employer_interacted_read_status_counts(tmp_path):
+    """read = работодатель посмотрел резюме — валидный сигнал интереса."""
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v1", "Acme", "read", "/chat/1")
+    assert h.employer_interacted(vacancy_id="v1") is True
+
+
+def test_employer_interacted_no_match_false(tmp_path):
+    """Нет responses по вакансии/работодателю → False."""
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v1", "Acme", "invitation", "/chat/1")
+    assert h.employer_interacted(vacancy_id="v999") is False
+    assert h.employer_interacted(employer="Nobody") is False
+
+
+def test_employer_interacted_manual_offer_counts(tmp_path):
+    """Липкая ручная пометка оффера (#13) — тоже сигнал взаимодействия."""
+    h = History(tmp_path / "h.db")
+    h.mark_offer("v1", "r1")
+    assert h.employer_interacted(vacancy_id="v1") is True
+
+
+def test_employer_interacted_both_vacancy_and_employer(tmp_path):
+    """Комбинированный запрос: оба критерия в одном вызове."""
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v1", "Acme", "discard", "/chat/1")
+    # discard = отказ, но резюме видели → взаимодействие есть.
+    assert h.employer_interacted(vacancy_id="v1", employer="Acme") is True
+
+
+# --- parse_scoring: prefilter ----------------------------------------------
+
+
+def test_parse_scoring_no_prefilter_is_none():
+    """Без подсекции prefilter → None (фильтр откл.)."""
+    cfg = parse_scoring({"weights": {"must_have": 3.0}}, "scoring")
+    assert cfg is not None
+    assert cfg.prefilter is None
+
+
+def test_parse_scoring_prefilter_disabled_by_default():
+    """Пустой prefilter → None; enabled не задан → дефолт disabled."""
+    cfg = parse_scoring({"prefilter": {}}, "scoring")
+    assert cfg.prefilter is None  # пустой raw → None (как weights)
+
+
+def test_parse_scoring_prefilter_enabled_with_thresholds():
+    cfg = parse_scoring(
+        {"prefilter": {"enabled": True, "rating_min": 4.0, "reviews_min": 50}},
+        "scoring",
+    )
+    assert cfg.prefilter is not None
+    assert cfg.prefilter.enabled is True
+    assert cfg.prefilter.rating_min == 4.0
+    assert cfg.prefilter.reviews_min == 50
+
+
+def test_parse_scoring_prefilter_enabled_uses_soft_defaults():
+    """enabled без порогов → мягкие дефолты PrefilterConfig."""
+    cfg = parse_scoring({"prefilter": {"enabled": True}}, "scoring")
+    assert cfg.prefilter is not None
+    assert cfg.prefilter.enabled is True
+    assert cfg.prefilter.rating_min == PrefilterConfig.rating_min
+    assert cfg.prefilter.reviews_min == PrefilterConfig.reviews_min
+
+
+def test_parse_scoring_prefilter_bad_rating_raises():
+    with pytest.raises(ConfigError):
+        parse_scoring({"prefilter": {"enabled": True, "rating_min": "oops"}}, "scoring")
+
+
+# --- filter_candidates: интеграция pre-фильтра ------------------------------
+
+
+def test_filter_candidates_prefilter_skips_low_employer_signal():
+    """Pre-фильтр enabled: unknown-карточка без сигнала → [skip]."""
+    filters = SearchFilters(text="x")
+    cards = [
+        card("1", company="Яндекс"),  # top_tech → проходит
+        card("2", company="ООО Ромашка"),  # unknown → отсев
+    ]
+    candidates, skipped = filter_candidates(
+        cards, filters, "r1", FakeHistory(interacted=False), THRESHOLDS
+    )
+    assert [c.vacancy_id for c in candidates] == ["1"]
+    assert len(skipped) == 1
+    assert skipped[0][0].vacancy_id == "2"
+    assert skipped[0][1] == PREFILTER_SKIP_REASON
+
+
+def test_filter_candidates_prefilter_disabled_keeps_all():
+    """thresholds=None → pre-фильтр откл., всё проходит (обратная совместимость)."""
+    filters = SearchFilters(text="x")
+    cards = [card("1", company="ООО Ромашка")]
+    candidates, skipped = filter_candidates(cards, filters, "r1", FakeHistory(), None)
+    assert len(candidates) == 1
+    assert skipped == []
+
+
+def test_filter_candidates_prefilter_after_dedup_and_stoplist():
+    """Pre-фильтр идёт ПОСЛЕ дедупа/стоп-листов (более определённые причины)."""
+    filters = SearchFilters(text="x", exclude_employers=["BadCorp"])
+    cards = [
+        card("1", company="ООО Ромашка"),  # unknown, но не в стопе → pre-фильтр skip
+        card("2", company="BadCorp"),  # стоп-список → причина «стоп-список», не pre-фильтр
+    ]
+    history = FakeHistory(applied={("r1", "3")})
+    cards.append(card("3", company="ООО Ромашка"))  # уже откликались → dedup
+    candidates, skipped = filter_candidates(cards, filters, "r1", history, THRESHOLDS)
+    assert candidates == []
+    reasons = {c.vacancy_id: r for c, r in skipped}
+    assert "уже откликались" in reasons["3"]
+    assert "стоп-списке" in reasons["2"]
+    assert reasons["1"] == PREFILTER_SKIP_REASON
+
+
+# --- полная интеграция: load_config → resume.scoring.prefilter --------------
+
+
+def _write_config(tmp_path, body: str):
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def test_load_config_prefilter_section(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+            scoring:
+              weights:
+                must_have: 3.0
+              prefilter:
+                enabled: true
+                rating_min: 4.0
+                reviews_min: 25
+        """,
+    )
+    config = load_config(path)
+    resume = config.resumes[0]
+    assert resume.scoring is not None
+    assert resume.scoring.prefilter is not None
+    assert resume.scoring.prefilter.enabled is True
+    assert resume.scoring.prefilter.rating_min == 4.0
+    assert resume.scoring.prefilter.reviews_min == 25
+
+
+def test_load_config_prefilter_absent_is_none(tmp_path):
+    """Без секции scoring → resume.scoring=None → prefilter нет (обратная совместимость)."""
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python"
+        """,
+    )
+    config = load_config(path)
+    assert config.resumes[0].scoring is None

--- a/tests/test_scoring_prefilter.py
+++ b/tests/test_scoring_prefilter.py
@@ -214,6 +214,19 @@ def test_employer_interacted_both_vacancy_and_employer(tmp_path):
     assert h.employer_interacted(vacancy_id="v1", employer="Acme") is True
 
 
+def test_employer_interacted_vacancy_id_none_employer_match(tmp_path):
+    """vacancy_id=None + employer — матч по имени компании (account-scope).
+
+    Сценарий pre-фильтра: новой карточки ещё нет в responses, но работодатель
+    отвечал по ДРУГОЙ своей вакансии. vacancy_id=None (новая) → поиск только по
+    employer; SQLite `vacancy_id = ?` с None не добавляется в clauses.
+    """
+    h = History(tmp_path / "h.db")
+    h.upsert_response("v_old", "Acme", "invitation", "/chat/1")
+    assert h.employer_interacted(vacancy_id=None, employer="Acme") is True
+    assert h.employer_interacted(vacancy_id=None, employer="Nobody") is False
+
+
 # --- parse_scoring: prefilter ----------------------------------------------
 
 


### PR DESCRIPTION
Эвристический **pre-LLM фильтр** вакансий по tier/trusted/rating/invitation — отсекает мусор ДО LLM-скоринга (#74), 0 токенов. Уточнение HIGH-идеи №1 из #84: LLM-бинарный отсев = трата токенов, эвристика по tier/trusted/rating/invitation делает то же лучше и бесплатно.

## Что делает
Чистая функция `employer_passes_prefilter(card, history, resume_id, thresholds)` — решение «стоит ли откликаться» без единого LLM-вызова:
- ✅ проходит: известная компания (`top_tech`/`big_corp`), ИЛИ trusted-бейдж, ИЛИ `rating ≥ rating_min`, ИЛИ `reviews_count ≥ reviews_min`, ИЛИ работодатель раньше приглашал/смотрел (`history.employer_interacted`);
- ❌ отсев: неизвестная компания без всего → `[skip] low employer signal (no tier/rating/reviews/interaction)`.

Применяется в `filter_candidates` ПОСЛЕ дедупа/стоп-листов и ДО `rank_candidates` (который может звать LLM) → отсечённые карточки не доходят до LLM-скоринга.

## Реализация
- `src/hhru_bot/scoring.py` — `employer_passes_prefilter` (переиспользует `classify_employer`/`EmployerInfo` из #74), `PREFILTER_SKIP_REASON`.
- `src/hhru_bot/history.py` — `employer_interacted(vacancy_id, employer, resume_id)`: account-scope JOIN `responses` (#12) + `manual_offers` (#13) по `vacancy_id` и/или `employer`. Взаимодействие = любой активный статус (read/response/invitation/discard/offer) ИЛИ липкая пометка оффера. В конец файла.
- `src/hhru_bot/config_sections/scoring.py` — `PrefilterConfig`: opt-in (`enabled: false` по умолчанию), мягкие дефолты `rating_min=3.5` / `reviews_min=10`, парсинг с валидацией (не-число → `ConfigError`).
- `src/hhru_bot/search.py` — `filter_candidates` расширен опциональным `prefilter_thresholds` (None/disabled = no-op, обратно совместимо).
- `src/hhru_bot/commands/_common.py` / `commands/search.py` — пороги извлекаются из `resume.scoring.prefilter`.

## Зона (НЕ пересекается с #82/#83)
Интеграция — через чистую `filter_candidates` (безопасное расширение). `run_apply_for_resume` НЕ трогался напрямую (только извлечение порогов в `_common.py`), зона не конфликтует с #83 (wiring LLM-скоринга в apply-цикл).

## Опциональность + обратная совместимость
- Без секции `scoring` → `resume.scoring=None` → pre-фильтр отключен, поведение не меняется.
- `scoring.prefilter` без `enabled: true` → отключен.
- `history=None` → безопасно пропускает (нет данных о взаимодействии).

## Тесты
ТДД, 29 новых тестов (`tests/test_scoring_prefilter.py`):
- `employer_passes_prefilter`: disabled→pass, top_tech/big_corp→pass, trusted→pass, rating/reviews на границе→pass, interaction→pass, unknown+ничего→skip, low-rating+few-reviews→skip, employer_info=None→skip.
- `history.employer_interacted`: по vacancy_id, по employer, read-статус, manual_offer, no-match→false, комбинированный.
- `parse_scoring`: нет prefilter→None, enabled+пороги, мягкие дефолты, не-число→ConfigError.
- `filter_candidates`: pre-фильтр skip, disabled keeps all, порядок после дедупа/стоп-листов.
- `load_config`: секция prefilter, отсутствие→None.

## Проверки
- `ruff check src/ tests/` — чисто.
- `ruff format --check src/ tests/` — чисто.
- `pytest` — **538 passed** (29 новых).
- gen_cli_docs — без изменений (не новая команда).
- Эмодзи — ни одной.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)