### PR TITLE
fix: close fail-closed gaps in responses and commands

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -78,7 +78,11 @@ def main(argv: list[str] | None = None) -> None:
 
     try:
         failed = args.func(args)
-        if failed:
+        # Fail-closed contract (#148) is opt-in: only commands that report a
+        # real bool success flag (search/apply/run) can trip sys.exit(1).
+        # Commands returning other truthy values (e.g. clear-skipped's int
+        # deleted-row count) or None must not be mistaken for a failure.
+        if failed is True:
             sys.exit(1)
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -77,7 +77,9 @@ def main(argv: list[str] | None = None) -> None:
         setup_logging(verbose=args.verbose)
 
     try:
-        args.func(args)
+        failed = args.func(args)
+        if failed:
+            sys.exit(1)
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")
         sys.exit(130)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -226,7 +226,7 @@ def run_apply_for_resume(
     history: History,
     throttle: Throttle,
     args: argparse.Namespace,
-) -> None:
+) -> bool:
     """Цикл откликов по одному резюме (search → filter → apply с троттлингом).
 
     Перенесено дословно из cli._apply_for_resume. Принципы CLAUDE.md сохранены:
@@ -247,7 +247,7 @@ def run_apply_for_resume(
         throttle.check_apply_limit(resume.resume_id, args.dry_run)
     except LimitReached as e:
         print(f"Пропуск: {e}")
-        return
+        return False
 
     try:
         cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
@@ -255,7 +255,7 @@ def run_apply_for_resume(
         # Один сбой рендера не должен скрыться как пустой apply-план или
         # остановить обработку остальных резюме в команде apply/run.
         print(f"[FAIL] {e}")
-        return
+        return True
     scoring_provider = _build_scoring_provider(config, resume)
     plan = build_apply_plan(
         cards,
@@ -316,3 +316,4 @@ def run_apply_for_resume(
         throttle.wait(f"после отклика на '{card.title}'")
 
     print(f"Итого откликов за этот запуск: {applied_count}")
+    return False

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -240,6 +240,11 @@ def run_apply_for_resume(
     #101: план (filter → rank → limit) строится чистой build_apply_plan;
     здесь остаётся только execution-оркестрация (providers, apply_to_vacancy,
     запись истории, throttle).
+
+    #148: возвращает True, если поиск вакансий завершился неопределённо
+    (VacancySearchIndeterminate) — apply.run() агрегирует это по всем
+    резюме и транслирует в ненулевой exit code через cli.main(). False —
+    во всех остальных случаях (включая исчерпанный дневной лимит).
     """
     print(f"\n=== Отклики для резюме: {resume.id} ===")
 

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -19,7 +19,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace) -> bool:
     from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..history import History
@@ -30,9 +30,11 @@ def run(args: argparse.Namespace) -> None:
     resumes = resumes_from_args(config, args)
     throttle = Throttle(config.throttle, history)
 
+    failed = False
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
         page = context.new_page()
         for resume in resumes:
-            run_apply_for_resume(page, config, resume, history, throttle, args)
+            failed = run_apply_for_resume(page, config, resume, history, throttle, args) or failed
+    return failed

--- a/src/hhru_bot/commands/run.py
+++ b/src/hhru_bot/commands/run.py
@@ -21,7 +21,11 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace) -> bool:
     print("=== Полный цикл: search -> apply -> bump ===")
-    apply_cmd.run(args)
+    apply_failed = apply_cmd.run(args)
+    # Apply and bump are independent actions: even if vacancy search is
+    # indeterminate, bump still has a valid, unrelated resume-page operation.
+    # Keep bump for the same resume and report apply's failure to the caller.
     bump_cmd.run(args)
