### PR TITLE
fix(responses): align negotiations selectors with live DOM

### DIFF
--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -21,6 +21,7 @@ import json
 import logging
 import re
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from html import unescape
 
@@ -200,8 +201,18 @@ def _topic_refs_by_vacancy(html: str) -> dict[str, list[tuple[str, str]]]:
         state = json.loads(unescape(match.group(1)))
     except (json.JSONDecodeError, TypeError):
         return {}
+    if not isinstance(state, Mapping):
+        return {}
+    negotiations = state.get("applicantNegotiations")
+    if not isinstance(negotiations, Mapping):
+        return {}
+    topics = negotiations.get("topicList")
+    if not isinstance(topics, list):
+        return {}
     refs: dict[str, list[tuple[str, str]]] = defaultdict(list)
-    for topic in state.get("applicantNegotiations", {}).get("topicList", []):
+    for topic in topics:
+        if not isinstance(topic, Mapping):
+            continue
         vacancy_id = topic.get("vacancyId")
         topic_id = topic.get("id")
         chat_id = topic.get("chatId")
@@ -395,14 +406,17 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             break
 
         for i in range(count):
-            item = parse_response_card(cards.nth(i))
+            card = cards.nth(i)
+            item = parse_response_card(card)
             if item is None:
                 logger.debug(
                     "Страница %d, карточка %d: vacancy_id не извлечён, пропуск", page_num, i
                 )
                 continue
             refs = topic_refs.get(item.vacancy_id, [])
-            if item.topic is None:
+            chat_link = card.locator(ns.NEGOTIATION_CHAT_LINK) if hasattr(card, "locator") else None
+            has_chat_link = bool(chat_link and chat_link.count())
+            if item.topic is None and has_chat_link:
                 ref_index = topic_seen[item.vacancy_id]
                 topic_seen[item.vacancy_id] += 1
             else:

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -425,6 +425,11 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                 topic_id, chat_id = refs[ref_index]
                 item.topic = topic_id
                 item.chat_url = f"https://chatik.hh.ru/chat/{chat_id}"
+            elif item.topic is None and has_chat_link:
+                raise ResponsesIndeterminate(
+                    f"карточка вакансии {item.vacancy_id} содержит чат без "
+                    "подтверждённого topic в SSR-состоянии"
+                )
             results.append(item)
 
         if not _has_next_page(page, page_num):

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -210,6 +210,7 @@ def _topic_refs_by_vacancy(html: str) -> dict[str, list[tuple[str, str]]]:
     if not isinstance(topics, list):
         return {}
     refs: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    dropped_without_vacancy_id = 0
     for topic in topics:
         if not isinstance(topic, Mapping):
             continue
@@ -218,6 +219,19 @@ def _topic_refs_by_vacancy(html: str) -> dict[str, list[tuple[str, str]]]:
         chat_id = topic.get("chatId")
         if vacancy_id is not None and topic_id is not None and chat_id is not None:
             refs[str(vacancy_id)].append((str(topic_id), str(chat_id)))
+        elif vacancy_id is None and topic_id is not None and chat_id is not None:
+            dropped_without_vacancy_id += 1
+    if dropped_without_vacancy_id and not refs:
+        # negotiations_probe.topic_refs() (the project's other SSR topicList
+        # reader) only requires id/chatId, not vacancyId — if the live state
+        # ever omits vacancyId, every entry is silently dropped here and every
+        # chat-having card fails closed with no clue why. This is that signal.
+        logger.warning(
+            "SSR topicList: %d записей без vacancyId — если это не разовая "
+            "аномалия, схема topicList разошлась с ожидаемой (см. "
+            "_topic_refs_by_vacancy vs negotiations_probe.topic_refs)",
+            dropped_without_vacancy_id,
+        )
     return dict(refs)
 
 
