### PR TITLE
fix(apply): use wait_for_url instead of expect_navigation for response form (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,18 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
 
 4. **Форма отклика — двухшаговая навигация.** `VACANCY_APPLY_BUTTON` на странице вакансии
    это `<a href="/applicant/vacancy_response?...">`, а НЕ триггер модалки на той же
-   странице. `apply.py` кликает и ждёт `page.expect_navigation(...)`, и только потом ищет
-   поля формы. Не переписывай на «клик → искать модалку сразу».
+   странице. `apply.py`/`apply/steps.py::navigate_to_response_form` кликает и ждёт
+   `page.wait_for_url(...)`, и только потом ищет поля формы. Не переписывай на
+   «клик → искать модалку сразу». **Не `page.expect_navigation()`** (#179): у
+   залогиненного пользователя переход на `/applicant/vacancy_response` рендерится
+   как same-document/SPA-навигация (`history.pushState`) — `domcontentloaded`
+   там не наступает, хотя `page.url` меняется и отклик реально уходит на hh.ru;
+   `expect_navigation(wait_until="domcontentloaded")` в этом случае падает по
+   таймауту даже при успешном клике. `wait_for_url` следит только за URL и
+   работает для обоих случаев (полная перезагрузка и client-side routing).
+   Таймаут `wait_for_url` перехватывается и логируется, не крашит pipeline —
+   дальнейшие шаги (submit-кнопка/detect_questions) сами решают, загрузилась
+   ли форма.
 
 5. **Пустой результат требует подтверждения состояния страницы.** Если браузерный
    путь не смог подтвердить DOM из-за timeout, сетевой ошибки, анти-бота или дрейфа

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,17 +87,22 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
 4. **Форма отклика — двухшаговая навигация.** `VACANCY_APPLY_BUTTON` на странице вакансии
    это `<a href="/applicant/vacancy_response?...">`, а НЕ триггер модалки на той же
    странице. `apply.py`/`apply/steps.py::navigate_to_response_form` кликает и ждёт
-   `page.wait_for_url(...)`, и только потом ищет поля формы. Не переписывай на
-   «клик → искать модалку сразу». **Не `page.expect_navigation()`** (#179): у
-   залогиненного пользователя переход на `/applicant/vacancy_response` рендерится
-   как same-document/SPA-навигация (`history.pushState`) — `domcontentloaded`
-   там не наступает, хотя `page.url` меняется и отклик реально уходит на hh.ru;
-   `expect_navigation(wait_until="domcontentloaded")` в этом случае падает по
-   таймауту даже при успешном клике. `wait_for_url` следит только за URL и
-   работает для обоих случаев (полная перезагрузка и client-side routing).
-   Таймаут `wait_for_url` перехватывается и логируется, не крашит pipeline —
-   дальнейшие шаги (submit-кнопка/detect_questions) сами решают, загрузилась
-   ли форма.
+   `page.wait_for_url(..., wait_until="commit")`, и только потом ищет поля формы.
+   Не переписывай на «клик → искать модалку сразу». **Не `page.expect_navigation()`**
+   (#179): у залогиненного пользователя переход на `/applicant/vacancy_response`
+   рендерится как same-document/SPA-навигация (`history.pushState`) —
+   `domcontentloaded` там не наступает, хотя `page.url` меняется и отклик реально
+   уходит на hh.ru; `expect_navigation(wait_until="domcontentloaded")` в этом
+   случае падает по таймауту даже при успешном клике. **`wait_until` обязателен
+   явно**: `page.wait_for_url()` реализован через тот же `expect_navigation`
+   внутри Playwright и без явного `wait_until` дефолтится на `"load"` — это
+   строже, а не мягче `domcontentloaded`, и не решило бы проблему.
+   `wait_until="commit"` — единственное значение, не ждущее lifecycle-событие
+   документа вообще. И клик по кнопке отклика, и `wait_for_url` обёрнуты в
+   try/except `PlaywrightError` (не только timeout) — ошибка здесь просто
+   логируется и разбор вакансии прекращается через `return`, не крашит pipeline
+   и не обрывает цикл apply по остальным вакансиям/резюме; дальнейшие шаги
+   (submit-кнопка/detect_questions) сами решают, загрузилась ли форма.
 
 5. **Пустой результат требует подтверждения состояния страницы.** Если браузерный
    путь не смог подтвердить DOM из-за timeout, сетевой ошибки, анти-бота или дрейфа

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -73,20 +73,39 @@ def navigate_to_response_form(page: Page) -> None:
 
     Фиксированный sleep после навигации заменён на явное ожидание готовности DOM:
     ждём любого индикатора формы (кнопка отправки), максимум APPLY_TIMEOUT_MS.
+
+    #179: раньше ожидание было ``page.expect_navigation(wait_until="domcontentloaded")``.
+    Живая диагностика (боевой аккаунт, vacancy_id 136221532) показала: кнопка
+    отклика сменилась на "уже откликнулись" (submit реально ушёл на hh.ru), но
+    ``expect_navigation`` всё равно упал по TimeoutError 90с — переход на
+    ``/applicant/vacancy_response`` у залогиненного пользователя рендерится как
+    SPA same-document навигация (``history.pushState``), а не полноценная
+    перезагрузка документа; ``domcontentloaded`` в этом случае не наступает
+    вообще, хотя ``page.url`` меняется. ``page.wait_for_url()`` следит именно
+    за URL, а не за lifecycle-событием документа — работает для обоих случаев
+    (полная перезагрузка и client-side routing).
     """
     from ..selector_groups import apply_form
 
     apply_button = page.locator(vacancy_page.VACANCY_APPLY_BUTTON).first
-    # #80: потолок навигации на форму отклика — GOTO_TIMEOUT_MS (как у всех goto).
-    # Двухшаговая навигация (CLAUDE.md п.4) — это сетевой запрос hh.ru, который под
-    # DDoS-Guard грузится 33с+; APPLY_TIMEOUT_MS (10с) тут падал, context-wide
-    # set_default_navigation_timeout перебивается явным timeout.
-    with page.expect_navigation(wait_until="domcontentloaded", timeout=GOTO_TIMEOUT_MS):
-        # no_wait_after=True: клик НЕ ждёт навигацию своим внутренним action-timeout
-        # шагом (дефолт set_default_timeout 30с, а не navigation-timeout) — иначе на
-        # навигации 33с+ он упал бы через 30с раньше 90с expect_navigation. Ожидание
-        # навигации полностью владеет внешний 90с waiter expect_navigation.
-        apply_button.click(no_wait_after=True)
+    # #80/#179: потолок навигации на форму отклика — GOTO_TIMEOUT_MS (как у всех
+    # goto). Двухшаговая навигация (CLAUDE.md п.4) — это сетевой запрос hh.ru,
+    # который под DDoS-Guard грузится 33с+; APPLY_TIMEOUT_MS (10с) тут падал.
+    apply_button.click(no_wait_after=True)
+    # #179: таймаут ожидания URL сам по себе не означает, что клик/отклик не
+    # ушёл (симметрично SubmitClickUncertain #176) — не крашим весь pipeline
+    # необработанным исключением, а логируем и отдаём управление дальше.
+    # fill_response_form (через отсутствие APPLY_SUBMIT_BUTTON) и detect_questions
+    # сами вернут корректный fail/skip, если форма реально не загрузилась.
+    try:
+        page.wait_for_url("**/applicant/vacancy_response**", timeout=GOTO_TIMEOUT_MS)
+    except PlaywrightTimeoutError:
+        logger.warning(
+            "Навигация на форму отклика не подтвердилась за %d мс "
+            "(URL не сменился на /applicant/vacancy_response) — "
+            "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
+            GOTO_TIMEOUT_MS,
+        )
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
     try:
         page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -77,13 +77,33 @@ def navigate_to_response_form(page: Page) -> None:
     #179: раньше ожидание было ``page.expect_navigation(wait_until="domcontentloaded")``.
     Живая диагностика (боевой аккаунт, vacancy_id 136221532) показала: кнопка
     отклика сменилась на "уже откликнулись" (submit реально ушёл на hh.ru), но
-    ``expect_navigation`` всё равно упал по TimeoutError 90с — переход на
-    ``/applicant/vacancy_response`` у залогиненного пользователя рендерится как
-    SPA same-document навигация (``history.pushState``), а не полноценная
-    перезагрузка документа; ``domcontentloaded`` в этом случае не наступает
-    вообще, хотя ``page.url`` меняется. ``page.wait_for_url()`` следит именно
-    за URL, а не за lifecycle-событием документа — работает для обоих случаев
-    (полная перезагрузка и client-side routing).
+    ``expect_navigation`` всё равно упал по TimeoutError 90с — гипотеза: переход
+    на ``/applicant/vacancy_response`` у залогиненного пользователя рендерится
+    как SPA same-document навигация (``history.pushState``), а не полноценная
+    перезагрузка документа, и ``domcontentloaded`` в этом случае не наступает,
+    хотя ``page.url`` меняется.
+
+    ``page.wait_for_url()`` реализован через тот же ``expect_navigation`` внутри
+    (``playwright._impl._frame.Frame.wait_for_url``) и БЕЗ явного ``wait_until``
+    дефолтится на ``"load"`` — это строже, а не мягче ``domcontentloaded``, и не
+    решило бы проблему. ``wait_until="commit"`` — единственное значение, которое
+    не ждёт lifecycle-событие документа вообще (срабатывает по первому байту
+    ответа/навигационному событию), поэтому здесь передан явно.
+
+    #179 (code-review): и клик, и ожидание URL оборачиваются в try/except
+    ``PlaywrightError`` (не только ``PlaywrightTimeoutError`` — non-timeout
+    ошибки вроде «page/context closed» тоже возможны и раньше пробрасывались
+    бы наверх необработанными). Это НЕ то же самое, что #176
+    ``SubmitClickUncertain``: там ошибка происходит вокруг submit-клика,
+    последнего необратимого шага формы, и pipeline обязан трактовать её как
+    «действие могло уйти» (``acted=True``). Здесь клик по кнопке ОТКЛИКА
+    (переход на форму) — до заполнения и до submit; аналогично прочим ранним
+    отказам (#163) он не означает следа на hh.ru, поэтому исключение просто
+    логируется и разбор продолжается через return, а не пробрасывается —
+    fill_response_form (через отсутствие APPLY_SUBMIT_BUTTON) и
+    detect_questions сами вернут корректный fail/skip для этой вакансии, не
+    обрывая цикл apply по остальным вакансиям/резюме (иначе один сбойный клик
+    на первой же вакансии останавливает весь прогон — регрессия #163/#176).
     """
     from ..selector_groups import apply_form
 
@@ -91,30 +111,37 @@ def navigate_to_response_form(page: Page) -> None:
     # #80/#179: потолок навигации на форму отклика — GOTO_TIMEOUT_MS (как у всех
     # goto). Двухшаговая навигация (CLAUDE.md п.4) — это сетевой запрос hh.ru,
     # который под DDoS-Guard грузится 33с+; APPLY_TIMEOUT_MS (10с) тут падал.
-    apply_button.click(no_wait_after=True)
-    # #179: таймаут ожидания URL сам по себе не означает, что клик/отклик не
-    # ушёл (симметрично SubmitClickUncertain #176) — не крашим весь pipeline
-    # необработанным исключением, а логируем и отдаём управление дальше.
-    # fill_response_form (через отсутствие APPLY_SUBMIT_BUTTON) и detect_questions
-    # сами вернут корректный fail/skip, если форма реально не загрузилась.
     try:
-        page.wait_for_url("**/applicant/vacancy_response**", timeout=GOTO_TIMEOUT_MS)
-    except PlaywrightTimeoutError:
+        apply_button.click(no_wait_after=True)
+    except PlaywrightError as exc:
+        # Клик по apply-кнопке — до submit, ранний отказ (#163): на hh.ru следа
+        # нет, не крашим цикл откликов необработанным исключением.
+        logger.warning("Клик по кнопке отклика упал с ошибкой (%s) — вакансия пропущена", exc)
+        return
+    # #179: таймаут/ошибка ожидания URL сама по себе не означает, что клик не
+    # сработал — не крашим весь pipeline необработанным исключением, а
+    # логируем и отдаём управление дальше. fill_response_form (через
+    # отсутствие APPLY_SUBMIT_BUTTON) и detect_questions сами вернут
+    # корректный fail/skip, если форма реально не загрузилась.
+    try:
+        page.wait_for_url(
+            "**/applicant/vacancy_response**", wait_until="commit", timeout=GOTO_TIMEOUT_MS
+        )
+    except PlaywrightError as exc:
         logger.warning(
-            "Навигация на форму отклика не подтвердилась за %d мс "
-            "(URL не сменился на /applicant/vacancy_response) — "
+            "Навигация на форму отклика не подтвердилась (%s) — "
             "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
-            GOTO_TIMEOUT_MS,
+            exc,
         )
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
     try:
         page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(
             state="visible", timeout=APPLY_TIMEOUT_MS
         )
-    except PlaywrightTimeoutError:
+    except PlaywrightError as exc:
         # Форма не загрузилась — fill_response_form всё равно вернёт причину отказа
         # (submit не найден), логируем для диагностики устаревшего селектора.
-        logger.warning("Форма отклика не отрисовалась за %d мс", APPLY_TIMEOUT_MS)
+        logger.warning("Форма отклика не отрисовалась (%s)", exc)
 
 
 def _is_visible(page: Page, selector: str, *, timeout_ms: int) -> bool:

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -42,10 +42,10 @@ class PageStateIndeterminate(RuntimeError):
 # Потолок ожидания навигации по hh.ru. Дефолт Playwright 30с — hh.ru под
 # DDoS-Guard/нагрузкой грузится 33с+ (см. #80), и goto падает. Ставим
 # context-wide через set_default_navigation_timeout — покрывает ВСЕ goto/
-# expect_navigation одним источником (включая двухшаговую навигацию формы
-# отклика, CLAUDE.md п.4), без явного timeout в каждом вызове. 90с (не 120с
-# как в auth.py раньше): достаточно для медленного hh.ru, но не слепое
-# зависание на 1.5 мин при реально упавшем запросе.
+# wait_for_url одним источником (включая двухшаговую навигацию формы отклика,
+# CLAUDE.md п.4, #179), без явного timeout в каждом вызове. 90с (не 120с как в
+# auth.py раньше): достаточно для медленного hh.ru, но не слепое зависание на
+# 1.5 мин при реально упавшем запросе.
 GOTO_TIMEOUT_MS = 90_000
 
 # Retry goto: DDoS-Guard регулярно пропускает запрос со 2-й попытки. 3 попытки,
@@ -131,8 +131,8 @@ def launch_context(
             )
 
         context: BrowserContext = browser.new_context(**context_kwargs)
-        # #80: потолок навигации context-wide — покрывает ВСЕ goto/expect_navigation
-        # единым источником (включая двухшаговую навигацию формы отклика).
+        # #80: потолок навигации context-wide — покрывает ВСЕ goto/wait_for_url
+        # единым источником (включая двухшаговую навигацию формы отклика, #179).
         context.set_default_navigation_timeout(GOTO_TIMEOUT_MS)
         # Убираем navigator.webdriver и подделываем window.chrome — без этого
         # hh.ru детектит Playwright и не активирует кнопку входа. Приём из

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import logging
 import pkgutil
 import sys
 from pathlib import Path
@@ -87,6 +88,21 @@ def main(argv: list[str] | None = None) -> None:
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")
         sys.exit(130)
+    except SystemExit:
+        # sys.exit() из самой команды (напр. load_config_or_exit) — не наш случай,
+        # пробрасываем как есть, не логируем как крах.
+        raise
+    except Exception:
+        # #179: раньше необработанное исключение из args.func (напр. Playwright
+        # TimeoutError, не пойманный внутри pipeline) печаталось Python'ом только
+        # в stderr — traceback не попадал в data/logs/hhru_bot.log, хотя
+        # setup_logging() уже успел настроить FileHandler на этот момент.
+        # logger.exception пишет полный traceback туда же, куда обычные логи.
+        if args.command != "log":
+            logging.getLogger("hhru_bot").exception(
+                "Необработанное исключение в команде '%s'", args.command
+            )
+        raise
 
 
 if __name__ == "__main__":

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -96,14 +96,28 @@ def main(argv: list[str] | None = None) -> None:
         # TimeoutError, не пойманный внутри pipeline) печаталось Python'ом только
         # в stderr — traceback не попадал в data/logs/hhru_bot.log, хотя
         # setup_logging() уже успел настроить FileHandler на этот момент.
-        # logger.exception пишет полный traceback туда же, куда обычные логи.
         # SystemExit НЕ попадает сюда — он подкласс BaseException, не Exception
         # (sys.exit() из самой команды, напр. load_config_or_exit, пробрасывается
         # мимо этого except как раньше, не логируется как крах).
         if logging_enabled:
-            logging.getLogger("hhru_bot").exception(
-                "Необработанное исключение в команде '%s'", args.command
+            # #179 code-review round 2: logger.exception() пишет в ОБА handler'а
+            # (console + file, оба на "hhru_bot" — logging_setup.py), а следующий
+            # bare raise даёт Python допечатать тот же traceback в stderr ещё раз
+            # через excepthook — пользователь видел бы его дважды. Пишем запись
+            # только в FileHandler напрямую, консоль получает traceback один раз
+            # от самого Python (стандартное поведение необработанного исключения).
+            record = logging.getLogger("hhru_bot").makeRecord(
+                "hhru_bot",
+                logging.ERROR,
+                __file__,
+                0,
+                "Необработанное исключение в команде '%s'",
+                (args.command,),
+                sys.exc_info(),
             )
+            for handler in logging.getLogger("hhru_bot").handlers:
+                if isinstance(handler, logging.FileHandler):
+                    handler.handle(record)
         raise
 
 

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -74,7 +74,10 @@ def main(argv: list[str] | None = None) -> None:
     # локально» (#21), делает ветку «файл не найден» недостижимой (setup_logging
     # создаёт пустой лог) и падает PermissionError в read-only-директории.
     # log сам ничего не логирует — ему не нужны handlers (цикл ревью #61, #58).
-    if args.command != "log":
+    # #179: то же условие решает, есть ли у логгера hhru_bot FileHandler — нужно
+    # ниже ещё раз (except Exception), считаем один раз, не дублируем условие.
+    logging_enabled = args.command != "log"
+    if logging_enabled:
         setup_logging(verbose=args.verbose)
 
     try:
@@ -88,17 +91,16 @@ def main(argv: list[str] | None = None) -> None:
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")
         sys.exit(130)
-    except SystemExit:
-        # sys.exit() из самой команды (напр. load_config_or_exit) — не наш случай,
-        # пробрасываем как есть, не логируем как крах.
-        raise
     except Exception:
         # #179: раньше необработанное исключение из args.func (напр. Playwright
         # TimeoutError, не пойманный внутри pipeline) печаталось Python'ом только
         # в stderr — traceback не попадал в data/logs/hhru_bot.log, хотя
         # setup_logging() уже успел настроить FileHandler на этот момент.
         # logger.exception пишет полный traceback туда же, куда обычные логи.
-        if args.command != "log":
+        # SystemExit НЕ попадает сюда — он подкласс BaseException, не Exception
+        # (sys.exit() из самой команды, напр. load_config_or_exit, пробрасывается
+        # мимо этого except как раньше, не логируется как крах).
+        if logging_enabled:
             logging.getLogger("hhru_bot").exception(
                 "Необработанное исключение в команде '%s'", args.command
             )

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -67,14 +67,11 @@ class _ApplyFakePage:
             return _FakeLocator(present=True)
         return _FakeLocator(present=False)
 
-    def expect_navigation(self, **_kwargs):  # noqa: ARG002
-        import contextlib
-
-        @contextlib.contextmanager
-        def _cm():
-            yield
-
-        return _cm()
+    def wait_for_url(self, _url_pattern, **_kwargs):  # noqa: ARG002
+        # #179: navigate_to_response_form больше не использует expect_navigation.
+        # Этот путь — dry-run, до формы не доходим (см. докстринг класса), метод
+        # не должен вызываться, но определён для консистентности с реальным Page.
+        return None
 
 
 def _resume_with_profile() -> ResumeConfig:

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -101,14 +101,9 @@ class FakePage:
             return _FakeLocator(present=self._success, click_error=self._submit_click_error)
         return _FakeLocator(present=False)
 
-    def expect_navigation(self, **_kwargs):
-        import contextlib
-
-        @contextlib.contextmanager
-        def _cm():
-            yield
-
-        return _cm()
+    def wait_for_url(self, _url_pattern, **_kwargs):
+        # #179: navigate_to_response_form больше не использует expect_navigation.
+        return None
 
 
 def _vacancy() -> VacancyCard:

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -150,14 +150,9 @@ class FakeProbePage:
             return _FakeLocator(present=False)
         return _FakeLocator(present=False)
 
-    def expect_navigation(self, **_kwargs):
-        import contextlib
-
-        @contextlib.contextmanager
-        def _cm():
-            yield
-
-        return _cm()
+    def wait_for_url(self, _url_pattern, **_kwargs):
+        # #179: navigate_to_response_form больше не использует expect_navigation.
+        return None
 
 
 def _vacancy() -> VacancyCard:

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -174,11 +174,12 @@ class FakeStepsPage:
         self.states: dict[str, _SelectorState] = {}
         self.navigation_entered = 0
         self.last_navigation_timeout: int | None = None
+        self.last_navigation_wait_until: str | None = None
         # #179: wait_for_url заменил expect_navigation. wait_for_url_error=None —
         # успешный кейс (URL сменился); задать PlaywrightTimeoutError — имитация
         # same-document/SPA-навигации, где URL меняется, но lifecycle-событие
         # документа не наступает (тест регрессии на этот баг ниже).
-        self.wait_for_url_calls: list[tuple[str, int | None]] = []
+        self.wait_for_url_calls: list[tuple[str, str | None, int | None]] = []
         self.wait_for_url_error: Exception | None = None
 
     def _state(self, selector: str) -> _SelectorState:
@@ -207,13 +208,19 @@ class FakeStepsPage:
             return _FakeLocator(selector, self._state(base), href_filter=href)
         return _FakeLocator(selector, self._state(selector))
 
-    def wait_for_url(self, url_pattern: str, *, timeout: int | None = None) -> None:
+    def wait_for_url(
+        self, url_pattern: str, *, wait_until: str | None = None, timeout: int | None = None
+    ) -> None:
         # #179: заменяет expect_navigation. Фиксируем timeout — регрессия #80:
         # двухшаговая навигация на форму отклика должна использовать потолок
         # GOTO_TIMEOUT_MS (медленный hh.ru), а не дефолт/короткий APPLY_TIMEOUT_MS.
+        # wait_until фиксируем отдельно — регрессия B1 code-review: wait_for_url
+        # БЕЗ явного wait_until дефолтится на "load" внутри Playwright (строже
+        # domcontentloaded), поэтому вызывающий код обязан передавать "commit".
         self.navigation_entered += 1
         self.last_navigation_timeout = timeout
-        self.wait_for_url_calls.append((url_pattern, timeout))
+        self.last_navigation_wait_until = wait_until
+        self.wait_for_url_calls.append((url_pattern, wait_until, timeout))
         if self.wait_for_url_error is not None:
             raise self.wait_for_url_error
 
@@ -236,14 +243,14 @@ def test_wait_apply_button_missing_returns_false():
 # --- navigate_to_response_form ---
 
 
-def test_navigate_clicks_inside_expect_navigation_and_waits_submit():
+def test_navigate_clicks_apply_button_and_waits_submit():
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
     steps.navigate_to_response_form(page)
 
-    # Клик по apply-кнопке + вход в expect_navigation.
+    # Клик по apply-кнопке + ожидание URL через wait_for_url (#179).
     assert page.navigation_entered == 1
     assert page._state(vacancy_page.VACANCY_APPLY_BUTTON).clicks == 1
 
@@ -260,8 +267,8 @@ def test_navigate_does_not_raise_when_form_never_renders():
 
 
 def test_navigate_uses_goto_timeout_for_form_navigation():
-    # #80 регрессия: двухшаговая навигация на форму отклика (expect_navigation
-    # после клика по apply-кнопке) — это сетевая навигация hh.ru, которая под
+    # #80 регрессия: двухшаговая навигация на форму отклика (wait_for_url после
+    # клика по apply-кнопке, #179) — это сетевая навигация hh.ru, которая под
     # DDoS-Guard грузится 33с+. Де­фолт/короткий APPLY_TIMEOUT_MS (10с) тут
     # падает; потолок должен быть GOTO_TIMEOUT_MS, как и у всех goto в проекте.
     page = FakeStepsPage()
@@ -287,7 +294,24 @@ def test_navigate_uses_wait_for_url_not_expect_navigation():
 
     steps.navigate_to_response_form(page)
 
-    assert page.wait_for_url_calls == [("**/applicant/vacancy_response**", GOTO_TIMEOUT_MS)]
+    assert page.wait_for_url_calls == [
+        ("**/applicant/vacancy_response**", "commit", GOTO_TIMEOUT_MS)
+    ]
+
+
+def test_navigate_wait_for_url_uses_commit_not_default_load():
+    # #179 регрессия (B1, independent review): page.wait_for_url() реализован
+    # через тот же expect_navigation внутри Playwright и БЕЗ явного wait_until
+    # дефолтится на "load" — строже, чем domcontentloaded, который заменяли.
+    # wait_until="commit" — единственное значение, не ждущее lifecycle-событие
+    # документа вообще. Без явной передачи фикс не решал бы исходную проблему.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)
+
+    assert page.last_navigation_wait_until == "commit"
 
 
 def test_navigate_wait_for_url_timeout_does_not_raise():
@@ -309,12 +333,47 @@ def test_navigate_wait_for_url_timeout_does_not_raise():
     assert apply_state.clicks == 1
 
 
+def test_navigate_wait_for_url_non_timeout_error_does_not_raise():
+    # #179 (code-review): раньше wait_for_url ловил только PlaywrightTimeoutError,
+    # хотя non-timeout PlaywrightError (page/context closed, navigation aborted)
+    # тоже возможен и пробрасывался бы наверх необработанным, роняя весь цикл
+    # apply по остальным вакансиям/резюме.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    page.wait_for_url_error = Error("Target page, context or browser has been closed")
+
+    steps.navigate_to_response_form(page)  # не должен бросать
+
+    apply_state = page._state(vacancy_page.VACANCY_APPLY_BUTTON)
+    assert apply_state.clicks == 1
+
+
+def test_navigate_apply_button_click_error_does_not_raise():
+    # #179 (code-review): клик по apply-кнопке (до submit, до заполнения формы)
+    # раньше не был обёрнут вообще — любой PlaywrightError из click() пробрасывался
+    # наверх необработанным через pipeline._run (вызывается без try/except на
+    # этой строке) и ронял весь цикл apply по остальным вакансиям/резюме. Ранний
+    # отказ (#163, аналогично прочим шагам до submit) — не uncertain, просто fail
+    # для текущей вакансии; wait_for_url/submit-поиск не должны выполняться после.
+    page = FakeStepsPage()
+    apply_state = page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    apply_state.click_error = Error("Target page, context or browser has been closed")
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)  # не должен бросать
+
+    assert page.navigation_entered == 0  # wait_for_url не вызывался после сбойного клика
+
+
 def test_navigate_clicks_apply_button_with_no_wait_after():
     # #80 регрессия (cycle-2): Locator.click, триггерящий навигацию, имеет внутренний
     # шаг «wait for initiated navigations», ограниченный ACTION timeout
     # (set_default_timeout, дефолт 30с), а НЕ set_default_navigation_timeout. На
-    # навигации 33с+ клик падал бы через 30с раньше 90с expect_navigation. Фикс:
-    # no_wait_after=True — ожидание навигации полностью владеет внешний 90с waiter.
+    # навигации 33с+ клик падал бы через 30с раньше 90с ожидания. Фикс:
+    # no_wait_after=True — клик не ждёт навигацию сам; следующий явный
+    # page.wait_for_url(timeout=GOTO_TIMEOUT_MS, #179) — единственный владелец
+    # 90с ожидания.
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -2,14 +2,13 @@
 
 Без браузера — через FakePage, имитирующий минимальный Playwright API, который
 использует steps.py: locator(...).wait_for(state='visible', timeout=...),
-click(), fill(), expect_navigation(). Страхуют поведение wait'ов: time.sleep
+click(), fill(), wait_for_url(). Страхуют поведение wait'ов: time.sleep
 убран, опциональные поля определяются ловом PlaywrightTimeoutError, обязательный
 submit даёт отказ при отсутствии.
 """
 
 from __future__ import annotations
 
-import contextlib
 import re
 
 import pytest
@@ -175,6 +174,12 @@ class FakeStepsPage:
         self.states: dict[str, _SelectorState] = {}
         self.navigation_entered = 0
         self.last_navigation_timeout: int | None = None
+        # #179: wait_for_url заменил expect_navigation. wait_for_url_error=None —
+        # успешный кейс (URL сменился); задать PlaywrightTimeoutError — имитация
+        # same-document/SPA-навигации, где URL меняется, но lifecycle-событие
+        # документа не наступает (тест регрессии на этот баг ниже).
+        self.wait_for_url_calls: list[tuple[str, int | None]] = []
+        self.wait_for_url_error: Exception | None = None
 
     def _state(self, selector: str) -> _SelectorState:
         return self.states.setdefault(selector, _SelectorState())
@@ -202,14 +207,15 @@ class FakeStepsPage:
             return _FakeLocator(selector, self._state(base), href_filter=href)
         return _FakeLocator(selector, self._state(selector))
 
-    @contextlib.contextmanager
-    def expect_navigation(self, **kwargs):
+    def wait_for_url(self, url_pattern: str, *, timeout: int | None = None) -> None:
+        # #179: заменяет expect_navigation. Фиксируем timeout — регрессия #80:
+        # двухшаговая навигация на форму отклика должна использовать потолок
+        # GOTO_TIMEOUT_MS (медленный hh.ru), а не дефолт/короткий APPLY_TIMEOUT_MS.
         self.navigation_entered += 1
-        # Фиксируем timeout навигации — регрессия #80: двухшаговая навигация на
-        # форму отклика должна использовать потолок GOTO_TIMEOUT_MS (медленный
-        # hh.ru), а не дефолт/короткий APPLY_TIMEOUT_MS.
-        self.last_navigation_timeout = kwargs.get("timeout")
-        yield
+        self.last_navigation_timeout = timeout
+        self.wait_for_url_calls.append((url_pattern, timeout))
+        if self.wait_for_url_error is not None:
+            raise self.wait_for_url_error
 
 
 # --- wait_apply_button ---
@@ -265,6 +271,42 @@ def test_navigate_uses_goto_timeout_for_form_navigation():
     steps.navigate_to_response_form(page)
 
     assert page.last_navigation_timeout == GOTO_TIMEOUT_MS
+
+
+def test_navigate_uses_wait_for_url_not_expect_navigation():
+    # #179: диагностика на боевом аккаунте показала, что клик по apply-кнопке
+    # реально отправляет отклик (кнопка меняется на "уже откликнулись"), но
+    # expect_navigation(wait_until='domcontentloaded') всё равно падал таймаутом
+    # 90с — переход на /applicant/vacancy_response у залогиненного пользователя
+    # рендерится как same-document/SPA-навигация (history.pushState), и
+    # domcontentloaded не наступает, хотя URL меняется. wait_for_url следит
+    # именно за URL — работает для обоих случаев.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page)
+
+    assert page.wait_for_url_calls == [("**/applicant/vacancy_response**", GOTO_TIMEOUT_MS)]
+
+
+def test_navigate_wait_for_url_timeout_does_not_raise():
+    # #179 регрессия: раньше TimeoutError из ожидания навигации не был перехвачен
+    # steps.navigate_to_response_form — пробрасывался наверх необработанным и
+    # ронял весь apply-цикл traceback'ом (реальный краш на боевом аккаунте,
+    # vacancy_id=136221532). Клик мог реально уйти (симметрично #176
+    # SubmitClickUncertain) — навигация не подтвердилась, но это не повод
+    # крашить процесс: дальнейшие шаги (submit-кнопка/detect_questions) сами
+    # определят, загрузилась ли форма.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    page.wait_for_url_error = PlaywrightTimeoutError("Timeout 90000ms exceeded.")
+
+    steps.navigate_to_response_form(page)  # не должен бросать
+
+    apply_state = page._state(vacancy_page.VACANCY_APPLY_BUTTON)
+    assert apply_state.clicks == 1
 
 
 def test_navigate_clicks_apply_button_with_no_wait_after():

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -43,8 +43,8 @@ def _fake_playwright(monkeypatch, *, calls):
 def test_launch_context_sets_default_navigation_timeout(monkeypatch, tmp_path):
     """#80 минимум: после new_context — set_default_navigation_timeout(GOTO_TIMEOUT_MS).
 
-    Покрывает ВСЕ goto/expect_navigation единым источником (включая двухшаговую
-    навигацию формы отклика, CLAUDE.md п.4) — без явного timeout в каждом вызове.
+    Покрывает ВСЕ goto/wait_for_url единым источником (включая двухшаговую
+    навигацию формы отклика, CLAUDE.md п.4, #179) — без явного timeout в каждом вызове.
     """
     calls: dict = {}
     _fake_playwright(monkeypatch, calls=calls)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -313,13 +313,17 @@ def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch):
 
     monkeypatch.setattr(whoami_module, "run", _boom)
 
-    with pytest.raises(RuntimeError, match="simulated navigate_to_response_form crash"):
-        main(["whoami"])
+    try:
+        with pytest.raises(RuntimeError, match="simulated navigate_to_response_form crash"):
+            main(["whoami"])
 
-    log_file = LOG_DIR / "hhru_bot.log"
-    assert log_file.exists()
-    content = log_file.read_text(encoding="utf-8")
-    assert "Необработанное исключение в команде 'whoami'" in content
-    assert "RuntimeError: simulated navigate_to_response_form crash (#179)" in content
-
-    logging.getLogger("hhru_bot").handlers.clear()
+        log_file = LOG_DIR / "hhru_bot.log"
+        assert log_file.exists()
+        content = log_file.read_text(encoding="utf-8")
+        assert "Необработанное исключение в команде 'whoami'" in content
+        assert "RuntimeError: simulated navigate_to_response_form crash (#179)" in content
+    finally:
+        # main() настраивает FileHandler на hhru_bot заново при каждом вызове
+        # (root.handlers.clear() внутри setup_logging), но если assert выше упадёт,
+        # handler останется висеть на последующие тесты — чистим в любом случае.
+        logging.getLogger("hhru_bot").handlers.clear()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 import pytest
 
@@ -289,3 +290,36 @@ def test_clear_skipped_success_does_not_exit_nonzero(tmp_path):
         main(["--history", str(history_path), "clear-skipped"])
     except SystemExit as e:
         pytest.fail(f"main() exited with {e.code} on a successful deletion")
+
+
+def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch):
+    """#179: необработанное исключение из args.func (напр. непойманный внутри
+    apply-пайплайна Playwright TimeoutError) раньше уходило только в stderr
+    Python'а — traceback не попадал в data/logs/hhru_bot.log, хотя setup_logging()
+    к этому моменту уже настроил FileHandler. main() обязан залогировать полный
+    traceback (logger.exception) перед тем, как перевыбросить исключение дальше
+    (поведение для пользователя — тот же traceback + ненулевой exit — не меняется).
+
+    LOG_DIR — module-level константа (см. logging_setup.py), вычисленная от cwd
+    на момент импорта, поэтому тест не гоняет cwd, а читает файл там, где
+    setup_logging() реально его создал.
+    """
+    from hhru_bot.logging_setup import LOG_DIR
+
+    def _boom(_args: argparse.Namespace) -> bool:
+        raise RuntimeError("simulated navigate_to_response_form crash (#179)")
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated navigate_to_response_form crash"):
+        main(["whoami"])
+
+    log_file = LOG_DIR / "hhru_bot.log"
+    assert log_file.exists()
+    content = log_file.read_text(encoding="utf-8")
+    assert "Необработанное исключение в команде 'whoami'" in content
+    assert "RuntimeError: simulated navigate_to_response_form crash (#179)" in content
+
+    logging.getLogger("hhru_bot").handlers.clear()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -292,13 +292,13 @@ def test_clear_skipped_success_does_not_exit_nonzero(tmp_path):
         pytest.fail(f"main() exited with {e.code} on a successful deletion")
 
 
-def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch):
+def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch, capsys):
     """#179: необработанное исключение из args.func (напр. непойманный внутри
     apply-пайплайна Playwright TimeoutError) раньше уходило только в stderr
     Python'а — traceback не попадал в data/logs/hhru_bot.log, хотя setup_logging()
-    к этому моменту уже настроил FileHandler. main() обязан залогировать полный
-    traceback (logger.exception) перед тем, как перевыбросить исключение дальше
-    (поведение для пользователя — тот же traceback + ненулевой exit — не меняется).
+    к этому моменту уже настроил FileHandler. main() обязан записать полный
+    traceback в файл перед тем, как перевыбросить исключение дальше (поведение
+    для пользователя — тот же traceback в консоли + ненулевой exit — не меняется).
 
     LOG_DIR — module-level константа (см. logging_setup.py), вычисленная от cwd
     на момент импорта, поэтому тест не гоняет cwd, а читает файл там, где
@@ -322,6 +322,13 @@ def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch):
         content = log_file.read_text(encoding="utf-8")
         assert "Необработанное исключение в команде 'whoami'" in content
         assert "RuntimeError: simulated navigate_to_response_form crash (#179)" in content
+
+        # #179 code-review round 2: логирование должно писать ТОЛЬКО в файл —
+        # console_handler на "hhru_bot" (StreamHandler, stderr) не должен получить
+        # эту запись, иначе Python допечатает тот же traceback после raise ещё
+        # раз через excepthook, и пользователь увидит его дважды.
+        stderr = capsys.readouterr().err
+        assert "Необработанное исключение в команде 'whoami'" not in stderr
     finally:
         # main() настраивает FileHandler на hhru_bot заново при каждом вызове
         # (root.handlers.clear() внутри setup_logging), но если assert выше упадёт,

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -86,14 +86,9 @@ class _ApplyFakePage:
             return _FakeLocator(present=True)
         return _FakeLocator(present=False)
 
-    def expect_navigation(self, **_kwargs):  # noqa: ARG002
-        import contextlib
-
-        @contextlib.contextmanager
-        def _cm():
-            yield
-
-        return _cm()
+    def wait_for_url(self, _url_pattern, **_kwargs):  # noqa: ARG002
+        # #179: navigate_to_response_form больше не использует expect_navigation.
+        return None
 
 
 def _read_resume_ids(history_db) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Проблема

Issue #179: боевой прогон `apply --resume python --limit 1` (issue #69) упал необработанным `playwright._impl._errors.TimeoutError: Timeout 90000ms exceeded` в `apply/steps.py:84` (`navigate_to_response_form`, ожидание `page.expect_navigation(...)`).

## Диагностика (по CLAUDE.md — сверка вживую перед патчем)

Использовал headless Playwright-бота с боевой сессией (нет Chrome MCP) для read-only проверки DOM:

1. `probe --vacancy-id 136221532` (та же вакансия, что упала боевым прогоном) — кнопка отклика сейчас имеет `data-qa="vacancy-response-link-view-topic"` (просмотр уже отправленного отклика), а не `vacancy-response-link-top`. **Значит клик реально отправил отклик на hh.ru** — просто локально это не подтвердилось из-за краша.
2. Диагностический скрипт (без клика) на свежей вакансии показал: `VACANCY_APPLY_BUTTON` — валидный `<a href="/applicant/vacancy_response?...">`, селектор корректный, не устарел.
3. Вывод: клик срабатывает и отклик уходит, но `page.expect_navigation(wait_until="domcontentloaded")` не подтверждает переход. У залогиненного пользователя переход на `/applicant/vacancy_response`, судя по всему, рендерится как **same-document/SPA-навигация** (`history.pushState`) — `domcontentloaded` в этом случае не наступает вообще, хотя `page.url` меняется.

## Фикс

- **`apply/steps.py`**: `navigate_to_response_form` использует `page.wait_for_url("**/applicant/vacancy_response**", timeout=GOTO_TIMEOUT_MS)` вместо `page.expect_navigation(...)` — следит только за URL, работает и для полной перезагрузки, и для client-side routing. Таймаут этого ожидания теперь перехватывается и логируется (симметрично `#176` `SubmitClickUncertain`), не пробрасывается наружу — дальнейшие шаги (`APPLY_SUBMIT_BUTTON`/`detect_questions`) сами решают, загрузилась ли форма.
- **`cli.py`** (побочная находка из issue): `main()` теперь логирует необработанные исключения из `args.func` через `logger.exception(...)` перед перевыбросом. Раньше traceback уходил только в stderr Python'а, минуя `data/logs/hhru_bot.log`, хотя `setup_logging()` к этому моменту уже настроил `FileHandler`. Поведение для пользователя не меняется (тот же traceback в консоли + ненулевой exit) — просто теперь то же самое попадает и в файл.
- **CLAUDE.md** п.4 обновлён под актуальный механизм навигации.

## Тесты (TDD)

- `tests/test_apply_steps.py`: два новых теста — `test_navigate_uses_wait_for_url_not_expect_navigation` (регрессия на переход API) и `test_navigate_wait_for_url_timeout_does_not_raise` (регрессия на сам баг — таймаут навигации не должен крашить pipeline).
- `tests/test_cli_commands.py`: `test_unhandled_exception_from_command_is_logged_to_file` — необработанное исключение из команды попадает в `data/logs/hhru_bot.log`.
- Обновлены существующие `FakeStepsPage`/`FakePage`/`FakeProbePage` (`test_apply_steps.py`, `test_apply_pipeline.py`, `test_apply_probe.py`) под новый API (`wait_for_url` вместо `expect_navigation`).

```
PYTHONPATH=src python3 -m pytest tests/ -q   # 507 passed
ruff check .                                  # All checks passed!
ruff format --check .                         # 153 files already formatted
```

## Риски / известные ограничения

- Селектор `VACANCY_APPLY_BUTTON` подтверждён живым диагностическим прогоном (не только curl-дампом) — рабочий.
- Гипотеза про SPA-навигацию подтверждена косвенно (кнопка сменилась на "уже откликнулись" после краша) — прямого наблюдения "клик → URL меняется без domcontentloaded" в реальном браузере не делал (это потребовало бы ещё одного боевого клика по непроверенному коду; решил не рисковать вторым непреднамеренным откликом). `wait_for_url` — корректный fix независимо от точной причины: он ждёт именно то, что нужно (смену URL), а не promise конкретного lifecycle-события.
- `has_applied()`/history для вакансии 136221532 не содержит записи `success` — сам отклик, отправленный сломанным кодом до этого фикса, не задедуплицирован локально (сервер его засчитал, а local history — нет). Не в скоупе этого PR (issue #69 — операционный прогон, не код).

Closes #179