+    return bool(apply_failed)

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -86,7 +86,7 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
             logger.warning("Не записать вакансию %s в рынок: %s", card.vacancy_id, e)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace) -> bool:
     from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..search import (
@@ -100,6 +100,7 @@ def run(args: argparse.Namespace) -> None:
     history = History(args.history)
     resumes = resumes_from_args(config, args)
 
+    failed = False
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
@@ -113,6 +114,7 @@ def run(args: argparse.Namespace) -> None:
                 # диагностический отказ за traceback. Следующее резюме можно
                 # обработать независимо.
                 print(f"[FAIL] {e}")
+                failed = True
                 continue
             # #66: запись собранных карточек в рынок (побочный эффект сбора) —
             # между search_vacancies и filter_candidates, не трогая отбор/скоринг.
@@ -136,3 +138,4 @@ def run(args: argparse.Namespace) -> None:
                 print(f"  [candidate] score={score:+.2f} {_format_card_line(c)}{detail}")
             for card, reason in skipped:
                 print(f"  [skip] {_format_card_line(card)} — {reason}")
+    return failed

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -278,8 +278,9 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
 
         # DOMContentLoaded приходит раньше JS-карточек. Перед count() ждём attached
         # ограниченное время: так delayed-render карточки попадают в обход. У
-        # negotiations нет проверенного empty-state, поэтому timeout сохраняет
-        # совместимый контракт честно пустого inbox и логируется.
+        # negotiations нет проверенного empty-state, поэтому на первой странице
+        # timeout сохраняет совместимый контракт честно пустого inbox; на
+        # подтверждённой последующей странице он означает indeterminate.
         #
         # #142: почему НЕ ready_selector в goto_hh выше — тут нужна ДРУГАЯ семантика,
         # чем у goto_hh(ready_selector=...): (1) state="attached" (наличие в DOM, а не

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -288,11 +288,13 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
         # (3) таймаут НЕ фатален — warning + трактуем как empty, тогда как goto_hh
         # с ready_selector рейзит (что для healthcheck/apply верно, а для read-only
         # сбора ответов уронило бы всю команду на genuinely-пустом ящике).
+        cards_rendered = True
         try:
             page.locator(ns.NEGOTIATION_ITEM).first.wait_for(
                 state="attached", timeout=RENDER_TIMEOUT_MS
             )
         except PlaywrightError:
+            cards_rendered = False
             logger.warning(
                 "Страница %d: карточки переписки не появились за %d мс — "
                 "список пуст либо устарел селектор negotiations-item",
@@ -303,6 +305,11 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
         cards = page.locator(ns.NEGOTIATION_ITEM)
         count = cards.count()
         if count == 0:
+            if page_num > 0 and not cards_rendered:
+                raise ResponsesIndeterminate(
+                    f"страницы {page_num} не подтверждена: карточки переписки "
+                    f"не появились за {RENDER_TIMEOUT_MS} мс после подтверждённой пагинации"
+                )
             logger.info("Страница %d: ответов не найдено, останавливаюсь", page_num)
             break
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import argparse
 
-from hhru_bot.cli import build_parser, register_commands
+import pytest
+
+from hhru_bot.cli import build_parser, main, register_commands
+from hhru_bot.history import SKIP_REASONS, History
 
 
 def _build() -> argparse.ArgumentParser:
@@ -260,3 +263,24 @@ def test_log_default_lines():
     sub = action.choices["log"]
     lines = next(a for a in sub._actions if "--lines" in a.option_strings)
     assert lines.default == 50
+
+
+def test_clear_skipped_success_does_not_exit_nonzero(tmp_path):
+    """cli.main() must not treat clear-skipped's deleted-row count as failure.
+
+    #148 made cli.main() call sys.exit(1) on any truthy command return, to
+    fail closed on VacancySearchIndeterminate from search/apply/run. But
+    clear_skipped.run() returns the number of deleted rows (int), not a bool
+    success flag — a successful deletion of N>0 rows is truthy and must not
+    be mistaken for an indeterminate-search failure.
+    """
+    history_path = tmp_path / "h.db"
+    history = History(history_path)
+    history.record_skip("r1", "v1", SKIP_REASONS.STOPWORD_TITLE)
+
+    # main() doesn't sys.exit on success at all; if clear-skipped's positive
+    # deleted-count is (mis)treated as failure, main() raises SystemExit(1).
+    try:
+        main(["--history", str(history_path), "clear-skipped"])
+    except SystemExit as e:
+        pytest.fail(f"main() exited with {e.code} on a successful deletion")

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -150,3 +150,27 @@ def test_fetch_responses_timeout_preserves_empty_inbox_contract(monkeypatch):
     monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
 
     assert responses.fetch_responses(page, max_pages=1) == []
+
+
+def test_fetch_responses_timeout_on_confirmed_later_page_is_indeterminate(monkeypatch):
+    """A confirmed next page must not be silently treated as an empty page."""
+    page = _ResponsesPage([])
+    visits = 0
+
+    def goto(_page, _url):
+        nonlocal visits
+        visits += 1
+        if visits == 2:
+            page.cards.cards = []
+
+    monkeypatch.setattr(responses, "goto_hh", goto)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "_has_next_page", lambda _page, page_num: page_num == 0)
+
+    # The first page contains a card and confirms that page 1 exists.  The
+    # second page then times out before any card is attached.
+    page.cards.cards = [object()]
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: None)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="страницы 1"):
+        responses.fetch_responses(page, max_pages=2)


### PR DESCRIPTION
## Summary
- raise `ResponsesIndeterminate` when a confirmed later page times out rendering cards
- propagate indeterminate vacancy-search failures as exit code 1 from search, apply, and run
- keep bump independent in `run`, with the decision documented in code

## Tests
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `pytest -q`

Closes #148