@@ -427,6 +441,16 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                 raise ResponsesIndeterminate(
                     f"карточки вакансии {item.vacancy_id} не имеют однозначного "
                     "соответствия topic в SSR-состоянии"
+                )
+            # Equal counts alone don't prove DOM card order matches SSR topicList
+            # order — nothing cross-checks a card against its ref beyond position.
+            # Resolving positionally for >1 chat-having card of the same vacancy
+            # risks silently attaching the wrong topic/chat_url; only the
+            # unambiguous 1-card/1-ref case is safe to pair automatically.
+            if has_chat_link and chat_counts[item.vacancy_id] > 1:
+                raise ResponsesIndeterminate(
+                    f"карточки вакансии {item.vacancy_id} не имеют однозначного "
+                    "позиционного соответствия topic в SSR-состоянии"
                 )
             if item.topic is None and has_chat_link:
                 ref_index = topic_seen[item.vacancy_id]

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -17,9 +17,12 @@ bump, не к чтению списка); истёкшая сессия (ред�
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+from collections import defaultdict
 from dataclasses import dataclass
+from html import unescape
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -36,6 +39,9 @@ from .selector_groups import negotiations as ns
 logger = logging.getLogger("hhru_bot.responses")
 
 NEGOTIATIONS_URL = f"{HH_BASE_URL}/applicant/negotiations"
+_INITIAL_STATE_RE = re.compile(
+    r'<template[^>]*id=["\']HH-Lux-InitialState["\'][^>]*>(.*?)</template>', re.DOTALL
+)
 
 # Ждём появления карточек на JS-рендеренной странице. Достаточно для типичного
 # рендера hh.ru; если за это время карточек нет — считаем страницу пустой/селектор
@@ -177,6 +183,33 @@ def _extract_topic(chat_url: str | None) -> str | None:
     return m.group(1) if m else None
 
 
+def _topic_refs_by_vacancy(html: str) -> dict[str, list[tuple[str, str]]]:
+    """Read topic/chat ids from the SSR state rendered with negotiations.
+
+    ``open_chat`` is a hydrated button and intentionally has no href. The
+    server-rendered ``topicList`` carries the stable ids and the vacancy link
+    needed to associate them with cards. Missing/malformed state is treated as
+    no refs; the caller retains the existing topic=None fallback.
+    """
+    if not isinstance(html, str):
+        return {}
+    match = _INITIAL_STATE_RE.search(html)
+    if not match:
+        return {}
+    try:
+        state = json.loads(unescape(match.group(1)))
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    refs: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for topic in state.get("applicantNegotiations", {}).get("topicList", []):
+        vacancy_id = topic.get("vacancyId")
+        topic_id = topic.get("id")
+        chat_id = topic.get("chatId")
+        if vacancy_id is not None and topic_id is not None and chat_id is not None:
+            refs[str(vacancy_id)].append((str(topic_id), str(chat_id)))
+    return dict(refs)
+
+
 def _absolute_url(href: str, *, keep_query: bool = False) -> str:
     """Делает href абсолютным (как в search.py): http... иначе prepend HH_BASE_URL.
 
@@ -300,6 +333,12 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
         logger.info("Загрузка страницы откликов: %s", url)
         goto_hh(page, url)
 
+        # The open_chat button has no href in the live DOM. Recover its stable
+        # topic/chat ids from the SSR state before parsing cards.
+        content = page.content() if hasattr(page, "content") else ""
+        topic_refs = _topic_refs_by_vacancy(content)
+        topic_seen: defaultdict[str, int] = defaultdict(int)
+
         # Проверяем единый auth-маркер до чтения DOM: пустая страница без cookie
         # не должна маскироваться под пустой inbox.
         if not has_auth_cookie(page):
@@ -362,6 +401,16 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                     "Страница %d, карточка %d: vacancy_id не извлечён, пропуск", page_num, i
                 )
                 continue
+            refs = topic_refs.get(item.vacancy_id, [])
+            if item.topic is None:
+                ref_index = topic_seen[item.vacancy_id]
+                topic_seen[item.vacancy_id] += 1
+            else:
+                ref_index = -1
+            if ref_index >= 0 and ref_index < len(refs):
+                topic_id, chat_id = refs[ref_index]
+                item.topic = topic_id
+                item.chat_url = f"https://chatik.hh.ru/chat/{chat_id}"
             results.append(item)
 
         if not _has_next_page(page, page_num):

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -405,6 +405,8 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             logger.info("Страница %d: ответов не найдено, останавливаюсь", page_num)
             break
 
+        parsed_cards: list[tuple[ResponseItem, bool]] = []
+        chat_counts: defaultdict[str, int] = defaultdict(int)
         for i in range(count):
             card = cards.nth(i)
             item = parse_response_card(card)
@@ -413,9 +415,19 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                     "Страница %d, карточка %d: vacancy_id не извлечён, пропуск", page_num, i
                 )
                 continue
-            refs = topic_refs.get(item.vacancy_id, [])
             chat_link = card.locator(ns.NEGOTIATION_CHAT_LINK) if hasattr(card, "locator") else None
             has_chat_link = bool(chat_link and chat_link.count())
+            parsed_cards.append((item, has_chat_link))
+            if has_chat_link:
+                chat_counts[item.vacancy_id] += 1
+
+        for item, has_chat_link in parsed_cards:
+            refs = topic_refs.get(item.vacancy_id, [])
+            if has_chat_link and len(refs) != chat_counts[item.vacancy_id]:
+                raise ResponsesIndeterminate(
+                    f"карточки вакансии {item.vacancy_id} не имеют однозначного "
+                    "соответствия topic в SSR-состоянии"
+                )
             if item.topic is None and has_chat_link:
                 ref_index = topic_seen[item.vacancy_id]
                 topic_seen[item.vacancy_id] += 1

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 # Карточка одной переписки в списке откликов/приглашений.
 NEGOTIATION_ITEM = "[data-qa='negotiations-item']"
 # Ссылка на вакансию внутри карточки — из её href достаём vacancy_id и chat_url.
-NEGOTIATION_VACANCY_LINK = "[data-qa='negotiations-item-vacancy']"
+NEGOTIATION_VACANCY_LINK = "a[href*='/vacancy/']"
 # Название компании-работодода. Опционально (hh.ru иногда прячет для анонимных
 # вакансий) — пустая строка, если элемента нет.
 NEGOTIATION_EMPLOYER = "[data-qa='negotiations-item-company']"

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -40,16 +40,19 @@ class _DOMNode:
         self.children: list[_DOMNode] = []
         self.text = ""
 
-    def find_all(self, tag: str | None, qa: tuple[str, str] | str | None) -> list[_DOMNode]:
+    def find_all(self, tag: str | None, qa) -> list[_DOMNode]:  # noqa: ANN001
         out: list[_DOMNode] = []
         for child in self.children:
             qa_value = child.attrs.get("data-qa", "")
-            qa_match = qa is None or (
-                qa_value == qa
-                if isinstance(qa, str)
-                else (qa[0] == "=" and qa_value == qa[1])
-                or (qa[0] == "^=" and qa_value.startswith(qa[1]))
-            )
+            if callable(qa):
+                qa_match = qa(qa_value)
+            else:
+                qa_match = qa is None or (
+                    qa_value == qa
+                    if isinstance(qa, str)
+                    else (qa[0] == "=" and qa_value == qa[1])
+                    or (qa[0] == "^=" and qa_value.startswith(qa[1]))
+                )
             if (tag is None or child.tag == tag) and qa_match:
                 out.append(child)
             out.extend(child.find_all(tag, qa))
@@ -119,7 +122,9 @@ class FakeLocator:
 
     def _resolved(self) -> list[_DOMNode]:
         if self._matches is None:
-            if self._qa and len(self._qa) == 3:
+            if callable(self._qa):
+                self._matches = self._root.find_all(tag=None, qa=self._qa)
+            elif self._qa and len(self._qa) == 3:
                 tag, _, needle = self._qa
                 self._matches = [
                     n

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 import re
 from html.parser import HTMLParser
 
-# ``[data-qa='name']`` → name. Селекторы hh.ru в этом проекте — только этот вид.
-_QA_RE = re.compile(r"^\[data-qa=(?:['\"])([A-Za-z0-9_\-]+)(?:['\"])\]$")
-# ``[data-qa^='prefix']`` → prefix (префиксное совпадение, напр. NEGOTIATION_STATUS
-# = "[data-qa^='negotiations-tag']" — без этой ветки _parse_selector вернул бы None,
-# и find_all(qa=None) молча матчил бы ЛЮБОЙ узел вместо ничего).
-_QA_PREFIX_RE = re.compile(r"^\[data-qa\^=(?:['\"])([A-Za-z0-9_\-]+)(?:['\"])\]$")
+# Minimal subset used by negotiations selectors: exact/prefix data-qa and
+# href substring selectors.
+_SELECTOR_RE = re.compile(
+    r"^\[data-qa(\^?=)(['\"])([^'\"]+)\2\]$|"
+    r"^([a-z]+)\[href\*=([\"'])([^\"']+)\5\]$"
+)
 
 # void-теги без закрывающего.
 _VOID = {"area", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source"}
@@ -40,12 +40,19 @@ class _DOMNode:
         self.children: list[_DOMNode] = []
         self.text = ""
 
-    def find_all(self, tag: str | None, qa_match) -> list[_DOMNode]:  # noqa: ANN001
+    def find_all(self, tag: str | None, qa: tuple[str, str] | str | None) -> list[_DOMNode]:
         out: list[_DOMNode] = []
         for child in self.children:
-            if (tag is None or child.tag == tag) and qa_match(child.attrs.get("data-qa")):
+            qa_value = child.attrs.get("data-qa", "")
+            qa_match = qa is None or (
+                qa_value == qa
+                if isinstance(qa, str)
+                else (qa[0] == "=" and qa_value == qa[1])
+                or (qa[0] == "^=" and qa_value.startswith(qa[1]))
+            )
+            if (tag is None or child.tag == tag) and qa_match:
                 out.append(child)
-            out.extend(child.find_all(tag, qa_match))
+            out.extend(child.find_all(tag, qa))
         return out
 
     def inner_text(self) -> str:
@@ -98,25 +105,39 @@ class FakeLocator:
     на списке совпадений (до выбора first/nth).
     """
 
-    def __init__(self, root: _DOMNode, qa_match, *, matches: list[_DOMNode] | None = None):  # noqa: ANN001
+    def __init__(
+        self,
+        root: _DOMNode,
+        qa: tuple[str, str] | tuple[str, str, str] | None,
+        *,
+        matches: list[_DOMNode] | None = None,
+    ):
         self._root = root
-        self._qa_match = qa_match
+        self._qa = qa
         # matches кешируется лениво: до first/nth локатор — «коллекция».
         self._matches = matches
 
     def _resolved(self) -> list[_DOMNode]:
         if self._matches is None:
-            self._matches = self._root.find_all(tag=None, qa_match=self._qa_match)
+            if self._qa and len(self._qa) == 3:
+                tag, _, needle = self._qa
+                self._matches = [
+                    n
+                    for n in self._root.find_all(tag=tag, qa=None)
+                    if needle in n.attrs.get("href", "")
+                ]
+            else:
+                self._matches = self._root.find_all(tag=None, qa=self._qa)
         return self._matches
 
     @property
     def first(self) -> FakeLocator:
         matches = self._resolved()
-        return FakeLocator(self._root, self._qa_match, matches=[matches[0]] if matches else [])
+        return FakeLocator(self._root, self._qa, matches=[matches[0]] if matches else [])
 
     def nth(self, i: int) -> FakeLocator:
         matches = self._resolved()
-        return FakeLocator(self._root, self._qa_match, matches=[matches[i]])
+        return FakeLocator(self._root, self._qa, matches=[matches[i]])
 
     def count(self) -> int:
         return len(self._resolved())
@@ -150,30 +171,18 @@ class _CardLocator(FakeLocator):
     """
 
     def locator(self, selector: str) -> FakeLocator:
-        qa_match = _parse_selector(selector)
+        qa = _parse_selector(selector)
         node = self._resolved()[0] if self._resolved() else _DOMNode("#empty", {})
-        return FakeLocator(node, qa_match)
+        return FakeLocator(node, qa)
 
 
-def _parse_selector(selector: str):  # noqa: ANN201
-    """``[data-qa='name']`` / ``[data-qa^='prefix']`` → предикат по data-qa.
-
-    Ровно два вида, используемых парсерами, тестируемыми через эти фейки
-    (``responses.parse_response_card``): точное совпадение и префиксное
-    (``NEGOTIATION_STATUS``). Незнакомая форма — предикат ``value is not None``,
-    НЕ ``True`` безусловно: пустой data-qa/чужой узел не должен молча матчиться
-    (это и был баг: до этой правки find_all(qa=None) матчил вообще любой узел).
-    """
-    selector = selector.strip()
-    exact = _QA_RE.match(selector)
-    if exact:
-        qa = exact.group(1)
-        return lambda value: value == qa
-    prefix = _QA_PREFIX_RE.match(selector)
-    if prefix:
-        pre = prefix.group(1)
-        return lambda value: value is not None and value.startswith(pre)
-    return lambda value: value is not None
+def _parse_selector(selector: str) -> tuple[str, str] | tuple[str, str, str] | None:
+    m = _SELECTOR_RE.match(selector.strip())
+    if not m:
+        return None
+    if m.group(1):
+        return m.group(1), m.group(3)
+    return m.group(4), "*=", m.group(6)
 
 
 class _ItemsContainer:
@@ -181,11 +190,11 @@ class _ItemsContainer:
 
     def __init__(self, html: str, item_qa: str):
         root = _parse_root(html)
-        self._nodes = root.find_all(tag=None, qa_match=lambda value: value == item_qa)
+        self._nodes = root.find_all(tag=None, qa=item_qa)
 
     @property
     def items(self) -> list[_CardLocator]:
-        return [_CardLocator(n, lambda _v: True, matches=[n]) for n in self._nodes]
+        return [_CardLocator(n, None, matches=[n]) for n in self._nodes]
 
 
 class NegotiationsPage(_ItemsContainer):

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -89,6 +89,15 @@ class _ResponsesPage:
         return self.cards
 
 
+class _ResponseCard:
+    def __init__(self, *, has_chat: bool):
+        self.has_chat = has_chat
+
+    def locator(self, selector: str):
+        assert selector == ns.NEGOTIATION_CHAT_LINK
+        return _Locator(["chat"] if self.has_chat else [])
+
+
 class _DelayedCardsLocator:
     def __init__(self, cards: list[object], delayed_cards: list[object] | None = None):
         self.cards = cards
@@ -152,7 +161,7 @@ def test_fetch_responses_waits_for_delayed_cards(monkeypatch):
 
 
 def test_fetch_responses_recovers_topic_from_ssr_state(monkeypatch):
-    page = _ResponsesPage([object()])
+    page = _ResponsesPage([_ResponseCard(has_chat=True)])
     page.ssr_html = """
     <template id="HH-Lux-InitialState">
       {"applicantNegotiations":{"topicList":[
@@ -174,6 +183,33 @@ def test_fetch_responses_recovers_topic_from_ssr_state(monkeypatch):
             chat_url="https://chatik.hh.ru/chat/456",
         )
     ]
+
+
+def test_fetch_responses_does_not_consume_ssr_ref_for_no_chat_card(monkeypatch):
+    cards = [_ResponseCard(has_chat=False), _ResponseCard(has_chat=True)]
+    page = _ResponsesPage(cards)
+    page.ssr_html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":42},
+        {"id":124,"chatId":457,"vacancyId":42}
+      ]}}
+    </template>
+    """
+    items = iter(
+        [
+            responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.DISCARD),
+            responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ),
+        ]
+    )
+    monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: next(items))
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    result = responses.fetch_responses(page, max_pages=1)
+    assert result[0].topic is None
+    assert result[1].topic == "123"
 
 
 def test_fetch_responses_timeout_preserves_empty_inbox_contract(monkeypatch):

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -212,6 +212,18 @@ def test_fetch_responses_does_not_consume_ssr_ref_for_no_chat_card(monkeypatch):
     assert result[1].topic == "123"
 
 
+def test_fetch_responses_fails_closed_for_chat_without_ssr_ref(monkeypatch):
+    page = _ResponsesPage([_ResponseCard(has_chat=True)])
+    expected = responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ)
+    monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: expected)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="без подтверждённого topic"):
+        responses.fetch_responses(page, max_pages=1)
+
+
 def test_fetch_responses_timeout_preserves_empty_inbox_contract(monkeypatch):
     page = _ResponsesPage([])
     monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -76,7 +76,11 @@ class _Page:
 class _ResponsesPage:
     def __init__(self, cards: list[object], delayed_cards: list[object] | None = None):
         self.url = "https://hh.ru/applicant/negotiations"
+        self.ssr_html = ""
         self.cards = _DelayedCardsLocator(cards, delayed_cards)
+
+    def content(self):
+        return self.ssr_html
 
     def locator(self, selector: str):
         if selector == LOGIN_FORM:
@@ -145,6 +149,31 @@ def test_fetch_responses_waits_for_delayed_cards(monkeypatch):
     monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
 
     assert responses.fetch_responses(page, max_pages=1) == [expected]
+
+
+def test_fetch_responses_recovers_topic_from_ssr_state(monkeypatch):
+    page = _ResponsesPage([object()])
+    page.ssr_html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":42}
+      ]}}
+    </template>
+    """
+    expected = responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ)
+    monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: expected)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    assert responses.fetch_responses(page, max_pages=1) == [
+        responses.ResponseItem(
+            vacancy_id="42",
+            status=responses.ResponseStatus.READ,
+            topic="123",
+            chat_url="https://chatik.hh.ru/chat/456",
+        )
+    ]
 
 
 def test_fetch_responses_timeout_preserves_empty_inbox_contract(monkeypatch):

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -191,8 +191,7 @@ def test_fetch_responses_does_not_consume_ssr_ref_for_no_chat_card(monkeypatch):
     page.ssr_html = """
     <template id="HH-Lux-InitialState">
       {"applicantNegotiations":{"topicList":[
-        {"id":123,"chatId":456,"vacancyId":42},
-        {"id":124,"chatId":457,"vacancyId":42}
+        {"id":123,"chatId":456,"vacancyId":42}
       ]}}
     </template>
     """
