### PR TITLE
fix(probe): return healthcheck failure status

### DIFF
--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -310,7 +310,7 @@ def _first_resume_url(config) -> str | None:
     return getattr(resume, "resume_url", None)
 
 
-def run_healthcheck(args: argparse.Namespace) -> None:
+def run_healthcheck(args: argparse.Namespace) -> bool:
     """Открывает браузер и печатает ASCII-таблицу статусов ключевых селекторов.
 
     Read-only: только ``goto`` + ``locator.count()``. ``set_default_navigation_timeout``
@@ -361,11 +361,13 @@ def run_healthcheck(args: argparse.Namespace) -> None:
             + "; ".join(parts)
             + f"; опциональных отсутствует {optional_absent} (норма)"
         )
+        return True
     else:
         print(
             f"[OK] все {required_ok} обязательных селекторов найдены "
             f"(опциональных отсутствует {optional_absent} — норма)"
         )
+        return False
 
 
 # --- probe-дамп формы (#8) -------------------------------------------------
@@ -394,10 +396,9 @@ def _vacancy_from_url(url: str):
     )
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace) -> bool | None:
     if getattr(args, "healthcheck", False):
-        run_healthcheck(args)
-        return
+        return run_healthcheck(args)
 
     from ..apply.probe import probe_vacancy
     from ..browser import launch_context

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -13,6 +13,8 @@ format_healthcheck_table прогоняются на FakePage поверх HTML-
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -423,3 +425,68 @@ def test_run_healthcheck_fail_only_on_required_missing(capsys):
     # required CARD найден, COMP optional отсутствует → НЕ провал
     missing = sum(1 for pg in pages for r in pg.results if r.fails)
     assert missing == 0
+
+
+@pytest.mark.parametrize(
+    ("pages", "expected_exit"),
+    [
+        (
+            [
+                probe_cmd.PageCheck(
+                    "search",
+                    "u",
+                    [probe_cmd.SelectorCheck("CARD", "s", 1)],
+                )
+            ],
+            None,
+        ),
+        (
+            [
+                probe_cmd.PageCheck(
+                    "search",
+                    "u",
+                    [probe_cmd.SelectorCheck("CARD", "s", 0)],
+                )
+            ],
+            1,
+        ),
+        (
+            [probe_cmd.PageCheck("search", "u", [], unreachable=True)],
+            1,
+        ),
+        (
+            [probe_cmd.PageCheck("search", "u", [], unauthenticated=True)],
+            1,
+        ),
+    ],
+)
+def test_healthcheck_cli_exit_code(monkeypatch, pages, expected_exit, capsys):
+    """The healthcheck result reaches CLI's real fail-closed exit contract."""
+    from hhru_bot import cli
+
+    class _Context:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def new_page(self):
+            return object()
+
+    monkeypatch.setattr(cli, "setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        "hhru_bot.config.load_config_or_exit",
+        lambda _path: SimpleNamespace(storage_state_file="session.json"),
+    )
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *_a, **_kw: _Context())
+    monkeypatch.setattr(probe_cmd, "_healthcheck_spec", lambda _config: [])
+    monkeypatch.setattr(probe_cmd, "check_selectors", lambda *_a, **_kw: pages)
+
+    if expected_exit is None:
+        cli.main(["probe", "--healthcheck"])
+        assert "[OK]" in capsys.readouterr().out
+    else:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(["probe", "--healthcheck"])
+        assert exc_info.value.code == expected_exit


### PR DESCRIPTION
Closes #160

## Summary
- return `True` from `run_healthcheck()` when the existing `[FAIL]` branch is selected, otherwise `False`
- propagate the healthcheck result through the probe command wrapper so `cli.main()` emits exit 1
- add CLI-level tests asserting the real exit code for healthy, required-missing, unreachable, and unauthenticated cases

## Tests
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

No merge requested.