### PR TITLE
test: autouse-фикстура изоляции LOG_DIR от реального data/logs (#131)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,33 @@
 Тесты не запускают браузер — Playwright нужен только для импорта модулей,
 вся тестируемая логика чистая (без Page/браузера).
 """
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hhru_bot import logging_setup
+from hhru_bot.commands import log_cmd
+
+
+@pytest.fixture(autouse=True)
+def _isolate_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Страховка от записи тестов в реальный data/logs/hhru_bot.log (#131).
+
+    До этой фикстуры изоляция держалась на дисциплине каждого отдельного теста
+    (см. локальный monkeypatch в test_log_command_does_not_create_log, #129/#130) —
+    не на инварианте. Здесь уводим LOG_DIR на tmp_path для ВСЕХ тестов сессии.
+
+    DEFAULT_LOG_PATH (log_cmd.py) вычисляется на импорте модуля как
+    `LOG_DIR / "hhru_bot.log"` и сам не пересчитается при подмене LOG_DIR —
+    патчим его отдельно тем же tmp_path.
+
+    Монки этой фикстуры и локальные monkeypatch внутри отдельных тестов
+    накладываются безопасно (LIFO): более специфичный тестовый monkeypatch
+    отменяется первым при teardown, эта фикстура — последней.
+    """
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOG_DIR", log_dir)
+    monkeypatch.setattr(log_cmd, "DEFAULT_LOG_PATH", log_dir / "hhru_bot.log")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from hhru_bot import logging_setup
+from hhru_bot.apply import probe
 from hhru_bot.commands import log_cmd
 
 
@@ -22,9 +23,9 @@ def _isolate_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (см. локальный monkeypatch в test_log_command_does_not_create_log, #129/#130) —
     не на инварианте. Здесь уводим LOG_DIR на tmp_path для ВСЕХ тестов сессии.
 
-    DEFAULT_LOG_PATH (log_cmd.py) вычисляется на импорте модуля как
-    `LOG_DIR / "hhru_bot.log"` и сам не пересчитается при подмене LOG_DIR —
-    патчим его отдельно тем же tmp_path.
+    DEFAULT_LOG_PATH (log_cmd.py) и PROBE_LOG_DIR (apply/probe.py) вычисляются
+    на импорте модуля как `LOG_DIR / "hhru_bot.log"` / `= LOG_DIR` и сами не
+    пересчитаются при подмене LOG_DIR — патчим их отдельно тем же tmp_path.
 
     Монки этой фикстуры и локальные monkeypatch внутри отдельных тестов
     накладываются безопасно (LIFO): более специфичный тестовый monkeypatch
@@ -33,3 +34,4 @@ def _isolate_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     log_dir = tmp_path / "logs"
     monkeypatch.setattr(logging_setup, "LOG_DIR", log_dir)
     monkeypatch.setattr(log_cmd, "DEFAULT_LOG_PATH", log_dir / "hhru_bot.log")
+    monkeypatch.setattr(probe, "PROBE_LOG_DIR", log_dir)


### PR DESCRIPTION
## Summary

- Добавлена autouse-фикстура `_isolate_log_dir` в `tests/conftest.py`, которая на время каждого теста уводит `logging_setup.LOG_DIR` и `commands/log_cmd.DEFAULT_LOG_PATH` на `tmp_path`.
- До этого изоляция от записи в реальный `data/logs/hhru_bot.log` держалась на дисциплине каждого отдельного теста (`test_log_command_does_not_create_log`, #129/#130), а не на инварианте на уровне сессии.
- `DEFAULT_LOG_PATH` вычисляется на импорте модуля (`LOG_DIR / "hhru_bot.log"`) и сам не пересчитается при подмене `LOG_DIR` — патчится отдельно тем же `tmp_path`.
- Локальный monkeypatch внутри `test_log_command_does_not_create_log` продолжает работать как есть — накладывается поверх фикстуры безопасно (LIFO teardown), тест по-прежнему проверяет поведение READ-контракта для дефолтного пути.

Closes #131

## Verification

- Прогнаны оба состояния окружения из #129: реального лога нет / реальный лог существует — MD5 реального `data/logs/hhru_bot.log` не менялся ни в одном прогоне.
- Мутационная проверка: временно вернул регрессию READ-контракта в `cli.py` (убрал пропуск `setup_logging` для команды `log`) — `test_log_command_does_not_create_log` упал как положено (`DID NOT RAISE SystemExit`), при этом реальный лог остался нетронут благодаря фикстуре из conftest. Регрессия откачена.
- `ruff check .` — чисто.
- `ruff format --check .` — чисто.
- `pytest tests/ -q` — все тесты зелёные.

## Test plan

- [x] ruff check
- [x] ruff format --check
- [x] pytest tests/ (полный набор)
- [x] Мутационная проверка регрессии READ-контракта
- [x] MD5 реального лога не изменился в обоих состояниях окружения

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqAEDM7JtkgFXDKcc9D4Xe