### PR TITLE
fix(throttle): skip wait and failed records for pre-action outcomes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
    - Кулдаун поднятия резюме: жёстко `BUMP_COOLDOWN = 4 часа` (`can_bump_now()`), сверх
      дневного лимита.
    - `throttle.wait()` — случайная пауза `min_delay..max_delay` секунд после каждого
-     действия.
+     РЕАЛЬНОГО действия на hh.ru — клика поднятия/submit отклика (`BumpResult.acted`/
+     `ApplyResult.acted`, #163). Ранние выходы до действия (плейсхолдер в конфиге,
+     форма входа, hint «рано», dry-run) не ждут паузу и не пишут `failed` в actions:
+     на hh.ru не осталось следа, пауза не от чего не защищает.
 
 4. **Форма отклика — двухшаговая навигация.** `VACANCY_APPLY_BUTTON` на странице вакансии
    это `<a href="/applicant/vacancy_response?...">`, а НЕ триггер модалки на той же

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -40,6 +40,12 @@ class ApplyResult:
     # submit НЕ выполнялся. В отличие от fail, skip не пишет status='failed' в actions
     # и не расходует дневной лимит/троттл (см. commands/_common.run_apply_for_resume).
     skipped: bool = False
+    # #163: реальное действие на hh.ru выполнено (submit формы отклика).
+    # False у всех выходов до submit (форма входа, «уже откликались», кнопка
+    # не найдена, dry-run) — цикл откликов не пишет их в actions и не ждёт
+    # throttle.wait. True после submit-клика: даже провал подтверждения
+    # успеха (wait_success_confirmation) — отправка была, пауза обязательна.
+    acted: bool = False
 
 
 @dataclass
@@ -57,17 +63,34 @@ class ApplyContext:
     letter_provider: CoverLetterProvider | None = None
     # Заполняется в _run после рендера письма — итоговый variant для ApplyResult.
     letter_variant: str = VARIANT_TEMPLATE
+    # #163: submit выполнен. Выставляется в _run после успешного fill_response_form
+    # (клик по кнопке отправки — его последний шаг); все ПОСЛЕДУЮЩИЕ исходы
+    # (успех, провал подтверждения) несут acted=True через fail()/ok().
+    acted: bool = False
 
     def fail(self, reason: str) -> ApplyResult:
-        return ApplyResult(self.vacancy, False, reason, letter_variant=self.letter_variant)
+        return ApplyResult(
+            self.vacancy,
+            False,
+            reason,
+            letter_variant=self.letter_variant,
+            acted=self.acted,
+        )
 
     def ok(self, reason: str) -> ApplyResult:
-        return ApplyResult(self.vacancy, True, reason, letter_variant=self.letter_variant)
+        return ApplyResult(
+            self.vacancy,
+            True,
+            reason,
+            letter_variant=self.letter_variant,
+            acted=self.acted,
+        )
 
     def skip(self, reason: str) -> ApplyResult:
         # #95: skip отличён от fail — отправки не было, но и ошибки нет. success=False,
         # skipped=True: цикл откликов пишет record_skip (НЕ record_action failed) и
         # не ждёт throttle. mirror of fail()/ok() — несёт letter_variant для консистентности.
