### PR TITLE
fix: detect revoked sessions across browser flows

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 
 from playwright.sync_api import Page
 
-from ..browser import goto_hh
+from ..browser import goto_hh, has_login_form
 from ..search import VacancyCard
 from . import steps as apply_steps
 from .dedup import check_already_responded
@@ -101,6 +101,8 @@ def apply_to_vacancy(
 def _run(ctx: ApplyContext) -> ApplyResult:
     logger.info("Открываю вакансию: %s (%s)", ctx.vacancy.title, ctx.vacancy.url)
     goto_hh(ctx.page, ctx.vacancy.url)
+    if has_login_form(ctx.page):
+        return ctx.fail("Сессия недействительна: страница содержит форму входа. Выполните login.")
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)
 
     if reason := check_already_responded(ctx.page, ctx.vacancy):

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from playwright.sync_api import Page
 
-from ..browser import PAGE_STATE, goto_hh
+from ..browser import PAGE_STATE, goto_hh, has_login_form
 from ..logging_setup import LOG_DIR
 from ..search import VacancyCard
 from ..selector_groups import apply_form
@@ -151,6 +151,12 @@ def probe_vacancy(
 
     logger.info("[PROBE] Открываю вакансию: %s (%s)", vacancy.title, vacancy.url)
     goto_hh(page, vacancy.url)
+    if has_login_form(page):
+        return ProbeResult(
+            vacancy,
+            False,
+            "Сессия недействительна: страница содержит форму входа. Выполните login.",
+        )
 
     if reason := check_already_responded(page, vacancy):
         logger.info("[PROBE] Вакансия '%s' уже откликнута — пропускаю без дампа", vacancy.title)

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -8,7 +8,7 @@ from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from . import selectors as sel
-from .browser import HH_BASE_URL, goto_hh
+from .browser import HH_BASE_URL, goto_hh, has_login_form
 from .config import ResumeConfig
 
 logger = logging.getLogger("hhru_bot.bump")
@@ -36,6 +36,12 @@ def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
     )
     logger.info("Открываю резюме: %s", url)
     goto_hh(page, url)
+    if has_login_form(page):
+        return BumpResult(
+            resume.id,
+            False,
+            "Сессия недействительна: страница содержит форму входа. Выполните login.",
+        )
 
     # #139: гонка рендера — раньше hint читался сразу через count() > 0, без
     # ожидания. Непрогрузившаяся страница резюме давала 0 совпадений (не

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -73,6 +73,7 @@ def run(args: argparse.Namespace) -> None:
     from ..config import ConfigError, load_config_or_exit
     from ..copy_resume import copy_resume_on_hh
     from ..history import History
+    from ..responses import NotAuthenticated
 
     config = load_config_or_exit(args.config)
     try:
@@ -103,6 +104,16 @@ def run(args: argparse.Namespace) -> None:
         ) as context:
             page = context.new_page()
             result = copy_resume_on_hh(page, resume, args.dry_run)
+    except NotAuthenticated as e:
+        history.record_action(
+            resume.resume_id,
+            resume.resume_id,
+            "copy_resume",
+            "failed",
+            str(e),
+        )
+        print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
+        sys.exit(1)
     except Exception as e:
         # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
         # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -20,8 +20,9 @@ from dataclasses import dataclass
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh
+from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh, has_login_form
 from .config import ResumeConfig
+from .responses import NotAuthenticated
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -173,11 +174,15 @@ def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
 
 def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyResumeResult:
     logger.info("Открываю список резюме: %s", RESUMES_LIST_URL)
