### PR TITLE
fix(bump,apply): treat Playwright failure at click as uncertain acted outcome (#176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,9 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
    `(resume_id, vacancy_id)` для `action='apply'` со статусом `success`/`dry_run` —
    `has_applied()` опирается на него. **Важно:** `dry_run`-отклики тоже пишутся в историю
    и считаются «уже откликались», поэтому повторный `--dry-run` по той же вакансии её
-   отсеет. `count_today()`/`last_action_at()` для лимитов считают только `status='success'`.
+   отсеет. `count_today()`/`last_action_at()` для лимитов считают `status='success'` и
+   `status='uncertain'` (#176: действие могло выполниться при упавшем посреди клика
+   Playwright — fail-closed, `uncertain` тоже дедуплицируется `has_applied()`).
 
 3. **Двухуровневый троттлинг** в `throttle.py`:
    - Дневные лимиты (`daily_apply_limit`, `daily_bump_limit`) — проверяются перед каждым
@@ -78,7 +80,9 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
      РЕАЛЬНОГО действия на hh.ru — клика поднятия/submit отклика (`BumpResult.acted`/
      `ApplyResult.acted`, #163). Ранние выходы до действия (плейсхолдер в конфиге,
      форма входа, hint «рано», dry-run) не ждут паузу и не пишут `failed` в actions:
-     на hh.ru не осталось следа, пауза не от чего не защищает.
+     на hh.ru не осталось следа, пауза не от чего не защищает. Исключение Playwright
+     в момент самого клика — это НЕ ранний выход: клик мог уйти, поэтому такой исход
+     несёт `acted=True` + `uncertain=True` (статус `uncertain` в actions, #176).
 
 4. **Форма отклика — двухшаговая навигация.** `VACANCY_APPLY_BUTTON` на странице вакансии
    это `<a href="/applicant/vacancy_response?...">`, а НЕ триггер модалки на той же

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -213,8 +213,17 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         ctx.probe("submitted", vacancy_title=ctx.vacancy.title)
 
         if not wait_success_confirmation(ctx.page):
+            # Честный union-poll до таймаута БЕЗ сигнала — достоверно
+            # проверили и не нашли успеха, осознанный fail-closed #163
+            # (wait_success_confirmation docstring): uncertain НЕ ставим.
             return ctx.fail("не удалось подтвердить успешную отправку отклика")
     except PlaywrightError as exc:
+        # #177 round 3 (Codex): исключение — НЕ то же самое, что False выше.
+        # Мы не смогли даже проверить (browser/page упал посреди опроса),
+        # а не «проверили и не нашли» — тот же класс неопределённости, что
+        # и SubmitClickUncertain при самом клике. uncertain=True обязателен,
+        # иначе has_applied() не отсечёт вакансию и уйдёт второй отклик.
+        ctx.uncertain = True
         logger.warning(
             "[FAIL] %s — ошибка Playwright после отправки (%s), успех не подтверждён",
             ctx.vacancy.title,

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from ..browser import goto_hh, has_login_form
@@ -23,6 +24,7 @@ from .dedup import check_already_responded
 from .letter import VARIANT_TEMPLATE, CoverLetterProvider, render_cover_letter
 from .probe import NOOP_PROBE, ProbeHook
 from .questions import detect_questions
+from .steps import SubmitClickUncertain
 from .success import wait_success_confirmation
 
 logger = logging.getLogger("hhru_bot.apply")
@@ -46,6 +48,12 @@ class ApplyResult:
     # throttle.wait. True после submit-клика: даже провал подтверждения
     # успеха (wait_success_confirmation) — отправка была, пауза обязательна.
     acted: bool = False
+    # #176: отправка могла уйти, но результат неизвестен — Playwright бросил
+    # исключение во время/сразу после submit-клика. fail-closed: acted=True +
+    # uncertain=True, чтобы цикл откликов писал action со статусом 'uncertain'
+    # (дедупликация has_applied его видит — без этого возможен повторный
+    # отклик на ту же вакансию) и выдерживал троттл-паузу.
+    uncertain: bool = False
 
 
 @dataclass
@@ -67,6 +75,8 @@ class ApplyContext:
     # (клик по кнопке отправки — его последний шаг); все ПОСЛЕДУЮЩИЕ исходы
     # (успех, провал подтверждения) несут acted=True через fail()/ok().
     acted: bool = False
+    # #176: как в ApplyResult — выставляется в _run при SubmitClickUncertain.
+    uncertain: bool = False
 
     def fail(self, reason: str) -> ApplyResult:
         return ApplyResult(
@@ -75,6 +85,7 @@ class ApplyContext:
             reason,
             letter_variant=self.letter_variant,
             acted=self.acted,
+            uncertain=self.uncertain,
         )
 
     def ok(self, reason: str) -> ApplyResult:
@@ -165,17 +176,51 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         logger.info("[skip] %s — %s", ctx.vacancy.title, questions.reason)
         return ctx.skip(questions.reason)
 
-    if reason := apply_steps.fill_response_form(ctx.page, ctx.resume_id, letter):
+    # #176: окно действия. Submit-клик — единственный необратимый шаг формы;
+    # исключение в момент/сразу после него (navigation timeout после POST,
+    # target closed) не означает, что отклик НЕ ушёл. Трактовка fail-closed:
+    #   * SubmitClickUncertain (клик мог уйти) — acted+uncertain: запись
+    #     'uncertain' в actions (дедупликация его видит) + троттл-пауза;
+    #   * прочий PlaywrightError из заполнения (до submit: toggle/fill) —
+    #     чистый fail с acted=False: на hh.ru следа нет, как у остальных
+    #     ранних выходов #163, но traceback больше не рвёт цикл откликов.
+    try:
+        reason = apply_steps.fill_response_form(ctx.page, ctx.resume_id, letter)
+    except SubmitClickUncertain:
+        ctx.acted = True
+        ctx.uncertain = True
+        logger.warning(
+            "[FAIL] %s — submit-клик упал с исключением, отправка могла уйти",
+            ctx.vacancy.title,
+        )
+        return ctx.fail("submit-клик упал с исключением — отправка могла уйти, исход неопределён")
+    except PlaywrightError as exc:
+        logger.warning(
+            "[FAIL] %s — ошибка Playwright при заполнении формы (%s)", ctx.vacancy.title, exc
+        )
+        return ctx.fail(f"ошибка Playwright при заполнении формы отклика: {exc}")
+    if reason:
         return ctx.fail(reason)
 
     # #163: fill_response_form без причины = submit-клик выполнен (последний шаг
     # заполнения). Дальнейшие исходы — «после действия»: пауза и запись в actions.
     ctx.acted = True
 
-    ctx.probe("submitted", vacancy_title=ctx.vacancy.title)
+    # #176: подтверждение успеха — тоже «после действия»: исключение здесь
+    # (а не только False) обязано вернуться fail-результатом с acted=True,
+    # иначе цикл упадёт трейсбеком и отправка не попадёт в history/троттл.
+    try:
+        ctx.probe("submitted", vacancy_title=ctx.vacancy.title)
 
-    if not wait_success_confirmation(ctx.page):
-        return ctx.fail("не удалось подтвердить успешную отправку отклика")
+        if not wait_success_confirmation(ctx.page):
+            return ctx.fail("не удалось подтвердить успешную отправку отклика")
+    except PlaywrightError as exc:
+        logger.warning(
+            "[FAIL] %s — ошибка Playwright после отправки (%s), успех не подтверждён",
+            ctx.vacancy.title,
+            exc,
+        )
+        return ctx.fail(f"ошибка Playwright после отправки отклика ({exc}) — успех не подтверждён")
 
     logger.info("Отклик отправлен: %s", ctx.vacancy.title)
     return ctx.ok("success")

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -39,6 +39,22 @@ OPTIONAL_FIELD_TIMEOUT_MS = 1_500
 RESUME_SELECT_TIMEOUT_MS = APPLY_TIMEOUT_MS
 
 
+class SubmitClickUncertain(Exception):
+    """Submit-клик отправлен/отправляется, но Playwright бросил исключение (#176).
+
+    Кнопка отправки — последний шаг fill_response_form; исключение в момент
+    клика (navigation timeout после POST, target closed при редиректе) не
+    означает, что отклик НЕ ушёл. steps сознательно НЕ решает, выполнено ли
+    действие (это ответственность pipeline: acted/uncertain/запись в history) —
+    он лишь честно маркирует точку «клик мог уйти», отличая её от обычных
+    отказов до submit (те возвращаются причиной, не исключением).
+    """
+
+    def __init__(self, cause: PlaywrightError):
+        super().__init__(f"submit-клик упал с исключением ({cause})")
+        self.playwright_error = cause
+
+
 def wait_apply_button(page: Page) -> bool:
     """Ждёт появления кнопки отклика на странице вакансии. False — не дождались."""
     try:
@@ -170,7 +186,17 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     if not _is_visible(page, apply_form.APPLY_SUBMIT_BUTTON, timeout_ms=APPLY_TIMEOUT_MS):
         return "кнопка отправки отклика не найдена в форме"
 
-    page.locator(apply_form.APPLY_SUBMIT_BUTTON).click()
+    # #176: submit — единственное необратимое действие формы. Playwright может
+    # бросить исключение уже после того, как POST отклика ушёл (navigation
+    # timeout, target closed при редиректе) — глотать его как обычный отказ
+    # нельзя (это «отправки не было», а мы не знаем), пробрасывать сырым тоже
+    # (pipeline упадёт до записи в history). Маркируем SubmitClickUncertain —
+    # pipeline трактует его fail-closed как acted+uncertain.
+    try:
+        page.locator(apply_form.APPLY_SUBMIT_BUTTON).click()
+    except PlaywrightError as exc:
+        logger.warning("Submit-клик упал с исключением (%s) — отправка могла уйти", exc)
+        raise SubmitClickUncertain(exc) from exc
     return None
 
 

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -31,6 +31,12 @@ class BumpResult:
     # кнопка не найдена) и у dry-run: на hh.ru не осталось следа, поэтому
     # команда не пишет такие исходы в actions и не ждёт throttle.wait.
     acted: bool = False
+    # #176: действие могло выполниться, но результат неизвестен — Playwright
+    # бросил исключение во время/сразу после клика (navigation timeout,
+    # target closed). fail-closed: acted=True + uncertain=True, чтобы команда
+    # гарантированно писала action со статусом 'uncertain' (кулдаун 4ч и
+    # дневной лимит его видят) и выдерживала троттл-паузу.
+    uncertain: bool = False
 
 
 def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
@@ -87,6 +93,30 @@ def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
         logger.info("[DRY-RUN] Поднял бы резюме '%s' в поиске", resume.id)
         return BumpResult(resume.id, True, "dry-run")
 
-    bump_button.click()
+    # #176: клик по кнопке поднятия — единственное необратимое действие bump.
+    # Playwright может бросить исключение уже ПОСЛЕ того, как клик уйдёт на
+    # hh.ru (navigation timeout, target closed при редиректе после действия).
+    # Проброс исключения наружу рвёт цикл команды ДО record_action/throttle.wait
+    # — поднятие на hh.ru произошло, но локальная история об этом не узнала
+    # (обход кулдауна 4ч и повторное поднятие). fail-closed в сторону «действие
+    # выполнено»: любой PlaywrightError в этой точке = acted+uncertain, запись
+    # и пауза гарантированы; ложный «acted» хуже лишь лишней паузой, пропущенный
+    # — повторным поднятием для анти-фрода hh.ru.
+    try:
+        bump_button.click()
+    except PlaywrightError as exc:
+        logger.warning(
+            "Клик поднятия резюме '%s' упал с исключением (%s) — действие могло "
+            "уйти на hh.ru, исход считаем неопределённым",
+            resume.id,
+            exc,
+        )
+        return BumpResult(
+            resume.id,
+            False,
+            f"клик поднятия выполнен, исход неопределён (Playwright: {exc})",
+            acted=True,
+            uncertain=True,
+        )
     logger.info("Резюме '%s' поднято в поиске", resume.id)
     return BumpResult(resume.id, True, "success", acted=True)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -322,7 +322,17 @@ def run_apply_for_resume(
         # Провалы до submit (форма входа, «уже откликались», кнопка не найдена)
         # на hh.ru не отправлялись — остаются в консоли/логе, не в статистике.
         if result.acted or (args.dry_run and result.success):
-            status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+            # #176: uncertain — submit мог уйти, но результат неизвестен. Такой
+            # статус видит дедупликация has_applied (повторный запуск не
+            # откликнется на ту же вакансию вторым письмом) — «просто failed»
+            # не годится. dry_run по определению без клика — uncertain там
+            # невозможен.
+            if args.dry_run:
+                status = "dry_run"
+            elif result.uncertain:
+                status = "uncertain"
+            else:
+                status = "success" if result.success else "failed"
             history.record_action(
                 resume.resume_id,
                 card.vacancy_id,

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -51,7 +51,17 @@ def run(args: argparse.Namespace) -> None:
             # форма входа, hint «рано») не результат взаимодействия с hh.ru —
             # они остаются в консоли/логе, но не засоряют статистику.
             if result.acted or (args.dry_run and result.success):
-                status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+                # #176: uncertain — клик мог уйти, но результат неизвестен.
+                # Такой статус видят кулдаун can_bump_now и дневной лимит
+                # (count_today), поэтому «просто failed» не годится: он не
+                # остановил бы повторное поднятие раньше 4ч. dry_run по
+                # определению без клика — uncertain там невозможен.
+                if args.dry_run:
+                    status = "dry_run"
+                elif result.uncertain:
+                    status = "uncertain"
+                else:
+                    status = "success" if result.success else "failed"
                 # Для action='bump' нет естественного vacancy_id (поднятие резюме,
                 # не отклик). actions.vacancy_id NOT NULL — заполняем resume.resume_id
                 # как sentinel; UNIQUE-индекс idx_resume_vacancy_apply существует

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -29,9 +29,12 @@ CREATE TABLE IF NOT EXISTS actions (
     created_at TEXT NOT NULL
 );
 
+-- #177: 'uncertain' тоже дедуплицируется в has_applied() (клик мог реально
+-- уйти на hh.ru, статус неизвестен) — индекс обязан покрывать этот статус,
+-- иначе гонка/повтор вставит несколько uncertain-строк для одной пары.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_resume_vacancy_apply
     ON actions(resume_id, vacancy_id)
-    WHERE action = 'apply' AND status IN ('success', 'dry_run');
+    WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain');
 
 -- responses — мониторинг ответов работодателей (#12, account-scope).
 -- Одна строка НА ПЕРЕПИСКУ: текущий «свежий» статус ответа работодателя,
@@ -255,6 +258,17 @@ class History:
             # IF NOT EXISTS не добавит колонку в уже существующую таблицу (#51) —
             # поэтому ALTER'ом идемпотентно доводим старые базы.
             _ensure_column(conn, "vacancies_seen", "employer_tier", "TEXT")
+            # #177: CREATE UNIQUE INDEX IF NOT EXISTS не пересоздаст индекс с новым
+            # WHERE-условием на уже существующей БД (тот же caveat #51, что и для
+            # колонок) — старые базы содержат idx_resume_vacancy_apply без
+            # 'uncertain' в условии. Пересоздаём индекс явно на каждом открытии;
+            # DROP+CREATE идемпотентны и дешёвы (индекс маленький).
+            conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
+            conn.execute(
+                "CREATE UNIQUE INDEX idx_resume_vacancy_apply "
+                "ON actions(resume_id, vacancy_id) "
+                "WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain')"
+            )
 
     def has_applied(self, resume_id: str, vacancy_id: str) -> bool:
         # #176: 'uncertain' (submit мог уйти, Playwright упал в момент клика)

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -11,6 +12,8 @@ if TYPE_CHECKING:
     # импорт внутри метода разрывает цикл history <-> search (search тянет history
     # на верхнем уровне через SKIP_REASONS), здесь — только для type-checking.
     from .search import SalaryInfo
+
+logger = logging.getLogger("hhru_bot.history")
 
 # Схема SQLite — одна константа, CREATE TABLE IF NOT EXISTS для всех таблиц.
 # Системы миграций для такого маленького проекта не нужно (оверинжиниринг): при
@@ -261,14 +264,11 @@ class History:
             # #177: CREATE UNIQUE INDEX IF NOT EXISTS не пересоздаст индекс с новым
             # WHERE-условием на уже существующей БД (тот же caveat #51, что и для
             # колонок) — старые базы содержат idx_resume_vacancy_apply без
-            # 'uncertain' в условии. Пересоздаём индекс явно на каждом открытии;
-            # DROP+CREATE идемпотентны и дешёвы (индекс маленький).
-            conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
-            conn.execute(
-                "CREATE UNIQUE INDEX idx_resume_vacancy_apply "
-                "ON actions(resume_id, vacancy_id) "
-                "WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain')"
-            )
+            # 'uncertain' в условии. Доводим его по аналогии с _ensure_column:
+            # сначала читаем текущее DDL из sqlite_master, DROP+CREATE только
+            # если оно отличается от желаемого (иначе КАЖДЫЙ CLI-вызов делал бы
+            # лишнюю write-миграцию с захватом schema-lock — cycle-review #177).
+            _ensure_apply_index(conn)
 
     def has_applied(self, resume_id: str, vacancy_id: str) -> bool:
         # #176: 'uncertain' (submit мог уйти, Playwright упал в момент клика)
@@ -1509,3 +1509,55 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl_type: 
     existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
     if column not in existing:
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}")
+
+
+_APPLY_INDEX_SQL = (
+    "CREATE UNIQUE INDEX idx_resume_vacancy_apply "
+    "ON actions(resume_id, vacancy_id) "
+    "WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain')"
+)
+
+
+def _ensure_apply_index(conn: sqlite3.Connection) -> None:
+    """Идемпотентно доводит idx_resume_vacancy_apply до актуального условия (#177).
+
+    CREATE UNIQUE INDEX IF NOT EXISTS не пересоздаст индекс с новым WHERE на
+    уже существующей БД (тот же caveat #51, что и у _ensure_column) — старые
+    базы содержат индекс без 'uncertain' в условии. Как и _ensure_column,
+    сначала читаем текущее определение из sqlite_master и трогаем индекс
+    ТОЛЬКО если оно отличается — иначе каждый CLI-вызов делал бы лишний
+    DROP+CREATE под write/schema-lock (cycle-review #177, round 2).
+
+    'uncertain' появился в PR #176 (уже в main) ДО этого индекс-фикса, поэтому
+    на реальных установках уже могли накопиться дубли (resume_id, vacancy_id)
+    со статусом 'uncertain' под старым (более узким) индексом — CREATE UNIQUE
+    INDEX на них упадёт IntegrityError и History() будет ронять вообще все
+    команды бота. Явно проверяем дубли ПЕРЕД пересозданием: если они есть —
+    не создаём индекс и логируем warning, оставляя дедупликацию на чистой
+    Python-логике has_applied() (SELECT, не зависит от индекса) до ручной
+    чистки БД администратором — это безопаснее, чем падать намертво.
+    """
+    current = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_resume_vacancy_apply'"
+    ).fetchone()
+    if current is not None and current[0] == _APPLY_INDEX_SQL:
+        return
+
+    dupes = conn.execute(
+        "SELECT resume_id, vacancy_id, COUNT(*) c FROM actions "
+        "WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain') "
+        "GROUP BY resume_id, vacancy_id HAVING c > 1"
+    ).fetchall()
+    conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
+    if dupes:
+        logger.warning(
+            "idx_resume_vacancy_apply не пересоздан: найдено %d пар "
+            "(resume_id, vacancy_id) с дублирующимися apply-записями "
+            "(success/dry_run/uncertain). UNIQUE constraint на них упал бы "
+            "с IntegrityError. Дедупликация продолжает работать через "
+            "has_applied(), но без DB-уровня защиты — почистите дубли в "
+            "actions вручную.",
+            len(dupes),
+        )
+        return
+    conn.execute(_APPLY_INDEX_SQL)

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -257,12 +257,17 @@ class History:
             _ensure_column(conn, "vacancies_seen", "employer_tier", "TEXT")
 
     def has_applied(self, resume_id: str, vacancy_id: str) -> bool:
+        # #176: 'uncertain' (submit мог уйти, Playwright упал в момент клика)
+        # тоже дедуплицируется: неопределённый отклик обязан отсекать вакансию
+        # от повторного отклика — это дешевле, чем второе письмо работодателю.
+        # Обычный 'failed' (клик был, успеха не подтвердили) дедупликацией
+        # остаётся НЕ виден — как раньше.
         with self._connect() as conn:
             row = conn.execute(
                 """
                 SELECT 1 FROM actions
                 WHERE resume_id = ? AND vacancy_id = ? AND action = 'apply'
-                  AND status IN ('success', 'dry_run')
+                  AND status IN ('success', 'dry_run', 'uncertain')
                 LIMIT 1
                 """,
                 (resume_id, vacancy_id),
@@ -297,12 +302,14 @@ class History:
             )
 
     def count_today(self, resume_id: str, action: str) -> int:
+        # #176: 'uncertain' расходует дневной лимит — действие могло выполниться
+        # на hh.ru, fail-closed считает его состоявшимся (dry_run/failed — нет).
         today = datetime.now().date().isoformat()
         with self._connect() as conn:
             row = conn.execute(
                 """
                 SELECT COUNT(*) AS cnt FROM actions
-                WHERE resume_id = ? AND action = ? AND status = 'success'
+                WHERE resume_id = ? AND action = ? AND status IN ('success', 'uncertain')
                   AND created_at >= ?
                 """,
                 (resume_id, action, today),
@@ -310,11 +317,13 @@ class History:
             return row["cnt"] if row else 0
 
     def last_action_at(self, resume_id: str, action: str) -> datetime | None:
+        # #176: 'uncertain' запускает кулдаун (can_bump_now 4ч) — поднятие могло
+        # выполниться; 'dry_run'/'failed' кулдаун не запускают, как раньше.
         with self._connect() as conn:
             row = conn.execute(
                 """
                 SELECT created_at FROM actions
-                WHERE resume_id = ? AND action = ? AND status = 'success'
+                WHERE resume_id = ? AND action = ? AND status IN ('success', 'uncertain')
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
@@ -350,12 +359,13 @@ class History:
     def summary(self, resume_id: str | None, period: str) -> dict:
         """Срез счётчиков action × status за период.
 
-        Возвращает {"apply": {"success","dry_run","failed"}, "bump": {...}, "total"}.
-        Пустой период → все нули. resume_id=None означает «по всем резюме».
+        Возвращает {"apply": {"success","dry_run","failed","uncertain"},
+        "bump": {...}, "total"}. Пустой период → все нули. resume_id=None
+        означает «по всем резюме».
         """
         result: dict = {
-            "apply": {"success": 0, "dry_run": 0, "failed": 0},
-            "bump": {"success": 0, "dry_run": 0, "failed": 0},
+            "apply": {"success": 0, "dry_run": 0, "failed": 0, "uncertain": 0},
+            "bump": {"success": 0, "dry_run": 0, "failed": 0, "uncertain": 0},
             "total": 0,
         }
         where = []

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -1548,16 +1548,21 @@ def _ensure_apply_index(conn: sqlite3.Connection) -> None:
         "WHERE action = 'apply' AND status IN ('success', 'dry_run', 'uncertain') "
         "GROUP BY resume_id, vacancy_id HAVING c > 1"
     ).fetchall()
-    conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
     if dupes:
+        # #177 round 3 (Codex): старый индекс НЕ трогаем, если пересборку
+        # выполнить нельзя — раньше DROP выполнялся безусловно ДО этой
+        # проверки, снимая DB-уровня UNIQUE-защиту целиком (включая для
+        # success/dry_run пар, которые старый индекс ещё покрывал), даже
+        # если дубли есть только среди новых 'uncertain' записей.
         logger.warning(
             "idx_resume_vacancy_apply не пересоздан: найдено %d пар "
             "(resume_id, vacancy_id) с дублирующимися apply-записями "
             "(success/dry_run/uncertain). UNIQUE constraint на них упал бы "
             "с IntegrityError. Дедупликация продолжает работать через "
-            "has_applied(), но без DB-уровня защиты — почистите дубли в "
-            "actions вручную.",
+            "has_applied(), но без обновлённой DB-уровня защиты для "
+            "'uncertain' — почистите дубли в actions вручную.",
             len(dupes),
         )
         return
+    conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
     conn.execute(_APPLY_INDEX_SQL)

--- a/src/hhru_bot/report.py
+++ b/src/hhru_bot/report.py
@@ -43,6 +43,11 @@ _SUMMARY_HEADERS = {
     "success": "Успех",
     "dry_run": "Прогон",
     "failed": "Провал",
+    # #176: действие могло выполниться, но Playwright упал в момент клика —
+    # исход неизвестен (fail-closed: такие строки дедуплицируются и расходуют
+    # дневной лимит, поэтому в сводке им отдельная колонка, а не смешение
+    # с «Провал»).
+    "uncertain": "Неопредел.",
 }
 
 
@@ -55,30 +60,23 @@ def _check_format(fmt: str) -> None:
 
 # --- summary ----------------------------------------------------------------
 
+# Порядок статусных колонок сводки (один источник правды для table/csv/md).
+_SUMMARY_STATUS_ORDER = ("success", "dry_run", "failed", "uncertain")
+
 
 def _summary_rows(summary: dict) -> list[list[str]]:
     rows: list[list[str]] = []
     for action in _SUMMARY_ACTIONS:
         bucket = summary.get(action, {})
-        rows.append(
-            [
-                action,
-                str(bucket.get("success", 0)),
-                str(bucket.get("dry_run", 0)),
-                str(bucket.get("failed", 0)),
-            ]
-        )
+        rows.append([action] + [str(bucket.get(s, 0)) for s in _SUMMARY_STATUS_ORDER])
     return rows
 
 
 def format_summary(summary: dict, fmt: str) -> str:
     """Отрисовать сводку action × status (+ total) в выбранном формате."""
     _check_format(fmt)
-    header = [
-        _SUMMARY_HEADERS["action"],
-        _SUMMARY_HEADERS["success"],
-        _SUMMARY_HEADERS["dry_run"],
-        _SUMMARY_HEADERS["failed"],
+    header = [_SUMMARY_HEADERS["action"]] + [
+        _SUMMARY_HEADERS[s] for s in _SUMMARY_STATUS_ORDER
     ]
     rows = _summary_rows(summary)
     total = summary.get("total", 0)
@@ -87,20 +85,22 @@ def format_summary(summary: dict, fmt: str) -> str:
         # CSV — экспорт для машин: машиночитаемые имена колонок.
         out = io.StringIO()
         w = csv.writer(out)
-        w.writerow(["action", "success", "dry_run", "failed"])
+        w.writerow(["action", *_SUMMARY_STATUS_ORDER])
         w.writerows(rows)
-        w.writerow(["total", total, "", ""])
+        w.writerow(["total", total, *["" for _ in _SUMMARY_STATUS_ORDER[1:]]])
         return out.getvalue().rstrip("\n")
 
     if fmt == "md":
-        lines = ["| " + " | ".join(header) + " |", "| --- | --- | --- | --- |"]
+        sep = "| " + " | ".join(["---"] * len(header)) + " |"
+        lines = ["| " + " | ".join(header) + " |", sep]
         for r in rows:
             lines.append("| " + " | ".join(r) + " |")
-        lines.append(f"| **Итого** | {total} |  |  |")
+        tail = " | ".join([str(total)] + [""] * (len(header) - 2))
+        lines.append(f"| **Итого** | {tail} |")
         return "\n".join(lines)
 
     # table — ASCII
-    return _ascii_table(header, rows, footer=["Итого", str(total), "", ""])
+    return _ascii_table(header, rows, footer=["Итого", str(total)] + [""] * (len(header) - 2))
 
 
 # --- actions ----------------------------------------------------------------

--- a/src/hhru_bot/report.py
+++ b/src/hhru_bot/report.py
@@ -75,9 +75,7 @@ def _summary_rows(summary: dict) -> list[list[str]]:
 def format_summary(summary: dict, fmt: str) -> str:
     """Отрисовать сводку action × status (+ total) в выбранном формате."""
     _check_format(fmt)
-    header = [_SUMMARY_HEADERS["action"]] + [
-        _SUMMARY_HEADERS[s] for s in _SUMMARY_STATUS_ORDER
-    ]
+    header = [_SUMMARY_HEADERS["action"]] + [_SUMMARY_HEADERS[s] for s in _SUMMARY_STATUS_ORDER]
     rows = _summary_rows(summary)
     total = summary.get("total", 0)
 

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -17,8 +17,12 @@ class _FakeLocator:
     def first(self):
         return self
 
-    def __init__(self, present: bool = False, attrs: dict[str, str] | None = None,
-                 click_error: Exception | None = None):
+    def __init__(
+        self,
+        present: bool = False,
+        attrs: dict[str, str] | None = None,
+        click_error: Exception | None = None,
+    ):
         self._present = present
         self._attrs = attrs or {}
         # #176: PlaywrightError в момент click() (клик мог уйти на hh.ru).

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -299,10 +299,15 @@ def test_apply_submit_click_error_is_uncertain_acted():
 
 
 def test_apply_confirmation_error_after_submit_keeps_acted(monkeypatch):
-    """#176: submit-клик прошёл, но wait_success_confirmation упал с PlaywrightError
-    (не вернул False, а бросил). Отправка БЫЛА — исключение не должно выносить
-    её из-под записи: возвращаем fail с acted=True (uncertain=False — сам клик
-    завершился успешно, неизвестен только финальный статус)."""
+    """#177 round 3 (Codex): submit-клик прошёл, но wait_success_confirmation
+    упал с PlaywrightError (не вернул False, а бросил). Это НЕ то же самое,
+    что честный union-poll до таймаута без сигнала (result.uncertain=False,
+    см. test_apply_submit_unconfirmed_is_acted — там мы ДОСТОВЕРНО проверили
+    и не нашли успеха, осознанный fail-closed #163). Exception означает, что
+    мы вообще не смогли проверить (browser/page упал посреди опроса) — тот же
+    класс неопределённости, что и SubmitClickUncertain при самом клике.
+    Поэтому acted=True И uncertain=True: дедупликация обязана отсечь
+    вакансию, а не оставить её доступной для повторного отклика."""
     from playwright.sync_api import Error as PlaywrightError
 
     def _raise(_page):
@@ -313,7 +318,7 @@ def test_apply_confirmation_error_after_submit_keeps_acted(monkeypatch):
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
     assert result.success is False
     assert result.acted is True
-    assert result.uncertain is False
+    assert result.uncertain is True
     assert "не подтверждён" in result.reason
 
 

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -17,9 +17,12 @@ class _FakeLocator:
     def first(self):
         return self
 
-    def __init__(self, present: bool = False, attrs: dict[str, str] | None = None):
+    def __init__(self, present: bool = False, attrs: dict[str, str] | None = None,
+                 click_error: Exception | None = None):
         self._present = present
         self._attrs = attrs or {}
+        # #176: PlaywrightError в момент click() (клик мог уйти на hh.ru).
+        self._click_error = click_error
 
     def count(self) -> int:
         return 1 if self._present else 0
@@ -31,6 +34,8 @@ class _FakeLocator:
             raise PlaywrightTimeoutError("not present")
 
     def click(self, **_kwargs) -> None:
+        if self._click_error is not None:
+            raise self._click_error
         return None
 
     def fill(self, _value: str) -> None:
@@ -59,6 +64,7 @@ class FakePage:
         apply_button: bool = True,
         success: bool = True,
         submit_in_form: bool = False,
+        submit_click_error: Exception | None = None,
     ):
         self.url = ""
         self.goto_calls: list[str] = []
@@ -68,6 +74,8 @@ class FakePage:
         # в apply/questions.py::_form_scope) — по умолчанию False, чтобы явно
         # моделировать indeterminate-путь там, где тест его не настраивает.
         self._submit_in_form = submit_in_form
+        # #176: PlaywrightError в момент submit-клика (клик мог уйти).
+        self._submit_click_error = submit_click_error
 
     def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
@@ -86,7 +94,7 @@ class FakePage:
         # Прочие селекторы формы — считаем отсутствующими (форма не заполнена,
         # но submit присутствует в фейковом успехе через success-путь ниже).
         if selector == apply_form.APPLY_SUBMIT_BUTTON:
-            return _FakeLocator(present=self._success)
+            return _FakeLocator(present=self._success, click_error=self._submit_click_error)
         return _FakeLocator(present=False)
 
     def expect_navigation(self, **_kwargs):
@@ -259,3 +267,65 @@ def test_apply_non_dry_run_indeterminate_is_fail_not_skip():
     assert result.skipped is False
     assert "границы формы" in result.reason
     assert result.acted is False  # #163: indeterminate — до submit, без паузы
+
+
+# --- #176: окно действия — исключение Playwright не теряет acted/запись --------
+
+
+def test_apply_submit_click_error_is_uncertain_acted():
+    """#176: Playwright упал в момент submit-клика — POST отклика мог уйти.
+    Раньше исключение пробрасывалось из apply_to_vacancy: run_apply_for_resume
+    не перехватывал его, цикл валился трейсбеком ДО record_action/throttle.wait,
+    и отправленный (возможно) отклик выпадал из дедупликации has_applied.
+    Fail-closed: результат с acted+uncertain — команда пишет 'uncertain' и
+    ждёт паузу."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    page = FakePage(
+        apply_button=True,
+        success=True,
+        submit_in_form=True,
+        submit_click_error=PlaywrightError("Target page, context or browser has been closed"),
+    )
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+    assert result.success is False
+    assert result.acted is True
+    assert result.uncertain is True
+    assert "неопределён" in result.reason
+
+
+def test_apply_confirmation_error_after_submit_keeps_acted(monkeypatch):
+    """#176: submit-клик прошёл, но wait_success_confirmation упал с PlaywrightError
+    (не вернул False, а бросил). Отправка БЫЛА — исключение не должно выносить
+    её из-под записи: возвращаем fail с acted=True (uncertain=False — сам клик
+    завершился успешно, неизвестен только финальный статус)."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    def _raise(_page):
+        raise PlaywrightError("Page closed while polling success markers")
+
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", _raise)
+    page = FakePage(apply_button=True, success=True, submit_in_form=True)
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+    assert result.success is False
+    assert result.acted is True
+    assert result.uncertain is False
+    assert "не подтверждён" in result.reason
+
+
+def test_apply_prefill_playwright_error_is_clean_fail(monkeypatch):
+    """#176: PlaywrightError из заполнения формы ДО submit (toggle/fill упали) —
+    отправки не было, acted=False (без записи и паузы, как у ранних выходов
+    #163), но traceback больше не рвёт цикл откликов: чистый fail-результат."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    def _raise(*_a, **_kw):
+        raise PlaywrightError("Element is not attached to the DOM")
+
+    monkeypatch.setattr(pipeline_module.apply_steps, "fill_response_form", _raise)
+    page = FakePage(apply_button=True, success=True, submit_in_form=True)
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+    assert result.success is False
+    assert result.acted is False
+    assert result.uncertain is False
+    assert "ошибка Playwright" in result.reason

--- a/tests/test_apply_placeholder.py
+++ b/tests/test_apply_placeholder.py
@@ -66,6 +66,9 @@ class _StubResult:
     reason = None
     letter_variant = None
     skipped = False
+    # #163/#176: командный цикл читает acted/uncertain у любого результата
+    acted = False
+    uncertain = False
 
 
 def test_placeholder_url_fails_closed_before_any_action(tmp_path, monkeypatch):

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import re
 
+import pytest
 from playwright.sync_api import Error
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -91,6 +92,10 @@ class _FakeLocator:
         # навигацию, должен идти с no_wait_after=True (ожидание навигации владеет
         # внешний 90с expect_navigation, а не внутренний 30с action-timeout клика).
         self._state.click_kwargs.append(kwargs)
+        # #176: имитация Playwright-исключения в момент клика (navigation timeout
+        # после POST, target closed) — действие могло уйти на hh.ru.
+        if self._state.click_error is not None:
+            raise self._state.click_error
         if self._href_filter is not None:
             # Strict href-локатор: ровно одна живая опция с этим href, иначе Error
             # (как реальный Playwright strict mode при != 1 совпадении).
@@ -158,6 +163,9 @@ class _SelectorState:
         # Имитация не-timeout PlaywrightError в wait_for (cycle-5): runtime/selector
         # failure, который НЕ должен маскироваться под «выбора нет».
         self.wait_error = False
+        # #176: PlaywrightError в момент click() — клик мог уйти (POST отправлен,
+        # но ожидание после клика упало). None = обычный успешный клик.
+        self.click_error: Exception | None = None
 
 
 class FakeStepsPage:
@@ -302,6 +310,21 @@ def test_fill_form_missing_submit_returns_reason_no_click():
 
     assert result is not None
     assert "кнопка отправки отклика не найдена" in result
+
+
+def test_fill_form_submit_click_error_raises_uncertain_marker():
+    """#176: Playwright упал в момент submit-клика (navigation timeout после
+    POST, target closed) — POST отклика МОГ уйти. Это принципиально не обычный
+    отказ строкой (тот означает «отправки не было»): steps маркирует исход
+    SubmitClickUncertain, а решение acted/uncertain/запись оставляет pipeline.
+    Раньше исключение пробрасывалось сырым и валило цикл откликов до
+    record_action/throttle.wait."""
+    page = FakeStepsPage()
+    submit = page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    submit.click_error = Error("Target page, context or browser has been closed")
+
+    with pytest.raises(steps.SubmitClickUncertain):
+        steps.fill_response_form(page, "RID", "письмо")
 
 
 # --- fill_response_form: опциональные поля ---

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -39,6 +39,7 @@ class _FakeLocator:
         *,
         render_delayed: bool = False,
         wait_error: bool = False,
+        click_error: bool = False,
     ):
         self._present = present
         self._click_log = click_log
@@ -49,6 +50,9 @@ class _FakeLocator:
         # wait_error=True: cycle-review #139 — не-timeout PlaywrightError
         # (strict-mode violation и т.п.), аномалия, а не легитимное отсутствие.
         self._wait_error = wait_error
+        # click_error=True: #176 — PlaywrightError в момент click() (клик мог
+        # уйти на hh.ru, но ожидание после клика упало).
+        self._click_error = click_error
 
     def count(self) -> int:
         if self._render_delayed:
@@ -65,6 +69,10 @@ class _FakeLocator:
             raise PlaywrightTimeoutError(f"{self._name} not visible")
 
     def click(self, **_kwargs) -> None:
+        if self._click_error:
+            # #176: клик «выполняется», но Playwright падает — как navigation
+            # timeout/target closed уже после отправки действия на hh.ru.
+            raise PlaywrightError(f"click on {self._name} failed after dispatch")
         if self._click_log is not None:
             self._click_log.append(self._name)
 
@@ -79,6 +87,7 @@ class FakeBumpPage:
         button_present: bool = True,
         hint_render_delayed: bool = False,
         hint_wait_error: bool = False,
+        button_click_error: bool = False,
     ):
         self.goto_calls: list[str] = []
         self.click_log: list[str] = []
@@ -86,6 +95,7 @@ class FakeBumpPage:
         self._button_present = button_present
         self._hint_render_delayed = hint_render_delayed
         self._hint_wait_error = hint_wait_error
+        self._button_click_error = button_click_error
 
     def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
@@ -100,7 +110,12 @@ class FakeBumpPage:
                 wait_error=self._hint_wait_error,
             )
         if selector == resume_page.RESUME_BUMP_BUTTON:
-            return _FakeLocator(self._button_present, self.click_log, "button")
+            return _FakeLocator(
+                self._button_present,
+                self.click_log,
+                "button",
+                click_error=self._button_click_error,
+            )
         return _FakeLocator(False)
 
 
@@ -222,3 +237,19 @@ def test_bump_login_form_is_checked_after_navigation(monkeypatch):
     assert result.success is False
     assert "Сессия недействительна" in result.reason
     assert events == ["goto", "auth"]
+
+
+def test_bump_click_error_is_uncertain_acted_not_traceback():
+    """#176: Playwright упал в момент клика поднятия (клик мог уйти на hh.ru).
+    Раньше исключение пробрасывалось наружу: bump_resume не возвращал BumpResult,
+    командный цикл валился трейсбеком ДО record_action/throttle.wait — поднятие
+    происходило, но история/кулдаун 4ч о нём не узнали бы. Fail-closed: возвращаем
+    acted+uncertain, команда по ним пишет action 'uncertain' и ждёт паузу."""
+    page = FakeBumpPage(hint_present=False, button_present=True, button_click_error=True)
+
+    result = bump_resume(page, _resume(), dry_run=False)
+
+    assert result.success is False
+    assert result.acted is True
+    assert result.uncertain is True
+    assert "неопределён" in result.reason

--- a/tests/test_history_schema.py
+++ b/tests/test_history_schema.py
@@ -186,3 +186,77 @@ def test_unique_index_upgraded_on_existing_db_with_old_condition(tmp_path):
             raise AssertionError("ожидалась IntegrityError после доводки индекса на старой БД")
     finally:
         conn.close()
+
+
+def test_history_open_does_not_crash_on_preexisting_uncertain_duplicates(tmp_path, caplog):
+    # #177 round 2 (Codex): 'uncertain' появился в PR #176 (уже в main) ДО того
+    # как индекс стал его покрывать (этот PR). Значит на реальных установках
+    # уже может существовать БД с дублями status='uncertain' для одной пары
+    # (resume_id, vacancy_id), накопленными под старым индексом. Пересоздание
+    # индекса с новым условием не должно ронять History() исключением —
+    # это заблокировало бы вообще все команды бота до ручной починки.
+    db_path = tmp_path / "h.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE actions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                resume_id TEXT NOT NULL,
+                vacancy_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                status TEXT NOT NULL,
+                reason TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX idx_resume_vacancy_apply
+                ON actions(resume_id, vacancy_id)
+                WHERE action = 'apply' AND status IN ('success', 'dry_run');
+            """
+        )
+        # два uncertain-дубля для одной пары — легально под старым индексом
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-02')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="hhru_bot.history"):
+        History(db_path)  # не должно бросить IntegrityError
+
+    assert any("idx_resume_vacancy_apply" in r.message for r in caplog.records)
+
+
+def test_index_not_rebuilt_when_already_current(tmp_path):
+    # #177 round 2 (Codex): DROP+CREATE не должен выполняться, если текущее
+    # определение индекса в sqlite_master уже совпадает с желаемым — иначе
+    # каждый CLI-вызов делал бы лишнюю write-миграцию (лишние SQLite
+    # write-locks). sqlite3.Connection — C-тип, execute() нельзя monkeypatch'ить
+    # напрямую (immutable type), поэтому используем conn.set_trace_callback —
+    # официальный API sqlite3 для перехвата исполняемых SQL-инструкций.
+    from hhru_bot.history import _ensure_apply_index
+
+    db_path = tmp_path / "h.db"
+    History(db_path)  # первое открытие — индекс создаётся с нужным условием
+
+    conn = sqlite3.connect(db_path)
+    executed_sql: list[str] = []
+    conn.set_trace_callback(executed_sql.append)
+    try:
+        _ensure_apply_index(conn)  # индекс уже актуален — должно быть no-op
+    finally:
+        conn.set_trace_callback(None)
+        conn.close()
+
+    assert not any("DROP INDEX" in sql for sql in executed_sql), executed_sql
+    assert not any("CREATE UNIQUE INDEX idx_resume_vacancy_apply" in sql for sql in executed_sql), (
+        executed_sql
+    )

--- a/tests/test_history_schema.py
+++ b/tests/test_history_schema.py
@@ -112,3 +112,77 @@ def test_history_works_after_schema_creation(tmp_path):
     # повторное открытие того же файла не падает и данные на месте
     h2 = History(tmp_path / "h.db")
     assert h2.has_applied("r1", "v1")
+
+
+def test_unique_index_prevents_duplicate_uncertain_apply():
+    # #177: 'uncertain' дедуплицируется в has_applied(), значит UNIQUE-индекс
+    # тоже обязан покрывать этот статус — иначе гонка/повтор может вставить
+    # несколько uncertain-строк для одной (resume_id, vacancy_id).
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-01')"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+                "VALUES ('r1','v1','apply','uncertain','','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("ожидалась IntegrityError от UNIQUE-индекса")
+    finally:
+        conn.close()
+
+
+def test_unique_index_upgraded_on_existing_db_with_old_condition(tmp_path):
+    # Существующая БД, созданная ДО #177, содержит индекс со старым условием
+    # WHERE status IN ('success', 'dry_run') — без 'uncertain'. IF NOT EXISTS
+    # не пересоздаст индекс с новым условием на уже существующей БД (тот же
+    # caveat #51, что и для колонок) — _init_schema должен доводить его явно
+    # (DROP INDEX IF EXISTS + CREATE), а не полагаться на IF NOT EXISTS.
+    db_path = tmp_path / "h.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE actions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                resume_id TEXT NOT NULL,
+                vacancy_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                status TEXT NOT NULL,
+                reason TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX idx_resume_vacancy_apply
+                ON actions(resume_id, vacancy_id)
+                WHERE action = 'apply' AND status IN ('success', 'dry_run');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    History(db_path)  # открытие существующей "старой" БД должно довести индекс
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-01')"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+                "VALUES ('r1','v1','apply','uncertain','','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("ожидалась IntegrityError после доводки индекса на старой БД")
+    finally:
+        conn.close()

--- a/tests/test_history_schema.py
+++ b/tests/test_history_schema.py
@@ -260,3 +260,68 @@ def test_index_not_rebuilt_when_already_current(tmp_path):
     assert not any("CREATE UNIQUE INDEX idx_resume_vacancy_apply" in sql for sql in executed_sql), (
         executed_sql
     )
+
+
+def test_ensure_apply_index_keeps_old_index_when_duplicates_found(tmp_path):
+    # #177 round 3 (Codex): при обнаружении дублей функция раньше БЕЗУСЛОВНО
+    # дропала старый индекс (DROP INDEX IF EXISTS) ДО проверки, а после —
+    # не восстанавливала ничего, если дубли найдены. Это снимало DB-уровня
+    # UNIQUE-защиту ПОЛНОСТЬЮ, включая для success/dry_run пар, которые
+    # раньше были защищены старым (более узким) индексом. Правильно: если
+    # пересборку выполнить нельзя (есть дубли), старый индекс не трогать —
+    # degraded (без 'uncertain' в условии), но не нулевая защита.
+    from hhru_bot.history import _ensure_apply_index
+
+    db_path = tmp_path / "h.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE actions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                resume_id TEXT NOT NULL,
+                vacancy_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                status TEXT NOT NULL,
+                reason TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX idx_resume_vacancy_apply
+                ON actions(resume_id, vacancy_id)
+                WHERE action = 'apply' AND status IN ('success', 'dry_run');
+            """
+        )
+        # дубль uncertain — новый статус, старым индексом не покрывается
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r1','v1','apply','uncertain','','2026-01-02')"
+        )
+        conn.commit()
+
+        _ensure_apply_index(conn)
+
+        index_row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_resume_vacancy_apply'"
+        ).fetchone()
+        assert index_row is not None, "старый индекс должен остаться, а не исчезнуть полностью"
+
+        # старая (degraded) защита всё ещё работает для success/dry_run
+        conn.execute(
+            "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+            "VALUES ('r2','v2','apply','success','','2026-01-01')"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at) "
+                "VALUES ('r2','v2','apply','success','','2026-01-02')"
+            )
+        except sqlite3.IntegrityError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("старый индекс должен был отсечь дубль success")
+    finally:
+        conn.close()

