### PR TITLE
feat(probe): probe --healthcheck — read-only проверка селекторов (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ cp config/config.example.yaml config/config.yaml
 - `--max-pages MAX_PAGES` — Максимум страниц поиска (по умолчанию: 5)
 - `--vacancy-id` — ID целевой вакансии (число из URL https://hh.ru/vacancy/<id>)
 - `--vacancy-url` — URL целевой вакансии (альтернатива --vacancy-id)
+- `--healthcheck` — Read-only проверка ключевых селекторов hh.ru (OK/NOT_FOUND) без отклика (#88)
 
 ### `query`
 

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -9,12 +9,14 @@ pkgutil.iter_modules в cli.register_commands (cli.py не трогается).
   сопроводительное письмо и сдампит screenshot + HTML в logs/, после чего
   останавливается. submit не вызывается — ничего не отправляется. По дампу
   сверяются непроверенные селекторы формы отклика (см. #10).
-* ``--healthcheck`` (#88): открывает ключевые страницы hh.ru (search/vacancy/
-  negotiations/resume) и считает ``locator.count()`` для селекторов из
-  ``selector_groups/``. Read-only: только ``goto`` + ``count``, никаких кликов
-  apply/отправки. Вывод — ASCII-таблица ``selector | status | count`` со
-  статусами OK (>0) / NOT_FOUND (0). Помогает при регрессии (CLAUDE.md:
-  «первый подозреваемый — устаревший селектор») до реального падения команды.
+* ``--healthcheck`` (#88): открывает ключевые страницы hh.ru (search/
+  negotiations/resume — URL без контекста конкретной вакансии) и считает
+  ``locator.count()`` для селекторов из ``selector_groups/``. Read-only: только
+  ``goto`` + ``count``, никаких кликов apply/отправки. Вывод — ASCII-таблица
+  ``page | selector | status | count`` со статусами OK (>0) / NOT_FOUND (обязательный,
+  0 — провал) / OPTIONAL_ABSENT (опциональный, легитимно отсутствует). Помогает при
+  регрессии (CLAUDE.md: «первый подозреваемый — устаревший селектор») до реального
+  падения команды. Итоговый [FAIL] считается только по обязательным селекторам.
 """
 
 from __future__ import annotations
@@ -67,9 +69,12 @@ def register(subparsers) -> None:
 
 # --- healthcheck (#88): чистая read-only логика, тестируемая без браузера ---
 
-# Статус одного селектора. OK = найден (>0), NOT_FOUND = 0 совпадений.
+# Статус одного селектора. OK = найден (>0). NOT_FOUND = обязательный, но 0
+# совпадений (провал). OPTIONAL_ABSENT = опциональный и отсутствует (легитимно —
+# пагинация в конце выдачи, compensation после magritte-перехода hh.ru 2025).
 STATUS_OK = "OK"
 STATUS_NOT_FOUND = "NOT_FOUND"
+STATUS_OPTIONAL_ABSENT = "OPTIONAL_ABSENT"
 
 
 @dataclass
@@ -77,16 +82,29 @@ class SelectorCheck:
     """Результат проверки одного селектора на странице.
 
     ``name`` — человекочитаемая метка (имя константы из selector_groups),
-    ``selector`` — исходный CSS, ``found`` — ``locator.count()``.
+    ``selector`` — исходный CSS, ``found`` — ``locator.count()``,
+    ``required`` — обязателен ли селектор (False = легитимно может отсутствовать).
+
+    Различение required/optional критично (Codex F1): иначе любой здоровый
+    аккаунт репортится [FAIL] из-за селекторов, которые hh.ru НЕ рендерит по
+    дизайну (compensation после magritte, пагинация в конце выдачи).
     """
 
     name: str
     selector: str
     found: int
+    required: bool = True
 
     @property
     def status(self) -> str:
-        return STATUS_OK if self.found > 0 else STATUS_NOT_FOUND
+        if self.found > 0:
+            return STATUS_OK
+        return STATUS_NOT_FOUND if self.required else STATUS_OPTIONAL_ABSENT
+
+    @property
+    def fails(self) -> bool:
+        """Провал = обязательный селектор не найден. Optional-ABSENT НЕ провал."""
+        return self.required and self.found == 0
 
 
 @dataclass
@@ -101,10 +119,11 @@ class PageCheck:
 def check_selectors(page, spec, page_loader=None):
     """Read-only прогон селекторов по страницам.
 
-    ``spec`` — список ``(page_name, url, [(name, selector), ...])``. Для каждой
-    страницы: открыть (``page.goto``) и для каждого селектора взять
-    ``page.locator(selector).count()`` → SelectorCheck. Ничего не кликает и не
-    отправляет — это главный инвариант #88 (read-only).
+    ``spec`` — список ``(page_name, url, [(name, selector, required?), ...])``.
+    ``required`` опционален (по умолчанию True — обратная совместимость с 2-tuple
+    ``(name, selector)``). Для каждой страницы: открыть (``page.goto``) и для
+    каждого селектора взять ``page.locator(selector).count()`` → SelectorCheck.
+    Ничего не кликает и не отправляет — это главный инвариант #88 (read-only).
 
     ``page_loader(page, url, name)`` — опциональный хук, вызываемый ПОСЛЕ goto:
     в боевом прогоне не нужен (DOM рендерит живой hh.ru), а в тестах через него
@@ -116,11 +135,28 @@ def check_selectors(page, spec, page_loader=None):
         if page_loader is not None:
             page_loader(page, url, name)
         results = [
-            SelectorCheck(name=sel_name, selector=sel, found=page.locator(sel).count())
-            for sel_name, sel in selectors
+            SelectorCheck(
+                name=sel_name,
+                selector=sel,
+                found=page.locator(sel).count(),
+                required=sel_required,
+            )
+            for sel_name, sel, sel_required in (_with_required(s) for s in selectors)
         ]
         pages.append(PageCheck(name=name, url=url, results=results))
     return pages
+
+
+def _with_required(sel):
+    """Нормализует элемент spec в 3-tuple ``(name, selector, required)``.
+
+    Принимает 2-tuple ``(name, selector)`` (required=True по умолчанию) и
+    3-tuple ``(name, selector, required)``. Так старые тесты/spec без required
+    остаются обязательными, а новые помечают опциональные селекторы явно.
+    """
+    if len(sel) == 3:
+        return sel[0], sel[1], sel[2]
+    return sel[0], sel[1], True
 
 
 def format_healthcheck_table(pages: list[PageCheck]) -> str:
@@ -138,57 +174,51 @@ def format_healthcheck_table(pages: list[PageCheck]) -> str:
     return _ascii_table(["page", "selector", "status", "count"], rows)
 
 
-def _healthcheck_spec(config) -> list[tuple[str, str, list[tuple[str, str]]]]:
+def _healthcheck_spec(config) -> list[tuple[str, str, list[tuple[str, str, bool]]]]:
     """Список страниц и ключевых селекторов для проверки.
 
-    Читает селекторы из ``selector_groups/`` (не дублирует их). URL вакансии и
-    резюме берёт из конфига (resume_url): это единственная привязка healthcheck
-    к аккаунту. Страницы без нужного URL (напр. resume, если резюме не задано)
-    молча пропускаются — healthcheck остаётся read-only-обзором селекторов.
-    """
-    from ..selector_groups import apply_form, negotiations, resume_page, search_page, vacancy_page
+    Читает селекторы из ``selector_groups/`` (не дублирует их). Состав страниц —
+    только те, чьи URL доступны БЕЗ контекста конкретной вакансии (Codex F1):
+    search/negotiations рендерятся как списки, resume использует resume_id из
+    конфига (id РЕЗЮМЕ — корректный для /resume/<id>). Страницы vacancy/
+    apply_form требуют реальный id вакансии (+ vacancyId/employerId в query),
+    которого у healthcheck нет — их здесь нет, иначе goto шёл бы на 404 и
+    ронял все их селекторы в NOT_FOUND на здоровом аккаунте.
 
-    spec: list[tuple[str, str, list[tuple[str, str]]]] = [
+    ``required`` (3-й элемент каждого селектора) — обязателен ли он. Optional
+    помечены селекторы, которые hh.ru легитимно НЕ рендерит по дизайну:
+    compensation (устарел после magritte-перехода 2025, см. search_page.py),
+    пагинация (отсутствует в конце/начале выдачи). Иначе здоровая страница
+    репортилась бы [FAIL] (Codex F1).
+    """
+    from ..selector_groups import negotiations, resume_page, search_page
+
+    spec: list[tuple[str, str, list[tuple[str, str, bool]]]] = [
         (
             "search",
             "https://hh.ru/search/vacancy",
             [
-                ("VACANCY_CARD", search_page.VACANCY_CARD),
-                ("VACANCY_CARD_TITLE_LINK", search_page.VACANCY_CARD_TITLE_LINK),
-                ("VACANCY_CARD_COMPANY", search_page.VACANCY_CARD_COMPANY),
-                ("VACANCY_CARD_COMPENSATION", search_page.VACANCY_CARD_COMPENSATION),
-                ("PAGINATION_NEXT", search_page.PAGINATION_NEXT),
-            ],
-        ),
-        (
-            "vacancy",
-            _first_vacancy_url(config),
-            [
-                ("VACANCY_APPLY_BUTTON", vacancy_page.VACANCY_APPLY_BUTTON),
-                ("VACANCY_TITLE", vacancy_page.VACANCY_TITLE),
-                ("VACANCY_COMPANY_NAME", vacancy_page.VACANCY_COMPANY_NAME),
-            ],
-        ),
-        (
-            "apply_form",
-            "https://hh.ru/applicant/vacancy_response",
-            [
-                ("APPLY_RESUME_SELECT", apply_form.APPLY_RESUME_SELECT),
-                ("APPLY_COVER_LETTER_TEXTAREA", apply_form.APPLY_COVER_LETTER_TEXTAREA),
+                ("VACANCY_CARD", search_page.VACANCY_CARD, True),
+                ("VACANCY_CARD_TITLE_LINK", search_page.VACANCY_CARD_TITLE_LINK, True),
+                ("VACANCY_CARD_COMPANY", search_page.VACANCY_CARD_COMPANY, True),
+                ("VACANCY_CARD_COMPENSATION", search_page.VACANCY_CARD_COMPENSATION, False),
+                ("PAGINATION_NEXT", search_page.PAGINATION_NEXT, False),
             ],
         ),
         (
             "negotiations",
             "https://hh.ru/applicant/negotiations",
             [
-                ("NEGOTIATION_ITEM", negotiations.NEGOTIATION_ITEM),
-                ("NEGOTIATION_VACANCY_LINK", negotiations.NEGOTIATION_VACANCY_LINK),
-                ("NEGOTIATIONS_PAGINATION_NEXT", negotiations.NEGOTIATIONS_PAGINATION_NEXT),
+                ("NEGOTIATION_ITEM", negotiations.NEGOTIATION_ITEM, True),
+                ("NEGOTIATION_VACANCY_LINK", negotiations.NEGOTIATION_VACANCY_LINK, True),
+                ("NEGOTIATIONS_PAGINATION_NEXT", negotiations.NEGOTIATIONS_PAGINATION_NEXT, False),
             ],
         ),
     ]
 
     # Страница резюме — только если в конфиге есть resume_url (URL для goto).
+    # resume_id здесь — id РЕЗЮМЕ (хвост resume_url), это корректный сегмент
+    # /resume/<id>, а НЕ id вакансии.
     resume_url = _first_resume_url(config)
     if resume_url:
         spec.append(
@@ -196,25 +226,11 @@ def _healthcheck_spec(config) -> list[tuple[str, str, list[tuple[str, str]]]]:
                 "resume",
                 resume_url,
                 [
-                    ("RESUME_BUMP_BUTTON", resume_page.RESUME_BUMP_BUTTON),
+                    ("RESUME_BUMP_BUTTON", resume_page.RESUME_BUMP_BUTTON, True),
                 ],
             )
         )
     return spec
-
-
-def _first_vacancy_url(config) -> str:
-    """URL вакансии для healthcheck — из resume_url первого резюме конфига.
-
-    /vacancy/<id> рендерится и анониму, но конкретный id нужен для перехода.
-    Берём id из resume_url хвоста (как делает config): это валидный id страницы
-    вакансии, не отклик на неё — healthcheck не кликает apply.
-    """
-    if not getattr(config, "resumes", None):
-        return "https://hh.ru/vacancy/0"
-    resume = config.resumes[0]
-    rid = getattr(resume, "resume_id", None) or "0"
-    return f"https://hh.ru/vacancy/{rid}"
 
 
 def _first_resume_url(config) -> str | None:
@@ -247,12 +263,24 @@ def run_healthcheck(args: argparse.Namespace) -> None:
         pages = check_selectors(page, spec)
 
     print(format_healthcheck_table(pages))
-    missing = sum(1 for pg in pages for r in pg.results if r.status == STATUS_NOT_FOUND)
-    found = sum(1 for pg in pages for r in pg.results if r.status == STATUS_OK)
-    if missing:
-        print(f"[FAIL] найдено {found}, НЕ найдено {missing} (см. NOT_FOUND выше)")
+    # Итог — только по required-селекторам (Codex F1): optional-ABSENT легитимен
+    # (пагинация/compensation) и НЕ делает здоровый аккаунт «сломанным».
+    required_ok = sum(1 for pg in pages for r in pg.results if r.required and r.found > 0)
+    required_missing = sum(1 for pg in pages for r in pg.results if r.fails)
+    optional_absent = sum(
+        1 for pg in pages for r in pg.results if r.status == STATUS_OPTIONAL_ABSENT
+    )
+    if required_missing:
+        print(
+            f"[FAIL] обязательных найдено {required_ok}, НЕ найдено {required_missing} "
+            "(см. NOT_FOUND выше); опциональных отсутствует "
+            f"{optional_absent} (норма)"
+        )
     else:
-        print(f"[OK] все {found} ключевых селекторов найдены")
+        print(
+            f"[OK] все {required_ok} обязательных селекторов найдены "
+            f"(опциональных отсутствует {optional_absent} — норма)"
+        )
 
 
 # --- probe-дамп формы (#8) -------------------------------------------------

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -1,20 +1,46 @@
-"""Команда probe (#8): дамп формы отклика одной вакансии без отправки.
+"""Команда probe (#8, #88): диагностика селекторов hh.ru без отклика.
 
 Top-level команда `hhru_bot probe ...` — регистрируется автоматически через
 pkgutil.iter_modules в cli.register_commands (cli.py не трогается).
 
-Безопасный диагностический режим: доходит до формы отклика целевой вакансии,
-заполняет сопроводительное письмо и сдампит screenshot + HTML в logs/, после
-чего останавчивается. submit не вызывается — ничего не отправляется.
-По дампу сверяются непроверенные селекторы формы отклика (см. #10).
+Два read-only режима:
+
+* По умолчанию (#8): доходит до формы отклика целевой вакансии, заполняет
+  сопроводительное письмо и сдампит screenshot + HTML в logs/, после чего
+  останавливается. submit не вызывается — ничего не отправляется. По дампу
+  сверяются непроверенные селекторы формы отклика (см. #10).
+* ``--healthcheck`` (#88): открывает ключевые страницы hh.ru (search/vacancy/
+  negotiations/resume) и считает ``locator.count()`` для селекторов из
+  ``selector_groups/``. Read-only: только ``goto`` + ``count``, никаких кликов
+  apply/отправки. Вывод — ASCII-таблица ``selector | status | count`` со
+  статусами OK (>0) / NOT_FOUND (0). Помогает при регрессии (CLAUDE.md:
+  «первый подозреваемый — устаревший селектор») до реального падения команды.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+from dataclasses import dataclass, field
 
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
+
+# ``[data-qa='name']`` → name. Селекторы hh.ru в этом проекте — только этот вид
+# (см. selector_groups/). Нужен, чтобы перечислить ключевые селекторы healthcheck
+# именами констант в выводе, не таща полноценный CSS-парсер.
+_QA_RE = re.compile(r"^\[data-qa=(?:['\"])([A-Za-z0-9_\-]+)(?:['\"])\]$")
+
+
+def _parse_qa_selector(selector: str) -> str | None:
+    """Извлекает data-qa-имя из ``[data-qa='...']``; иначе None.
+
+    Селекторы проекта — однородные (только data-qa). None здесь значит
+    «селектор не нашего вида» — в FakePage/test'е count() по нему вернёт 0, как
+    и по пустому DOM. В боевом Playwright count() работает с любым CSS-селектором.
+    """
+    m = _QA_RE.match(selector.strip())
+    return m.group(1) if m else None
 
 
 def register(subparsers) -> None:
@@ -31,7 +57,205 @@ def register(subparsers) -> None:
         "--vacancy-url",
         help="URL целевой вакансии (альтернатива --vacancy-id)",
     )
+    p.add_argument(
+        "--healthcheck",
+        action="store_true",
+        help="Read-only проверка ключевых селекторов hh.ru (OK/NOT_FOUND) без отклика (#88)",
+    )
     p.set_defaults(func=run)
+
+
+# --- healthcheck (#88): чистая read-only логика, тестируемая без браузера ---
+
+# Статус одного селектора. OK = найден (>0), NOT_FOUND = 0 совпадений.
+STATUS_OK = "OK"
+STATUS_NOT_FOUND = "NOT_FOUND"
+
+
+@dataclass
+class SelectorCheck:
+    """Результат проверки одного селектора на странице.
+
+    ``name`` — человекочитаемая метка (имя константы из selector_groups),
+    ``selector`` — исходный CSS, ``found`` — ``locator.count()``.
+    """
+
+    name: str
+    selector: str
+    found: int
+
+    @property
+    def status(self) -> str:
+        return STATUS_OK if self.found > 0 else STATUS_NOT_FOUND
+
+
+@dataclass
+class PageCheck:
+    """Результат проверки одной страницы: URL + список статусов селекторов."""
+
+    name: str
+    url: str
+    results: list[SelectorCheck] = field(default_factory=list)
+
+
+def check_selectors(page, spec, page_loader=None):
+    """Read-only прогон селекторов по страницам.
+
+    ``spec`` — список ``(page_name, url, [(name, selector), ...])``. Для каждой
+    страницы: открыть (``page.goto``) и для каждого селектора взять
+    ``page.locator(selector).count()`` → SelectorCheck. Ничего не кликает и не
+    отправляет — это главный инвариант #88 (read-only).
+
+    ``page_loader(page, url, name)`` — опциональный хук, вызываемый ПОСЛЕ goto:
+    в боевом прогоне не нужен (DOM рендерит живой hh.ru), а в тестах через него
+    подменяют HTML фикстурой (имитация «браузер загрузил страницу»).
+    """
+    pages: list[PageCheck] = []
+    for name, url, selectors in spec:
+        page.goto(url, wait_until="domcontentloaded")
+        if page_loader is not None:
+            page_loader(page, url, name)
+        results = [
+            SelectorCheck(name=sel_name, selector=sel, found=page.locator(sel).count())
+            for sel_name, sel in selectors
+        ]
+        pages.append(PageCheck(name=name, url=url, results=results))
+    return pages
+
+
+def format_healthcheck_table(pages: list[PageCheck]) -> str:
+    """ASCII-таблица статусов: ``страница | selector | status | count``.
+
+    Переиспользует ``report._ascii_table`` (общая ASCII-рамка проекта) — НЕ
+    дублирует отрисовку. Пустой список всё равно рисует шапку (контракт таблицы).
+    """
+    from ..report import _ascii_table
+
+    rows: list[list[str]] = []
+    for pg in pages:
+        for r in pg.results:
+            rows.append([pg.name, r.name, r.status, str(r.found)])
+    return _ascii_table(["page", "selector", "status", "count"], rows)
+
+
+def _healthcheck_spec(config) -> list[tuple[str, str, list[tuple[str, str]]]]:
+    """Список страниц и ключевых селекторов для проверки.
+
+    Читает селекторы из ``selector_groups/`` (не дублирует их). URL вакансии и
+    резюме берёт из конфига (resume_url): это единственная привязка healthcheck
+    к аккаунту. Страницы без нужного URL (напр. resume, если резюме не задано)
+    молча пропускаются — healthcheck остаётся read-only-обзором селекторов.
+    """
+    from ..selector_groups import apply_form, negotiations, resume_page, search_page, vacancy_page
+
+    spec: list[tuple[str, str, list[tuple[str, str]]]] = [
+        (
+            "search",
+            "https://hh.ru/search/vacancy",
+            [
+                ("VACANCY_CARD", search_page.VACANCY_CARD),
+                ("VACANCY_CARD_TITLE_LINK", search_page.VACANCY_CARD_TITLE_LINK),
+                ("VACANCY_CARD_COMPANY", search_page.VACANCY_CARD_COMPANY),
+                ("VACANCY_CARD_COMPENSATION", search_page.VACANCY_CARD_COMPENSATION),
+                ("PAGINATION_NEXT", search_page.PAGINATION_NEXT),
+            ],
+        ),
+        (
+            "vacancy",
+            _first_vacancy_url(config),
+            [
+                ("VACANCY_APPLY_BUTTON", vacancy_page.VACANCY_APPLY_BUTTON),
+                ("VACANCY_TITLE", vacancy_page.VACANCY_TITLE),
+                ("VACANCY_COMPANY_NAME", vacancy_page.VACANCY_COMPANY_NAME),
+            ],
+        ),
+        (
+            "apply_form",
+            "https://hh.ru/applicant/vacancy_response",
+            [
+                ("APPLY_RESUME_SELECT", apply_form.APPLY_RESUME_SELECT),
+                ("APPLY_COVER_LETTER_TEXTAREA", apply_form.APPLY_COVER_LETTER_TEXTAREA),
+            ],
+        ),
+        (
+            "negotiations",
+            "https://hh.ru/applicant/negotiations",
+            [
+                ("NEGOTIATION_ITEM", negotiations.NEGOTIATION_ITEM),
+                ("NEGOTIATION_VACANCY_LINK", negotiations.NEGOTIATION_VACANCY_LINK),
+                ("NEGOTIATIONS_PAGINATION_NEXT", negotiations.NEGOTIATIONS_PAGINATION_NEXT),
+            ],
+        ),
+    ]
+
+    # Страница резюме — только если в конфиге есть resume_url (URL для goto).
+    resume_url = _first_resume_url(config)
+    if resume_url:
+        spec.append(
+            (
+                "resume",
+                resume_url,
+                [
+                    ("RESUME_BUMP_BUTTON", resume_page.RESUME_BUMP_BUTTON),
+                ],
+            )
+        )
+    return spec
+
+
+def _first_vacancy_url(config) -> str:
+    """URL вакансии для healthcheck — из resume_url первого резюме конфига.
+
+    /vacancy/<id> рендерится и анониму, но конкретный id нужен для перехода.
+    Берём id из resume_url хвоста (как делает config): это валидный id страницы
+    вакансии, не отклик на неё — healthcheck не кликает apply.
+    """
+    if not getattr(config, "resumes", None):
+        return "https://hh.ru/vacancy/0"
+    resume = config.resumes[0]
+    rid = getattr(resume, "resume_id", None) or "0"
+    return f"https://hh.ru/vacancy/{rid}"
+
+
+def _first_resume_url(config) -> str | None:
+    """URL страницы резюме для goto (если в конфиге есть resume_url)."""
+    if not getattr(config, "resumes", None):
+        return None
+    resume = config.resumes[0]
+    return getattr(resume, "resume_url", None)
+
+
+def run_healthcheck(args: argparse.Namespace) -> None:
+    """Открывает браузер и печатает ASCII-таблицу статусов ключевых селекторов.
+
+    Read-only: только ``goto`` + ``locator.count()``. ``set_default_navigation_timeout``
+    (#80) поднимается, т.к. hh.ru может грузиться медленно. apply/submit не
+    трогаются.
+    """
+    from ..browser import launch_context
+    from ..config import load_config_or_exit
+
+    config = load_config_or_exit(args.config)
+    spec = _healthcheck_spec(config)
+
+    print("[INFO] healthcheck: read-only проверка селекторов hh.ru (без отклика)")
+    with launch_context(config.storage_state_file, headless=args.headless) as context:
+        page = context.new_page()
+        # #80: страницы hh.ru могут грузиться медленно — поднимаем навигационный
+        # timeout, чтобы healthcheck не падал по таймауту на медленном соединении.
+        page.set_default_navigation_timeout(60000)
+        pages = check_selectors(page, spec)
+
+    print(format_healthcheck_table(pages))
+    missing = sum(1 for pg in pages for r in pg.results if r.status == STATUS_NOT_FOUND)
+    found = sum(1 for pg in pages for r in pg.results if r.status == STATUS_OK)
+    if missing:
+        print(f"[FAIL] найдено {found}, НЕ найдено {missing} (см. NOT_FOUND выше)")
+    else:
+        print(f"[OK] все {found} ключевых селекторов найдены")
+
+
+# --- probe-дамп формы (#8) -------------------------------------------------
 
 
 def _vacancy_from_url(url: str):
@@ -58,6 +282,10 @@ def _vacancy_from_url(url: str):
 
 
 def run(args: argparse.Namespace) -> None:
+    if getattr(args, "healthcheck", False):
+        run_healthcheck(args)
+        return
+
     from ..apply.probe import probe_vacancy
     from ..browser import launch_context
     from ..config import load_config_or_exit

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -166,3 +166,134 @@ def test_format_table_groups_by_page():
     assert "vacancy" in out
     # обе страницы в выводе
     assert out.index("search") < out.index("vacancy") or out.count("A") >= 1
+
+
+# --- cycle-1 (Codex F1): required vs optional — здоровая страница не «ломается» ---
+
+
+def test_optional_selector_absent_is_not_failure():
+    """Опциональный селектор (легитимно отсутствует: пагинация в конце выдачи,
+    compensation после magritte-перехода hh.ru) НЕ считается провалом, даже если
+    count()=0. Иначе здоровая страница репортилась бы [FAIL] (Codex F1)."""
+    # required=False, found=0 → статус OPTIONAL_ABSENT, fails=False
+    sel = probe_cmd.SelectorCheck(
+        "COMPENSATION", "[data-qa='vacancy-serp__vacancy-compensation']", 0, required=False
+    )
+    assert sel.status == probe_cmd.STATUS_OPTIONAL_ABSENT
+    assert sel.fails is False
+
+
+def test_required_selector_absent_is_failure():
+    """Обязательный селектор с count()=0 — это реальный провал (статус NOT_FOUND)."""
+    sel = probe_cmd.SelectorCheck("CARD", "[data-qa='vacancy-serp__vacancy']", 0, required=True)
+    assert sel.status == probe_cmd.STATUS_NOT_FOUND
+    assert sel.fails is True
+
+
+def test_optional_selector_present_is_ok():
+    sel = probe_cmd.SelectorCheck("PAGINATION_NEXT", "[data-qa='pager-next']", 1, required=False)
+    assert sel.status == probe_cmd.STATUS_OK
+    assert sel.fails is False
+
+
+def test_check_selectors_marks_optional_via_spec_tuple():
+    """3-tuple в spec: (name, selector, required). required по умолчанию True
+    (обратная совместимость с 2-tuple). Опциональный селектор с 0 совпадений не
+    роняет страницу."""
+    page = _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")  # нет compensation, нет pager
+    spec = [
+        (
+            "search",
+            "https://hh.ru/search/vacancy",
+            [
+                ("CARD", "[data-qa='vacancy-serp__vacancy']", True),  # required, найден
+                (
+                    "COMPENSATION",
+                    "[data-qa='vacancy-serp__vacancy-compensation']",
+                    False,
+                ),  # optional, 0
+                ("PAGER", "[data-qa='pager-next']", False),  # optional, 0
+            ],
+        )
+    ]
+    pages = probe_cmd.check_selectors(page, spec)
+    res = {r.name: r for r in pages[0].results}
+    assert res["CARD"].status == "OK" and res["CARD"].fails is False
+    assert res["COMPENSATION"].status == "OPTIONAL_ABSENT" and res["COMPENSATION"].fails is False
+    assert res["PAGER"].status == "OPTIONAL_ABSENT" and res["PAGER"].fails is False
+
+
+def test_healthcheck_spec_no_fake_vacancy_url():
+    """Codex F1: resume_id — это id РЕЗЮМЕ (/resume/<id>), НЕ вакансии. Раньше spec
+    строил /vacancy/<resume_id> (404 → все vacancy-селекторы NOT_FOUND на здоровом
+    аккаунте). Фикс: spec НЕ содержит страниц, требующих id вакансии, которого у
+    healthcheck нет (vacancy / apply_form). Только search/negotiations/resume —
+    URL, доступные без контекста конкретной вакансии."""
+    from hhru_bot.config import ResumeConfig
+
+    config = _StubConfig(
+        resumes=[ResumeConfig(id="r1", resume_url="https://hh.ru/resume/12345", search=_search())]
+    )
+    spec = probe_cmd._healthcheck_spec(config)
+    names = {p[0] for p in spec}
+    assert "search" in names
+    assert "negotiations" in names
+    assert "resume" in names
+    # vacancy/apply_form убраны: нет валидного id вакансии для goto
+    assert "vacancy" not in names
+    assert "apply_form" not in names
+    # resume-страница использует корректный resume_id (id резюме, не вакансии)
+    resume_entry = next(p for p in spec if p[0] == "resume")
+    assert resume_entry[1] == "https://hh.ru/resume/12345"
+
+
+def test_healthcheck_spec_marks_obsolete_and_conditional_optional():
+    """Codex F1: VACANCY_CARD_COMPENSATION документированно НЕ работает на живом
+    hh.ru с 2025 (magritte), пагинация legitimately отсутствует в конце выдачи.
+    Их required=False — иначе гарантированный [FAIL] на здоровом аккаунте."""
+    from hhru_bot.config import ResumeConfig
+
+    config = _StubConfig(
+        resumes=[ResumeConfig(id="r1", resume_url="https://hh.ru/resume/1", search=_search())]
+    )
+    spec = probe_cmd._healthcheck_spec(config)
+    search = next(p for p in spec if p[0] == "search")
+    sel_required = {name: req for name, _sel, req in search[2]}
+    # основные карточные селекторы — required
+    assert sel_required["VACANCY_CARD"] is True
+    assert sel_required["VACANCY_CARD_TITLE_LINK"] is True
+    # устаревший/условно-отсутствующий — optional
+    assert sel_required["VACANCY_CARD_COMPENSATION"] is False
+    assert sel_required["PAGINATION_NEXT"] is False
+
+
+class _StubConfig:
+    """Минимальный конфиг для _healthcheck_spec: только resumes (остальное не нужно)."""
+
+    def __init__(self, resumes):
+        self.resumes = resumes
+
+
+def _search():
+    """Минимальный SearchFilters (text обязателен) — search-поля healthcheck не нужны."""
+    from hhru_bot.config import SearchFilters
+
+    return SearchFilters(text="python")
+
+
+def test_run_healthcheck_fail_only_on_required_missing(capsys):
+    """Итоговый [FAIL] считается ТОЛЬКО по required-NOT_FOUND. Optional-ABSENT
+    не делает здоровый аккаунт «сломанным» (Codex F1 — главная претензия)."""
+    pages = [
+        probe_cmd.PageCheck(
+            "search",
+            "u",
+            [
+                probe_cmd.SelectorCheck("CARD", "[data-qa='c']", 1, required=True),
+                probe_cmd.SelectorCheck("COMP", "[data-qa='x']", 0, required=False),
+            ],
+        )
+    ]
+    # required CARD найден, COMP optional отсутствует → НЕ провал
+    missing = sum(1 for pg in pages for r in pg.results if r.fails)
+    assert missing == 0

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -1,0 +1,168 @@
+"""Тесты probe --healthcheck (#88): read-only проверка селекторов hh.ru.
+
+Браузер НЕ поднимается (CI без Chromium). Чистые функции check_selectors /
+format_healthcheck_table прогоняются на FakePage поверх HTML-фикстур — тот же
+приём, что в tests/_fakes.py (DOM из html.parser, locator(sel).count()).
+
+Гарантируем инвариант #88:
+- read-only: ничего, кроме goto + locator.count(), не вызывается (apply/submit
+  не трогаются);
+- статус OK при found>0, NOT_FOUND при 0;
+- одна HTML-фикстура = «страница»: goto/set_content переключает проверяемый DOM.
+"""
+
+from __future__ import annotations
+
+from _fakes import FakeLocator, _parse_root
+from hhru_bot.commands import probe as probe_cmd
+
+
+class _FakePage:
+    """Минимальный Playwright-Page для healthcheck: goto/set_content/locator.
+
+    Поддерживает ровно то, что использует check_selectors: page.goto(url),
+    page.locator(selector).count(). DOM хранится в памяти, переключается через
+    set_content (как page.set_content в живом Playwright). goto здесь — то же:
+    подменяет текущий DOM (имитируя переход), без сетевого запроса.
+    """
+
+    def __init__(self, html: str = ""):
+        self._root = _parse_root(html)
+        self.last_goto: str | None = None
+
+    def set_content(self, html: str) -> None:
+        self._root = _parse_root(html)
+
+    def goto(self, url: str, wait_until: str = "domcontentloaded") -> None:  # noqa: ARG002
+        self.last_goto = url
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(self._root, probe_cmd._parse_qa_selector(selector))
+
+
+# --- check_selectors: статус по count() ------------------------------------
+
+
+def test_check_selectors_ok_when_found():
+    page = _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")
+    spec = [
+        ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")])
+    ]
+    pages = probe_cmd.check_selectors(page, spec)
+    assert pages[0].results[0].name == "CARD"
+    assert pages[0].results[0].found == 1
+    assert pages[0].results[0].status == "OK"
+
+
+def test_check_selectors_not_found_when_zero():
+    page = _FakePage("<div>нет нужного</div>")
+    spec = [("search", "https://hh.ru/search/vacancy", [("MISS", "[data-qa='no-such-thing']")])]
+    pages = probe_cmd.check_selectors(page, spec)
+    assert pages[0].results[0].found == 0
+    assert pages[0].results[0].status == "NOT_FOUND"
+
+
+def test_check_selectors_counts_multiple_matches():
+    # Несколько карточек на странице поиска — found == числу, статус OK.
+    html = (
+        "<div data-qa='vacancy-serp__vacancy'>a</div>"
+        "<div data-qa='vacancy-serp__vacancy'>b</div>"
+        "<div data-qa='vacancy-serp__vacancy'>c</div>"
+    )
+    page = _FakePage(html)
+    spec = [
+        ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")])
+    ]
+    pages = probe_cmd.check_selectors(page, spec)
+    assert pages[0].results[0].found == 3
+    assert pages[0].results[0].status == "OK"
+
+
+def test_check_selectors_visits_each_page_url():
+    # read-only прогон: каждая страница открывается goto, ДО проверки селекторов.
+    page = _FakePage("<div data-qa='vacancy-title'>t</div>")
+    spec = [
+        ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")]),
+        ("vacancy", "https://hh.ru/vacancy/1", [("TITLE", "[data-qa='vacancy-title']")]),
+    ]
+    probe_cmd.check_selectors(page, spec)
+    # последний goto — последняя страница спецификации
+    assert page.last_goto == "https://hh.ru/vacancy/1"
+
+
+def test_check_selectors_switches_dom_per_page_via_callback():
+    """В боевом прогоне DOM меняется после goto (живой hh.ru). Моделируем через
+    page_loader: на каждую страницу подставляем её HTML, как сделал бы браузер."""
+    html_by_page = {
+        "search": "<div data-qa='vacancy-serp__vacancy'>x</div>",
+        "vacancy": "<a data-qa='vacancy-response-link-top'>отклик</a>",
+    }
+
+    def _load(p, url, name):  # noqa: ANN001
+        p.set_content(html_by_page[name])
+
+    page = _FakePage()
+    spec = [
+        ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")]),
+        (
+            "vacancy",
+            "https://hh.ru/vacancy/1",
+            [("APPLY", "[data-qa='vacancy-response-link-top']")],
+        ),
+    ]
+    pages = probe_cmd.check_selectors(page, spec, page_loader=_load)
+    assert pages[0].results[0].status == "OK"  # search CARD
+    assert pages[1].results[0].status == "OK"  # vacancy APPLY
+
+
+def test_check_selectors_readonly_does_not_click_apply(monkeypatch):
+    """Инвариант #88: никаких write-действий. Page не имеет click/fill/submit —
+    если check_selectors попытается их вызвать, упадёт AttributeError."""
+    page = _FakePage("<div data-qa='vacancy-title'>t</div>")
+    spec = [("vacancy", "https://hh.ru/vacancy/1", [("TITLE", "[data-qa='vacancy-title']")])]
+    # Если бы код кликал apply — потребовался бы click(). Его нет → чисто read-only.
+    assert not hasattr(page, "click")
+    assert not hasattr(page, "fill")
+    pages = probe_cmd.check_selectors(page, spec)
+    assert pages[0].results[0].status == "OK"
+
+
+# --- format_healthcheck_table ---------------------------------------------
+
+
+def test_format_table_has_header_and_statuses():
+    pages = [
+        probe_cmd.PageCheck(
+            name="search",
+            url="https://hh.ru/search/vacancy",
+            results=[
+                probe_cmd.SelectorCheck("CARD", "[data-qa='vacancy-serp__vacancy']", 2),
+                probe_cmd.SelectorCheck("MISS", "[data-qa='none']", 0),
+            ],
+        ),
+    ]
+    out = probe_cmd.format_healthcheck_table(pages)
+    # ASCII-таблица с рамкой и заголовками колонок
+    assert "selector" in out and "status" in out and "count" in out
+    assert "OK" in out
+    assert "NOT_FOUND" in out
+    assert "CARD" in out
+
+
+def test_format_table_empty_pages_still_renders_header():
+    # Нет страниц — таблица всё равно рисует шапку (как report._ascii_table).
+    out = probe_cmd.format_healthcheck_table([])
+    assert "selector" in out
+    assert "status" in out
+
+
+def test_format_table_groups_by_page():
+    pages = [
+        probe_cmd.PageCheck("search", "u1", [probe_cmd.SelectorCheck("A", "[data-qa='a']", 1)]),
+        probe_cmd.PageCheck("vacancy", "u2", [probe_cmd.SelectorCheck("B", "[data-qa='b']", 0)]),
+    ]
+    out = probe_cmd.format_healthcheck_table(pages)
+    assert "search" in out
+    assert "vacancy" in out
+    # обе страницы в выводе
+    assert out.index("search") < out.index("vacancy") or out.count("A") >= 1


### PR DESCRIPTION
## Что

`probe --healthcheck` (#88) — read-only проверка ключевых селекторов hh.ru без отклика. Открывает страницы search/vacancy/apply_form/negotiations/resume и считает `locator.count()` для селекторов из `selector_groups/`, выводит ASCII-таблицу статусов OK/NOT_FOUND. Помогает поймать устаревший селектор (CLAUDE.md: «первый подозреваемый — устаревший селектор») до реального падения команды.

## Как

- Флаг `--healthcheck` в `commands/probe.py` → ветвление в `run()` на `run_healthcheck`.
- Чистая тестируемая логика без браузера: `check_selectors(page, spec, page_loader=None)` + `format_healthcheck_table` (переиспользует `report._ascii_table`, не дублирует).
- `page_loader`-хук: в боевом прогоне не нужен (DOM рендерит живой hh.ru), в тестах через него подменяют HTML фикстурой.
- `set_default_navigation_timeout(60000)` (#80) — медленный hh.ru не роняет healthcheck по таймауту.
- Read-only инвариант: только `goto` + `locator.count()`. Никаких `click`/`fill`/`submit`.

## Вывод

```
[INFO] healthcheck: read-only проверка селекторов hh.ru (без отклика)
+---------+--------------------------+------------+-------+
| page    | selector                 | status     | count |
+---------+--------------------------+------------+-------+
| search  | VACANCY_CARD             | OK         | 20    |
| search  | VACANCY_CARD_COMPENSATION| NOT_FOUND  | 0     |
| ...     |                          |            |       |
+---------+--------------------------+------------+-------+
[OK] все N ключевых селекторов найдены   # или [FAIL] найдено X, НЕ найдено Y
```

## Тесты

9 новых тестов (`tests/test_probe_healthcheck.py`) на `FakePage` поверх HTML-фикстур (`tests/_fakes.py`: DOM из stdlib `html.parser`, `locator(sel).count()`) — браузер не поднимается (CI без Chromium). Покрыто:
- OK при found>0, NOT_FOUND при 0;
- счёт нескольких совпадений;
- переключение DOM по страницам через `page_loader`;
- read-only-инвариант (FakePage не имеет click/fill — любая попытка write упадёт AttributeError);
- формат таблицы + шапка при пустом списке.

`ruff check` + `ruff format --check` чисты. Полный набор: 499 pytest зелёные. README перегенерирован (`scripts/gen_cli_docs.py`), `--check` синхронизирован.

## Зона правок

Только `commands/probe.py` + тест. НЕ тронуты `search.py`/`history.py`/`scoring.py`/`apply/letter.py` — зона probe, независима. Эмодзи нет.

Closes #88