### PR TITLE
fix(auth): poll page state during login

### DIFF
--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from playwright.sync_api import sync_playwright
 
-from .browser import GOTO_TIMEOUT_MS, HH_BASE_URL, goto_hh, has_auth_cookie
+from .browser import GOTO_TIMEOUT_MS, HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
 from .config import AppConfig
 
 logger = logging.getLogger("hhru_bot.auth")
@@ -14,10 +15,14 @@ def login(config: AppConfig) -> None:
     """
     Открывает hh.ru в headed-браузере и ждёт, пока пользователь вручную войдёт
     в аккаунт (логин/пароль, СМС-код, капча — всё, что попросит hh.ru).
-    После подтверждения в терминале сохраняет сессию (cookies + localStorage)
-    в файл, указанный в config.storage_state_file, чтобы остальные команды
-    могли переиспользовать вход без повторной авторизации.
+    После подтверждения по состоянию страницы сохраняет сессию
+    (cookies + localStorage) в файл, указанный в config.storage_state_file,
+    чтобы остальные команды могли переиспользовать вход без повторной
+    авторизации.
     """
+    poll_interval_seconds = 2
+    timeout_seconds = 300
+    progress_interval_seconds = 15
     storage_state_file = config.storage_state_file
     storage_state_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -51,10 +56,33 @@ def login(config: AppConfig) -> None:
         print()
         print("=" * 70)
         print("Откройте вкладку браузера и войдите в свой аккаунт на hh.ru.")
-        print("Когда окажетесь на главной странице (или в личном кабинете),")
-        print("вернитесь сюда и нажмите Enter, чтобы сохранить сессию.")
+        print("Вход будет подтверждён автоматически после проверки страницы.")
         print("=" * 70)
-        input("Нажмите Enter после успешного входа... ")
+        started_at = time.monotonic()
+        next_progress_at = progress_interval_seconds
+        while True:
+            elapsed = time.monotonic() - started_at
+            if has_auth_cookie(page) and not has_login_form(page):
+                break
+            if elapsed >= timeout_seconds:
+                if not has_auth_cookie(page):
+                    logger.warning(
+                        "Cookie hhtoken отсутствует — вход, похоже, не завершён. "
+                        "Сессия не будет сохранена.",
+                    )
+                    context.close()
+                    browser.close()
+                    raise RuntimeError("Cookie hhtoken отсутствует — сессия не сохранена")
+                context.close()
+                browser.close()
+                raise RuntimeError(
+                    f"Вход не завершён за {timeout_seconds} секунд, сессия не сохранена",
+                )
+            if elapsed >= next_progress_at:
+                remaining = max(0, timeout_seconds - int(elapsed))
+                print(f"[INFO] Ожидание входа... осталось около {remaining} с")
+                next_progress_at += progress_interval_seconds
+            time.sleep(poll_interval_seconds)
 
         # Реальный маркер залогиненности — cookie hhtoken, а не URL (hh.ru после
         # входа иногда оставляет путь входа в реферере/redirect — URL-проверка

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -84,18 +84,9 @@ def login(config: AppConfig) -> None:
                 next_progress_at += progress_interval_seconds
             time.sleep(poll_interval_seconds)
 
-        # Реальный маркер залогиненности — cookie hhtoken, а не URL (hh.ru после
-        # входа иногда оставляет путь входа в реферере/redirect — URL-проверка
-        # давала ложный warning при успешном входе).
-        if not has_auth_cookie(page):
-            logger.warning(
-                "Cookie hhtoken отсутствует — вход, похоже, не завершён. "
-                "Сессия не будет сохранена.",
-            )
-            context.close()
-            browser.close()
-            raise RuntimeError("Cookie hhtoken отсутствует — сессия не сохранена")
-
+        # Цикл выше выходит сюда только через `break` на строке успеха
+        # (has_auth_cookie(page) and not has_login_form(page)) — повторная
+        # проверка cookie здесь была бы недостижимым дублированием.
         context.storage_state(path=str(storage_state_file))
         logger.info("Сессия сохранена: %s", storage_state_file)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +23,8 @@ def test_login_does_not_save_session_without_hhtoken(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "sync_playwright", lambda: manager)
     monkeypatch.setattr(auth, "goto_hh", MagicMock())
     monkeypatch.setattr("builtins.input", lambda _: "")
+    monkeypatch.setattr(time, "monotonic", iter([0, 301, 301]).__next__)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
     context.cookies.return_value = [{"name": "other", "value": "abc"}]
 
     config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import itertools
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hhru_bot import auth
 
 
-def test_login_does_not_save_session_without_hhtoken(monkeypatch, tmp_path):
+def _make_playwright(monkeypatch):
+    """Собирает моки sync_playwright()/browser/context/page для login(); возвращает context."""
     context = MagicMock()