--- a/tests/test_history_stats.py
+++ b/tests/test_history_stats.py
@@ -22,6 +22,7 @@ def test_summary_empty_returns_zeros(tmp_path):
     assert s["apply"]["success"] == 0
     assert s["apply"]["dry_run"] == 0
     assert s["apply"]["failed"] == 0
+    assert s["apply"]["uncertain"] == 0
     assert s["bump"]["success"] == 0
     assert s["bump"]["failed"] == 0
     assert s["total"] == 0
@@ -29,21 +30,28 @@ def test_summary_empty_returns_zeros(tmp_path):
 
 def test_summary_counts_by_action_and_status(tmp_path):
     h = History(tmp_path / "h.db")
-    # 2 успешных отклика, 1 dry_run, 1 провал; 1 успешный bump, 1 проваленный bump
+    # 2 успешных отклика, 1 dry_run, 1 провал, 1 неопределённый; 1 успешный bump,
+    # 1 проваленный bump, 1 неопределённый bump
     h.record_action("r1", "v1", "apply", "success")
     h.record_action("r1", "v2", "apply", "success")
     h.record_action("r1", "v3", "apply", "dry_run")
     h.record_action("r1", "v4", "apply", "failed", "captcha")
+    h.record_action("r1", "v8", "apply", "uncertain", "submit упал после клика")
     h.record_action("r1", "r1", "bump", "success")
     h.record_action("r1", "r1", "bump", "failed", "cooldown")