+        # #163: acted всегда False — skip по определению до submit.
         return ApplyResult(
             self.vacancy,
             success=False,
@@ -144,6 +167,10 @@ def _run(ctx: ApplyContext) -> ApplyResult:
 
     if reason := apply_steps.fill_response_form(ctx.page, ctx.resume_id, letter):
         return ctx.fail(reason)
+
+    # #163: fill_response_form без причины = submit-клик выполнен (последний шаг
+    # заполнения). Дальнейшие исходы — «после действия»: пауза и запись в actions.
+    ctx.acted = True
 
     ctx.probe("submitted", vacancy_title=ctx.vacancy.title)
 

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -26,6 +26,11 @@ class BumpResult:
     resume_id: str
     success: bool
     reason: str = ""
+    # #163: реальное действие на hh.ru выполнено (клик по кнопке поднятия).
+    # False у всех ранних выходов (плейсхолдер, форма входа, hint «рано»,
+    # кнопка не найдена) и у dry-run: на hh.ru не осталось следа, поэтому
+    # команда не пишет такие исходы в actions и не ждёт throttle.wait.
+    acted: bool = False
 
 
 def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
@@ -84,4 +89,4 @@ def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
 
     bump_button.click()
     logger.info("Резюме '%s' поднято в поиске", resume.id)
-    return BumpResult(resume.id, True, "success")
+    return BumpResult(resume.id, True, "success", acted=True)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -231,7 +231,8 @@ def run_apply_for_resume(
 
     Перенесено дословно из cli._apply_for_resume. Принципы CLAUDE.md сохранены:
     дедупликация и стоп-листы через filter_candidates (history-based),
-    дневной лимит проверяется перед каждым откликом, throttle.wait между откликами.
+    дневной лимит проверяется перед каждым откликом, throttle.wait после
+    реальных отправок (#163: исходы до submit — без паузы и записи в actions).
 
     #17: если включён AI (секция ai + ai_profile) — отклик идёт через
     CoverLetterProvider; иначе (провайдер None) — статичный шаблон, поведение
@@ -302,15 +303,21 @@ def run_apply_for_resume(
             print(f"  [skip] {card.title} — {result.reason}")
             continue
 
-        status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
-        history.record_action(
-            resume.resume_id,
-            card.vacancy_id,
-            "apply",
-            status,
-            result.reason,
-            letter_variant=result.letter_variant,
-        )
+        # #163: actions — журнал реальных взаимодействий с hh.ru. Запись только
+        # после реального submit либо для успешной dry_run-симуляции — dry_run-
+        # строки НЕ трогаем: их читает дедупликация has_applied (CLAUDE.md п.2).
+        # Провалы до submit (форма входа, «уже откликались», кнопка не найдена)
+        # на hh.ru не отправлялись — остаются в консоли/логе, не в статистике.
+        if result.acted or (args.dry_run and result.success):
+            status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+            history.record_action(
+                resume.resume_id,
+                card.vacancy_id,
+                "apply",
+                status,
+                result.reason,
+                letter_variant=result.letter_variant,
+            )
 
         if result.success:
             applied_count += 1
@@ -318,7 +325,11 @@ def run_apply_for_resume(
         else:
             print(f"  [FAIL] {card.title} — {result.reason}")
 
-        throttle.wait(f"после отклика на '{card.title}'")
+        # #163: анти-бан-пауза — только после реальной отправки отклика (submit).
+        # Ранние выходы не оставляют на сайте следа, пауза там не от чего не
+        # защищает; после submit (включая неподтверждённый успех) — обязательна.
+        if result.acted:
+            throttle.wait(f"после отклика на '{card.title}'")
 
     print(f"Итого откликов за этот запуск: {applied_count}")
     return False

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -44,15 +44,30 @@ def run(args: argparse.Namespace) -> None:
                 continue
 
             result = bump_resume(page, resume, args.dry_run)
-            status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
-            # Для action='bump' нет естественного vacancy_id (поднятие резюме, не отклик).
-            # actions.vacancy_id NOT NULL — заполняем resume.resume_id как sentinel; UNIQUE-индекс
-            # idx_resume_vacancy_apply существует только WHERE action='apply', так что коллизий нет.
-            history.record_action(resume.resume_id, resume.resume_id, "bump", status, result.reason)
+
+            # #163: actions — журнал реальных взаимодействий с hh.ru. Запись
+            # только после реального клика по кнопке поднятия либо для успешной
+            # dry_run-симуляции; провалы до действия (плейсхолдер в конфиге,
+            # форма входа, hint «рано») не результат взаимодействия с hh.ru —
+            # они остаются в консоли/логе, но не засоряют статистику.
+            if result.acted or (args.dry_run and result.success):
+                status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+                # Для action='bump' нет естественного vacancy_id (поднятие резюме,
+                # не отклик). actions.vacancy_id NOT NULL — заполняем resume.resume_id
+                # как sentinel; UNIQUE-индекс idx_resume_vacancy_apply существует
+                # только WHERE action='apply', так что коллизий нет.
+                history.record_action(
+                    resume.resume_id, resume.resume_id, "bump", status, result.reason
+                )
 
             if result.success:
                 print(f"  [OK] {resume.id} поднято")
             else:
                 print(f"  [FAIL] {resume.id} — {result.reason}")
 
-            throttle.wait(f"после поднятия резюме '{resume.id}'")
+            # #163: анти-бан-пауза — только после реального действия на hh.ru
+            # (клика по кнопке). Ранние выходы не оставляют на сайте следа,
+            # пауза там не от чего не защищает; после реального поднятия
+            # троттлинг обязателен (CLAUDE.md: «не убирай троттлинг/лимиты»).
+            if result.acted:
+                throttle.wait(f"после поднятия резюме '{resume.id}'")

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -112,6 +112,7 @@ def test_apply_dry_run_success():
     assert result.success is True
     assert result.reason == "dry-run"
     assert page.goto_calls == ["https://hh.ru/vacancy/1"]
+    assert result.acted is False  # #163: симуляция без submit — без паузы
 
 
 def test_apply_login_form_is_checked_after_navigation(monkeypatch):
@@ -135,6 +136,7 @@ def test_apply_login_form_is_checked_after_navigation(monkeypatch):
     assert result.success is False
     assert "Сессия недействительна" in result.reason
     assert events == ["goto", "auth"]
+    assert result.acted is False  # #163: провал до submit — без паузы и записи
 
 
 def test_apply_already_responded_not_deduped_by_dom():
@@ -155,6 +157,7 @@ def test_apply_no_apply_button():
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
     assert result.success is False
     assert "кнопка отклика не найдена" in result.reason
+    assert result.acted is False  # #163: до submit — без паузы и записи
 
 
 def test_apply_probe_hook_invoked_noop_default():
@@ -228,6 +231,19 @@ def test_apply_non_dry_run_success_when_submit_scoped_in_form():
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
     assert result.success is True
     assert result.skipped is False
+    assert result.acted is True  # #163: submit выполнен — пауза обязательна
+
+
+def test_apply_submit_unconfirmed_is_acted(monkeypatch):
+    """#163: submit-клик был, но успех не подтвердился (wait_success_confirmation
+    False) — это провал ПОСЛЕ действия: acted=True, цикл откликов обязан
+    ждать паузу и писать failed. Регрессия против «фикс отключил троттлинг»."""
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    page = FakePage(apply_button=True, success=True, submit_in_form=True)
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+    assert result.success is False
+    assert "не удалось подтвердить" in result.reason
+    assert result.acted is True
 
 
 def test_apply_non_dry_run_indeterminate_is_fail_not_skip():
@@ -242,3 +258,4 @@ def test_apply_non_dry_run_indeterminate_is_fail_not_skip():
     assert result.success is False
     assert result.skipped is False
     assert "границы формы" in result.reason
+    assert result.acted is False  # #163: indeterminate — до submit, без паузы

--- a/tests/test_apply_scoring_integration.py
+++ b/tests/test_apply_scoring_integration.py
@@ -99,6 +99,7 @@ class _StubResult:
     reason = "stub"
     letter_variant = None
     skipped = False  # #95: совместимость с result.skipped в _common.run_apply_for_resume
+    acted = False  # #163: совместимость с result.acted в _common.run_apply_for_resume
 
 
 def test_run_apply_passes_llm_provider_when_ai_on(tmp_path, monkeypatch):

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -122,6 +122,7 @@ def test_bump_hint_present_blocks_click():
     assert result.success is False
     assert "рано" in result.reason
     assert page.click_log == []
+    assert result.acted is False  # #163: клика не было — без паузы и записи
 
 
 def test_bump_placeholder_url_does_not_navigate():
@@ -137,6 +138,7 @@ def test_bump_placeholder_url_does_not_navigate():
     assert result.success is False
     assert "плейсхолдер" in result.reason
     assert page.goto_calls == []
+    assert result.acted is False  # #163: отсев до навигации — hh.ru не тронут
 
 
 def test_bump_delayed_hint_still_blocks_click():
@@ -165,6 +167,7 @@ def test_bump_no_hint_clicks_button():
 
     assert result.success is True
     assert page.click_log == ["button"]
+    assert result.acted is True  # #163: реальный клик — пауза обязательна
 
 
 def test_bump_dry_run_does_not_click_even_without_hint():
@@ -174,6 +177,7 @@ def test_bump_dry_run_does_not_click_even_without_hint():
 
     assert result.success is True
     assert page.click_log == []
+    assert result.acted is False  # #163: симуляция без клика — без паузы
 
 
 def test_bump_hint_wait_error_is_fail_closed_not_traceback():

--- a/tests/test_throttle_policy.py
+++ b/tests/test_throttle_policy.py
@@ -1,0 +1,266 @@
+"""Политика троттлинга и записи истории «до действия» (#163).
+
+#163: пауза ``throttle.wait`` и запись в ``actions`` — только после РЕАЛЬНОГО
+действия на hh.ru (клик кнопки поднятия / submit отклика, ``acted=True``) либо
+для успешной dry_run-симуляции (dry_run-строки apply читает дедупликация
+``has_applied`` — их не трогаем). Провалы до действия (плейсхолдер в конфиге,
+форма входа, hint «рано», кнопка не найдена) не оставляют на hh.ru следа:
+без паузы и без строки ``failed``. Прецедент — #95 (skip без отправки уже не
+ждёт паузу и не пишется в actions).
+
+Уровень командных циклов (``bump.run`` / ``run_apply_for_resume``): браузер и
+поиск подменяются, ``Throttle.wait`` — шпион (реальный sleep в тестах недопустим),
+History — настоящая в tmp_path, чтобы проверять, ЧТО реально попало в actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+import pytest
+
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.search import VacancyCard
+from hhru_bot.throttle import Throttle
+
+
+def _resume(**overrides) -> ResumeConfig:
+    base = {
+        "id": "python",
+        "resume_url": "https://hh.ru/resume/AAA111",
+        "search": SearchFilters(text="python developer"),
+    }
+    base.update(overrides)
+    return ResumeConfig(**base)
+
+
+def _placeholder_resume() -> ResumeConfig:
+    # Тот же вид плейсхолдера, что в config.example.yaml (X{8,} в хвосте URL).
+    return _resume(resume_url="https://hh.ru/resume/XXXXXXXXXXXXXXXXXXXXXXXX")
+
+
+def _config(tmp_path, resume) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="Здравствуйте, {company_name}!",
+        resumes=[resume],
+    )
+
+
+def _read_actions(history_db) -> list[tuple[str, str]]:
+    """(action, status) из actions в порядке записи."""
+    conn = sqlite3.connect(history_db)
+    try:
+        return [tuple(r) for r in conn.execute("SELECT action, status FROM actions ORDER BY id")]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def wait_calls(monkeypatch):
+    """Шпион на Throttle.wait: собирает причины вызовов вместо реального sleep."""
+    calls: list[str] = []
+    monkeypatch.setattr(Throttle, "wait", lambda self, reason="": calls.append(reason))
+    return calls
+
+
+# --- bump: командный цикл ----------------------------------------------------
+
+
+class _FakeLaunchContext:
+    """launch_context без браузера: page не используется подменёнными шагами."""
+
+    def __enter__(self):
+        class _Ctx:
+            def new_page(self):
+                return object()
+
+        return _Ctx()
+
+    def __exit__(self, *_a):  # noqa: ARG002
+        return False
+
+
+def _run_bump(monkeypatch, tmp_path, config, *, dry_run: bool = False) -> None:
+    """bump.run с подменённым браузером/конфигом; throttle.wait — шпион фикстуры."""
+    from hhru_bot.commands import bump as bump_cmd
+
+    # String-path monkeypatch патчит символ в модуле-источнике: работает, потому
+    # что bump.run импортирует launch_context/load_config_or_exit лениво.
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeLaunchContext())  # noqa: ARG005
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)  # noqa: ARG005
+    bump_cmd.run(
+        argparse.Namespace(
+            config=None,
+            history=str(tmp_path / "history.db"),
+            dry_run=dry_run,
+            headless=True,
+            resume=None,
+            max_pages=5,
+        )
+    )
+
+
+def test_bump_placeholder_no_wait_no_record(tmp_path, monkeypatch, wait_calls, capsys):
+    """Приёмка #163: dry-run с плейсхолдером — без 16-секундной паузы и без
+    записи failed. Реальный bump_resume: плейсхолдер отсекается до goto_hh,
+    на hh.ru нет ни одного запроса — пауза не от чего не защищает."""
+    _run_bump(monkeypatch, tmp_path, _config(tmp_path, _placeholder_resume()), dry_run=True)
+
+    assert wait_calls == [], "плейсхолдер не ходил на hh.ru — пауза не нужна"
+    assert _read_actions(tmp_path / "history.db") == [], (
+        "отсев по локальному конфигу — не действие на hh.ru"
+    )
+    assert "[FAIL]" in capsys.readouterr().out, "провал по-прежнему виден пользователю"
+
+
+def test_bump_login_form_failure_no_wait_no_record(tmp_path, monkeypatch, wait_calls, capsys):
+    """Форма входа (#153) — провал до клика: без паузы и без записи failed."""
+    from hhru_bot.bump import BumpResult
+
+    resume = _resume()
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda page, r, dry_run: BumpResult(  # noqa: ARG005
+            r.id, False, "Сессия недействительна: страница содержит форму входа. Выполните login."
+        ),
+    )
+    _run_bump(monkeypatch, tmp_path, _config(tmp_path, resume))
+
+    assert wait_calls == []
+    assert _read_actions(tmp_path / "history.db") == []
+    assert "[FAIL]" in capsys.readouterr().out
+
+
+def test_bump_real_action_waits_and_records(tmp_path, monkeypatch, wait_calls, capsys):
+    """РЕГРЕССИЯ #163: после реального клика поднятия пауза обязательна и
+    success пишется в actions — фикс не должен отключить троттлинг там,
+    где он нужен (CLAUDE.md: «не убирай троттлинг/лимиты»)."""
+    from hhru_bot.bump import BumpResult
+
+    resume = _resume()
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda page, r, dry_run: BumpResult(r.id, True, "success", acted=True),  # noqa: ARG005
+    )
+    _run_bump(monkeypatch, tmp_path, _config(tmp_path, resume))
+
+    assert wait_calls == [f"после поднятия резюме '{resume.id}'"]
+    assert _read_actions(tmp_path / "history.db") == [("bump", "success")]
+    assert "[OK]" in capsys.readouterr().out
+
+
+def test_bump_dry_run_success_records_without_wait(tmp_path, monkeypatch, wait_calls):
+    """Успешная dry_run-симуляция пишется (параллель семантике apply), но без
+    паузы: клика не было, анти-бан-пауза не от чего не защищает."""
+    from hhru_bot.bump import BumpResult
+
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda page, r, dry_run: BumpResult(r.id, True, "dry-run"),  # noqa: ARG005
+    )
+    _run_bump(monkeypatch, tmp_path, _config(tmp_path, _resume()), dry_run=True)
+
+    assert wait_calls == []
+    assert _read_actions(tmp_path / "history.db") == [("bump", "dry_run")]
+
+
+# --- bump: записи без действия не влияют на лимиты (п.2 ишью) ----------------
+
+
+def test_non_success_rows_do_not_affect_limits(tmp_path):
+    """count_today/can_bump_now считают только success: dry_run/failed строки
+    не расходуют дневной лимит и не запускают кулдаун 4ч (проверка п.2 #163:
+    «если запись оставляем, она не должна попадать в счётчики дневных лимитов»)."""
+    from hhru_bot.history import History
+
+    history = History(tmp_path / "history.db")
+    history.record_action("AAA111", "AAA111", "bump", "failed", "кнопка не найдена")
+    history.record_action("AAA111", "AAA111", "bump", "dry_run", "dry-run")
+
+    throttle = Throttle(ThrottleConfig(), history)
+    assert history.count_today("AAA111", "bump") == 0
+    assert throttle.can_bump_now("AAA111") == (True, None)
+
+
+# --- apply: командный цикл ---------------------------------------------------
+
+
+def _vacancy() -> VacancyCard:
+    return VacancyCard(vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42")
+
+
+def _run_apply(monkeypatch, tmp_path, *, dry_run: bool, result) -> None:
+    """run_apply_for_resume с подменёнными поиском/откликом; throttle.wait — шпион."""
+    from hhru_bot.commands import _common
+    from hhru_bot.history import History
+
+    resume = _resume()
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(ThrottleConfig(), history)
+
+    monkeypatch.setattr(_common, "search_vacancies", lambda page, search, max_pages=5: [_vacancy()])  # noqa: ARG005
+    monkeypatch.setattr(
+        _common,
+        "apply_to_vacancy",
+        lambda *a, **kw: result,  # noqa: ARG005
+    )
+    args = argparse.Namespace(dry_run=dry_run, limit=1, max_pages=5, headless=True)
+    _common.run_apply_for_resume(
+        object(), _config(tmp_path, resume), resume, history, throttle, args
+    )
+
+
+def test_apply_preaction_failure_no_wait_no_record(tmp_path, monkeypatch, wait_calls, capsys):
+    """Провал до submit (форма входа и т.п.) — без паузы и без записи failed:
+    отправки не было, на hh.ru не осталось следа действия."""
+    from hhru_bot.apply import ApplyResult
+
+    result = ApplyResult(
+        _vacancy(), False, "Сессия недействительна: страница содержит форму входа."
+    )
+    _run_apply(monkeypatch, tmp_path, dry_run=False, result=result)
+
+    assert wait_calls == []
+    assert _read_actions(tmp_path / "history.db") == []
+    assert "[FAIL]" in capsys.readouterr().out
+
+
+def test_apply_submit_success_waits_and_records(tmp_path, monkeypatch, wait_calls):
+    """РЕГРЕССИЯ #163: после реального submit пауза обязательна, success пишется."""
+    from hhru_bot.apply import ApplyResult
+
+    result = ApplyResult(_vacancy(), True, "success", acted=True)
+    _run_apply(monkeypatch, tmp_path, dry_run=False, result=result)
+
+    assert wait_calls == [f"после отклика на '{_vacancy().title}'"]
+    assert _read_actions(tmp_path / "history.db") == [("apply", "success")]
+
+
+def test_apply_submit_unconfirmed_waits_and_records_failed(tmp_path, monkeypatch, wait_calls):
+    """Submit был, но успех не подтвердился (wait_success_confirmation) — это
+    провал ПОСЛЕ действия: пауза обязательна, failed пишется в actions."""
+    from hhru_bot.apply import ApplyResult
+
+    result = ApplyResult(_vacancy(), False, "не удалось подтвердить отправку", acted=True)
+    _run_apply(monkeypatch, tmp_path, dry_run=False, result=result)
+
+    assert wait_calls == [f"после отклика на '{_vacancy().title}'"]
+    assert _read_actions(tmp_path / "history.db") == [("apply", "failed")]
+
+
+def test_apply_dry_run_records_for_dedup_without_wait(tmp_path, monkeypatch, wait_calls):
+    """dry_run-строки apply НЕ убирать: их читает дедупликация has_applied
+    (CLAUDE.md п.2). Паузы при этом нет — клика не было."""
+    from hhru_bot.apply import ApplyResult
+    from hhru_bot.history import History
+
+    result = ApplyResult(_vacancy(), True, "dry-run")
+    _run_apply(monkeypatch, tmp_path, dry_run=True, result=result)
+
+    assert wait_calls == []
+    assert _read_actions(tmp_path / "history.db") == [("apply", "dry_run")]
+    # дедупликация видит симуляцию — повторный прогон отсечёт эту вакансию
+    assert History(tmp_path / "history.db").has_applied("AAA111", "42") is True


### PR DESCRIPTION
Closes #163

## Контекст

`commands/bump.py` после **любого** исхода `bump_resume` писал `record_action` и делал `throttle.wait()` (~8–25с). При этом у `bump_resume` есть исходы без следа на hh.ru: плейсхолдер `resume_url` (выход до `goto_hh`, #159), форма входа (#153), hint «поднимать рано», кнопка не найдена, dry-run. Команда, которая ничего не сделала на hh.ru, ждала ~16с на каждое резюме и засоряла историю записями `failed`. Тот же безусловный `throttle.wait()` — в apply-цикле (`_common.py`).

## Решение

Критерий: **пауза и запись в `actions` — только после реального действия на hh.ru** (клик кнопки поднятия / submit отклика). Прецедент — #95 (skip без отправки уже не ждёт паузу и не пишется в actions).

- `BumpResult.acted` (`src/hhru_bot/bump.py`) — `True` только после `bump_button.click()`.
- `ApplyResult.acted` (`src/hhru_bot/apply/pipeline.py`) — через `ctx.acted`, выставляется после успешного `fill_response_form` (submit-клик — его последний шаг). Поэтому провал `wait_success_confirmation` остаётся «после действия»: **пауза и `failed` сохраняются**.
- `commands/bump.py`, `commands/_common.py`: запись в `actions` и `throttle.wait()` — только при `acted` либо для успешной dry_run-симуляции.
- **Не тронуто**: реальное поднятие/submit — пауза обязательна (CLAUDE.md «не убирай троттлинг/лимиты»); dry_run-строки apply — их читает дедупликация `has_applied`; `throttle.py` (лимиты/кулдаун без изменений).

Ответ на п.2 ишью: записи `failed` для провалов без действия не пишутся вовсе (отсев по локальному конфигу — не результат взаимодействия с hh.ru, виден в консоли `[FAIL]` и в лог-файле); инвариант «`count_today()`/`can_bump_now()` считают только `success`» был верен и закреплён регрессионным тестом.

## Тесты

- Новый `tests/test_throttle_policy.py` (loop-level, шпион на `Throttle.wait`):
  - плейсхолдер (реальная ветка `bump_resume`, dry-run) → без паузы, без записи, `[FAIL]` в выводе — приёмка «без 16-секундной паузы»;
  - форма входа → без паузы и записи (bump и apply);
  - реальное поднятие → пауза + `success`; submit без подтверждения → пауза + `failed` (оба guard-а «фикс не отключил троттлинг»);
  - dry-run apply → строка `dry_run` сохранена (дедупликация видит), без паузы;
  - `failed`/`dry_run` строки не влияют на `count_today`/`can_bump_now`.
- `acted`-ассерты в `tests/test_bump.py` и `tests/test_apply_pipeline.py`.

Побочный эффект: dry-run интеграционные тесты перестали реально спать 8–25с на `throttle.wait` — suite ускорился до ~2.5с.

## Приёмка ишью

1. `ruff check` + `ruff format --check` + `pytest` — зелёные (900 passed).
2. `bump --dry-run` с плейсхолдером — без паузы (тест `test_bump_placeholder_no_wait_no_record`).
3. Троттлинг после реального поднятия/отклика сохранён (тесты).