### PR TITLE
fix(cookies): resolve Chrome profile by name and harden atomic write

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ config/
 
 ### `import-cookies`
 
-- `--profile PROFILE` — Путь к профилю Chrome (по умолчанию Default)
+- `--profile PROFILE` — Путь к профилю Chrome или имя профиля (Default, Profile 1) — имя резолвится от стандартного корня профилей Chrome
 
 ### `list-resumes`
 

--- a/src/hhru_bot/commands/import_cookies.py
+++ b/src/hhru_bot/commands/import_cookies.py
@@ -14,7 +14,8 @@ def register(subparsers) -> None:
     parser.add_argument(
         "--profile",
         type=Path,
-        help="Путь к профилю Chrome (по умолчанию Default)",
+        help="Путь к профилю Chrome или имя профиля (Default, Profile 1) — "
+        "имя резолвится от стандартного корня профилей Chrome",
     )
     parser.set_defaults(func=run)
 

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import math
 import os
-import shutil
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
@@ -32,7 +31,15 @@ def resolve_chrome_profile(profile: Path | None = None) -> Path:
     profile = profile or Path(DEFAULT_CHROME_PROFILE_NAME)
     if not profile.exists() and not profile.is_absolute():
         candidate = DEFAULT_CHROME_PROFILES_ROOT / profile
-        if candidate.exists() or profile.name == DEFAULT_CHROME_PROFILE_NAME:
+        # `len(profile.parts) == 1` — a bare profile name (e.g. "Default"),
+        # not a multi-segment relative path like "foo/Default" (cycle-review
+        # PR #173 round 2, claude/review): profile.name matches only the
+        # last path segment, so without this guard a relative path the
+        # caller meant literally would be silently redirected under the
+        # Chrome profiles root just because it ends in "Default".
+        if candidate.exists() or (
+            len(profile.parts) == 1 and profile.name == DEFAULT_CHROME_PROFILE_NAME
+        ):
             return candidate
     return profile
 
@@ -138,6 +145,13 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
         # codex — same attack class #171 closed for the `.tmp` path, left
         # open here). O_EXCL fails on any existing name, symlink or not, so
         # the backup inode is always a fresh file this call created.
+        #
+        # Write through the fd without closing it first (round 2, codex —
+        # closing the fd and then calling shutil.copy2(path) reopened a TOCTOU
+        # window: an attacker able to modify the storage directory could
+        # unlink the just-created backup and replace it with a symlink before
+        # copy2() ran). Reading and writing while the exclusively-created fd
+        # stays open means there is no path lookup left to redirect.
         candidate = destination.with_name(destination.name + ".bak")
         index = 1
         while True:
@@ -147,9 +161,22 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
                 candidate = destination.with_name(destination.name + f".bak.{index}")
                 index += 1
                 continue
-            os.close(fd)
             break
-        shutil.copy2(destination, candidate)
+        try:
+            source_stat = destination.stat()
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(destination.read_bytes())
+                # fd-relative metadata copy (not shutil.copystat(path)): a
+                # path-based call here would reopen the same TOCTOU window
+                # this fix closes above — os.futimens/os.fchmod act on the
+                # already-open descriptor, no path lookup left to redirect.
+                os.utime(handle.fileno(), ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns))
+        except BaseException:
+            # round 2 (claude/review): a failed copy must not leave an empty
+            # `.bak` file — O_EXCL on the next run would treat that name as
+            # permanently taken and the backup numbering would drift forever.
+            candidate.unlink(missing_ok=True)
+            raise
         backup = candidate
     destination.parent.mkdir(parents=True, exist_ok=True)
     # Write-then-rename: an interrupted/failed write must never leave the

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -130,11 +130,25 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
     destination = Path(destination)
     backup: Path | None = None
     if destination.exists():