-    # ready_selector=RESUME_LIST_CARD: ждём появления хотя бы одной карточки резюме
-    # (#142 — раньше готовность проверялась неявно, через wait_for конкретной
-    # карточки ниже). Это не заменяет ожидание конкретного resume_id ниже — там
-    # нужна именно карточка нужного резюме, а тут сигнал «список отрендерен».
-    goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
+    # Не передаём ready_selector: при отозванной сессии форма входа не содержит
+    # карточку и goto_hh сначала потратит все ретраи на её ожидание. После
+    # навигации проверяем серверный auth-маркер, а затем отдельно ждём карточку.
+    goto_hh(page, RESUMES_LIST_URL)
+    if has_login_form(page):
+        raise NotAuthenticated(
+            "страница содержит форму входа — сессия отвергнута сервером "
+            "(запустите `login`, затем повторите)"
+        )
 
     link_sel = RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume.resume_id)
     card_locator = page.locator(f"{RESUME_LIST_CARD}:has({link_sel})")
@@ -239,9 +244,13 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
     if not new_id or new_id == resume.resume_id:
         # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
-        # Тот же ready_selector, что при первом открытии (#142): симметрия — список
-        # гарантированно отрендерен до _card_hashes ниже.
-        goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
+        # Сначала снова проверяем форму входа, затем читаем diff списка.
+        goto_hh(page, RESUMES_LIST_URL)
+        if has_login_form(page):
+            raise NotAuthenticated(
+                "страница содержит форму входа — сессия отвергнута сервером "
+                "(запустите `login`, затем повторите)"
+            )
         created = _card_hashes(page) - before
         if len(created) != 1:
             return CopyResumeResult(

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -150,16 +150,33 @@ def list_resume_cards(page: Page, *, navigate: bool = True) -> list[ResumeCard]:
     return cards
 
 
-def _goto_resumes_list(page: Page) -> None:
+def _goto_resumes_list(page: Page, *, post_write: bool = False) -> None:
     """Navigate without a readiness retry, then fail fast on the login form.
 
     ``goto_hh(..., ready_selector=...)`` retries the whole navigation three
     times, so a revoked session would wait minutes before its already-rendered
     login form was inspected. The card readiness wait is deliberately split
     out and called by the fallback immediately before ``_card_hashes``.
+
+    ``post_write`` (Codex adversarial review, PR #158): this helper is called
+    twice — once before any click (safe to report as an ordinary pre-write
+    auth failure), and once from the fallback diff path AFTER
+    ``duplicate.click()`` has already fired the clone POST. A session revoked
+    server-side in that window must not be reported with pre-write wording —
+    the operator needs to know the clone may already exist before retrying
+    (mirrors the ``except Exception`` handler's caveat in
+    ``commands/copy_resume.py``, and the same "state not confirmed" pattern as
+    ``ResumeListIndeterminate`` above).
     """
     goto_hh(page, RESUMES_LIST_URL)
     if has_login_form(page):
+        if post_write:
+            raise NotAuthenticated(
+                "страница содержит форму входа после отправки запроса на "
+                "дублирование — состояние копии НЕ подтверждено, возможно "
+                "она уже создана (запустите `login`, затем проверьте список "
+                "резюме перед повтором)"
+            )
         raise NotAuthenticated(
             "страница содержит форму входа — сессия отвергнута сервером "
             "(запустите `login`, затем повторите)"
@@ -267,7 +284,10 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
     if not new_id or new_id == resume.resume_id:
         # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
-        _goto_resumes_list(page)
+        # post_write=True: клик по «Дублировать» уже отправлен выше, поэтому
+        # отзыв сессии здесь — это неподтверждённое состояние копии, а не
+        # обычный pre-write отказ (Codex adversarial review, PR #158).
+        _goto_resumes_list(page, post_write=True)
         _wait_resume_list_ready(page)
         created = _card_hashes(page) - before
         if len(created) != 1:

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -151,29 +151,30 @@ def list_resume_cards(page: Page, *, navigate: bool = True) -> list[ResumeCard]:
 
 
 def _goto_resumes_list(page: Page) -> None:
-    """Navigate to the list while preserving #142's ready-selector wait.
+    """Navigate without a readiness retry, then fail fast on the login form.
 
-    A revoked session renders the login form instead of a resume card. In that
-    case ``goto_hh`` exhausts its ready-selector retries first; inspect the
-    already navigated page in the timeout handler so the user gets the auth
-    diagnosis rather than a selector timeout. On the normal path the
-    ready-selector still guarantees that the fallback card diff reads a
-    rendered list.
+    ``goto_hh(..., ready_selector=...)`` retries the whole navigation three
+    times, so a revoked session would wait minutes before its already-rendered
+    login form was inspected. The card readiness wait is deliberately split
+    out and called by the fallback immediately before ``_card_hashes``.
     """
-    try:
-        goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
-    except PlaywrightTimeoutError:
-        if has_login_form(page):
-            raise NotAuthenticated(
-                "страница содержит форму входа — сессия отвергнута сервером "
-                "(запустите `login`, затем повторите)"
-            ) from None
-        raise
+    goto_hh(page, RESUMES_LIST_URL)
     if has_login_form(page):
         raise NotAuthenticated(
             "страница содержит форму входа — сессия отвергнута сервером "
             "(запустите `login`, затем повторите)"
         )
+
+
+def _wait_resume_list_ready(page: Page) -> None:
+    """Preserve #142's rendered-list guarantee for the fallback card diff."""
+    try:
+        page.locator(RESUME_LIST_CARD).first.wait_for(timeout=COPY_TIMEOUT_MS)
+    except PlaywrightTimeoutError:
+        raise ResumeListIndeterminate(
+            "карточки резюме не появились за отведённое время — состояние "
+            "/applicant/resumes не подтверждено"
+        ) from None
 
 
 def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
@@ -267,6 +268,7 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     if not new_id or new_id == resume.resume_id:
         # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
         _goto_resumes_list(page)
+        _wait_resume_list_ready(page)
         created = _card_hashes(page) - before
         if len(created) != 1:
             return CopyResumeResult(

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -22,6 +22,10 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh, has_login_form
 from .config import ResumeConfig
+
+# Reuse the established auth-state exception rather than defining a second
+# copy-resume-only variant; the command layer already treats this shared
+# PageStateIndeterminate subtype as an expired-session failure.
 from .responses import NotAuthenticated
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
@@ -146,6 +150,32 @@ def list_resume_cards(page: Page, *, navigate: bool = True) -> list[ResumeCard]:
     return cards
 
 
+def _goto_resumes_list(page: Page) -> None:
+    """Navigate to the list while preserving #142's ready-selector wait.
+
+    A revoked session renders the login form instead of a resume card. In that
+    case ``goto_hh`` exhausts its ready-selector retries first; inspect the
+    already navigated page in the timeout handler so the user gets the auth
+    diagnosis rather than a selector timeout. On the normal path the
+    ready-selector still guarantees that the fallback card diff reads a
+    rendered list.
+    """
+    try:
+        goto_hh(page, RESUMES_LIST_URL, ready_selector=RESUME_LIST_CARD)
+    except PlaywrightTimeoutError:
+        if has_login_form(page):
+            raise NotAuthenticated(
+                "страница содержит форму входа — сессия отвергнута сервером "
+                "(запустите `login`, затем повторите)"
+            ) from None
+        raise
+    if has_login_form(page):
+        raise NotAuthenticated(
+            "страница содержит форму входа — сессия отвергнута сервером "
+            "(запустите `login`, затем повторите)"
+        )
+
+
 def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
     """Идиома ``count → wait_for → count`` для строгого (strict-mode) Playwright.
 
@@ -174,15 +204,7 @@ def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
 
 def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyResumeResult:
     logger.info("Открываю список резюме: %s", RESUMES_LIST_URL)
-    # Не передаём ready_selector: при отозванной сессии форма входа не содержит
-    # карточку и goto_hh сначала потратит все ретраи на её ожидание. После
-    # навигации проверяем серверный auth-маркер, а затем отдельно ждём карточку.
-    goto_hh(page, RESUMES_LIST_URL)
-    if has_login_form(page):
-        raise NotAuthenticated(
-            "страница содержит форму входа — сессия отвергнута сервером "
-            "(запустите `login`, затем повторите)"
-        )
+    _goto_resumes_list(page)
 
     link_sel = RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume.resume_id)
     card_locator = page.locator(f"{RESUME_LIST_CARD}:has({link_sel})")
@@ -244,13 +266,7 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
     if not new_id or new_id == resume.resume_id:
         # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
-        # Сначала снова проверяем форму входа, затем читаем diff списка.
-        goto_hh(page, RESUMES_LIST_URL)
-        if has_login_form(page):
-            raise NotAuthenticated(
-                "страница содержит форму входа — сессия отвергнута сервером "
-                "(запустите `login`, затем повторите)"
-            )
+        _goto_resumes_list(page)
         created = _card_hashes(page) - before
         if len(created) != 1:
             return CopyResumeResult(

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import hhru_bot.apply.pipeline as pipeline_module
 from hhru_bot.apply import ProbeHook, apply_to_vacancy
 from hhru_bot.search import VacancyCard
 
@@ -111,6 +112,29 @@ def test_apply_dry_run_success():
     assert result.success is True
     assert result.reason == "dry-run"
     assert page.goto_calls == ["https://hh.ru/vacancy/1"]
+
+
+def test_apply_login_form_is_checked_after_navigation(monkeypatch):
+    page = FakePage()
+    events: list[str] = []
+
+    def fake_goto(p, url, **_kwargs):
+        events.append("goto")
+        p.goto(url)
+
+    def fake_has_login_form(_page):
+        events.append("auth")
+        assert events == ["goto", "auth"]
+        return True
+
+    monkeypatch.setattr(pipeline_module, "goto_hh", fake_goto)
+    monkeypatch.setattr(pipeline_module, "has_login_form", fake_has_login_form)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+
+    assert result.success is False
+    assert "Сессия недействительна" in result.reason
+    assert events == ["goto", "auth"]
 
 
 def test_apply_already_responded_not_deduped_by_dom():

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import hhru_bot.apply.probe as probe_module
 from hhru_bot.apply.probe import ProbeContext, dump_probe_snapshot, probe_vacancy
 from hhru_bot.search import VacancyCard
 
@@ -239,6 +240,29 @@ def test_probe_no_apply_button_fails(tmp_path: Path):
     assert result.success is False
     assert "кнопка отклика не найдена" in result.reason
     assert page.screenshot_calls == 0
+
+
+def test_probe_login_form_is_checked_after_navigation(tmp_path: Path, monkeypatch):
+    page = FakeProbePage()
+    events: list[str] = []
+
+    def fake_goto(p, url, **_kwargs):
+        events.append("goto")
+        p.goto(url)
+
+    def fake_has_login_form(_page):
+        events.append("auth")
+        assert events == ["goto", "auth"]
+        return True
+
+    monkeypatch.setattr(probe_module, "goto_hh", fake_goto)
+    monkeypatch.setattr(probe_module, "has_login_form", fake_has_login_form)
+
+    result = probe_vacancy(page, _vacancy(), "RID", "x", tmp_path)
+
+    assert result.success is False
+    assert "Сессия недействительна" in result.reason
+    assert events == ["goto", "auth"]
 
 
 def test_probe_dedup_step_is_passthrough(tmp_path: Path):

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+import hhru_bot.bump as bump_module
 from hhru_bot.bump import bump_resume
 from hhru_bot.config import ResumeConfig, SearchFilters
 from hhru_bot.selector_groups import resume_page
@@ -179,3 +180,26 @@ def test_bump_no_button_found_fails():
 
     assert result.success is False
     assert "не найдена" in result.reason
+
+
+def test_bump_login_form_is_checked_after_navigation(monkeypatch):
+    page = FakeBumpPage(hint_present=False)
+    events: list[str] = []
+
+    def fake_goto(p, url, **_kwargs):
+        events.append("goto")
+        p.goto(url)
+
+    def fake_has_login_form(_page):
+        events.append("auth")
+        assert events == ["goto", "auth"]
+        return True
+
+    monkeypatch.setattr(bump_module, "goto_hh", fake_goto)
+    monkeypatch.setattr(bump_module, "has_login_form", fake_has_login_form)
+
+    result = bump_resume(page, _resume(), dry_run=False)
+
+    assert result.success is False
+    assert "Сессия недействительна" in result.reason
+    assert events == ["goto", "auth"]

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -129,6 +129,8 @@ class StubPage:
     def locator(self, selector):
         if selector == LOGIN_FORM:
             return StubLocator(self, selector, count=0)
+        if selector == RESUME_LIST_CARD:
+            return StubLocator(self, selector, count=1)
         if selector == CARD_SEL:
             return self._card_locator or StubLocator(self, selector)
         if selector.startswith("[data-qa^='resume-card-link-'"):
@@ -180,7 +182,7 @@ def test_dry_run_does_not_click(monkeypatch):
 
 
 def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
-    """#153: auth probe runs after navigation, while #142 wait remains intact."""
+    """#153: auth probe is fast, then fallback waits for rendered cards (#142)."""
     page = StubPage(
         url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
     )
@@ -194,12 +196,18 @@ def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
 
     monkeypatch.setattr(cr, "goto_hh", _goto)
     monkeypatch.setattr(cr, "has_login_form", lambda p: page.events.append("auth") or False)
+    original_ready = cr._wait_resume_list_ready
+    monkeypatch.setattr(
+        cr,
+        "_wait_resume_list_ready",
+        lambda p: (page.events.append("ready"), original_ready(p))[1],
+    )
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert result.success
     # fallback-путь: goto_hh вызван дважды — auth probe follows each navigation.
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
-    assert page.events == ["goto", "auth", "goto", "auth"]
-    assert all(kw.get("ready_selector") == RESUME_LIST_CARD for kw in page.goto_kwargs)
+    assert page.events == ["goto", "auth", "goto", "auth", "ready"]
+    assert all("ready_selector" not in kw for kw in page.goto_kwargs)
 
 
 def test_card_not_found_fails_closed(monkeypatch):

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import pytest
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -208,6 +209,51 @@ def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
     assert page.events == ["goto", "auth", "goto", "auth", "ready"]
     assert all("ready_selector" not in kw for kw in page.goto_kwargs)
+
+
+def test_post_click_login_form_reports_unconfirmed_state(monkeypatch):
+    """Codex adversarial review (PR #158): session revoked AFTER the clone
+    click must not be reported with ordinary pre-write wording — the click
+    already fired the clone POST, so the operator needs to know the copy's
+    state is unconfirmed before retrying (regression for the finding)."""
+    page = StubPage(url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}])
+    _patch_env(monkeypatch, page)
+    goto_calls = []
+    original_goto = cr.goto_hh
+
+    def _goto(p, url, **kw):
+        goto_calls.append(url)
+        original_goto(p, url, **kw)
+
+    monkeypatch.setattr(cr, "goto_hh", _goto)
+    # Login form absent on the first (pre-click) navigation, present on the
+    # second (fallback, post-click) navigation.
+    monkeypatch.setattr(cr, "has_login_form", lambda p: len(goto_calls) >= 2)
+
+    with pytest.raises(cr.NotAuthenticated) as exc_info:
+        cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert len(goto_calls) == 2  # pre-click goto + fallback goto after the click
+    assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE), (CARD_SEL, DUP_SEL)]
+    message = str(exc_info.value)
+    assert "НЕ подтверждено" in message
+    assert "уже создана" in message
+
+
+def test_pre_click_login_form_reports_ordinary_failure(monkeypatch):
+    """Sanity check: the pre-write call site keeps the plain pre-write wording
+    (no false claim that a copy may already exist)."""
+    page = StubPage()
+    _patch_env(monkeypatch, page)
+    monkeypatch.setattr(cr, "has_login_form", lambda p: True)
+
+    with pytest.raises(cr.NotAuthenticated) as exc_info:
+        cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert page.clicks == []
+    message = str(exc_info.value)
+    assert "НЕ подтверждено" not in message
+    assert "уже создана" not in message
 
 
 def test_card_not_found_fails_closed(monkeypatch):

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -19,6 +19,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 import hhru_bot.copy_resume as cr
+from hhru_bot.browser import LOGIN_FORM
 from hhru_bot.config import ResumeConfig, SearchFilters
 from hhru_bot.selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
