### PR TITLE
fix(apply): reject placeholder resume URLs before applying

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from ..apply import apply_to_vacancy
 from ..apply.letter import CoverLetterProvider
-from ..config import AppConfig, ResumeConfig, SearchFilters
+from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
 from ..config_sections.scoring import ScoringWeights
 from ..history import SKIP_REASONS, History
 from ..search import (
@@ -245,9 +245,22 @@ def run_apply_for_resume(
     (VacancySearchIndeterminate) — apply.run() агрегирует это по всем
     резюме и транслирует в ненулевой exit code через cli.main(). False —
     во всех остальных случаях (включая исчерпанный дневной лимит).
+
+    #165: True также при плейсхолдере resume_url в конфиге — конфиг с
+    плейсхолдером фейлится явно и рано (до search/истории/отправки формы),
+    а не молча откликается default-резюме аккаунта.
     """
     print(f"\n=== Отклики для резюме: {resume.id} ===")
 
+    if is_resume_url_placeholder(resume.resume_url):
+        # Fail closed до любого write-действия: на форме с единственным
+        # резюме hh.ru не валидирует resume_id (#165), и отклик уходит
+        # default-резюме, а история пишется под фейковым id.
+        print(
+            f"[FAIL] {resume.id} — в конфиге указан плейсхолдер resume_url; "
+            "укажите реальный URL (получить можно через list-resumes --remote)"
+        )
+        return True
     try:
         throttle.check_apply_limit(resume.resume_id, args.dry_run)
     except LimitReached as e:

--- a/tests/test_apply_placeholder.py
+++ b/tests/test_apply_placeholder.py
@@ -1,0 +1,130 @@
+"""#165: плейсхолдер resume_url блокирует apply-цикл до любых действий.
+
+PR #162 (issue #159) подключил is_resume_url_placeholder() в bump и probe,
+но run_apply_for_resume плейсхолдер не проверял: если у аккаунта на hh.ru
+одно резюме, форма отклика не рендерит селектор резюме и fill_response_form
+отправляет отклик default-резюме, а история пишется под фейковым id
+``XXXX...``. Ранний гард закрывает оба сценария из ишью (одно/несколько
+резюме на аккаунте): до apply_to_vacancy дело не доходит вовсе.
+
+Образцы — test_bump.py::test_bump_placeholder_url_does_not_navigate и
+test_probe_healthcheck.py::test_check_selectors_skips_placeholder_url_without_goto.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+import pytest
+
+from hhru_bot.commands import _common
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.history import History
+from hhru_bot.search import VacancyCard
+from hhru_bot.throttle import Throttle
+
+_PLACEHOLDER_URL = "https://hh.ru/resume/XXXXXXXXXXXXXXXXXXXXXXXX"
+
+
+def _resume(url: str) -> ResumeConfig:
+    return ResumeConfig(
+        id="r1",
+        resume_url=url,
+        search=SearchFilters(text="python developer"),
+    )
+
+
+def _config(tmp_path, resume: ResumeConfig) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        # Нулевые задержки: контрольный тест доходит до throttle.wait.
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+    )
+
+
+def _apply_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=True,
+        headless=True,
+        max_pages=1,
+        limit=0,
+    )
+
+
+def _row_count(history_db, table: str) -> int:
+    with sqlite3.connect(history_db) as conn:
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+class _StubResult:
+    success = True
+    reason = None
+    letter_variant = None
+    skipped = False
+
+
+def test_placeholder_url_fails_closed_before_any_action(tmp_path, monkeypatch):
+    """Плейсхолдер → fail closed до search/apply/истории, возврат True (exit 1)."""
+    calls: list[str] = []
+
+    def _forbidden(name):
+        def _stub(*args, **kwargs):  # noqa: ARG001
+            calls.append(name)
+            pytest.fail(f"{name} must not be called with placeholder resume_url")
+
+        return _stub
+
+    monkeypatch.setattr(_common, "search_vacancies", _forbidden("search_vacancies"))
+    monkeypatch.setattr(_common, "apply_to_vacancy", _forbidden("apply_to_vacancy"))
+
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    config = _config(tmp_path, _resume(_PLACEHOLDER_URL))
+    throttle = Throttle(config.throttle, history)
+
+    failed = _common.run_apply_for_resume(
+        object(), config, config.resumes[0], history, throttle, _apply_args()
+    )
+
+    assert failed is True
+    assert calls == []
+    # История не пишется вовсе — в том числе под фейковым id XXXX...
+    assert _row_count(history_db, "actions") == 0
+    assert _row_count(history_db, "skipped") == 0
+
+
+def test_real_url_still_reaches_apply(tmp_path, monkeypatch):
+    """Обычный URL гард не ломает: цикл доходит до apply_to_vacancy."""
+    monkeypatch.setattr(
+        _common,
+        "search_vacancies",
+        lambda page, search, max_pages=1: [  # noqa: ARG001
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+    applied_resume_ids: list[str] = []
+
+    def _fake_apply(page, card, resume_id, template, dry_run, *, letter_provider=None):  # noqa: ARG001
+        applied_resume_ids.append(resume_id)
+        return _StubResult()
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", _fake_apply)
+
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    config = _config(tmp_path, _resume("https://hh.ru/resume/AAA111"))
+    throttle = Throttle(config.throttle, history)
+
+    failed = _common.run_apply_for_resume(
+        object(), config, config.resumes[0], history, throttle, _apply_args()
+    )
+
+    assert failed is False
+    assert applied_resume_ids == ["AAA111"]


### PR DESCRIPTION
Fixes #165

Follow-up к #159 / PR #162: `is_resume_url_placeholder()` подключён в `bump` и `probe`, но `run_apply_for_resume` (`commands/_common.py`) плейсхолдер не проверял. Если у аккаунта на hh.ru одно резюме, форма отклика не рендерит селектор резюме, и `fill_response_form` отправляла отклик default-резюме аккаунта, а история/дедуп писались под фейковым id `XXXX...` — тот же класс «лжи», что и #159: конфиг с плейсхолдером должен фейлиться явно и рано.

## Что сделано

- Ранний гард в `run_apply_for_resume` (`src/hhru_bot/commands/_common.py`): при плейсхолдере `resume_url` — `[FAIL]` с сообщением по аналогии с `bump.py` и возврат `True` → `apply.run()` → `sys.exit(1)` (как в healthcheck #162). Покрывает команды `apply` и `run`; гард пер-resume, остальные резюме в конфиге обрабатываются.
- До ensа не доходит вовсе: ни `search_vacancies`, ни записи истории, ни `apply_to_vacancy` — закрывает оба сценария из ишью (одно/несколько резюме на аккаунте).
- Docstring контракта #148 дополнен (#165: True также при плейсхолдере).
- Альтернативу из ишью (центральная проверка в `load_config`) не делаю: она фейлила бы `probe`/`whoami`/`login`, которым плейсхолдер не фатален, и противоречит прецеденту `_warn_if_scoring_keywords_inert`.

## Тесты

Новый `tests/test_apply_placeholder.py` (аналог `test_bump.py::test_bump_placeholder_url_does_not_navigate`):

- плейсхолдер → `failed is True`, `search_vacancies`/`apply_to_vacancy` не вызываются (fail-if-called стабы), таблицы `actions`/`skipped` в history пусты;
- контроль: обычный URL → цикл доходит до `apply_to_vacancy` с реальным `resume_id`.

`pytest` — 892 passed; `ruff check` / `ruff format --check` — чисто; `gen_cli_docs.py --check` — синхронизирован (CLI-интерфейс не менялся).