+        # Exclusive create (O_CREAT|O_EXCL), not candidate.exists(): a
+        # pre-planted symlink at the guessable `<destination>.bak` name can be
+        # *dangling*, so exists() (which follows symlinks) reports False and
+        # shutil.copy2() would then follow the symlink and write the session
+        # secret into the attacker's target (cycle-review PR #173 round 1,
+        # codex — same attack class #171 closed for the `.tmp` path, left
+        # open here). O_EXCL fails on any existing name, symlink or not, so
+        # the backup inode is always a fresh file this call created.
         candidate = destination.with_name(destination.name + ".bak")
         index = 1
-        while candidate.exists():
-            candidate = destination.with_name(destination.name + f".bak.{index}")
-            index += 1
+        while True:
+            try:
+                fd = os.open(candidate, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            except FileExistsError:
+                candidate = destination.with_name(destination.name + f".bak.{index}")
+                index += 1
+                continue
+            os.close(fd)
+            break
         shutil.copy2(destination, candidate)
         backup = candidate
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -163,6 +177,7 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
         # temp file.
         mode = os.fstat(fd).st_mode & 0o777
         if mode != 0o600:
+            os.close(fd)
             raise OSError(f"temp-файл сессии создан с режимом {mode:o} вместо 0600")
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(state, ensure_ascii=False, indent=2) + "\n")

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -6,6 +6,7 @@ import json
 import math
 import os
 import shutil
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
@@ -14,10 +15,30 @@ CHROME_EPOCH_OFFSET = 11_644_473_600
 MAX_PLAYWRIGHT_EXPIRES = 253_402_300_799  # 9999-12-31T23:59:59Z
 SAMESITE = {-1: "Lax", 0: "None", 1: "Lax", 2: "Strict"}
 
+DEFAULT_CHROME_PROFILES_ROOT = Path.home() / "Library/Application Support/Google/Chrome"
+DEFAULT_CHROME_PROFILE_NAME = "Default"
+
+
+def resolve_chrome_profile(profile: Path | None = None) -> Path:
+    """Resolve the Chrome profile directory.
+
+    Явный существующий путь — как есть (абсолютный или относительный cwd).
+    Имя профиля (`Default`, `Profile 1`) без существующего cwd-пути — от
+    стандартного корня профилей Chrome (macOS). Иначе — как введено:
+    несуществующий путь даст понятную ошибку "No such file or directory"
+    от read_chrome_cookies (find-one-shot-20260815: `--profile Default`
+    резолвился от cwd и падал, хотя профиль есть).
+    """
+    profile = profile or Path(DEFAULT_CHROME_PROFILE_NAME)
+    if not profile.exists() and not profile.is_absolute():
+        candidate = DEFAULT_CHROME_PROFILES_ROOT / profile
+        if candidate.exists() or profile.name == DEFAULT_CHROME_PROFILE_NAME:
+            return candidate
+    return profile
+
 
 def chrome_cookie_file(profile: Path | None = None) -> Path:
-    profile = profile or Path.home() / "Library/Application Support/Google/Chrome/Default"
-    return profile / "Cookies"
+    return resolve_chrome_profile(profile) / "Cookies"
 
 
 def chrome_expires_to_playwright(expires_utc: int | float) -> float:
@@ -126,13 +147,23 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
     # (typically 0644) rather than destination's mode — os.replace() would
     # otherwise silently widen a restrictive (0600) session file to
     # group/world-readable. storage_state_file holds a bearer token
-    # (hhtoken); create the temp file with 0o600 from the very first byte
-    # written via os.open(O_CREAT|O_EXCL, 0o600) — chmod()'ing *after*
-    # write_text() would still leave a race window where the plaintext
-    # secret sits at the umask-derived mode (Codex re-review, PR #168).
-    tmp = destination.with_name(destination.name + ".tmp")
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # (hhtoken); mkstemp() creates it with 0o600 from the very first byte
+    # (O_EXCL built in) AND with an unpredictable name, so a pre-planted
+    # symlink at a guessable `<destination>.tmp` can no longer redirect the
+    # secret into an attacker-controlled file (#171 — Codex review 3 of
+    # PR #168, merged without this fix).
+    fd, tmp_name = tempfile.mkstemp(
+        dir=destination.parent, prefix=destination.name + ".", suffix=".tmp"
+    )
+    tmp = Path(tmp_name)
     try:
+        # Defence-in-depth (#171): mkstemp already guarantees O_EXCL|O_CREAT
+        # with 0o600, but a compromised/widened mode here must fail loudly
+        # instead of leaking the bearer token through a group/world-readable
+        # temp file.
+        mode = os.fstat(fd).st_mode & 0o777
+        if mode != 0o600:
+            raise OSError(f"temp-файл сессии создан с режимом {mode:o} вместо 0600")
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(json.dumps(state, ensure_ascii=False, indent=2) + "\n")
     except BaseException:

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -31,15 +31,21 @@ def resolve_chrome_profile(profile: Path | None = None) -> Path:
     profile = profile or Path(DEFAULT_CHROME_PROFILE_NAME)
     if not profile.exists() and not profile.is_absolute():
         candidate = DEFAULT_CHROME_PROFILES_ROOT / profile
-        # `len(profile.parts) == 1` — a bare profile name (e.g. "Default"),
-        # not a multi-segment relative path like "foo/Default" (cycle-review
-        # PR #173 round 2, claude/review): profile.name matches only the
-        # last path segment, so without this guard a relative path the
-        # caller meant literally would be silently redirected under the
+        # `len(profile.parts) == 1` — a bare profile name (e.g. "Default",
+        # "Profile 1"), not a multi-segment relative path like "foo/Default"
+        # (cycle-review PR #173 round 2, claude/review): profile.name matches
+        # only the last path segment, so without this guard a relative path
+        # the caller meant literally would be silently redirected under the
         # Chrome profiles root just because it ends in "Default".
-        if candidate.exists() or (
-            len(profile.parts) == 1 and profile.name == DEFAULT_CHROME_PROFILE_NAME
-        ):
+        #
+        # round 3 (claude/review): the docstring and --profile help text both
+        # advertise arbitrary bare names ("Profile 1") as resolving under the
+        # Chrome root the same way "Default" does. The old check only special-
+        # cased the literal "Default" name, so a not-yet-existing bare name
+        # like "Profile 1" fell through to a plain cwd-relative Path instead —
+        # any single-segment bare name must resolve under the Chrome root,
+        # not just "Default".
+        if candidate.exists() or len(profile.parts) == 1:
             return candidate
     return profile
 
@@ -163,14 +169,29 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
                 continue
             break
         try:
-            source_stat = destination.stat()
+            # round 3 (claude/review): `destination.stat()` runs before `fd`
+            # is handed to os.fdopen(), so a failure here used to skip straight
+            # to `except` with the raw os.open() descriptor never closed —
+            # os.fdopen() is the only thing on this path that owns/closes fd.
+            # Wrap fd in os.fdopen() first so every failure below (including
+            # a failing destination.stat()) closes it via the `with` block.
             with os.fdopen(fd, "wb") as handle:
+                source_stat = destination.stat()
                 handle.write(destination.read_bytes())
                 # fd-relative metadata copy (not shutil.copystat(path)): a
                 # path-based call here would reopen the same TOCTOU window
                 # this fix closes above — os.futimens/os.fchmod act on the
                 # already-open descriptor, no path lookup left to redirect.
                 os.utime(handle.fileno(), ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns))
+                # round 3 (claude/review): intentionally NOT copying
+                # destination's mode bits here (unlike shutil.copy2, which
+                # this replaced). The `.bak` fd was opened with a fixed 0600
+                # above regardless of destination's actual mode, so a backup
+                # of a more permissive destination (e.g. one written by
+                # Playwright's own context.storage_state(), which does not
+                # set 0600) only ever gets *tightened*, never widened — safe
+                # for a file holding a bearer token even though it is not
+                # full metadata parity with copy2.
         except BaseException:
             # round 2 (claude/review): a failed copy must not leave an empty
             # `.bak` file — O_EXCL on the next run would treat that name as

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -10,6 +10,7 @@ from hhru_bot.cookie_import import (
     build_storage_state,
     chrome_expires_to_playwright,
     chrome_samesite_to_playwright,
+    resolve_chrome_profile,
     write_storage_state,
 )
 