+    h.record_action("r1", "r1", "bump", "uncertain", "клик упал после отправки")
 
     s = h.summary(resume_id="r1", period="all")
     assert s["apply"]["success"] == 2
     assert s["apply"]["dry_run"] == 1
     assert s["apply"]["failed"] == 1
+    # #176: uncertain — отдельный бакет (не смешивается с failed), иначе total
+    # сводки расходился бы с суммой статусных колонок stats
+    assert s["apply"]["uncertain"] == 1
     assert s["bump"]["success"] == 1
     assert s["bump"]["failed"] == 1
-    assert s["total"] == 6
+    assert s["bump"]["uncertain"] == 1
+    assert s["total"] == 8
 
 
 def test_summary_filters_by_resume(tmp_path):

--- a/tests/test_stats_command.py
+++ b/tests/test_stats_command.py
@@ -90,8 +90,9 @@ def test_stats_run_csv_export_machine_readable(capsys, tmp_path):
 
     stats_cmd.run(_args(config, tmp_path / "h.db", format="csv"))
     out = capsys.readouterr().out
-    # машиночитаемые имена колонок сводки
-    assert out.splitlines()[0] == "action,success,dry_run,failed"
+    # машиночитаемые имена колонок сводки (#176: добавлена колонка uncertain —
+    # действие могло выполниться при упавшем посреди клика Playwright)
+    assert out.splitlines()[0] == "action,success,dry_run,failed,uncertain"
 
 
 def test_stats_run_resume_filter(capsys, tmp_path):