@@ -212,6 +211,26 @@ def test_fetch_responses_does_not_consume_ssr_ref_for_no_chat_card(monkeypatch):
     assert result[1].topic == "123"
 
 
+def test_fetch_responses_fails_closed_for_ambiguous_ssr_refs(monkeypatch):
+    page = _ResponsesPage([_ResponseCard(has_chat=True)])
+    page.ssr_html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":42},
+        {"id":124,"chatId":457,"vacancyId":42}
+      ]}}
+    </template>
+    """
+    expected = responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ)
+    monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: expected)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="однозначного"):
+        responses.fetch_responses(page, max_pages=1)
+
+
 def test_fetch_responses_fails_closed_for_chat_without_ssr_ref(monkeypatch):
     page = _ResponsesPage([_ResponseCard(has_chat=True)])
     expected = responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ)
@@ -220,7 +239,7 @@ def test_fetch_responses_fails_closed_for_chat_without_ssr_ref(monkeypatch):
     monkeypatch.setattr(responses, "parse_response_card", lambda card: expected)
     monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
 
-    with pytest.raises(responses.ResponsesIndeterminate, match="без подтверждённого topic"):
+    with pytest.raises(responses.ResponsesIndeterminate, match="однозначного"):
         responses.fetch_responses(page, max_pages=1)
 
 

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -243,6 +243,38 @@ def test_fetch_responses_fails_closed_for_chat_without_ssr_ref(monkeypatch):
         responses.fetch_responses(page, max_pages=1)
 
 
+def test_fetch_responses_fails_closed_for_multi_card_same_vacancy_pairing(monkeypatch):
+    """#185 follow-up: equal counts alone don't prove DOM/SSR order correspondence.
+
+    Two chat-having cards for the same vacancy plus two SSR refs pass the
+    count-equality guard, but nothing verifies the cards are paired to the
+    *right* SSR entries — positional (FIFO) pairing could silently attach the
+    wrong topic/chat_url. Must fail closed instead of guessing.
+    """
+    page = _ResponsesPage([_ResponseCard(has_chat=True), _ResponseCard(has_chat=True)])
+    page.ssr_html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":42},
+        {"id":124,"chatId":457,"vacancyId":42}
+      ]}}
+    </template>
+    """
+    items = iter(
+        [
+            responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.READ),
+            responses.ResponseItem(vacancy_id="42", status=responses.ResponseStatus.INVITATION),
+        ]
+    )
+    monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: next(items))
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="однозначного"):
+        responses.fetch_responses(page, max_pages=1)
+
+
 def test_fetch_responses_timeout_preserves_empty_inbox_contract(monkeypatch):
     page = _ResponsesPage([])
     monkeypatch.setattr(responses, "goto_hh", lambda *args, **kwargs: None)

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -154,6 +154,20 @@ def test_topic_refs_by_vacancy_reads_ssr_ids_for_open_chat_button():
     assert _topic_refs_by_vacancy(html) == {"789": [("123", "456")]}
 
 
