### PR TITLE
fix(tests): изолировать test_log_command_does_not_create_log от реального LOG_DIR (#129)

### DIFF
--- a/tests/test_log_command.py
+++ b/tests/test_log_command.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from hhru_bot import logging_setup
 from hhru_bot.commands import log_cmd
 from hhru_bot.commands.log_cmd import follow, tail_lines
 
@@ -303,8 +304,22 @@ def test_log_command_does_not_create_log(tmp_path, monkeypatch):
     до run(), из-за чего missing-file-ветка была недостижима и команда «писала»
     локально. Теперь для log setup_logging не вызывается — файл не создаётся,
     и `log` честно рапортует об отсутствии лога.
+
+    Изоляция от реального лога (#129): `LOG_DIR`/`DEFAULT_LOG_PATH` абсолютны и
+    вычисляются НА ИМПОРТЕ модуля (`Path.cwd() / "logs"`), поэтому одного
+    `chdir(tmp_path)` мало — на машине разработчика, где `logs/hhru_bot.log`
+    существует, `main(["log"])` читал настоящий лог, печатал его хвост и не
+    бросал SystemExit. Подменяем оба пути на tmp_path: `DEFAULT_LOG_PATH` —
+    его `register()` кладёт в `set_defaults(log_path=...)` при каждом
+    `build_parser()`, то есть внутри `main`; `logging_setup.LOG_DIR` — на случай,
+    если setup_logging всё-таки вызовется (регрессия READ-контракта: тогда
+    файл создастся в tmp_path и ассерты это увидят, а не молча промахнутся
+    мимо реального каталога). Тест по-прежнему проверяет поведение ДЕФОЛТНОГО
+    пути — `--log-path` не передаётся.
     """
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(log_cmd, "DEFAULT_LOG_PATH", tmp_path / "logs" / "hhru_bot.log")
+    monkeypatch.setattr(logging_setup, "LOG_DIR", tmp_path / "logs")
     from hhru_bot.cli import main
 
     # лога нет и быть не должно после запуска


### PR DESCRIPTION
## Проблема

`tests/test_log_command.py::test_log_command_does_not_create_log` падал на любой машине,
где существует `logs/hhru_bot.log` — то есть у любого разработчика, который хоть раз
запускал бота. Это не флейк: воспроизводится стабильно.

Тест делал `monkeypatch.chdir(tmp_path)` и ожидал, что `log` не найдёт файл и выйдет
с nonzero. Но путь **не зависит от cwd на момент вызова**:

- `logging_setup.py:8` — `LOG_DIR = Path.cwd() / "logs"` вычисляется **на импорте модуля**;
- `commands/log_cmd.py:43` — `DEFAULT_LOG_PATH = LOG_DIR / "hhru_bot.log"`, тоже на импорте.

Оба абсолютны и заморожены до того, как тест сделает `chdir`. `main(["log"])` читал
настоящий лог разработчика, успешно печатал его хвост и не бросал `SystemExit`.
В CI зелёный только потому, что чекаут чистый (`logs/*.log` в `.gitignore`).

## Фикс

Подменяем оба пути на `tmp_path` перед вызовом `main(["log"])`:

```python
monkeypatch.setattr(log_cmd, "DEFAULT_LOG_PATH", tmp_path / "logs" / "hhru_bot.log")
monkeypatch.setattr(logging_setup, "LOG_DIR", tmp_path / "logs")
```

Патч `DEFAULT_LOG_PATH` работает потому, что `register()` кладёт его в
`set_defaults(log_path=...)` при каждом `build_parser()` — то есть уже **внутри** `main`,
после подмены атрибута модуля.

Тест **не переписан на явный `--log-path`**: предметом находки Codex в ревью #61 был
именно **дефолтный** путь (READ-контракт #21 — команда `log` не создаёт лог-файл),
поэтому дефолт должен остаться под тестом. Ассерты `assert not log_path.exists()` и
`assert not (tmp_path / "logs").exists()` теперь указывают на tmp_path и реально
достижимы, а не промахиваются мимо настоящего каталога.

## Продакшн-код не тронут

Изменён только `tests/test_log_command.py` (+15 строк, из них 11 — поясняющий докстринг).
Изоляция полностью достижима из теста, менять `log_cmd.py`/`logging_setup.py` не потребовалось.

## Критерий приёмки: оба состояния окружения

Полный прогон `pytest` в обоих состояниях, на одном и том же коммите:

| Состояние | До фикса | После фикса |
|---|---|---|
| 1. `logs/hhru_bot.log` **СУЩЕСТВУЕТ** | `FAILED ... DID NOT RAISE SystemExit` | **весь suite зелёный, 0 failed** |
| 2. `logs/hhru_bot.log` **ОТСУТСТВУЕТ** | PASSED | **весь suite зелёный, 0 failed** |

Состояние 1 воспроизведено явно — файл создавался перед прогоном:
`printf '... [INFO] hhru_bot.search: dev log line\n' > logs/hhru_bot.log`.
Тест зелёный **не** потому, что лог убран.

### Проверка, что тест не стал зелёным вхолостую

Мутационная проверка: временно вернул регрессию READ-контракта в `cli.py`
(убрал `if args.command != "log":`, то есть `setup_logging` снова вызывается для `log`)
при **существующем** реальном логе:

```
FAILED tests/test_log_command.py::test_log_command_does_not_create_log
```

Тест краснеет — значит ассерты достижимы и он действительно ловит регрессию READ-контракта
в том состоянии окружения, где раньше был бесполезен. Мутация откачена, продакшн-код в PR чист.

## Остальные тесты файла

Проверено: `cli.main` использует **только** этот тест (`grep` по `cli.main`/`chdir` даёт
единственное совпадение). Все прочие 17 тестов работают на tmp_path-файлах через `_args()`
и от реального `LOG_DIR` не зависят. Других тестов с этой зависимостью в `tests/` нет —
`logging_setup`/`hhru_bot.log` не упоминаются больше нигде. Гипотеза из ишью подтвердилась.

## Проверка

- `ruff check .` — All checks passed
- `ruff format --check .` — 129 files already formatted
- `pytest` (полный прогон) — зелёный в обоих состояниях окружения

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rp4kVgj3BQY1f8tMZsMXs