@@ -126,6 +127,8 @@ class StubPage:
         self.gotos = []
 
     def locator(self, selector):
+        if selector == LOGIN_FORM:
+            return StubLocator(self, selector, count=0)
         if selector == CARD_SEL:
             return self._card_locator or StubLocator(self, selector)
         if selector.startswith("[data-qa^='resume-card-link-'"):
@@ -176,10 +179,8 @@ def test_dry_run_does_not_click(monkeypatch):
     assert page.gotos == [cr.RESUMES_LIST_URL]
 
 
-def test_goto_hh_called_with_ready_selector(monkeypatch):
-    """#142: goto_hh открывает список резюме с ready_selector=RESUME_LIST_CARD —
-    готовность страницы проверяется в goto_hh, а не отдельным wait_for после.
-    Оба вызова (первичное открытие + fallback) должны передавать ready_selector."""
+def test_goto_hh_does_not_wait_for_card_before_login_check(monkeypatch):
+    """Форма входа должна проверяться до ожидания карточки и её ретраев."""
     page = StubPage(
         url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
     )
@@ -188,7 +189,7 @@ def test_goto_hh_called_with_ready_selector(monkeypatch):
     assert result.success
     # fallback-путь: goto_hh вызван дважды — обе с ready_selector
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
-    assert all(kw.get("ready_selector") == RESUME_LIST_CARD for kw in page.goto_kwargs)
+    assert all("ready_selector" not in kw for kw in page.goto_kwargs)
 
 
 def test_card_not_found_fails_closed(monkeypatch):

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -179,17 +179,27 @@ def test_dry_run_does_not_click(monkeypatch):
     assert page.gotos == [cr.RESUMES_LIST_URL]
 
 