-    page = MagicMock()
-    context.new_page.return_value = page
+    context.new_page.return_value = MagicMock()
     browser = MagicMock()
     browser.new_context.return_value = context
 
@@ -22,10 +23,15 @@ def test_login_does_not_save_session_without_hhtoken(monkeypatch, tmp_path):
     manager.__exit__.return_value = None
     monkeypatch.setattr(auth, "sync_playwright", lambda: manager)
     monkeypatch.setattr(auth, "goto_hh", MagicMock())
-    monkeypatch.setattr("builtins.input", lambda _: "")
-    monkeypatch.setattr(time, "monotonic", iter([0, 301, 301]).__next__)
     monkeypatch.setattr(time, "sleep", lambda _: None)
-    context.cookies.return_value = [{"name": "other", "value": "abc"}]
+    return context
+
+
+def test_login_does_not_save_session_without_hhtoken(monkeypatch, tmp_path):
+    context = _make_playwright(monkeypatch)
+    monkeypatch.setattr(auth, "has_auth_cookie", lambda p: False)
+    monkeypatch.setattr(auth, "has_login_form", lambda p: True)
+    monkeypatch.setattr(time, "monotonic", iter([0, 301, 301]).__next__)
 
     config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)
 
@@ -33,3 +39,52 @@ def test_login_does_not_save_session_without_hhtoken(monkeypatch, tmp_path):
         auth.login(config)
 
     context.storage_state.assert_not_called()
+
+
+def test_login_succeeds_when_auth_confirmed_on_third_poll(monkeypatch, tmp_path):
+    """Вход появился на 3-й итерации опроса -> storage_state сохранён, без исключений."""
+    context = _make_playwright(monkeypatch)
+    # Первые 2 опроса — форма ещё видна/куки нет, на 3-й — has_auth_cookie=True и
+    # has_login_form=False (позитивный маркер входа).
+    auth_cookie_results = itertools.chain([False, False, True], itertools.repeat(True))
+    login_form_results = itertools.chain([True, True, False], itertools.repeat(False))
+    monkeypatch.setattr(auth, "has_auth_cookie", lambda p: next(auth_cookie_results))
+    monkeypatch.setattr(auth, "has_login_form", lambda p: next(login_form_results))
+    monkeypatch.setattr(time, "monotonic", itertools.chain([0, 2, 4], itertools.repeat(4)).__next__)
+
+    config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)
+
+    auth.login(config)
+
+    context.storage_state.assert_called_once_with(path=str(config.storage_state_file))
+
+
+def test_login_times_out_when_login_form_never_disappears(monkeypatch, tmp_path):
+    """Кука есть, но форма входа осталась (отозванная сессия) -> НЕ успех, RuntimeError."""
+    context = _make_playwright(monkeypatch)
+    monkeypatch.setattr(auth, "has_auth_cookie", lambda p: True)
+    monkeypatch.setattr(auth, "has_login_form", lambda p: True)
+    monkeypatch.setattr(time, "monotonic", iter([0, 301, 301]).__next__)
+
+    config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)
+
+    with pytest.raises(RuntimeError, match="не завершён"):
+        auth.login(config)
+
+    context.storage_state.assert_not_called()
+
+
+def test_login_never_calls_input_in_non_tty(monkeypatch, tmp_path):
+    """Охранный тест против регресса #164: login() не должен звать input() вообще."""
+    context = _make_playwright(monkeypatch)
+    monkeypatch.setattr(auth, "has_auth_cookie", lambda p: True)
+    monkeypatch.setattr(auth, "has_login_form", lambda p: False)
+    monkeypatch.setattr(time, "monotonic", iter([0, 0]).__next__)
+
+    config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)
+
+    with patch("builtins.input", side_effect=EOFError("EOF when reading a line")) as mocked_input:
+        auth.login(config)
+
+    mocked_input.assert_not_called()
+    context.storage_state.assert_called_once_with(path=str(config.storage_state_file))


### PR DESCRIPTION
Closes #164

## Summary
- replace the blocking `input()` in `login()` with bounded page-state polling
- require both `has_auth_cookie(page)` and `not has_login_form(page)` before saving the session
- keep Chromium open while waiting, report progress, and fail with a clear timeout error
- preserve the existing missing-`hhtoken` failure path

## Validation
- `ruff check .`
- `ruff format --check .`
- `python -m pytest` (846 passed)

## Risks / follow-ups
- Enter is intentionally removed as an accelerator; polling is fully non-interactive and works from non-TTY contexts.
