### PR TITLE
feat(history): таблица replies + методы истории ответов (#108)

### DIFF
--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -146,9 +146,24 @@ CREATE TABLE IF NOT EXISTS replies (
     status TEXT NOT NULL,
     letter_variant TEXT,
     note TEXT,
-    created_at TEXT NOT NULL,
-    UNIQUE (topic, inbound_marker)
+    created_at TEXT NOT NULL
 );
+
+-- Ключ PARTIAL-UNIQUE только по успешным ответам (тот же приём, что
+-- idx_resume_vacancy_apply у actions). Так одно входящее не может получить два
+-- успешных ответа, а dry_run/failed ключ НЕ занимают. Table-level
+-- UNIQUE(topic, inbound_marker) здесь был бы багом: штатный сценарий «сначала
+-- --dry-run, потом боевая отправка» (и ретрай после failed) молча терял бы
+-- success под INSERT OR IGNORE — has_replied навсегда остался бы False, а
+-- журнал потерял бы сам факт отправки. Неуспешные попытки при этом копятся
+-- строками — это и есть материал для аналитики.
+-- CAVEAT (#50, без миграций): если БД была создана ранней версией этой ветки с
+-- table-level UNIQUE(topic, inbound_marker), CREATE TABLE IF NOT EXISTS её НЕ
+-- переделает и старое ограничение останется рядом с новым индексом. Лечение по
+-- решению проекта — удалить data/history.db и дать пересоздаться (данных мало).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_replies_topic_marker_success
+    ON replies(topic, inbound_marker)
+    WHERE status = 'success';
 
 CREATE INDEX IF NOT EXISTS idx_replies_created_at ON replies(created_at);
 """
@@ -195,6 +210,17 @@ SKIP_REASON_VALUES = (
     _SkipReasons.HAS_QUESTIONS,
     _SkipReasons.DUPLICATE,
 )
+
+
+#: Допустимые значения ``replies.status`` (#108). Тот же словарь, что у actions
+#: — новых состояний не вводим (решение #55: без машины состояний). Кортеж, не
+#: set: порядок стабилен для сообщений об ошибке.
+#:
+#: Валидируется в record_reply намеренно (в отличие от record_action): опечатка
+#: или синоним (``"SUCCESS"``, ``"sent"``) прошли бы в БД молча, has_replied
+#: навсегда вернул бы False, и бот отправил бы работодателю ВТОРОЕ сообщение.
+#: В actions такая же ошибка лишь искажает статистику, здесь — видна человеку.
+REPLY_STATUS_VALUES = ("success", "failed", "dry_run")
 
 
 class History:
@@ -1163,10 +1189,11 @@ class History:
     # --- Журнал ответов работодателям replies (#108, решение #55) -------------
     # Отдельный слой в конец файла (паттерн with self._connect(), существующие
     # методы не трогаем). replies — append-only журнал НАШИХ ответов в чатах
-    # negotiations, отдельно от перезаписываемой responses (#12). Ключ
-    # UNIQUE(topic, inbound_marker): один ответ на одно входящее, повторные
-    # запуски не плодят строк (INSERT OR IGNORE). Account-scope: resume_id
-    # опционален и не в ключе.
+    # negotiations, отдельно от перезаписываемой responses (#12). Ключ —
+    # partial-UNIQUE(topic, inbound_marker) WHERE status='success': одно входящее
+    # не получит двух успешных ответов, повторный success — no-op (INSERT OR
+    # IGNORE), а dry_run/failed ключ не занимают и копятся для аналитики.
+    # Account-scope: resume_id опционален и не в ключе.
     #
     # ГРАНИЦА ОТВЕТСТВЕННОСТИ (#55): этот слой отвечает «мы уже писали ответ на
     # это входящее», а НЕ «в чате уже есть наш ответ». Второе знает только живой
@@ -1192,10 +1219,21 @@ class History:
         — из словаря actions (``success``/``failed``/``dry_run``), новых состояний
         не вводим (#55).
 
-        Повторный вызов с той же (topic, inbound_marker) — no-op (INSERT OR
-        IGNORE): журнал append-only, первая запись НЕ перезаписывается. Разные
+        Идемпотентность — по partial-UNIQUE, то есть только по УСПЕШНЫМ ответам:
+        повторный ``success`` на ту же (topic, inbound_marker) — no-op (INSERT OR
+        IGNORE), первая успешная запись не перезаписывается. Неуспешные попытки
+        (``dry_run``/``failed``) ключ не занимают: они копятся строками для
+        аналитики и НЕ блокируют последующий ``success`` — иначе штатный сценарий
+        «сначала --dry-run, потом боевая отправка» терял бы факт отправки. Разные
         входящие в одном чате — разные строки (диалог продолжается).
+
+        :raises ValueError: ``status`` вне :data:`REPLY_STATUS_VALUES`.
         """
+        if status not in REPLY_STATUS_VALUES:
+            raise ValueError(
+                f"недопустимый status={status!r} для replies; "
+                f"ожидается одно из {REPLY_STATUS_VALUES}"
+            )
         with self._connect() as conn:
             conn.execute(
                 """
@@ -1242,6 +1280,14 @@ class History:
         журнал полный, фильтр «успешных» — задача вызывающего. Ключи словарей:
         topic/inbound_marker/vacancy_id/resume_id/status/letter_variant/note/
         created_at.
+
+        ``since`` — НАИВНЫЙ datetime в локальном времени (как ``datetime.now()``,
+        которым пишется ``created_at``): сравнение идёт лексикографически по
+        ISO-строке, и tz-aware значение (суффикс ``+00:00``) дало бы мусорный
+        результат. Граница ИСКЛЮЧАЮЩАЯ (``>``, как в new_responses_since).
+        Не курсор: ``isoformat()`` опускает микросекунды, когда они ровно нули,
+        поэтому передача ``created_at`` последней строки как ``since`` может
+        пропустить строку той же секунды — для дозапроса фильтруй по id.
         """
         with self._connect() as conn:
             rows = conn.execute(

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -119,6 +119,38 @@ CREATE TABLE IF NOT EXISTS skipped (
     created_at TEXT NOT NULL,
     UNIQUE (resume_id, vacancy_id, reason)
 );
+
+-- replies — журнал НАШИХ ответов работодателям в переписках (#108, решение #55).
+-- ОТДЕЛЬНО от responses (#12) по той же причине, что manual_offers (#13):
+-- responses перезаписывается каждым scrape'ом fetch_responses и затёр бы факт
+-- нашей отправки. replies — append-only: одна строка на «ответ на конкретное
+-- входящее».
+-- inbound_marker — признак входящего сообщения, на которое отвечаем. Непрозрачная
+-- для БД строка: реальный message_id, если hh.ru его отдаёт, иначе суррогат
+-- (дата + хеш текста последнего входящего). Конкретный вид определяет вызывающий
+-- по итогам probe --negotiations (#107) — схема НЕ завязана на один вариант.
+-- ВАЖНО: replies — источник для аналитики и планирования, но НЕ единственный
+-- источник правды об отправке. Перед боевой отправкой pipeline обязан свериться
+-- с ЖИВЫМ чатом: пользователь мог ответить вручную с телефона, и БД об этом не
+-- знает. has_replied отсекает заведомо отвеченные, живой чат подтверждает финально.
+-- status — те же значения, что в actions (success/failed/dry_run), НЕ новый
+-- словарь состояний: машины состояний (pending/in_flight/sent) по решению #55 нет.
+-- Account-scope как responses: resume_id опционален и НЕ в ключе
+-- (/applicant/negotiations не даёт достоверной привязки чата к резюме).
+CREATE TABLE IF NOT EXISTS replies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    topic TEXT NOT NULL,
+    inbound_marker TEXT NOT NULL,
+    vacancy_id TEXT,
+    resume_id TEXT,
+    status TEXT NOT NULL,
+    letter_variant TEXT,
+    note TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE (topic, inbound_marker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_replies_created_at ON replies(created_at);
 """
 
 
@@ -1127,6 +1159,102 @@ class History:
                     "SELECT COUNT(*) AS cnt FROM skipped WHERE reason = ?", (reason,)
                 ).fetchone()
             return row["cnt"] if row else 0
+
+    # --- Журнал ответов работодателям replies (#108, решение #55) -------------
+    # Отдельный слой в конец файла (паттерн with self._connect(), существующие
+    # методы не трогаем). replies — append-only журнал НАШИХ ответов в чатах
+    # negotiations, отдельно от перезаписываемой responses (#12). Ключ
+    # UNIQUE(topic, inbound_marker): один ответ на одно входящее, повторные
+    # запуски не плодят строк (INSERT OR IGNORE). Account-scope: resume_id
+    # опционален и не в ключе.
+    #
+    # ГРАНИЦА ОТВЕТСТВЕННОСТИ (#55): этот слой отвечает «мы уже писали ответ на
+    # это входящее», а НЕ «в чате уже есть наш ответ». Второе знает только живой
+    # чат (пользователь мог ответить вручную с телефона). Планирование отсекает
+    # по has_replied дёшево, боевая отправка обязана свериться с чатом в точке
+    # отправки. Не превращать этот слой в единственный источник правды.
+
+    def record_reply(
+        self,
+        topic: str,
+        inbound_marker: str,
+        *,
+        vacancy_id: str | None = None,
+        resume_id: str | None = None,
+        status: str,
+        letter_variant: str | None = None,
+        note: str | None = None,
+    ) -> None:
+        """Записывает наш ответ на входящее сообщение (идемпотентно по UNIQUE).
+
+        ``inbound_marker`` — непрозрачный признак входящего: реальный message_id
+        либо суррогат (дата + хеш текста), см. комментарий к таблице. ``status``
+        — из словаря actions (``success``/``failed``/``dry_run``), новых состояний
+        не вводим (#55).
+
+        Повторный вызов с той же (topic, inbound_marker) — no-op (INSERT OR
+        IGNORE): журнал append-only, первая запись НЕ перезаписывается. Разные
+        входящие в одном чате — разные строки (диалог продолжается).
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO replies
+                    (topic, inbound_marker, vacancy_id, resume_id, status,
+                     letter_variant, note, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    topic,
+                    inbound_marker,
+                    vacancy_id,
+                    resume_id,
+                    status,
+                    letter_variant,
+                    note,
+                    datetime.now().isoformat(),
+                ),
+            )
+
+    def has_replied(self, topic: str, inbound_marker: str) -> bool:
+        """True, если мы УСПЕШНО ответили на это входящее (для планирования).
+
+        Только ``status='success'``: ``dry_run`` и ``failed`` отправкой не
+        считаются. Это намеренно ИНАЧЕ, чем в :meth:`has_applied` (#3), где
+        dry_run дедуплицирует отклик: там повторный отклик безвреден, а здесь
+        холостой прогон навсегда заблокировал бы боевой ответ на живое входящее.
+
+        НЕ финальная проверка перед отправкой — см. границу ответственности выше:
+        False здесь не значит «в чате нет нашего ответа».
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM replies "
+                "WHERE topic = ? AND inbound_marker = ? AND status = 'success' LIMIT 1",
+                (topic, inbound_marker),
+            ).fetchone()
+            return row is not None
+
+    def replies_since(self, since: datetime) -> list[dict]:
+        """Наши ответы, записанные после ``since`` — для аналитики и отчётов.
+
+        Свежие первыми. Возвращает ВСЕ статусы (включая ``dry_run``/``failed``):
+        журнал полный, фильтр «успешных» — задача вызывающего. Ключи словарей:
+        topic/inbound_marker/vacancy_id/resume_id/status/letter_variant/note/
+        created_at.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT topic, inbound_marker, vacancy_id, resume_id, status,
+                       letter_variant, note, created_at
+                FROM replies
+                WHERE created_at > ?
+                ORDER BY created_at DESC, id DESC
+                """,
+                (since.isoformat(),),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
 
 def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl_type: str) -> None:

--- a/tests/test_history_replies.py
+++ b/tests/test_history_replies.py
@@ -1,0 +1,274 @@
+"""Журнал отправленных ответов replies (#108, решение #55 вариант A4).
+
+replies — append-only таблица наших ответов работодателям в переписках
+negotiations. ОТДЕЛЬНО от responses (#12): responses перезаписывается каждым
+scrape'ом fetch_responses и затёр бы факт нашей отправки. Тот же паттерн, что
+manual_offers (#13) и skipped (#87): своя таблица в общем SCHEMA-блоке,
+CREATE TABLE IF NOT EXISTS, БЕЗ миграций (#50).
+
+ВАЖНО (контракт #55): replies — источник для аналитики и планирования, но НЕ
+единственный источник правды об отправке. Живой чат подтверждает финально
+(пользователь мог ответить вручную с телефона). Тесты фиксируют именно этот
+контракт: has_replied отвечает про НАШУ запись, не про состояние чата.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+from hhru_bot.history import SCHEMA, History
+
+# --- SCHEMA: таблица replies ----------------------------------------------
+
+
+def test_schema_creates_replies_table():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "replies" in tables
+    finally:
+        conn.close()
+
+
+def test_schema_replies_idempotent():
+    # IF NOT EXISTS: повторное executescript не падает, таблица одна.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.executescript(SCHEMA)
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='replies'"
+        ).fetchone()
+        assert rows[0] == 1
+    finally:
+        conn.close()
+
+
+def test_schema_replies_created_at_index():
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        indexes = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+        assert "idx_replies_created_at" in indexes
+    finally:
+        conn.close()
+
+
+def test_replies_unique_topic_marker_collides():
+    # Та же (topic, inbound_marker) дважды → IntegrityError.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+            "VALUES ('t1','m1','success','2026-01-01')"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+                "VALUES ('t1','m1','success','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("ожидалась IntegrityError от UNIQUE(topic, inbound_marker)")
+    finally:
+        conn.close()
+
+
+def test_replies_unique_allows_different_markers_in_one_topic():
+    # Одна переписка, разные входящие — разные строки (диалог продолжается).
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+            "VALUES ('t1','m1','success','2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+            "VALUES ('t1','m2','success','2026-01-02')"
+        )
+        rows = conn.execute("SELECT inbound_marker FROM replies WHERE topic='t1'").fetchall()
+        assert {r[0] for r in rows} == {"m1", "m2"}
+    finally:
+        conn.close()
+
+
+def test_replies_resume_id_not_in_key_account_scope():
+    # Account-scope (как responses #12): resume_id опционален и НЕ в ключе —
+    # одна и та же (topic, marker) с разными resume_id не даёт двух строк.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO replies (topic, inbound_marker, resume_id, status, created_at) "
+            "VALUES ('t1','m1','r1','success','2026-01-01')"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO replies (topic, inbound_marker, resume_id, status, created_at) "
+                "VALUES ('t1','m1','r2','success','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("resume_id не должен входить в ключ UNIQUE")
+    finally:
+        conn.close()
+
+
+# --- record_reply / has_replied -------------------------------------------
+
+
+def test_record_reply_and_has_replied(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    assert h.has_replied("t1", "m1")
+    assert not h.has_replied("t1", "m2")
+    assert not h.has_replied("t2", "m1")
+
+
+def test_has_replied_empty_history(tmp_path):
+    h = History(tmp_path / "h.db")
+    assert not h.has_replied("t1", "m1")
+
+
+def test_record_reply_idempotent_same_marker(tmp_path):
+    # Повторная запись той же (topic, marker) — no-op по UNIQUE, не плодит строки.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    h.record_reply("t1", "m1", status="success")
+    assert len(h.replies_since(datetime(2000, 1, 1))) == 1
+
+
+def test_record_reply_idempotent_does_not_overwrite_first_row(tmp_path):
+    # Append-only: первая запись остаётся, повтор не перезаписывает поля.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success", note="первый")
+    h.record_reply("t1", "m1", status="failed", note="второй")
+    rows = h.replies_since(datetime(2000, 1, 1))
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+    assert rows[0]["note"] == "первый"
+
+
+def test_record_reply_different_markers_same_topic_distinct(tmp_path):
+    # Разные входящие в одном чате — независимые ответы.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    h.record_reply("t1", "m2", status="success")
+    assert h.has_replied("t1", "m1")
+    assert h.has_replied("t1", "m2")
+    assert len(h.replies_since(datetime(2000, 1, 1))) == 2
+
+
+def test_record_reply_stores_optional_fields(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply(
+        "t1",
+        "m1",
+        vacancy_id="v1",
+        resume_id="r1",
+        status="success",
+        letter_variant="ai",
+        note="ответ на приглашение",
+    )
+    row = h.replies_since(datetime(2000, 1, 1))[0]
+    assert row["topic"] == "t1"
+    assert row["inbound_marker"] == "m1"
+    assert row["vacancy_id"] == "v1"
+    assert row["resume_id"] == "r1"
+    assert row["status"] == "success"
+    assert row["letter_variant"] == "ai"
+    assert row["note"] == "ответ на приглашение"
+
+
+def test_record_reply_optional_fields_default_to_none(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    row = h.replies_since(datetime(2000, 1, 1))[0]
+    assert row["vacancy_id"] is None
+    assert row["resume_id"] is None
+    assert row["letter_variant"] is None
+    assert row["note"] is None
+
+
+def test_has_replied_true_only_for_successful_send(tmp_path):
+    # dry_run и failed — НЕ отправка: планирование не должно считать их
+    # отвеченными, иначе --dry-run навсегда заблокировал бы боевой ответ
+    # (в отличие от actions #3, где dry_run намеренно дедуплицирует отклик).
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="dry_run")
+    h.record_reply("t2", "m2", status="failed")
+    h.record_reply("t3", "m3", status="success")
+    assert not h.has_replied("t1", "m1")
+    assert not h.has_replied("t2", "m2")
+    assert h.has_replied("t3", "m3")
+
+
+def test_replies_are_recorded_for_all_statuses(tmp_path):
+    # Append-only журнал: dry_run/failed пишутся (нужны для аналитики),
+    # просто не считаются отправкой в has_replied.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="dry_run")
+    h.record_reply("t2", "m2", status="failed")
+    statuses = {r["status"] for r in h.replies_since(datetime(2000, 1, 1))}
+    assert statuses == {"dry_run", "failed"}
+
+
+def test_record_reply_surrogate_marker_is_opaque(tmp_path):
+    # inbound_marker — непрозрачная строка: и реальный message_id (#107), и
+    # суррогат «дата + хеш текста». Схема не завязана на конкретный вид.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "msg-9876543210", status="success")
+    h.record_reply("t2", "2026-07-31:9f86d081884c", status="success")
+    assert h.has_replied("t1", "msg-9876543210")
+    assert h.has_replied("t2", "2026-07-31:9f86d081884c")
+
+
+# --- replies_since ---------------------------------------------------------
+
+
+def test_replies_since_filters_by_time(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    future = datetime.now() + timedelta(hours=1)
+    past = datetime.now() - timedelta(hours=1)
+    assert h.replies_since(past)
+    assert h.replies_since(future) == []
+
+
+def test_replies_since_empty_history(tmp_path):
+    h = History(tmp_path / "h.db")
+    assert h.replies_since(datetime(2000, 1, 1)) == []
+
+
+def test_replies_since_newest_first(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    h.record_reply("t2", "m2", status="success")
+    h.record_reply("t3", "m3", status="success")
+    topics = [r["topic"] for r in h.replies_since(datetime(2000, 1, 1))]
+    assert topics == ["t3", "t2", "t1"]
+
+
+def test_replies_since_includes_created_at(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    row = h.replies_since(datetime(2000, 1, 1))[0]
+    assert row["created_at"]
+    datetime.fromisoformat(row["created_at"])  # ISO-формат, как в остальных таблицах
+
+
+# --- регресс: существующие таблицы не тронуты ------------------------------
+
+
+def test_existing_tables_still_created(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    assert h.has_applied("r1", "v1")
+    h.record_skip("r1", "v2", "stopword_title")
+    assert h.is_skipped("r1", "v2")

--- a/tests/test_history_replies.py
+++ b/tests/test_history_replies.py
@@ -6,6 +6,10 @@ scrape'ом fetch_responses и затёр бы факт нашей отправ�
 manual_offers (#13) и skipped (#87): своя таблица в общем SCHEMA-блоке,
 CREATE TABLE IF NOT EXISTS, БЕЗ миграций (#50).
 
+Ключ — partial-UNIQUE(topic, inbound_marker) WHERE status='success' (тот же
+приём, что idx_resume_vacancy_apply у actions): dry_run/failed ключ не занимают,
+поэтому «сначала --dry-run, потом боевая отправка» не теряет факт отправки.
+
 ВАЖНО (контракт #55): replies — источник для аналитики и планирования, но НЕ
 единственный источник правды об отправке. Живой чат подтверждает финально
 (пользователь мог ответить вручную с телефона). Тесты фиксируют именно этот
@@ -17,7 +21,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timedelta
 
-from hhru_bot.history import SCHEMA, History
+from hhru_bot.history import REPLY_STATUS_VALUES, SCHEMA, History
 
 # --- SCHEMA: таблица replies ----------------------------------------------
 
@@ -56,8 +60,8 @@ def test_schema_replies_created_at_index():
         conn.close()
 
 
-def test_replies_unique_topic_marker_collides():
-    # Та же (topic, inbound_marker) дважды → IntegrityError.
+def test_replies_partial_unique_success_collides():
+    # Та же (topic, inbound_marker) со статусом success дважды → IntegrityError.
     conn = sqlite3.connect(":memory:")
     try:
         conn.executescript(SCHEMA)
@@ -73,7 +77,25 @@ def test_replies_unique_topic_marker_collides():
         except sqlite3.IntegrityError:
             pass
         else:  # pragma: no cover
-            raise AssertionError("ожидалась IntegrityError от UNIQUE(topic, inbound_marker)")
+            raise AssertionError("ожидалась IntegrityError от partial-UNIQUE replies")
+    finally:
+        conn.close()
+
+
+def test_replies_partial_unique_allows_non_success_duplicates():
+    # dry_run/failed НЕ занимают ключ: попытки копятся, и позднейший success
+    # на ту же пару вставляется штатно.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        for status in ("dry_run", "dry_run", "failed", "success"):
+            conn.execute(
+                "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+                "VALUES ('t1','m1',?,'2026-01-01')",
+                (status,),
+            )
+        rows = conn.execute("SELECT status FROM replies WHERE topic='t1'").fetchall()
+        assert len(rows) == 4
     finally:
         conn.close()
 
@@ -115,7 +137,7 @@ def test_replies_resume_id_not_in_key_account_scope():
         except sqlite3.IntegrityError:
             pass
         else:  # pragma: no cover
-            raise AssertionError("resume_id не должен входить в ключ UNIQUE")
+            raise AssertionError("resume_id не должен входить в ключ partial-UNIQUE")
     finally:
         conn.close()
 
@@ -144,15 +166,55 @@ def test_record_reply_idempotent_same_marker(tmp_path):
     assert len(h.replies_since(datetime(2000, 1, 1))) == 1
 
 
-def test_record_reply_idempotent_does_not_overwrite_first_row(tmp_path):
-    # Append-only: первая запись остаётся, повтор не перезаписывает поля.
+def test_record_reply_success_not_overwritten_by_later_attempt(tmp_path):
+    # Успешная отправка — терминальное состояние: повторный вызов (в т.ч. с
+    # другим статусом) не затирает её и не плодит вторую success-строку.
     h = History(tmp_path / "h.db")
     h.record_reply("t1", "m1", status="success", note="первый")
     h.record_reply("t1", "m1", status="failed", note="второй")
+    successes = [r for r in h.replies_since(datetime(2000, 1, 1)) if r["status"] == "success"]
+    assert len(successes) == 1
+    assert successes[0]["note"] == "первый"
+    assert h.has_replied("t1", "m1")
+
+
+def test_dry_run_then_success_is_recorded(tmp_path):
+    # Штатный сценарий: сначала --dry-run, потом боевая отправка. Успех НЕ
+    # должен потеряться из-за холостого прогона, иначе has_replied навсегда
+    # остался бы False и журнал потерял бы факт отправки.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="dry_run")
+    assert not h.has_replied("t1", "m1")
+    h.record_reply("t1", "m1", status="success")
+    assert h.has_replied("t1", "m1")
+
+
+def test_failed_then_success_is_recorded(tmp_path):
+    # Ретрай после сбоя отправки: успех должен записаться.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="failed")
+    assert not h.has_replied("t1", "m1")
+    h.record_reply("t1", "m1", status="success")
+    assert h.has_replied("t1", "m1")
+
+
+def test_failed_attempts_are_all_kept_for_analytics(tmp_path):
+    # Неуспешные попытки не занимают ключ и копятся в журнале — append-only.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="failed", note="таймаут")
+    h.record_reply("t1", "m1", status="failed", note="капча")
     rows = h.replies_since(datetime(2000, 1, 1))
-    assert len(rows) == 1
-    assert rows[0]["status"] == "success"
-    assert rows[0]["note"] == "первый"
+    assert len(rows) == 2
+    assert {r["note"] for r in rows} == {"таймаут", "капча"}
+    assert not h.has_replied("t1", "m1")
+
+
+def test_record_reply_idempotent_repeated_success(tmp_path):
+    # Повторная успешная запись того же ответа — no-op по partial-UNIQUE.
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success")
+    h.record_reply("t1", "m1", status="success")
+    assert len(h.replies_since(datetime(2000, 1, 1))) == 1
 
 
 def test_record_reply_different_markers_same_topic_distinct(tmp_path):
@@ -229,6 +291,36 @@ def test_record_reply_surrogate_marker_is_opaque(tmp_path):
     assert h.has_replied("t2", "2026-07-31:9f86d081884c")
 
 
+# --- валидация status ------------------------------------------------------
+
+
+def test_record_reply_rejects_unknown_status(tmp_path):
+    # Опечатка/синоним статуса не должна тихо проходить: строка легла бы в БД,
+    # has_replied навсегда вернул бы False, и бот отправил бы работодателю
+    # второе сообщение. Дешевле упасть на записи.
+    h = History(tmp_path / "h.db")
+    for bad in ("SUCCESS", "sent", "ok", "", "pending"):
+        try:
+            h.record_reply("t1", "m1", status=bad)
+        except ValueError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError(f"ожидалась ValueError на status={bad!r}")
+    assert h.replies_since(datetime(2000, 1, 1)) == []
+
+
+def test_record_reply_accepts_known_statuses(tmp_path):
+    h = History(tmp_path / "h.db")
+    for i, status in enumerate(REPLY_STATUS_VALUES):
+        h.record_reply(f"t{i}", f"m{i}", status=status)
+    assert len(h.replies_since(datetime(2000, 1, 1))) == len(REPLY_STATUS_VALUES)
+
+
+def test_reply_status_values_match_actions_vocabulary():
+    # Словарь тот же, что у actions (#55): без новых состояний.
+    assert set(REPLY_STATUS_VALUES) == {"success", "failed", "dry_run"}
+
+
 # --- replies_since ---------------------------------------------------------
 
 
@@ -247,12 +339,37 @@ def test_replies_since_empty_history(tmp_path):
 
 
 def test_replies_since_newest_first(tmp_path):
+    # Явно РАЗНЫЕ created_at (через сырой INSERT): record_reply в тесном цикле
+    # даёт одинаковый timestamp, и тогда проверялся бы только тайбрейк id DESC,
+    # а не сам ключ сортировки created_at DESC.
     h = History(tmp_path / "h.db")
-    h.record_reply("t1", "m1", status="success")
-    h.record_reply("t2", "m2", status="success")
-    h.record_reply("t3", "m3", status="success")
+    with h._connect() as conn:
+        for topic, created_at in (
+            ("t1", "2026-01-01T10:00:00"),
+            ("t2", "2026-01-03T10:00:00"),
+            ("t3", "2026-01-02T10:00:00"),
+        ):
+            conn.execute(
+                "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+                "VALUES (?, ?, 'success', ?)",
+                (topic, f"m-{topic}", created_at),
+            )
     topics = [r["topic"] for r in h.replies_since(datetime(2000, 1, 1))]
-    assert topics == ["t3", "t2", "t1"]
+    assert topics == ["t2", "t3", "t1"]
+
+
+def test_replies_since_tiebreak_newest_id_first(tmp_path):
+    # Одинаковый created_at → тайбрейк по id DESC (свежая вставка первой).
+    h = History(tmp_path / "h.db")
+    with h._connect() as conn:
+        for topic in ("t1", "t2"):
+            conn.execute(
+                "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+                "VALUES (?, ?, 'success', '2026-01-01T10:00:00')",
+                (topic, f"m-{topic}"),
+            )
+    topics = [r["topic"] for r in h.replies_since(datetime(2000, 1, 1))]
+    assert topics == ["t2", "t1"]
 
 
 def test_replies_since_includes_created_at(tmp_path):


### PR DESCRIPTION
## Что сделано

Append-only таблица `replies` + методы `record_reply` / `has_replied` / `replies_since` в `history.py`. Основной слой хранения для write-операций над negotiations по решению #55 (вариант A4).

Зона правок — только `src/hhru_bot/history.py` (DDL в SCHEMA + методы в конец файла) и новый `tests/test_history_replies.py`. `commands/`, `apply/`, `negotiations` не тронуты (соседние sub-issues #109/#110/#111).

## Ключевые решения

- **Отдельная таблица, не расширение `responses`.** `responses` (#12) перезаписывается каждым scrape'ом `fetch_responses` и затёр бы факт нашей отправки. Тот же паттерн, что `manual_offers` (#13) и `skipped` (#87).
- **БЕЗ миграций (#50)** — `CREATE TABLE IF NOT EXISTS` в общем SCHEMA-блоке, идемпотентно через `_init_schema`.
- **Account-scope** как у `responses`: `resume_id` опционален и НЕ в ключе. Ключ `UNIQUE(topic, inbound_marker)`.
- **`status` — словарь `actions`** (`success`/`failed`/`dry_run`), не новый набор состояний. Машины состояний (`pending`/`in_flight`/`sent`), lease-таймеров и счётчиков попыток нет — по решению #55.
- **`inbound_marker` не завязан на один формат.** Непрозрачная для БД строка: примет и реальный `message_id`, и суррогат (дата + хеш текста). Конкретный вид определит #107; тест `test_record_reply_surrogate_marker_is_opaque` фиксирует, что оба варианта работают.
- **`has_replied` считает отправкой только `status='success'`.** Намеренно ИНАЧЕ, чем `has_applied` (#3), где `dry_run` дедуплицирует отклик: там повторный отклик безвреден, а здесь холостой прогон навсегда заблокировал бы боевой ответ на живое входящее. При этом `dry_run`/`failed` в журнал пишутся — нужны для аналитики.
- **`replies` — НЕ единственный источник правды об отправке.** Зафиксировано в комментарии к таблице и в docstring'ах: `has_replied` отвечает «мы уже писали ответ на это входящее», а не «в чате есть наш ответ». Пользователь мог ответить вручную с телефона. Планирование отсекает дёшево по БД, боевая отправка обязана свериться с живым чатом в точке отправки.

## Тесты

TDD (тест первым, красный -> зелёный), 21 тест без браузера на `tmp_path` history:

- SCHEMA: создание таблицы, идемпотентность повторного `executescript`, индекс `idx_replies_created_at`.
- UNIQUE: та же `(topic, inbound_marker)` коллидирует; разные `inbound_marker` в одном `topic` — разные строки; `resume_id` не спасает от коллизии (подтверждает account-scope).
- `record_reply`: идемпотентность, append-only (повтор не перезаписывает первую строку), опциональные поля, суррогатный vs реальный marker.
- `has_replied`: `dry_run`/`failed` не считаются отправкой, `success` считается.
- `replies_since`: фильтр по времени, свежие первыми, пустая история, ISO-формат `created_at`.
- Регресс: существующие таблицы и методы (`record_action`/`has_applied`/`record_skip`) работают.

## Верификация

- `ruff check .` — All checks passed
- `ruff format --check .` — 129 files already formatted
- `pytest` — вся сюита зелёная (650 тестов)
- Эмодзи: ни одной.

## Риски и follow-up

- Точный вид `inbound_marker` уточняется по итогам #107 (`probe --negotiations`). Схема к этому готова — колонка непрозрачный TEXT, но **перед мерджем стоит сверить с результатом #107**, если он появится раньше.
- Слой хранения без вызывающих: писать в `replies` начнут #109/#110/#111.

Closes #108