### PR TITLE
fix(browser): healthcheck/copy-resume через goto_hh с ready_selector (#142)

### DIFF
--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -27,6 +27,10 @@ import re
 import sys
 from dataclasses import dataclass, field
 
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from ..browser import goto_hh
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -129,23 +133,26 @@ def check_selectors(page, spec, page_loader=None):
 
     ``spec`` — список ``(page_name, url, [(name, selector, required?), ...])``.
     ``required`` опционален (по умолчанию True — обратная совместимость с 2-tuple
-    ``(name, selector)``). Для каждой страницы: открыть (``page.goto``) и для
-    каждого селектора взять ``page.locator(selector).count()`` → SelectorCheck.
-    Ничего не кликает и не отправляет — это главный инвариант #88 (read-only).
+    ``(name, selector)``). Для каждой страницы: открыть через ``goto_hh`` (с retry
+    и backoff, как у всех путей hh.ru) и для каждого селектора взять
+    ``page.locator(selector).count()`` → SelectorCheck. Ничего не кликает и не
+    отправляет — это главный инвариант #88 (read-only).
 
     ``page_loader(page, url, name)`` — опциональный хук, вызываемый ПОСЛЕ goto:
     в боевом прогоне не нужен (DOM рендерит живой hh.ru), а в тестах через него
     подменяют HTML фикстурой (имитация «браузер загрузил страницу»).