@@ -156,3 +157,76 @@ def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeyp
         )
     finally:
         os.umask(old_umask)
+
+
+def test_write_does_not_follow_preplanned_symlink_on_tmp_name(tmp_path: Path):
+    # #171: temp-файл создавался по предсказуемому фиксированному имени
+    # `<destination>.tmp` через os.open(O_CREAT|O_TRUNC) без O_EXCL — на
+    # multi-user хосте атакующий мог заранее положить симлинк с этим именем
+    # и получить секрет сессии (hhtoken) в свой файл с правами атакующего.
+    # mkstemp() создаёт файл с непредсказуемым именем и O_EXCL — симлинк
+    # по угаданному имени больше не преследуется.
+    destination = tmp_path / "storage" / "hh_session.json"
+    destination.parent.mkdir()
+    attacker_target = tmp_path / "attacker_readable.json"
+    attacker_target.write_text("junk", encoding="utf-8")
+    attacker_target.chmod(0o666)
+    os.symlink(attacker_target, destination.with_name(destination.name + ".tmp"))
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"cookies": [], "origins": []}
+    assert attacker_target.read_text(encoding="utf-8") == "junk", (
+        "секрет сессии утёк в файл-цель симлинка"
+    )
+    assert (destination.stat().st_mode & 0o777) == 0o600
+
+
+def test_no_leftover_tmp_files_after_write(tmp_path: Path):
+    destination = tmp_path / "hh_session.json"
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_profile_name_resolves_from_chrome_profiles_root(tmp_path: Path, monkeypatch):
+    # find-one-shot-20260815: `--profile Default` резолвился от cwd и падал
+    # "No such file or directory: 'Default/Cookies'", хотя профиль есть в
+    # стандартном корне Chrome. Имя профиля без cwd-пути должно резолвиться
+    # от ~/Library/Application Support/Google/Chrome.
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    profiles_root = tmp_path / "Chrome"
+    (profiles_root / "Default").mkdir(parents=True)
+    (profiles_root / "Profile 1").mkdir(parents=True)
+    monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", profiles_root)
+
+    assert resolve_chrome_profile(Path("Default")) == profiles_root / "Default"
+    assert resolve_chrome_profile(Path("Profile 1")) == profiles_root / "Profile 1"
+
+
+def test_explicit_profile_path_wins_over_profiles_root(tmp_path: Path, monkeypatch):
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    profiles_root = tmp_path / "Chrome"
+    profiles_root.mkdir()
+    monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", profiles_root)
+
+    local_profile = tmp_path / "custom-profile"
+    local_profile.mkdir()
+    assert resolve_chrome_profile(local_profile) == local_profile
+    assert resolve_chrome_profile(local_profile.resolve()) == local_profile.resolve()
+
+    # несуществующее имя не подменяется молча на корень Chrome — ошибку
+    # выдаст read_chrome_cookies с исходным путём
+    missing = Path("no-such-profile")
+    assert resolve_chrome_profile(missing) == missing
+
+
+def test_default_profile_is_chrome_default(monkeypatch, tmp_path: Path):
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", tmp_path)
+    assert resolve_chrome_profile(None) == tmp_path / "Default"

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -207,6 +207,27 @@ def test_profile_name_resolves_from_chrome_profiles_root(tmp_path: Path, monkeyp
     assert resolve_chrome_profile(Path("Profile 1")) == profiles_root / "Profile 1"
 
 
+def test_bare_profile_name_resolves_under_chrome_root_even_if_not_yet_created(
+    tmp_path: Path, monkeypatch
+):
+    # cycle-review PR #173 round 3 (claude/review): the docstring and
+    # --profile help text both advertise "Profile 1" as a bare name that
+    # resolves under the Chrome profiles root the same way "Default" does.
+    # The old fallback guard only special-cased the literal string "Default"
+    # (`profile.name == DEFAULT_CHROME_PROFILE_NAME`), so any other bare
+    # profile name that did not already exist under the Chrome root — e.g. a
+    # not-yet-materialized "Profile 1" directory — silently fell through to a
+    # plain cwd-relative Path instead, contradicting the documented contract.
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    profiles_root = tmp_path / "Chrome"
+    profiles_root.mkdir()
+    monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", profiles_root)
+
+    # Nothing exists under profiles_root yet, and no cwd-relative path either.
+    assert resolve_chrome_profile(Path("Profile 1")) == profiles_root / "Profile 1"
+
+
 def test_explicit_profile_path_wins_over_profiles_root(tmp_path: Path, monkeypatch):
     import hhru_bot.cookie_import as cookie_import_mod
 
@@ -219,10 +240,11 @@ def test_explicit_profile_path_wins_over_profiles_root(tmp_path: Path, monkeypat
     assert resolve_chrome_profile(local_profile) == local_profile
     assert resolve_chrome_profile(local_profile.resolve()) == local_profile.resolve()
 
-    # несуществующее имя не подменяется молча на корень Chrome — ошибку
-    # выдаст read_chrome_cookies с исходным путём
-    missing = Path("no-such-profile")
-    assert resolve_chrome_profile(missing) == missing
+    # A path with more than one segment (not a bare profile name) is never
+    # redirected under the Chrome root, existing or not — the caller meant it
+    # literally relative to cwd; read_chrome_cookies gives a clear error.
+    missing_multi_segment = Path("some/dir/no-such-profile")
+    assert resolve_chrome_profile(missing_multi_segment) == missing_multi_segment
 
 
 def test_default_profile_is_chrome_default(monkeypatch, tmp_path: Path):
@@ -279,6 +301,50 @@ def test_backup_does_not_follow_preplanned_dangling_symlink(tmp_path: Path):
     write_storage_state({"cookies": [], "origins": []}, destination)
 
     assert not dangling_target.exists(), "секрет сессии утёк в файл-цель dangling symlink"
+
+
+def test_backup_stat_failure_closes_fd_before_raising(tmp_path: Path, monkeypatch):
+    # cycle-review PR #173 round 3 (claude/review): `fd = os.open(candidate,
+    # ...)` (the exclusively-created `.bak` fd) used to be handed to
+    # os.fdopen() only AFTER `destination.stat()` had already run inside the
+    # same try block. If that stat() call raised, the `except BaseException`
+    # handler unlinked the candidate name but never closed the raw fd from
+    # os.open() — os.fdopen() was the only thing on that path that owned it,
+    # and it was never reached. Fail destination.stat() on its second call
+    # (the first is destination.exists() at function entry) and confirm the
+    # backup fd is actually closed afterwards, not leaked.
+    destination = tmp_path / "hh_session.json"
+    destination.write_text(json.dumps({"cookies": [{"value": "secret"}]}), encoding="utf-8")
+
+    opened_bak_fds: list[int] = []
+    real_open = os.open
+
+    def _spy_open(path, flags, mode=0o777):
+        fd = real_open(path, flags, mode)
+        if str(path).endswith(".bak"):
+            opened_bak_fds.append(fd)
+        return fd
+
+    call_count = {"n": 0}
+    real_stat = Path.stat
+
+    def _selective_failing_stat(self, *args, **kwargs):
+        if self == destination:
+            call_count["n"] += 1
+            if call_count["n"] > 1:
+                raise OSError("simulated stat failure")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", _spy_open)
+    monkeypatch.setattr(Path, "stat", _selective_failing_stat)
+
+    with pytest.raises(OSError, match="simulated stat failure"):
+        write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert opened_bak_fds, "test did not exercise the backup os.open() path"
+    for fd in opened_bak_fds:
+        with pytest.raises(OSError):
+            os.fstat(fd)  # closed fd raises EBADF; an open one would succeed
 
 
 def test_relative_multi_segment_profile_path_is_not_redirected(tmp_path: Path, monkeypatch):

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -279,3 +279,88 @@ def test_backup_does_not_follow_preplanned_dangling_symlink(tmp_path: Path):
     write_storage_state({"cookies": [], "origins": []}, destination)
 
     assert not dangling_target.exists(), "секрет сессии утёк в файл-цель dangling symlink"
+
+
+def test_relative_multi_segment_profile_path_is_not_redirected(tmp_path: Path, monkeypatch):
+    # cycle-review PR #173 round 2 (claude/review): the fallback condition
+    # `profile.name == DEFAULT_CHROME_PROFILE_NAME` matches only the last
+    # path segment (Path.name), so a relative path like `foo/Default` (not
+    # just the bare name `Default`) was silently rewritten to
+    # `DEFAULT_CHROME_PROFILES_ROOT / "foo/Default"`, discarding the
+    # caller's relative-to-cwd path.
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    profiles_root = tmp_path / "Chrome"
+    profiles_root.mkdir()
+    monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", profiles_root)
+
+    multi_segment = Path("foo/Default")
+    assert resolve_chrome_profile(multi_segment) == multi_segment
+
+
+def test_backup_copy_failure_leaves_no_empty_bak_file(tmp_path: Path, monkeypatch):
+    # cycle-review PR #173 round 2 (claude/review): the O_EXCL backup-name
+    # loop created the `.bak` inode BEFORE shutil.copy2() actually wrote
+    # content into it. If copy2() failed partway, the empty `.bak` file was
+    # left on disk with no cleanup — the next run's O_EXCL check would then
+    # treat that name as permanently taken, drifting backup numbering
+    # forever on every retried failure.
+    import hhru_bot.cookie_import as cookie_import_mod
+
+    destination = tmp_path / "hh_session.json"
+    destination.write_text('{"old": 1}', encoding="utf-8")
+
+    def _broken_read_bytes(self, *args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cookie_import_mod.Path, "read_bytes", _broken_read_bytes)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_storage_state({"cookies": [], "origins": []}, destination)
+
+    backup_candidate = destination.with_name(destination.name + ".bak")
+    assert not backup_candidate.exists(), "failed backup copy left an empty .bak file behind"
+
+
+def test_backup_write_survives_symlink_swap_after_exclusive_create(tmp_path: Path, monkeypatch):
+    # cycle-review PR #173 round 2 (codex, high/0.98): the backup inode was
+    # created exclusively (O_CREAT|O_EXCL) and its fd closed, THEN
+    # shutil.copy2(path) wrote through the (now closed) path — reopening a
+    # TOCTOU window. A local attacker able to modify the storage directory
+    # could unlink the freshly created backup file and replace it with a
+    # symlink in the window between close() and copy2(); copy2() would
+    # follow the symlink and leak the session secret into the attacker's
+    # target. The fix writes through the already-open fd instead of a path
+    # lookup, so there is no window left to race. Simulate an attacker
+    # racing the exclusive-create step: swap the backup name for a symlink
+    # right after os.open() returns, before any write happens.
+    destination = tmp_path / "hh_session.json"
+    destination.write_text(json.dumps({"cookies": [{"value": "secret-hhtoken"}]}), encoding="utf-8")
+    backup_path = destination.with_name(destination.name + ".bak")
+    attacker_target = tmp_path / "attacker_owned.json"
+
+    real_open = os.open
+    swapped = False
+
+    def _racing_open(path, flags, mode=0o777, *args, **kwargs):
+        nonlocal swapped
+        fd = real_open(path, flags, mode, *args, **kwargs)
+        if not swapped and str(path) == str(backup_path) and (flags & os.O_EXCL):
+            # Simulate an attacker winning the race right after the
+            # exclusive create: unlink the just-created inode and replace
+            # the name with a symlink to an attacker-owned file. If the
+            # implementation still writes by reopening `path` (as the old
+            # shutil.copy2(path) call did), it would now follow this symlink.
+            swapped = True
+            os.unlink(path)
+            os.symlink(attacker_target, path)
+        return fd
+
+    monkeypatch.setattr(os, "open", _racing_open)
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert not attacker_target.exists(), "секрет сессии утёк в файл-цель symlink через TOCTOU-гонку"
+    assert backup_path.is_symlink(), (
+        "sanity: the race actually replaced the backup path with a symlink"
+    )

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -230,3 +230,52 @@ def test_default_profile_is_chrome_default(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(cookie_import_mod, "DEFAULT_CHROME_PROFILES_ROOT", tmp_path)
     assert resolve_chrome_profile(None) == tmp_path / "Default"
+
+
+def test_mode_check_failure_closes_fd_before_raising(tmp_path: Path, monkeypatch):
+    # cycle-review PR #173 round 1 (claude/review): when the defence-in-depth
+    # mode check (#171) finds mkstemp() returned an fd with the wrong mode,
+    # it raises OSError before os.fdopen(fd, ...) ever runs — so nothing
+    # takes ownership of the raw fd. The `except BaseException` handler only
+    # unlinked the temp file, never os.close()d the fd, leaking a descriptor
+    # on every trip through this branch. Spy on os.close to confirm the fd
+    # from mkstemp() is actually closed once the mode check trips.
+    destination = tmp_path / "hh_session.json"
+    real_fstat = os.fstat
+    closed_fds: list[int] = []
+    real_close = os.close
+
+    def _fake_fstat(fd, *args, **kwargs):
+        result = real_fstat(fd, *args, **kwargs)
+        # Report a widened mode so the defence-in-depth check trips.
+        return os.stat_result((0o100644,) + tuple(result)[1:])
+
+    def _spy_close(fd, *args, **kwargs):
+        closed_fds.append(fd)
+        return real_close(fd, *args, **kwargs)
+
+    monkeypatch.setattr(os, "fstat", _fake_fstat)
+    monkeypatch.setattr(os, "close", _spy_close)
+
+    with pytest.raises(OSError, match="0600"):
+        write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert closed_fds, "mkstemp() fd was never closed after the mode check raised"
+
+
+def test_backup_does_not_follow_preplanned_dangling_symlink(tmp_path: Path):
+    # cycle-review PR #173 round 1 (codex, high/0.98): the backup-name loop
+    # picked a candidate with `candidate.exists()`, which returns False for a
+    # dangling symlink — so a pre-planted `<destination>.bak -> /attacker`
+    # symlink was accepted as the backup name and shutil.copy2() followed it,
+    # writing the session content (including hhtoken) into the attacker's
+    # target file. This is the same symlink-attack class #171 closed for the
+    # `.tmp` path, left open here for `.bak`.
+    destination = tmp_path / "hh_session.json"
+    destination.write_text(json.dumps({"cookies": [{"value": "secret-hhtoken"}]}), encoding="utf-8")
+    dangling_target = tmp_path / "attacker_readable.json"
+    os.symlink(dangling_target, destination.with_name(destination.name + ".bak"))
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert not dangling_target.exists(), "секрет сессии утёк в файл-цель dangling symlink"


### PR DESCRIPTION
## Summary
- `resolve_chrome_profile()`: `--profile` теперь принимает и путь, и имя профиля (`Default`, `Profile 1`) — имя резолвится от стандартного корня профилей Chrome (`~/Library/Application Support/Google/Chrome`), а не от cwd. Раньше `--profile Default` падал с `No such file or directory`, хотя профиль есть.
- `write_storage_state()`: temp-файл сессии теперь создаётся через `tempfile.mkstemp()` вместо предсказуемого имени `<destination>.tmp` — закрывает возможность symlink-атаки на multi-user хосте (#171, Codex review 3 PR #168, который был смёржен без этого фикса). Добавлена defence-in-depth проверка режима файла (0o600) с единообразным cleanup через `except BaseException`.

## Test plan
- `pytest tests/test_cookie_import.py -q` — 15/15 зелёные (включая новые тесты на symlink-атаку, отсутствие leftover tmp-файлов, резолв имени профиля).
- `ruff check` + `ruff format --check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #171