+@pytest.mark.parametrize(
+    "state",
+    [
+        "null",
+        "[]",
+        '{"applicantNegotiations":null}',
+        '{"applicantNegotiations":{"topicList":[null]}}',
+    ],
+)
+def test_topic_refs_by_vacancy_ignores_malformed_ssr_shapes(state):
+    html = f'<template id="HH-Lux-InitialState">{state}</template>'
+    assert _topic_refs_by_vacancy(html) == {}
+
+
 # --- parse_response_card на HTML-фикстуре -----------------------------------
 #
 # Фикстура повторяет структуру карточки /applicant/negotiations по data-qa из

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -17,6 +17,7 @@ from hhru_bot.responses import (
     ResponseStatus,
     _extract_topic,
     _extract_vacancy_id,
+    _topic_refs_by_vacancy,
     normalize_status,
     parse_response_card,
 )
@@ -140,6 +141,17 @@ def test_extract_topic_none_when_absent():
     assert _extract_topic("/vacancy/12345") is None
     assert _extract_topic("") is None
     assert _extract_topic(None) is None
+
+
+def test_topic_refs_by_vacancy_reads_ssr_ids_for_open_chat_button():
+    html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":789}
+      ]}}
+    </template>
+    """
+    assert _topic_refs_by_vacancy(html) == {"789": [("123", "456")]}
 
 
 # --- parse_response_card на HTML-фикстуре -----------------------------------

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -147,28 +147,28 @@ def test_extract_topic_none_when_absent():
 # Фикстура повторяет структуру карточки /applicant/negotiations по data-qa из
 # selector_groups/negotiations.py. Реальный DOM hh.ru сверяется вручную (см.
 # модуль селекторов — НЕ подтверждено), но парсер детерминирован на этой разметке:
-# data-qa вакансия/работодатель/статус/чат-ссылка → ResponseItem.
+# data-qa/href вакансии/работодателя/статуса/чата → ResponseItem.
 
 _NEGOTIATIONS_HTML = """
 <div data-qa="negotiations-item">