+
+    #120: недоступность страницы — это РЕЗУЛЬТАТ проверки, а не авария.
+    ``goto_hh`` исчерпал retry (до 3 попыток) и пробросил PlaywrightTimeoutError/
+    PlaywrightError — отмечаем страницу ``unreachable`` и идём дальше, таблица
+    печатается всегда. Ловим именно эти два класса: ``goto_hh`` рейзит их, а
+    широкий ``except Exception`` прятал бы баги в самом коде.
     """
     pages: list[PageCheck] = []
     for name, url, selectors in spec:
         try:
-            page.goto(url, wait_until="domcontentloaded")
-        except Exception as exc:
-            # #120: недоступность страницы — это РЕЗУЛЬТАТ проверки, а не авария.
-            # Раньше таймаут goto ронял всю команду трейсбеком Playwright, и
-            # статусы остальных страниц не проверялись вовсе. Отмечаем страницу
-            # как недоступную и идём дальше — таблица печатается всегда.
+            goto_hh(page, url)
+        except (PlaywrightTimeoutError, PlaywrightError) as exc:
             logger.warning("healthcheck: страница '%s' недоступна (%s): %s", name, url, exc)
             pages.append(PageCheck(name=name, url=url, results=[], unreachable=True))
             continue
@@ -301,9 +308,11 @@ def run_healthcheck(args: argparse.Namespace) -> None:
     print("[INFO] healthcheck: read-only проверка селекторов hh.ru (без отклика)")
     with launch_context(config.storage_state_file, headless=args.headless) as context:
         page = context.new_page()
-        # #80: страницы hh.ru могут грузиться медленно — поднимаем навигационный
-        # timeout, чтобы healthcheck не падал по таймауту на медленном соединении.
-        page.set_default_navigation_timeout(60000)
+        # Навигационный потолок уже выставлен context-wide в launch_context
+        # (set_default_navigation_timeout(GOTO_TIMEOUT_MS), см. browser.py) — тот же
+        # источник, что у всех путей hh.ru. Раньше тут был хардкод 60000 (меньше
+        # GOTO_TIMEOUT_MS=90_000) — #142: убран, чтобы healthcheck не падал быстрее
+        # остального кода на медленном hh.ru.
         pages = check_selectors(page, spec)
 
     print(format_healthcheck_table(pages))

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -136,27 +136,47 @@ def list_resume_cards(page: Page) -> list[ResumeCard]:
     return cards
 
 
+def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
+    """Идиома ``count → wait_for → count`` для строгого (strict-mode) Playwright.
+
+    Возвращает итоговое число совпадений, либо ``-1`` (элемент не появился за
+    ``timeout_ms`` — PlaywrightTimeoutError). Контракт callsite: ``1`` — ок,
+    ``0``-после-wait или ``-1`` — не найдено, ``>1`` — неоднозначно (fail-closed).
+
+    Зачем ``count()`` ДО ``wait_for``: Playwright-локаторы строгие — ``wait_for()``
+    на локаторе с >1 совпадением кидает ``playwright.sync_api.Error`` ("strict mode
+    violation"), НЕ ``TimeoutError``. Проверка ``count() != 1`` первой ловит
+    неоднозначность предсказуемо (fail-closed), а не улетает необработанным
+    исключением мимо ``cli.main`` (там ловится только ``KeyboardInterrupt``).
+
+    #142: идиома повторялась дважды (карточка резюме + кнопка «Дублировать»),
+    вынесена сюда, чтобы правки strict-mode-логики были в одном месте.
+    """
+    match_count = locator.count()
+    if match_count == 0:
+        try:
+            locator.wait_for(timeout=timeout_ms)
+            match_count = locator.count()
+        except PlaywrightTimeoutError:
+            return -1
+    return match_count
+
+
 def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyResumeResult:
     logger.info("Открываю список резюме: %s", RESUMES_LIST_URL)
-    goto_hh(page, RESUMES_LIST_URL)
+    # ready_selector=RESUME_LIST_CARD: ждём появления хотя бы одной карточки резюме
+    # (#142 — раньше готовность проверялась неявно, через wait_for конкретной
+    # карточки ниже). Это не заменяет ожидание конкретного resume_id ниже — там
+    # нужна именно карточка нужного резюме, а тут сигнал «список отрендерен».
+    goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
 
     link_sel = RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume.resume_id)
     card_locator = page.locator(f"{RESUME_LIST_CARD}:has({link_sel})")
-    # count() ДО wait_for/click намеренно: Playwright-локаторы строгие — wait_for()
-    # на локаторе с >1 совпадением кидает playwright.sync_api.Error ("strict mode
-    # violation"), НЕ TimeoutError. Ветка card_locator.count() != 1 ниже проверяет
-    # это первой, чтобы неоднозначность ловилась предсказуемо (fail-closed), а не
-    # улетала необработанным исключением мимо cli.main (там ловится только
-    # KeyboardInterrupt).
-    match_count = card_locator.count()
-    if match_count == 0:
-        try:
-            card_locator.wait_for(timeout=COPY_TIMEOUT_MS)
-            match_count = card_locator.count()
-        except PlaywrightTimeoutError:
-            return CopyResumeResult(
-                resume.id, False, reason=f"резюме {resume.resume_id} не найдено в списке резюме"
-            )
+    match_count = _wait_single_match_count(card_locator, timeout_ms=COPY_TIMEOUT_MS)
+    if match_count == -1:
+        return CopyResumeResult(
+            resume.id, False, reason=f"резюме {resume.resume_id} не найдено в списке резюме"
+        )
     if match_count != 1:
         return CopyResumeResult(
             resume.id,
@@ -178,20 +198,16 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     # Скоупим ПОД card, не под page: RESUME_DUPLICATE_INLINE — инлайн-кнопка на
     # каждой карточке, и при нескольких резюме на странице page.locator(...).first
     # взял бы первую в DOM-порядке, а не кнопку открытой карточки — риск скопировать
-    # чужое резюме. То же строгое count()-до-wait_for, что и для card_locator выше.
+    # чужое резюме. То же строгое count()-до-wait_for через _wait_single_match_count.
     duplicate_locator = card.locator(f"{RESUME_DUPLICATE_MENU_ITEM}, {RESUME_DUPLICATE_INLINE}")
-    dup_count = duplicate_locator.count()
-    if dup_count == 0:
-        try:
-            duplicate_locator.wait_for(timeout=COPY_TIMEOUT_MS)
-            dup_count = duplicate_locator.count()
-        except PlaywrightTimeoutError:
-            return CopyResumeResult(
-                resume.id,
-                False,
-                reason="кнопка «Дублировать» не найдена: либо достигнут лимит резюме hh.ru "
-                "(кнопка при этом не рендерится), либо селектор устарел",
-            )
+    dup_count = _wait_single_match_count(duplicate_locator, timeout_ms=COPY_TIMEOUT_MS)
+    if dup_count == -1:
+        return CopyResumeResult(
+            resume.id,
+            False,
+            reason="кнопка «Дублировать» не найдена: либо достигнут лимит резюме hh.ru "
+            "(кнопка при этом не рендерится), либо селектор устарел",
+        )
     if dup_count != 1:
         return CopyResumeResult(
             resume.id,
@@ -214,7 +230,9 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
     if not new_id or new_id == resume.resume_id:
         # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
-        goto_hh(page, RESUMES_LIST_URL)
+        # Тот же ready_selector, что при первом открытии (#142): симметрия — список
+        # гарантированно отрендерен до _card_hashes ниже.
+        goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
         created = _card_hashes(page) - before
         if len(created) != 1:
             return CopyResumeResult(

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -276,10 +276,18 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                 "cookie hhtoken не найден — сессия истекла (запустите `login`, затем повторите)"
             )
 
-        # DOMContentLoaded приходит раньше JS-карточек. Перед count() ждём
-        # attached ограниченное время: так delayed-render карточки попадают в
-        # обход. У negotiations нет проверенного empty-state, поэтому timeout
-        # сохраняет совместимый контракт честно пустого inbox и логируется.
+        # DOMContentLoaded приходит раньше JS-карточек. Перед count() ждём attached
+        # ограниченное время: так delayed-render карточки попадают в обход. У
+        # negotiations нет проверенного empty-state, поэтому timeout сохраняет
+        # совместимый контракт честно пустого inbox и логируется.
+        #
+        # #142: почему НЕ ready_selector в goto_hh выше — тут нужна ДРУГАЯ семантика,
+        # чем у goto_hh(ready_selector=...): (1) state="attached" (наличие в DOM, а не
+        # visible — карточка может быть ниже сгиба); (2) короткий RENDER_TIMEOUT_MS
+        # (10с, не 90с GOTO_TIMEOUT_MS — пустой inbox должен детектиться быстро);
+        # (3) таймаут НЕ фатален — warning + трактуем как empty, тогда как goto_hh
+        # с ready_selector рейзит (что для healthcheck/apply верно, а для read-only
+        # сбора ответов уронило бы всю команду на genuinely-пустом ящике).
         try:
             page.locator(ns.NEGOTIATION_ITEM).first.wait_for(
                 state="attached", timeout=RENDER_TIMEOUT_MS

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -164,3 +164,41 @@ def test_has_auth_cookie_false_on_empty_cookies():
 
 def test_browser_has_no_legacy_url_auth_checker():
     assert not hasattr(browser, "is_logged_in")
+
+
+def test_goto_hh_waits_for_ready_selector(monkeypatch):
+    """#142: ready_selector — после удачного goto ждём data-qa маркер страницы.
+
+    Параметр существовал с #80, но ни один caller его не передавал (мёртвый).
+    Гарантируем, что goto_hh(url, ready_selector=sel) вызывает
+    page.locator(sel).wait_for(timeout=GOTO_TIMEOUT_MS) после goto.
+    """
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    page = MagicMock(name="Page")
+    page.goto.return_value = None
+
+    goto_hh(page, "https://hh.ru/applicant/resumes", ready_selector="[data-qa='resume']")
+
+    page.locator.assert_called_once_with("[data-qa='resume']")
+    page.locator.return_value.wait_for.assert_called_once_with(timeout=GOTO_TIMEOUT_MS)
+
+
+def test_goto_hh_ready_selector_absent_retries_then_raises(monkeypatch):
+    """#142: ready_selector не появился → wait_for кидает TimeoutError → retry+raise.
+
+    goto_hh должен трактовать таймаут ready_selector так же, как таймаут самого
+    goto: retry до _GOTO_MAX_ATTEMPTS, на последней — проброс. Иначе caller,
+    передавший ready_selector, получил бы «успешный» goto на непрогрузившейся
+    странице.
+    """
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    page = MagicMock(name="Page")
+    page.goto.return_value = None
+    # ready_selector не появляется ни на одной попытке
+    page.locator.return_value.wait_for.side_effect = PlaywrightTimeoutError("no marker")
+
+    with pytest.raises(PlaywrightTimeoutError):
+        goto_hh(page, "https://hh.ru/applicant/resumes", ready_selector="[data-qa='resume']")
+
+    # retry сработал: 3 goto-попытки (ready_selector проверяется после каждой)
+    assert page.goto.call_count == 3

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -153,7 +153,15 @@ class StubPage:
 
 
 def _patch_env(monkeypatch, page):
-    monkeypatch.setattr(cr, "goto_hh", lambda p, url, **kw: page.gotos.append(url))
+    # Захватываем kwargs (ready_selector), чтобы тест мог проверить, что goto_hh
+    # вызывается с ready_selector=RESUME_LIST_CARD (#142).
+    page.goto_kwargs = []
+
+    def _goto(p, url, **kw):
+        page.gotos.append(url)
+        page.goto_kwargs.append(kw)
+
+    monkeypatch.setattr(cr, "goto_hh", _goto)
     monkeypatch.setattr(
         cr, "_card_hashes", lambda p: page._card_hashes.pop(0) if page._card_hashes else set()
     )
@@ -166,6 +174,21 @@ def test_dry_run_does_not_click(monkeypatch):
     assert result.success
     assert page.clicks == []
     assert page.gotos == [cr.RESUMES_LIST_URL]
+
+
+def test_goto_hh_called_with_ready_selector(monkeypatch):
+    """#142: goto_hh открывает список резюме с ready_selector=RESUME_LIST_CARD —
+    готовность страницы проверяется в goto_hh, а не отдельным wait_for после.
+    Оба вызова (первичное открытие + fallback) должны передавать ready_selector."""
+    page = StubPage(
+        url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
+    )
+    _patch_env(monkeypatch, page)
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+    assert result.success
+    # fallback-путь: goto_hh вызван дважды — обе с ready_selector
+    assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
+    assert all(kw.get("ready_selector") == RESUME_LIST_CARD for kw in page.goto_kwargs)
 
 
 def test_card_not_found_fails_closed(monkeypatch):

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -13,8 +13,26 @@ format_healthcheck_table прогоняются на FakePage поверх HTML-
 
 from __future__ import annotations
 
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
 from _fakes import FakeLocator, _parse_root
 from hhru_bot.commands import probe as probe_cmd
+
+
+def _stub_goto_hh(monkeypatch, page):
+    """Подменяет probe_cmd.goto_hh на вызов page.goto (без retry/backoff).
+
+    check_selectors (#142) ходит через goto_hh, а не через сырой page.goto. В
+    тестах goto_hh не нужен (retry/backoff покрыты отдельным test_browser_navigation),
+    поэтому редиректим его обратно на _FakePage.goto, переключающий DOM.
+    """
+
+    def _goto(p, url, **kwargs):  # noqa: ANN001
+        p.goto(url, wait_until="domcontentloaded")
+
+    monkeypatch.setattr(probe_cmd, "goto_hh", _goto)
+    return page
 
 
 class _FakePage:
@@ -43,8 +61,8 @@ class _FakePage:
 # --- check_selectors: статус по count() ------------------------------------
 
 
-def test_check_selectors_ok_when_found():
-    page = _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")
+def test_check_selectors_ok_when_found(monkeypatch):
+    page = _stub_goto_hh(monkeypatch, _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>"))
     spec = [
         ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")])
     ]
@@ -54,22 +72,22 @@ def test_check_selectors_ok_when_found():
     assert pages[0].results[0].status == "OK"
 
 
-def test_check_selectors_not_found_when_zero():
-    page = _FakePage("<div>нет нужного</div>")
+def test_check_selectors_not_found_when_zero(monkeypatch):
+    page = _stub_goto_hh(monkeypatch, _FakePage("<div>нет нужного</div>"))
     spec = [("search", "https://hh.ru/search/vacancy", [("MISS", "[data-qa='no-such-thing']")])]
     pages = probe_cmd.check_selectors(page, spec)
     assert pages[0].results[0].found == 0
     assert pages[0].results[0].status == "NOT_FOUND"
 
 
-def test_check_selectors_counts_multiple_matches():
+def test_check_selectors_counts_multiple_matches(monkeypatch):
     # Несколько карточек на странице поиска — found == числу, статус OK.
     html = (
         "<div data-qa='vacancy-serp__vacancy'>a</div>"
         "<div data-qa='vacancy-serp__vacancy'>b</div>"
         "<div data-qa='vacancy-serp__vacancy'>c</div>"
     )
-    page = _FakePage(html)
+    page = _stub_goto_hh(monkeypatch, _FakePage(html))
     spec = [
         ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")])
     ]
@@ -78,9 +96,9 @@ def test_check_selectors_counts_multiple_matches():
     assert pages[0].results[0].status == "OK"
 
 
-def test_check_selectors_visits_each_page_url():
+def test_check_selectors_visits_each_page_url(monkeypatch):
     # read-only прогон: каждая страница открывается goto, ДО проверки селекторов.
-    page = _FakePage("<div data-qa='vacancy-title'>t</div>")
+    page = _stub_goto_hh(monkeypatch, _FakePage("<div data-qa='vacancy-title'>t</div>"))
     spec = [
         ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")]),
         ("vacancy", "https://hh.ru/vacancy/1", [("TITLE", "[data-qa='vacancy-title']")]),
@@ -90,7 +108,7 @@ def test_check_selectors_visits_each_page_url():
     assert page.last_goto == "https://hh.ru/vacancy/1"
 
 
-def test_check_selectors_switches_dom_per_page_via_callback():
+def test_check_selectors_switches_dom_per_page_via_callback(monkeypatch):
     """В боевом прогоне DOM меняется после goto (живой hh.ru). Моделируем через
     page_loader: на каждую страницу подставляем её HTML, как сделал бы браузер."""
     html_by_page = {
@@ -101,7 +119,7 @@ def test_check_selectors_switches_dom_per_page_via_callback():
     def _load(p, url, name):  # noqa: ANN001
         p.set_content(html_by_page[name])
 
-    page = _FakePage()
+    page = _stub_goto_hh(monkeypatch, _FakePage())
     spec = [
         ("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='vacancy-serp__vacancy']")]),
         (
@@ -118,13 +136,63 @@ def test_check_selectors_switches_dom_per_page_via_callback():
 def test_check_selectors_readonly_does_not_click_apply(monkeypatch):
     """Инвариант #88: никаких write-действий. Page не имеет click/fill/submit —
     если check_selectors попытается их вызвать, упадёт AttributeError."""
-    page = _FakePage("<div data-qa='vacancy-title'>t</div>")
+    page = _stub_goto_hh(monkeypatch, _FakePage("<div data-qa='vacancy-title'>t</div>"))
     spec = [("vacancy", "https://hh.ru/vacancy/1", [("TITLE", "[data-qa='vacancy-title']")])]
     # Если бы код кликал apply — потребовался бы click(). Его нет → чисто read-only.
     assert not hasattr(page, "click")
     assert not hasattr(page, "fill")
     pages = probe_cmd.check_selectors(page, spec)
     assert pages[0].results[0].status == "OK"
+
+
+def test_check_selectors_unreachable_page_not_treated_as_all_not_found(monkeypatch):
+    """#120/#142: goto_hh исчерпал retry и пробросил PlaywrightTimeoutError —
+    страница помечается unreachable, а НЕ «все селекторы NOT_FOUND».
+
+    Регрессионный тест из issue #142: при непрогрузившемся JS healthcheck должен
+    рапортовать «не проверено» (UNREACHABLE), а не честный, но вводящий в
+    заблуждение NOT_FOUND по всем селекторам — иначе провал выглядит как
+    «сломанные селекторы», хотя причина в сети/DDoS-Guard.
+    """
+    # goto_hh падает (имитация: hh.ru не отвечает даже после 3 попыток).
+    monkeypatch.setattr(
+        probe_cmd,
+        "goto_hh",
+        lambda p, url, **kw: (_ for _ in ()).throw(PlaywrightTimeoutError("network timeout")),
+    )
+    page = _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")
+    spec = [
+        (
+            "search",
+            "https://hh.ru/search/vacancy",
+            [
+                ("CARD", "[data-qa='vacancy-serp__vacancy']", True),
+                ("TITLE", "[data-qa='vacancy-serp__vacancy-title']", True),
+            ],
+        )
+    ]
+    pages = probe_cmd.check_selectors(page, spec)
+    assert pages[0].unreachable is True
+    assert pages[0].results == []  # селекторы НЕ проверялись
+    # таблица рисует UNREACHABLE, а не NOT_FOUND по каждому селектору
+    out = probe_cmd.format_healthcheck_table(pages)
+    assert probe_cmd.STATUS_UNREACHABLE in out
+    assert "NOT_FOUND" not in out
+
+
+def test_check_selectors_unreachable_does_not_swallow_unrelated_exception(monkeypatch):
+    """#142: except сужен до (PlaywrightTimeoutError, PlaywrightError) — только то,
+    что рейзит goto_hh. Баг в коде (KeyError/AttributeError/...) НЕ должен
+    маскироваться под unreachable — он должен падать открыто (fail-loud)."""
+    monkeypatch.setattr(
+        probe_cmd,
+        "goto_hh",
+        lambda p, url, **kw: (_ for _ in ()).throw(RuntimeError("bug in code, not network")),
+    )
+    page = _FakePage()
+    spec = [("search", "https://hh.ru/search/vacancy", [("CARD", "[data-qa='x']")])]
+    with pytest.raises(RuntimeError, match="bug in code"):
+        probe_cmd.check_selectors(page, spec)
 
 
 # --- format_healthcheck_table ---------------------------------------------
@@ -196,11 +264,13 @@ def test_optional_selector_present_is_ok():
     assert sel.fails is False
 
 
-def test_check_selectors_marks_optional_via_spec_tuple():
+def test_check_selectors_marks_optional_via_spec_tuple(monkeypatch):
     """3-tuple в spec: (name, selector, required). required по умолчанию True
     (обратная совместимость с 2-tuple). Опциональный селектор с 0 совпадений не
     роняет страницу."""
-    page = _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")  # нет compensation, нет pager
+    page = _stub_goto_hh(
+        monkeypatch, _FakePage("<div data-qa='vacancy-serp__vacancy'>x</div>")
+    )  # нет compensation, нет pager
     spec = [
         (
             "search",


### PR DESCRIPTION
## Summary
- `check_selectors` (probe healthcheck) теперь ходит через `goto_hh` вместо сырого `page.goto` — retry/backoff и таймаут навигации из единого источника (`browser.py`), except сужен до `(PlaywrightTimeoutError, PlaywrightError)`.
- `copy_resume_on_hh` передаёт `ready_selector=RESUME_LIST_CARD` в оба вызова `goto_hh` на список резюме — готовность списка проверяется в одном месте.
- Вынесена дедуплицированная идиома `count() -> wait_for() -> count()` (strict-mode Playwright) в `_wait_single_match_count`.
- Убран устаревший хардкод `set_default_navigation_timeout(60000)` в probe.py — используется context-wide `GOTO_TIMEOUT_MS=90_000` из `launch_context`.
- Прошёл `/simplify` (4 параллельных агента: reuse/simplification/efficiency/altitude) — правок не потребовалось, единственная находка (жёсткость `ready_selector` под нужды одного вызывающего) сознательно оставлена без изменений как преждевременная абстракция.

Closes #142

## Test plan
- [ ] `pytest tests/test_browser_navigation.py tests/test_copy_resume_browser.py tests/test_probe_healthcheck.py`
- [ ] `./scripts/run.sh probe --healthcheck` вручную на реальном hh.ru

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZQ6WcVZkfPKd3Gf6fgotv