### PR TITLE
fix(probe): detect unauthenticated healthcheck pages

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -26,6 +26,7 @@ PAGE_STATE = {
     "confirmed": "confirmed",
     "indeterminate": "indeterminate",
     "unreachable": "unreachable",
+    "unauthenticated": "unauthenticated",
 }
 
 

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from ..browser import PAGE_STATE, goto_hh
+from ..browser import PAGE_STATE, goto_hh, has_login_form
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -84,6 +84,7 @@ STATUS_NOT_FOUND = "NOT_FOUND"
 STATUS_OPTIONAL_ABSENT = "OPTIONAL_ABSENT"
 # #120: страница не открылась (таймаут/сеть) — селекторы не проверялись.
 STATUS_UNREACHABLE = PAGE_STATE["unreachable"].upper()
+STATUS_UNAUTHENTICATED = PAGE_STATE["unauthenticated"].upper()
 
 
 @dataclass
@@ -126,11 +127,16 @@ class PageCheck:
     # #120: страница не открылась (таймаут/сетевая ошибка). Селекторы не
     # проверялись — это не «все NOT_FOUND», а «проверка не состоялась».
     unreachable: bool = False
+    unauthenticated: bool = False
 
     @property
     def page_state(self) -> str:
         """Общее состояние страницы без изменения старого bool-контракта."""
-        return PAGE_STATE["unreachable"] if self.unreachable else PAGE_STATE["confirmed"]
+        if self.unreachable:
+            return PAGE_STATE["unreachable"]
+        if self.unauthenticated:
+            return PAGE_STATE["unauthenticated"]
+        return PAGE_STATE["confirmed"]
 
 
 def check_selectors(page, spec, page_loader=None):
@@ -163,6 +169,10 @@ def check_selectors(page, spec, page_loader=None):
             continue
         if page_loader is not None:
             page_loader(page, url, name)
+        if has_login_form(page):
+            logger.warning("healthcheck: страница '%s' требует авторизацию", name)
+            pages.append(PageCheck(name=name, url=url, results=[], unauthenticated=True))
+            continue
         results = [
             SelectorCheck(
                 name=sel_name,
@@ -202,6 +212,9 @@ def format_healthcheck_table(pages: list[PageCheck]) -> str:
             # #120: страница не открылась — одна строка вместо списка селекторов,
             # чтобы не выдавать «не проверено» за «не найдено».
             rows.append([pg.name, "-", STATUS_UNREACHABLE, "-"])
+            continue
+        if pg.page_state == PAGE_STATE["unauthenticated"]:
+            rows.append([pg.name, "-", STATUS_UNAUTHENTICATED, "-"])
             continue
         for r in pg.results:
             rows.append([pg.name, r.name, r.status, str(r.found)])
@@ -329,7 +342,8 @@ def run_healthcheck(args: argparse.Namespace) -> None:
         1 for pg in pages for r in pg.results if r.status == STATUS_OPTIONAL_ABSENT
     )
     unreachable = sum(1 for pg in pages if pg.unreachable)
-    if required_missing or unreachable:
+    unauthenticated = sum(1 for pg in pages if pg.unauthenticated)
+    if required_missing or unreachable or unauthenticated:
         parts = []
         if required_missing:
             parts.append(f"НЕ найдено {required_missing} обязательных (см. NOT_FOUND выше)")
@@ -337,6 +351,11 @@ def run_healthcheck(args: argparse.Namespace) -> None:
             # #120: недоступная страница — тоже провал: её селекторы не проверены,
             # и молча рапортовать [OK] по остальным было бы враньём.
             parts.append(f"недоступно страниц: {unreachable} (см. UNREACHABLE выше)")
+        if unauthenticated:
+            parts.append(
+                f"сессия недействительна на страниц: {unauthenticated} "
+                "(выполните login; селекторы не проверялись)"
+            )
         print(
             f"[FAIL] обязательных найдено {required_ok}; "
             + "; ".join(parts)

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -80,6 +80,62 @@ def test_check_selectors_not_found_when_zero(monkeypatch):
     assert pages[0].results[0].status == "NOT_FOUND"
 
 
+def test_check_selectors_marks_login_page_without_reporting_selector_drift(monkeypatch):
+    """A rejected session is a page state, not a zero-count selector result."""
+    page = _stub_goto_hh(
+        monkeypatch,
+        _FakePage("<div data-qa='account-login-form'>login</div>"),
+    )
+    spec = [
+        (
+            "negotiations",
+            "https://hh.ru/applicant/negotiations",
+            [("ITEM", "[data-qa='negotiation-item']")],
+        )
+    ]
+
+    pages = probe_cmd.check_selectors(page, spec)
+
+    assert pages[0].page_state == probe_cmd.PAGE_STATE["unauthenticated"]
+    assert pages[0].results == []
+    out = probe_cmd.format_healthcheck_table(pages)
+    assert probe_cmd.STATUS_UNAUTHENTICATED in out
+    assert "NOT_FOUND" not in out
+
+
+def test_check_selectors_still_checks_anonymous_search_when_private_page_is_logged_out(
+    monkeypatch,
+):
+    """The login state of one page must not suppress useful search results."""
+    page = _stub_goto_hh(monkeypatch, _FakePage())
+    html_by_page = {
+        "search": "<div data-qa='vacancy-serp__vacancy'>x</div>",
+        "negotiations": "<div data-qa='account-login-form'>login</div>",
+    }
+
+    def _load(p, url, name):  # noqa: ANN001
+        p.set_content(html_by_page[name])
+
+    spec = [
+        (
+            "search",
+            "https://hh.ru/search/vacancy",
+            [("CARD", "[data-qa='vacancy-serp__vacancy']")],
+        ),
+        (
+            "negotiations",
+            "https://hh.ru/applicant/negotiations",
+            [("ITEM", "[data-qa='negotiation-item']")],
+        ),
+    ]
+
+    pages = probe_cmd.check_selectors(page, spec, page_loader=_load)
+
+    assert pages[0].results[0].status == probe_cmd.STATUS_OK
+    assert pages[1].unauthenticated is True
+    assert pages[1].results == []
+
+
 def test_check_selectors_counts_multiple_matches(monkeypatch):
     # Несколько карточек на странице поиска — found == числу, статус OK.
     html = (


### PR DESCRIPTION
Closes #154

## Summary
- add an unauthenticated page state to healthcheck results
- detect the login form after navigation and skip authenticated-only selector counts
- preserve anonymous search checks and report an actionable `login` message

## Tests
- ruff check .
- ruff format --check .
- PYTHONPATH=src pytest -q tests/test_probe_healthcheck.py tests/test_page_state.py

Full `PYTHONPATH=src pytest -q` was started but could not complete in this shared workspace because multiple concurrent pytest runs stalled around 17%; focused tests passed.