### PR TITLE
fix(probe): reject placeholder resume URLs

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -27,6 +27,7 @@ PAGE_STATE = {
     "indeterminate": "indeterminate",
     "unreachable": "unreachable",
     "unauthenticated": "unauthenticated",
+    "placeholder": "placeholder",
 }
 
 

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -9,7 +9,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from . import selectors as sel
 from .browser import HH_BASE_URL, goto_hh, has_login_form
-from .config import ResumeConfig
+from .config import ResumeConfig, is_resume_url_placeholder
 
 logger = logging.getLogger("hhru_bot.bump")
 
@@ -29,6 +29,13 @@ class BumpResult:
 
 
 def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
+    if is_resume_url_placeholder(resume.resume_url):
+        return BumpResult(
+            resume.id,
+            False,
+            "В конфиге указан плейсхолдер resume_url; укажите реальный URL "
+            "(получить можно через list-resumes --remote)",
+        )
     url = (
         resume.resume_url
         if resume.resume_url.startswith("http")

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -31,6 +31,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from ..browser import PAGE_STATE, goto_hh, has_login_form
+from ..config import is_resume_url_placeholder
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -85,6 +86,8 @@ STATUS_OPTIONAL_ABSENT = "OPTIONAL_ABSENT"
 # #120: страница не открылась (таймаут/сеть) — селекторы не проверялись.
 STATUS_UNREACHABLE = PAGE_STATE["unreachable"].upper()
 STATUS_UNAUTHENTICATED = PAGE_STATE["unauthenticated"].upper()
+# The URL was never opened: it is the placeholder shipped in config.example.yaml.
+STATUS_PLACEHOLDER = "PLACEHOLDER_CONFIG"
 
 
 @dataclass
@@ -128,6 +131,7 @@ class PageCheck:
     # проверялись — это не «все NOT_FOUND», а «проверка не состоялась».
     unreachable: bool = False
     unauthenticated: bool = False
+    placeholder: bool = False
 
     @property
     def page_state(self) -> str:
@@ -136,6 +140,8 @@ class PageCheck:
             return PAGE_STATE["unreachable"]
         if self.unauthenticated:
             return PAGE_STATE["unauthenticated"]
+        if self.placeholder:
+            return PAGE_STATE["placeholder"]
         return PAGE_STATE["confirmed"]
 
 
@@ -161,6 +167,14 @@ def check_selectors(page, spec, page_loader=None):
     """
     pages: list[PageCheck] = []
     for name, url, selectors in spec:
+        if is_resume_url_placeholder(url):
+            logger.warning(
+                "healthcheck: страница '%s' не проверялась: resume_url содержит "
+                "плейсхолдер; укажите реальный URL (получить можно через list-resumes --remote)",
+                name,
+            )
+            pages.append(PageCheck(name=name, url=url, results=[], placeholder=True))
+            continue
         try:
             goto_hh(page, url)
         except (PlaywrightTimeoutError, PlaywrightError) as exc:
@@ -215,6 +229,9 @@ def format_healthcheck_table(pages: list[PageCheck]) -> str:
             continue
         if pg.page_state == PAGE_STATE["unauthenticated"]:
             rows.append([pg.name, "-", STATUS_UNAUTHENTICATED, "-"])
+            continue
+        if pg.page_state == PAGE_STATE["placeholder"]:
+            rows.append([pg.name, "-", STATUS_PLACEHOLDER, "-"])
             continue
         for r in pg.results:
             rows.append([pg.name, r.name, r.status, str(r.found)])
@@ -343,7 +360,8 @@ def run_healthcheck(args: argparse.Namespace) -> None:
     )
     unreachable = sum(1 for pg in pages if pg.unreachable)
     unauthenticated = sum(1 for pg in pages if pg.unauthenticated)
-    if required_missing or unreachable or unauthenticated:
+    placeholders = sum(1 for pg in pages if pg.placeholder)
+    if required_missing or unreachable or unauthenticated or placeholders:
         parts = []
         if required_missing:
             parts.append(f"НЕ найдено {required_missing} обязательных (см. NOT_FOUND выше)")
@@ -355,6 +373,11 @@ def run_healthcheck(args: argparse.Namespace) -> None:
             parts.append(
                 f"сессия недействительна на страниц: {unauthenticated} "
                 "(выполните login; селекторы не проверялись)"
+            )
+        if placeholders:
+            parts.append(
+                f"плейсхолдеров resume_url: {placeholders} "
+                "(заполните resume_url; получить реальный можно через list-resumes --remote)"
             )
         print(
             f"[FAIL] обязательных найдено {required_ok}; "

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,6 +10,17 @@ from typing import TYPE_CHECKING
 import yaml
 
 logger = logging.getLogger("hhru_bot.config")
+
+# The shipped example deliberately uses X/Y runs instead of a real resume id.
+# Keep this recognition narrow: arbitrary resume ids remain valid config values.
+_RESUME_PLACEHOLDER_RE = re.compile(r"^(?:X{8,}|Y{8,})$")
+
+
+def is_resume_url_placeholder(resume_url: str) -> bool:
+    """Return whether ``resume_url`` contains the example-config placeholder."""
+    resume_id = resume_url.rstrip("/").rsplit("/", 1)[-1]
+    return bool(_RESUME_PLACEHOLDER_RE.fullmatch(resume_id))
+
 
 if TYPE_CHECKING:
     # Только для статического анализа; реальный импорт был бы циклическим

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -124,6 +124,21 @@ def test_bump_hint_present_blocks_click():
     assert page.click_log == []
 
 
+def test_bump_placeholder_url_does_not_navigate():
+    page = FakeBumpPage(hint_present=False)
+    resume = ResumeConfig(
+        id="r1",
+        resume_url="https://hh.ru/resume/XXXXXXXXXXXXXXXXXXXXXXXX",
+        search=SearchFilters(text="python", area=1),
+    )
+
+    result = bump_resume(page, resume, dry_run=False)
+
+    assert result.success is False
+    assert "плейсхолдер" in result.reason
+    assert page.goto_calls == []
+
+
 def test_bump_delayed_hint_still_blocks_click():
     """РЕГРЕССИЯ #139: hint появляется не мгновенно (гонка рендера) — на момент
     немедленного ``count()`` его в DOM ещё нет, но он в итоге отрисуется.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,13 @@ from pathlib import Path
 
 import pytest
 
-from hhru_bot.config import ConfigError, ResumeConfig, SearchFilters, load_config
+from hhru_bot.config import (
+    ConfigError,
+    ResumeConfig,
+    SearchFilters,
+    is_resume_url_placeholder,
+    load_config,
+)
 from hhru_bot.config_sections.ai_profile import AIProfile
 
 
@@ -46,6 +52,30 @@ def test_load_config_minimal(tmp_path):
     # дефолты throttle
     assert config.throttle.daily_apply_limit == 40
     assert config.throttle.min_delay_seconds == 8
+
+
+@pytest.mark.parametrize(
+    "resume_url",
+    [
+        "https://hh.ru/resume/XXXXXXXXXXXXXXXXXXXXXXXX",
+        "https://hh.ru/resume/YYYYYYYYYYYYYYYYYYYYYYYY",
+        "/resume/XXXXXXXXXXXXXXXXXXXXXXXX/",
+    ],
+)
+def test_is_resume_url_placeholder(resume_url):
+    assert is_resume_url_placeholder(resume_url)
+
+
+@pytest.mark.parametrize(
+    "resume_url",
+    [
+        "https://hh.ru/resume/12345678",
+        "https://hh.ru/resume/ABC123",
+        "https://hh.ru/resume/XYXYXYXY",
+    ],
+)
+def test_real_resume_url_is_not_placeholder(resume_url):
+    assert not is_resume_url_placeholder(resume_url)
 
 
 def test_load_config_full_search_filters(tmp_path):

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -393,6 +393,31 @@ def test_healthcheck_spec_marks_obsolete_and_conditional_optional():
     assert sel_required["PAGINATION_NEXT"] is False
 
 
+def test_check_selectors_skips_placeholder_url_without_goto(monkeypatch):
+    """A config placeholder is a config problem, not selector drift."""
+    page = _FakePage()
+    monkeypatch.setattr(
+        probe_cmd,
+        "goto_hh",
+        lambda *_args, **_kwargs: pytest.fail("placeholder URL must not be opened"),
+    )
+    spec = [
+        (
+            "resume",
+            "https://hh.ru/resume/XXXXXXXXXXXXXXXXXXXXXXXX",
+            [("RESUME_BUMP_BUTTON", "[data-qa='resume-edit-actions']", True)],
+        )
+    ]
+
+    pages = probe_cmd.check_selectors(page, spec)
+
+    assert pages[0].page_state == probe_cmd.PAGE_STATE["placeholder"]
+    assert pages[0].results == []
+    out = probe_cmd.format_healthcheck_table(pages)
+    assert probe_cmd.STATUS_PLACEHOLDER in out
+    assert "NOT_FOUND" not in out
+
+
 class _StubConfig:
     """Минимальный конфиг для _healthcheck_spec: только resumes (остальное не нужно)."""
 


### PR DESCRIPTION
Closes #159

## Summary
- detect the example-config resume URL placeholder before any navigation
- report a dedicated `PLACEHOLDER_CONFIG` page state instead of selector drift
- fail healthcheck with an address-specific hint to fill `resume_url` (real URL via `list-resumes --remote`)
- make `bump_resume` fail closed before navigating to the placeholder URL

The `config.py` helper is shared by probe and bump so both URL-consuming paths use the same narrow recognition (`X...`/`Y...` placeholder runs). No new hh.ru DOM selector was introduced.

The healthcheck placeholder condition is included in the same `[FAIL]` branch as unreachable/unauthenticated pages, so it will receive the exit-code behavior from the separate #160 `run_healthcheck` return change once #160 is merged.

## Verification
- `ruff check .`
- `ruff format --check .`
- `pytest` — 854 passed

Known warning: pytest emits the existing `pytest-asyncio` deprecation warning about unset fixture loop scope.