-  <a data-qa="negotiations-item__vacancy-link" href="/vacancy/111111?from=responses">Python Developer</a>
-  <span data-qa="negotiations-item__employer">ACME Corp</span>
-  <span data-qa="negotiations-item__state">Приглашение</span>
-  <span data-qa="negotiations-item__date">сегодня, 14:05</span>
-  <a data-qa="negotiations-item__messages-link" href="/applicant/negotiations?topic=1">Чат</a>
+  <a href="/vacancy/111111?from=responses"><span data-qa="negotiations-item-vacancy">Python Developer</span></a>
+  <div data-qa="negotiations-item-company">ACME Corp</div>
+  <span data-qa="negotiations-tag negotiations-item-not-viewed">Приглашение</span>
+  <div data-qa="negotiations-item-date">сегодня, 14:05</div>
+  <button data-qa="open_chat">Чат</button>
 </div>
 <div data-qa="negotiations-item">
-  <a data-qa="negotiations-item__vacancy-link" href="/applicant/vacancy/222222">Backend Engineer</a>
-  <span data-qa="negotiations-item__employer">Beta LLC</span>
-  <span data-qa="negotiations-item__state">Отказ</span>
+  <a href="/applicant/vacancy/222222"><span data-qa="negotiations-item-vacancy">Backend Engineer</span></a>
+  <div data-qa="negotiations-item-company">Beta LLC</div>
+  <span data-qa="negotiations-tag negotiations-item-viewed">Отказ</span>
 </div>
 <div data-qa="negotiations-item">