--- a/tests/test_throttle_policy.py
+++ b/tests/test_throttle_policy.py
@@ -264,3 +264,68 @@ def test_apply_dry_run_records_for_dedup_without_wait(tmp_path, monkeypatch, wai
     assert _read_actions(tmp_path / "history.db") == [("apply", "dry_run")]
     # дедупликация видит симуляцию — повторный прогон отсечёт эту вакансию
     assert History(tmp_path / "history.db").has_applied("AAA111", "42") is True
+
+
+# --- #176: uncertain — клик мог уйти, запись/пауза/лимиты обязательны ---------
+
+
+def test_bump_uncertain_waits_and_records_uncertain(tmp_path, monkeypatch, wait_calls, capsys):
+    """#176: Playwright упал в момент клика поднятия — действие могло уйти на
+    hh.ru. Командный цикл обязан писать action (статус 'uncertain', НЕ 'failed'
+    — его не видят кулдаун/лимит) и выдерживать анти-бан-паузу."""
+    from hhru_bot.bump import BumpResult
+
+    resume = _resume()
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda page, r, dry_run: BumpResult(  # noqa: ARG005
+            r.id,
+            False,
+            "клик поднятия выполнен, исход неопределён",
+            acted=True,
+            uncertain=True,
+        ),
+    )
+    _run_bump(monkeypatch, tmp_path, _config(tmp_path, resume))
+
+    assert wait_calls == [f"после поднятия резюме '{resume.id}'"]
+    assert _read_actions(tmp_path / "history.db") == [("bump", "uncertain")]
+    assert "[FAIL]" in capsys.readouterr().out
+
+
+def test_apply_uncertain_waits_and_records_uncertain(tmp_path, monkeypatch, wait_calls):
+    """#176: submit-клик упал с исключением — отклик мог уйти. Запись
+    'uncertain' (дедупликация has_applied его видит) + пауза, как минимум
+    требование ишью: «гарантированно писать запись и выдерживать паузу»."""
+    from hhru_bot.apply import ApplyResult
+    from hhru_bot.history import History
+
+    result = ApplyResult(
+        _vacancy(), False, "submit-клик упал с исключением", acted=True, uncertain=True
+    )
+    _run_apply(monkeypatch, tmp_path, dry_run=False, result=result)
+
+    assert wait_calls == [f"после отклика на '{_vacancy().title}'"]
+    assert _read_actions(tmp_path / "history.db") == [("apply", "uncertain")]
+    # дедупликация отсечёт вакансию при повторном запуске — второго письма
+    # работодателю не будет, даже если первый отклик действительно ушёл
+    assert History(tmp_path / "history.db").has_applied("AAA111", "42") is True
+
+
+def test_uncertain_rows_affect_limits_cooldown_and_dedup(tmp_path):
+    """#176, антитеза test_non_success_rows_do_not_affect_limits: uncertain-строки
+    fail-closed — расходуют дневной лимит (count_today), запускают кулдаун 4ч
+    (can_bump_now через last_action_at) и дедуплицируют отклик. Действие могло
+    выполниться на hh.ru — локальная история обязана считать его состоявшимся."""
+    from hhru_bot.history import History
+
+    history = History(tmp_path / "history.db")
+    history.record_action("AAA111", "AAA111", "bump", "uncertain", "исход неопределён")
+    history.record_action("AAA111", "42", "apply", "uncertain", "submit упал после клика")
+
+    throttle = Throttle(ThrottleConfig(), history)
+    assert history.count_today("AAA111", "bump") == 1
+    can_bump, wait_left = throttle.can_bump_now("AAA111")
+    assert can_bump is False
+    assert wait_left is not None
+    assert history.has_applied("AAA111", "42") is True