-def test_goto_hh_does_not_wait_for_card_before_login_check(monkeypatch):
-    """Форма входа должна проверяться до ожидания карточки и её ретраев."""
+def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
+    """#153: auth probe runs after navigation, while #142 wait remains intact."""
     page = StubPage(
         url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
     )
     _patch_env(monkeypatch, page)
+    page.events = []
+    original_goto = cr.goto_hh
+
+    def _goto(p, url, **kw):
+        page.events.append("goto")
+        original_goto(p, url, **kw)
+
+    monkeypatch.setattr(cr, "goto_hh", _goto)
+    monkeypatch.setattr(cr, "has_login_form", lambda p: page.events.append("auth") or False)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert result.success
-    # fallback-путь: goto_hh вызван дважды — обе с ready_selector
+    # fallback-путь: goto_hh вызван дважды — auth probe follows each navigation.
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
-    assert all("ready_selector" not in kw for kw in page.goto_kwargs)
+    assert page.events == ["goto", "auth", "goto", "auth"]
+    assert all(kw.get("ready_selector") == RESUME_LIST_CARD for kw in page.goto_kwargs)
 
 
 def test_card_not_found_fails_closed(monkeypatch):


### PR DESCRIPTION
Closes #153

## Summary
- apply existing has_login_form checks after navigation in copy-resume, bump, apply pipeline, and apply probe
- avoid copy-resume ready-selector retries before stale-session detection
- report copy-resume authentication failures as a concise CLI failure

## Tests
- ruff check src tests
- ruff format --check src tests
- pytest -q

## Risk
- Authentication-form detection remains a positive DOM signal; other page-state behavior is unchanged.