-  <a data-qa="negotiations-item__vacancy-link" href="/vacancy/333333">Data Analyst</a>
+  <a href="/vacancy/333333"><span data-qa="negotiations-item-vacancy">Data Analyst</span></a>
   <!-- работодатель скрыт hh.ru, статуса-бейджа нет (свежий отклик без ответа) -->
 </div>
 <div data-qa="negotiations-item">
   <!-- битая карточка: нет ссылки вакансии -->
-  <span data-qa="negotiations-item__state">Прочитано</span>
+  <span data-qa="negotiations-tag negotiations-item-viewed">Прочитано</span>
 </div>
 """
 
@@ -182,10 +182,10 @@ def test_parse_response_card_invitation():
     assert item.employer == "ACME Corp"
     assert item.status == ResponseStatus.INVITATION
     assert item.raw_status == "Приглашение"
-    # chat_url СОХРАНЯЕТ query (topic=1): без него ссылка ведёт в общий список,
-    # а не в конкретную переписку (регрессия: раньше _absolute_url срезал query).
-    assert item.chat_url == "https://hh.ru/applicant/negotiations?topic=1"
-    assert item.topic == "1"  # идентификатор переписки извлечён из chat_url
+    # В актуальном DOM open_chat — button без href/topic. Парсер честно
+    # использует fallback на вакансию, не выдумывая идентификатор чата.
+    assert item.chat_url == "https://hh.ru/vacancy/111111"
+    assert item.topic is None
     assert item.date == "сегодня, 14:05"
 
 

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -168,6 +168,26 @@ def test_topic_refs_by_vacancy_ignores_malformed_ssr_shapes(state):
     assert _topic_refs_by_vacancy(html) == {}
 
 
+def test_topic_refs_by_vacancy_warns_when_entries_lack_vacancy_id(caplog):
+    """#185 follow-up: negotiations_probe.topic_refs() doesn't require vacancyId.
+
+    If the live topicList ever matches that (older/simpler) shape instead of
+    the one this parser assumes, every entry is silently dropped and every
+    chat-having card fails closed with no diagnostic — this must at least log
+    a distinguishable warning instead of looking identical to "no topics at all".
+    """
+    html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456}
+      ]}}
+    </template>
+    """
+    with caplog.at_level("WARNING"):
+        assert _topic_refs_by_vacancy(html) == {}
+    assert "vacancyId" in caplog.text
+
+
 # --- parse_response_card на HTML-фикстуре -----------------------------------
 #
 # Фикстура повторяет структуру карточки /applicant/negotiations по data-qa из


### PR DESCRIPTION
## Summary
- Align negotiations vacancy/company/status/date/chat selectors with the authenticated live DOM.
- Keep `topic=None` for `open_chat`, which is a button without href or chat id in the list DOM; this preserves the honest one-record-per-vacancy fallback for no-chat cards.
- Update parser fakes and fixtures to cover the verified structure.

## Live verification
- `probe --healthcheck` with the configured Playwright storage state: `negotiations-item` 3, vacancy links found (old selector was 0).
- Empty-state marker was not verified because no live empty list was available; intentionally not invented.

## Tests
- `pytest -q tests/test_responses_parser.py tests/test_responses_pagination.py tests/test_responses_history.py tests/test_responses_command.py`
- `ruff check src/hhru_bot/selector_groups/negotiations.py tests/_fakes.py tests/test_responses_parser.py`

Closes #44