### PR DESCRIPTION
## Что и почему (#176)

Pre-existing дефект (найден Codex при cycle-review PR #175): если Playwright бросает исключение **в момент или сразу после клика-действия** (navigation timeout после POST, target closed), исключение пробрасывалось наружу — командный цикл падал трейсбеком до `record_action`/`throttle.wait`. Действие на hh.ru при этом могло уже произойти, а локальная история об этом не узнавала:

- `has_applied` не отсекал вакансию → повторный отклик вторым письмом;
- `can_bump_now` не запускал кулдаун 4ч → повторное поднятие;
- анти-фрод пауза не выдерживалась.

## Решение: fail-closed в сторону «действие выполнено» + статус `uncertain`

- **`bump.py`** — клик кнопки поднятия под `try/except PlaywrightError`: возвращается `BumpResult(acted=True, uncertain=True)`.
- **`apply/steps.py`** — submit-клик (последний шаг `fill_response_form`) при исключении кидает новый маркер `SubmitClickUncertain`, а не глотается и не маскируется под обычный отказ строкой («отправки не было» — а мы не знаем).
- **`apply/pipeline.py`**:
  - `SubmitClickUncertain` → `fail` с `acted+uncertain`;
  - прочий `PlaywrightError` из заполнения формы (до submit) → чистый fail с `acted=False` (следа на hh.ru нет — консистентно с #163), но traceback больше не рвёт цикл;
  - post-submit фаза (`probe` + `wait_success_confirmation`) под защитой: исключение после отправки возвращает fail с `acted=True`, не теряя запись/паузу.
- **`commands/bump.py`, `commands/_common.py`** — маппинг нового статуса `uncertain` (НЕ `failed` — его не видят лимиты и дедупликация).
- **`history.py`** — `uncertain` учитывается в:
  - `has_applied` — дедупликация отсекает вакансию (лучше не откликнуться повторно, чем отправить дубль);
  - `count_today` — дневные лимиты расходуются;
  - `last_action_at` — кулдаун bump 4ч срабатывает;
  - `summary` — отдельный бакет (иначе total ≠ сумме колонок).
- **`report.py`** — колонка «Неопредел.» в сводке stats (table/csv/md).
- **CLAUDE.md** — ключевые решения №2/№3 дополнены про `uncertain`.

## Тесты

- клик поднятия падает → `acted=True, uncertain=True`, без traceback (`test_bump.py`);
- submit-клик падает → `SubmitClickUncertain` из `fill_response_form` (`test_apply_steps.py`) и fail `acted+uncertain` из `apply_to_vacancy` (`test_apply_pipeline.py`);
- `wait_success_confirmation` кидает → fail с `acted=True` (запись/пауза не теряются);
- PlaywrightError до submit → чистый fail `acted=False`, цикл не падает;
- командный уровень: uncertain-исходы пишут `("bump"|"apply", "uncertain")` и ждут паузу (`test_throttle_policy.py`);
- uncertain-строки влияют на лимиты/кулдаун/дедуп (антитеза теста «failed/dry_run не влияют»).

Closes #176