### PR TITLE
refactor(_common): вынести чистую build_apply_plan из run_apply_for_resume (#101)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -9,15 +9,17 @@ from __future__ import annotations
 
 import argparse
 import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..apply import apply_to_vacancy
 from ..apply.letter import CoverLetterProvider
-from ..config import AppConfig, ResumeConfig
+from ..config import AppConfig, ResumeConfig, SearchFilters
 from ..config_sections.scoring import ScoringWeights
 from ..history import History
 from ..search import (
     _LLM_SHORTLIST_DEFAULT,
+    VacancyCard,
     filter_candidates,
     rank_candidates,
     search_vacancies,
@@ -25,7 +27,7 @@ from ..search import (
 from ..throttle import LimitReached, Throttle
 
 if TYPE_CHECKING:
-    from ..scoring import LLMScoringProvider
+    from ..scoring import LLMScoringProvider, ScoringProvider
 
 logger = logging.getLogger("hhru_bot.cli")
 
@@ -154,6 +156,68 @@ def _build_scoring_provider(
     )
 
 
+@dataclass
+class ApplyPlan:
+    """План отклика по резюме: ранжированные кандидаты + статистика построения.
+
+    Чистый результат build_apply_plan (#101) — без браузера, без побочных
+    эффектов. ranked — тот же формат, что возвращает rank_candidates: список
+    (карточка, score, разбивка факторов), уже урезанный по limit. total/
+    after_filter/after_limit — счётчики для логов/отчётов по стадиям
+    filter -> rank -> limit; skipped — пары (карточка, причина) из
+    filter_candidates, для отладочного логирования вызывающей стороной.
+    """
+
+    ranked: list[tuple[VacancyCard, float, dict[str, float]]]
+    skipped: list[tuple[VacancyCard, str]] = field(default_factory=list)
+    total: int = 0
+    after_filter: int = 0
+    after_limit: int = 0
+
+
+def build_apply_plan(
+    candidates: list[VacancyCard],
+    filters: SearchFilters,
+    resume: ResumeConfig,
+    history: History,
+    scoring_provider: ScoringProvider | None = None,
+    limit: int | None = None,
+) -> ApplyPlan:
+    """Строит план откликов: filter -> pre-LLM -> rank -> slice по limit.
+
+    Чистая функция (без браузера) — вынесена из run_apply_for_resume (#101),
+    чтобы решения filter/rank/limit были тестируемы без hh.ru. candidates —
+    СЫРЫЕ карточки из search_vacancies (ещё без применения exclude_employers/
+    exclude_keywords/истории — это делает filter_candidates внутри, см.
+    CLAUDE.md про разделение поиска и фильтрации).
+
+    limit: None или 0 (CLI-конвенция args.limit по умолчанию 0 = флаг не задан)
+    означают "без среза" — берутся все ranked-кандидаты, как раньше
+    (candidates[:limit] с limit=len(ranked)).
+    """
+    prefilter = getattr(getattr(resume, "scoring", None), "prefilter", None)
+    filtered, skipped = filter_candidates(candidates, filters, resume.resume_id, history, prefilter)
+
+    ranked = rank_candidates(
+        filtered,
+        filters,
+        resume,
+        scoring_provider=scoring_provider,
+        llm_shortlist=_LLM_SHORTLIST_DEFAULT,
+    )
+
+    effective_limit = limit if limit else len(ranked)
+    sliced = ranked[:effective_limit]
+
+    return ApplyPlan(
+        ranked=sliced,
+        skipped=skipped,
+        total=len(candidates),
+        after_filter=len(filtered),
+        after_limit=len(sliced),
+    )
+
+
 def run_apply_for_resume(
     page,
     config: AppConfig,
@@ -171,6 +235,10 @@ def run_apply_for_resume(
     #17: если включён AI (секция ai + ai_profile) — отклик идёт через
     CoverLetterProvider; иначе (провайдер None) — статичный шаблон, поведение
     не меняется. letter_variant пишется в history для A/B-среза (Этап 3).
+
+    #101: план (filter → rank → limit) строится чистой build_apply_plan;
+    здесь остаётся только execution-оркестрация (providers, apply_to_vacancy,
+    запись истории, throttle).
     """
     print(f"\n=== Отклики для резюме: {resume.id} ===")
 
@@ -181,38 +249,24 @@ def run_apply_for_resume(
         return
 
     cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
-    # pre-LLM фильтр работодателя (#85): пороги из опц. секции scoring.prefilter.
-    # resume.scoring=None / prefilter=None / enabled=False → фильтр откл. (no-op
-    # внутри filter_candidates), обратная совместимость.
-    prefilter = getattr(getattr(resume, "scoring", None), "prefilter", None)
-    candidates, skipped = filter_candidates(
-        cards, resume.search, resume.resume_id, history, prefilter
-    )
-
-    for card, reason in skipped:
-        logger.debug("Пропуск вакансии %s: %s", card.title, reason)
-
-    # Ранжирование кандидатов по score (#15) — строго между filter_candidates
-    # и срезом [:limit], чтобы дневной лимит уходил на лучшие совпадения.
-    # #81: при включённом AI ранжирование идёт через LLMScoringProvider (#74),
-    # иначе (провайдер None) — чистая эвристика #15 (поведение не меняется).
-    # llm_shortlist обязателен при провайдере: предранжирование эвристикой →
-    # LLM только по топ-10, иначе десятки синхронных запросов (анти-фрод, F3).
     scoring_provider = _build_scoring_provider(config, resume)
-    ranked = rank_candidates(
-        candidates,
+    plan = build_apply_plan(
+        cards,
         resume.search,
         resume,
+        history,
         scoring_provider=scoring_provider,
-        llm_shortlist=_LLM_SHORTLIST_DEFAULT,
+        limit=args.limit,
     )
 
-    limit = args.limit if args.limit else len(ranked)
+    for card, reason in plan.skipped:
+        logger.debug("Пропуск вакансии %s: %s", card.title, reason)
+
     cover_letter_template = config.cover_letter_for(resume)
     letter_provider = _build_letter_provider(config, resume, cover_letter_template)
 
     applied_count = 0
-    for card, _score, _breakdown in ranked[:limit]:
+    for card, _score, _breakdown in plan.ranked:
         try:
             throttle.check_apply_limit(resume.resume_id, args.dry_run)
         except LimitReached as e:

--- a/tests/test_apply_plan.py
+++ b/tests/test_apply_plan.py
@@ -1,0 +1,146 @@
+"""TDD #101: build_apply_plan — чистая план-конструкция, вынесенная из run_apply_for_resume.
+
+Проверяет контракты filter -> pre-LLM -> rank -> limit без браузера: собирает
+из filter_candidates/rank_candidates ApplyPlan (ранжированные кандидаты +
+статистика). Реюзает фикстуры-паттерны test_apply_scoring_integration.py.
+"""
+
+from __future__ import annotations
+
+from hhru_bot.commands._common import ApplyPlan, build_apply_plan
+from hhru_bot.config import ResumeConfig, SearchFilters
+from hhru_bot.history import History
+from hhru_bot.search import VacancyCard
+
+
+def _card(vacancy_id: str, title: str = "Python Dev", company: str = "Acme") -> VacancyCard:
+    return VacancyCard(
+        vacancy_id=vacancy_id,
+        title=title,
+        company=company,
+        url=f"https://hh.ru/vacancy/{vacancy_id}",
+    )
+
+
+def _resume(search: SearchFilters | None = None, **kwargs) -> ResumeConfig:
+    return ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=search if search is not None else SearchFilters(text="python developer"),
+        **kwargs,
+    )
+
+
+def _history(tmp_path) -> History:
+    return History(tmp_path / "history.db")
+
+
+def test_build_apply_plan_returns_all_candidates_without_limit(tmp_path):
+    cards = [_card("1"), _card("2"), _card("3")]
+    resume = _resume()
+    history = _history(tmp_path)
+
+    plan = build_apply_plan(cards, resume.search, resume, history)
+
+    assert isinstance(plan, ApplyPlan)
+    assert [c.vacancy_id for c, _score, _breakdown in plan.ranked] == ["1", "2", "3"]
+    assert plan.total == 3
+    assert plan.after_filter == 3
+    assert plan.after_limit == 3
+    assert plan.skipped == []
+
+
+def test_build_apply_plan_filters_already_applied(tmp_path):
+    cards = [_card("1"), _card("2")]
+    resume = _resume()
+    history = _history(tmp_path)
+    history.record_action(resume.resume_id, "1", "apply", "success", "ok")
+
+    plan = build_apply_plan(cards, resume.search, resume, history)
+
+    assert [c.vacancy_id for c, _s, _b in plan.ranked] == ["2"]
+    assert plan.total == 2
+    assert plan.after_filter == 1
+    assert plan.after_limit == 1
+    assert len(plan.skipped) == 1
+    assert plan.skipped[0][0].vacancy_id == "1"
+
+
+def test_build_apply_plan_filters_stoplist_employer(tmp_path):
+    cards = [_card("1", company="BadCorp"), _card("2", company="GoodCorp")]
+    resume = _resume(search=SearchFilters(text="python", exclude_employers=["BadCorp"]))
+    history = _history(tmp_path)
+
+    plan = build_apply_plan(cards, resume.search, resume, history)
+
+    assert [c.vacancy_id for c, _s, _b in plan.ranked] == ["2"]
+    assert plan.after_filter == 1
+
+
+def test_build_apply_plan_applies_limit_after_ranking(tmp_path):
+    cards = [_card("1", title="Junior PHP"), _card("2", title="Senior Python")]
+    resume = _resume(
+        search=SearchFilters(text="python", must_have=["python"]),
+    )
+    history = _history(tmp_path)
+
+    plan = build_apply_plan(cards, resume.search, resume, history, limit=1)
+
+    assert plan.total == 2
+    assert plan.after_filter == 2
+    assert plan.after_limit == 1
+    # Без scoring-секции веса нейтральны (_ZERO_WEIGHTS) -> порядок входа сохранён,
+    # даже если "Senior Python" совпадает с must_have по названию сильнее.
+    assert [c.vacancy_id for c, _s, _b in plan.ranked] == ["1"]
+
+
+def test_build_apply_plan_limit_none_means_no_slice(tmp_path):
+    cards = [_card(str(i)) for i in range(5)]
+    resume = _resume()
+    history = _history(tmp_path)
+
+    plan = build_apply_plan(cards, resume.search, resume, history, limit=None)
+
+    assert plan.after_limit == 5
+
+
+def test_build_apply_plan_limit_zero_means_no_slice(tmp_path):
+    """CLI-конвенция: args.limit=0 ('--limit' не передан) означает "без лимита"."""
+    cards = [_card(str(i)) for i in range(4)]
+    resume = _resume()
+    history = _history(tmp_path)
+
+    plan = build_apply_plan(cards, resume.search, resume, history, limit=0)
+
+    assert plan.after_limit == 4
+
+
+def test_build_apply_plan_uses_scoring_provider_when_given(tmp_path):
+    cards = [_card("1", title="Junior"), _card("2", title="Senior")]
+    resume = _resume()
+    history = _history(tmp_path)
+
+    class _FixedScoreProvider:
+        def score(self, card, resume_profile=None):  # noqa: ARG002
+            from hhru_bot.scoring import ScoreOutcome
+
+            score = 90.0 if card.vacancy_id == "1" else 10.0
+            return ScoreOutcome(score_0_100=score, breakdown={}, rationale="")
+
+    plan = build_apply_plan(
+        cards, resume.search, resume, history, scoring_provider=_FixedScoreProvider()
+    )
+
+    assert [c.vacancy_id for c, _s, _b in plan.ranked] == ["1", "2"]
+
+
+def test_build_apply_plan_empty_candidates(tmp_path):
+    resume = _resume()
+    history = _history(tmp_path)
+
+    plan = build_apply_plan([], resume.search, resume, history)
+
+    assert plan.ranked == []
+    assert plan.total == 0
+    assert plan.after_filter == 0
+    assert plan.after_limit == 0


### PR DESCRIPTION
## Что сделано

Вынесена чистая `build_apply_plan()` из `run_apply_for_resume` (пере-аудит #100).

- `build_apply_plan(candidates, filters, resume, history, scoring_provider=None, limit=None) -> ApplyPlan` в `commands/_common.py`: собирает `filter_candidates -> pre-LLM (#85) -> rank_candidates (#74/#81) -> slice по limit`. Чистая функция без браузера, тестируется без hh.ru.
- `ApplyPlan` dataclass: `ranked` (список (card, score, breakdown), уже урезанный по limit), `skipped` (пары карточка/причина из filter_candidates), `total`/`after_filter`/`after_limit` — счётчики по стадиям.
- `run_apply_for_resume` делегирует plan-construction этой функции, сам остаётся execution-оркестратором: providers setup, `apply_to_vacancy` по плану, запись истории, throttle.
- Поведение не меняется: `limit=None`/`0` (CLI-конвенция `args.limit` по умолчанию `0`) означает "без среза", как и раньше.

## Тесты

8 новых тестов на `build_apply_plan` в `tests/test_apply_plan.py`: без фильтров, дедуп по истории (уже откликались), стоп-лист по работодателю, лимит после ранжирования, `limit=None`/`0` без среза, кастомный `scoring_provider`, пустой список кандидатов.

Регресс: существующие интеграционные тесты (`test_apply_scoring_integration.py`, `test_apply_letter_integration.py`, `test_history_key_consistency.py`) зелёные без изменений — они monkeypatch'ат `_common.rank_candidates`/`_common.search_vacancies` по module-level имени, что продолжает работать, так как `build_apply_plan` вызывает те же module-level функции внутри `_common.py`.

## Проверки

- `ruff check` — чисто
- `ruff format --check` — чисто
- `pytest` — все тесты зелёные (полный набор, без регрессий)

## Зона изменений

Строго `src/hhru_bot/commands/_common.py` + новый `tests/test_apply_plan.py`, как указано в issue. `apply/pipeline.py` и `apply/steps.py` не тронуты.

Closes #101