### PR TITLE
feat(probe): add read-only negotiations dump

### DIFF
--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -513,6 +513,11 @@ def run_negotiations(args: argparse.Namespace) -> bool:
     with launch_context(config.storage_state_file, headless=args.headless) as context:
         page = context.new_page()
         goto_hh(page, list_url)
+        items = page.locator(negotiations.NEGOTIATION_ITEM)
+        try:
+            items.first.wait_for(state="attached", timeout=10_000)
+        except PlaywrightError:
+            logger.warning("negotiations: cards did not attach within 10 seconds")
         list_html = page.content()
         try:
             refs = topic_refs(list_html)
@@ -538,7 +543,6 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             )
         )
         print("RAW HTML fragment (first card):")
-        items = page.locator(negotiations.NEGOTIATION_ITEM)
         if items.count():
             print(items.first.evaluate("el => el.outerHTML")[:4000])
 

--- a/src/hhru_bot/commands/responses.py
+++ b/src/hhru_bot/commands/responses.py
@@ -182,7 +182,17 @@ def run(args: argparse.Namespace) -> None:
 
         print(f"Собрано карточек переписки: {len(cards)}")
 
+        skipped_ambiguous = 0
         for card in cards:
+            if card.topic_ambiguous:
+                # Несколько SSR-topic кандидатов на одну вакансию — fetch_responses
+                # намеренно оставил topic=None (см. ResponseItem.topic_ambiguous).
+                # history.upsert_response матчит существующую строку по
+                # (vacancy_id, topic IS NULL): персистить такую карточку наравне с
+                # легитимными без-чата ответами слило бы разные переписки одной
+                # вакансии в одну строку истории. Пропускаем запись, не гадаем.
+                skipped_ambiguous += 1
+                continue
             outcome = history.upsert_response(
                 vacancy_id=card.vacancy_id,
                 employer=card.employer or None,
@@ -202,6 +212,12 @@ def run(args: argparse.Namespace) -> None:
             f"Новых ответов: {inserted + updated} "
             f"(новых записей: {inserted}, смен статуса: {updated})"
         )
+        if skipped_ambiguous:
+            print(
+                f"[WARN] Пропущено записей с неоднозначным topic: {skipped_ambiguous} "
+                "(несколько переписок на одну вакансию, сопоставление с чатом не "
+                "подтверждено — см. лог warning)"
+            )
     else:
         print("Режим --since-hours 0: обход hh.ru пропущен, вывожу всю историю ответов.")
 

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from html import unescape
+
+logger = logging.getLogger("hhru_bot.negotiations_probe")
 
 _STATE_RE = re.compile(
     r'<template[^>]*id=["\']HH-Lux-InitialState["\'][^>]*>(.*?)</template>', re.DOTALL
@@ -28,15 +31,21 @@ def parse_initial_state(html: str) -> dict:
 
 
 def topic_refs(html: str) -> list[TopicRef]:
-    """Return the topic/chat mapping rendered in the negotiations SSR state."""
+    """Return the topic/chat mapping rendered in the negotiations SSR state.
+
+    A topic entry missing ``id``/``chatId``/``vacancyId`` is dropped (fetch_responses
+    can't attach it to a card without a vacancy_id to key on); dropped entries are
+    logged so a silently shrinking mapping is diagnosable, matching the warning-log
+    contract of the SSR-recovery except-path in responses.py.
+    """
     topics = parse_initial_state(html).get("applicantNegotiations", {}).get("topicList", [])
-    return [
-        TopicRef(str(topic["id"]), str(topic["chatId"]), str(topic["vacancyId"]))
-        for topic in topics
-        if topic.get("id") is not None
-        and topic.get("chatId") is not None
-        and topic.get("vacancyId") is not None
-    ]
+    refs: list[TopicRef] = []
+    for topic in topics:
+        if topic.get("id") is None or topic.get("chatId") is None or topic.get("vacancyId") is None:
+            logger.debug("SSR topic entry missing id/chatId/vacancyId, dropped: %r", topic)
+            continue
+        refs.append(TopicRef(str(topic["id"]), str(topic["chatId"]), str(topic["vacancyId"])))
+    return refs
 
 
 def chat_url(chat_id: str, chatik_origin: str = "https://chatik.hh.ru") -> str:

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -16,6 +16,7 @@ _STATE_RE = re.compile(
 class TopicRef:
     topic_id: str
     chat_id: str
+    vacancy_id: str | None = None
 
 
 def parse_initial_state(html: str) -> dict:
@@ -30,9 +31,11 @@ def topic_refs(html: str) -> list[TopicRef]:
     """Return the topic/chat mapping rendered in the negotiations SSR state."""
     topics = parse_initial_state(html).get("applicantNegotiations", {}).get("topicList", [])
     return [
-        TopicRef(str(topic["id"]), str(topic["chatId"]))
+        TopicRef(str(topic["id"]), str(topic["chatId"]), str(topic["vacancyId"]))
         for topic in topics
-        if topic.get("id") is not None and topic.get("chatId") is not None
+        if topic.get("id") is not None
+        and topic.get("chatId") is not None
+        and topic.get("vacancyId") is not None
     ]
 
 

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -400,22 +400,37 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             # DOM card order matches SSR topicList order (no live fixture with >1
             # topic per vacancy exists yet to confirm/refute it — same category as
             # the _form_scope() DOM-structure assumption in apply/questions.py).
-            # When exactly one candidate exists for a vacancy_id the pairing is
-            # unambiguous regardless of ordering, so it's safe to attach. When more
-            # than one candidate remains, guessing positionally risks attaching the
-            # wrong chat to the wrong negotiation — leave those unresolved instead.
+            # Decide per vacancy_id GROUP up front, from counts only — never mutate
+            # refs_by_vacancy (e.g. via candidates.pop()) while iterating cards.
+            # Regression (#186 round 4): consuming the shared candidate list one
+            # card at a time meant a second card for the same vacancy_id could see
+            # an already-drained list (len 0) after an earlier card popped its sole
+            # candidate — neither the "exactly one" nor the "more than one" branch
+            # matched, so the second card silently kept topic_ambiguous=False and
+            # was persisted as if it legitimately had no chat. Only attach when the
+            # vacancy_id has exactly one card AND exactly one SSR candidate — the
+            # only case that's unambiguous regardless of ordering. Any other
+            # mismatch (more cards than candidates, more candidates than cards, or
+            # multiple cards at all) marks every unresolved card for that
+            # vacancy_id as ambiguous instead of guessing positionally.
+            cards_by_vacancy: dict[str, list] = {}
             for result in results[page_start:]:
-                candidates = refs_by_vacancy.get(result.vacancy_id, [])
-                if result.topic is None and len(candidates) == 1:
-                    ref = candidates.pop(0)
-                    result.topic = ref.topic_id
-                    result.chat_url = chat_url(ref.chat_id)
-                elif result.topic is None and len(candidates) > 1:
-                    result.topic_ambiguous = True
+                if result.topic is None:
+                    cards_by_vacancy.setdefault(result.vacancy_id, []).append(result)
+            for vacancy_id, cards in cards_by_vacancy.items():
+                candidates = refs_by_vacancy.get(vacancy_id, [])
+                if len(cards) == 1 and len(candidates) == 1:
+                    ref = candidates[0]
+                    cards[0].topic = ref.topic_id
+                    cards[0].chat_url = chat_url(ref.chat_id)
+                elif candidates:
+                    for card in cards:
+                        card.topic_ambiguous = True
                     logger.warning(
-                        "Отклик vacancy_id=%s: %d кандидатов SSR-topic на одну "
-                        "вакансию — сопоставление неоднозначно, topic не присвоен",
-                        result.vacancy_id,
+                        "Отклик vacancy_id=%s: %d карточек и %d кандидатов SSR-topic "
+                        "— сопоставление неоднозначно, topic не присвоен",
+                        vacancy_id,
+                        len(cards),
                         len(candidates),
                     )
         except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -383,19 +383,28 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             refs_by_vacancy: dict[str, list] = {}
             for ref in refs:
                 refs_by_vacancy.setdefault(ref.vacancy_id or "", []).append(ref)
-            # NOT verified on a live multi-topic-per-vacancy dump: when one employer
-            # has several negotiations (several topics for the same vacancy_id), this
-            # assumes DOM card order matches SSR topicList order and pairs them
-            # positionally (FIFO pop). If hh.ru ever orders them differently, a topic
-            # can attach to the wrong card. No live fixture with >1 topic per vacancy
-            # exists yet to confirm/refute this — treat as an open assumption, same
-            # category as the _form_scope() DOM-structure assumption in apply/questions.py.
+            # Fail-closed on ambiguity: pairing an SSR topic to a DOM card relies on
+            # matching by vacancy_id alone, and there is no verified invariant that
+            # DOM card order matches SSR topicList order (no live fixture with >1
+            # topic per vacancy exists yet to confirm/refute it — same category as
+            # the _form_scope() DOM-structure assumption in apply/questions.py).
+            # When exactly one candidate exists for a vacancy_id the pairing is
+            # unambiguous regardless of ordering, so it's safe to attach. When more
+            # than one candidate remains, guessing positionally risks attaching the
+            # wrong chat to the wrong negotiation — leave those unresolved instead.
             for result in results[page_start:]:
                 candidates = refs_by_vacancy.get(result.vacancy_id, [])
-                if result.topic is None and candidates:
+                if result.topic is None and len(candidates) == 1:
                     ref = candidates.pop(0)
                     result.topic = ref.topic_id
                     result.chat_url = chat_url(ref.chat_id)
+                elif result.topic is None and len(candidates) > 1:
+                    logger.warning(
+                        "Отклик vacancy_id=%s: %d кандидатов SSR-topic на одну "
+                        "вакансию — сопоставление неоднозначно, topic не присвоен",
+                        result.vacancy_id,
+                        len(candidates),
+                    )
         except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
             logger.warning("SSR topic mapping unavailable; keeping parsed chat URLs")
 

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -356,6 +356,7 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             logger.info("Страница %d: ответов не найдено, останавливаюсь", page_num)
             break
 
+        page_start = len(results)
         for i in range(count):
             item = parse_response_card(cards.nth(i))
             if item is None:
@@ -367,7 +368,12 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
 
         # The live open_chat control is a button without href.  Recover the
         # stable topic from the same page's SSR state, preserving distinct
-        # negotiations for one vacancy.
+        # negotiations for one vacancy. Slice by page_start (count of items
+        # actually appended this page), NOT by the DOM card count `count` —
+        # parse_response_card can skip cards (missing vacancy_id), so `count`
+        # overcounts and a `-count:` slice would reach into the previous
+        # page's already-resolved results and risk assigning them this
+        # page's SSR topics.
         try:
             from .negotiations_probe import chat_url, topic_refs
 
@@ -377,13 +383,20 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
             refs_by_vacancy: dict[str, list] = {}
             for ref in refs:
                 refs_by_vacancy.setdefault(ref.vacancy_id or "", []).append(ref)
-            for result in results[-count:]:
+            # NOT verified on a live multi-topic-per-vacancy dump: when one employer
+            # has several negotiations (several topics for the same vacancy_id), this
+            # assumes DOM card order matches SSR topicList order and pairs them
+            # positionally (FIFO pop). If hh.ru ever orders them differently, a topic
+            # can attach to the wrong card. No live fixture with >1 topic per vacancy
+            # exists yet to confirm/refute this — treat as an open assumption, same
+            # category as the _form_scope() DOM-structure assumption in apply/questions.py.
+            for result in results[page_start:]:
                 candidates = refs_by_vacancy.get(result.vacancy_id, [])
                 if result.topic is None and candidates:
                     ref = candidates.pop(0)
                     result.topic = ref.topic_id
                     result.chat_url = chat_url(ref.chat_id)
-        except (TypeError, ValueError, KeyError, json.JSONDecodeError):
+        except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
             logger.warning("SSR topic mapping unavailable; keeping parsed chat URLs")
 
         if not _has_next_page(page, page_num):

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -131,7 +131,18 @@ class ResponseItem:
     вакансий, чата нет при отказе, дата рендерится не всегда). raw_status —
     оригинальный текст бейджа для вывода/диагностики. topic — идентификатор
     переписки (из chat_url ?topic=...), уникальный для конкретного чата; None,
-    если chat_url без topic (ответ без чата).
+    если chat_url без topic (ответ без чата ЛИБО неоднозначная SSR-привязка —
+    см. topic_ambiguous).
+
+    topic_ambiguous различает эти два случая topic=None: True — SSR-состояние
+    страницы содержало >1 topic-кандидата для этой вакансии, сопоставить с
+    конкретной карточкой однозначно не удалось (см. fail-closed guard в
+    fetch_responses); False (по умолчанию) — карточка легитимно без чата
+    (напр. discard) ИЛИ topic успешно сопоставлен. history.upsert_response
+    матчит существующую строку по ``(vacancy_id, topic IS NULL)``, поэтому
+    несколько ambiguous-карточек одной вакансии персистились бы как одна и та
+    же NULL-строка, сливая/перезаписывая разные переписки — commands/responses
+    обязан пропускать upsert для topic_ambiguous=True карточек.
     """
 
     vacancy_id: str
@@ -141,6 +152,7 @@ class ResponseItem:
     topic: str | None = None
     date: str = ""
     raw_status: str = ""
+    topic_ambiguous: bool = False
 
 
 def _extract_vacancy_id(href: str) -> str | None:
@@ -399,6 +411,7 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                     result.topic = ref.topic_id
                     result.chat_url = chat_url(ref.chat_id)
                 elif result.topic is None and len(candidates) > 1:
+                    result.topic_ambiguous = True
                     logger.warning(
                         "Отклик vacancy_id=%s: %d кандидатов SSR-topic на одну "
                         "вакансию — сопоставление неоднозначно, topic не присвоен",

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -17,6 +17,7 @@ bump, не к чтению списка); истёкшая сессия (ред�
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -363,6 +364,27 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
                 )
                 continue
             results.append(item)
+
+        # The live open_chat control is a button without href.  Recover the
+        # stable topic from the same page's SSR state, preserving distinct
+        # negotiations for one vacancy.
+        try:
+            from .negotiations_probe import chat_url, topic_refs
+
+            if not hasattr(page, "content"):
+                raise ValueError("page.content unavailable")
+            refs = topic_refs(page.content())
+            refs_by_vacancy: dict[str, list] = {}
+            for ref in refs:
+                refs_by_vacancy.setdefault(ref.vacancy_id or "", []).append(ref)
+            for result in results[-count:]:
+                candidates = refs_by_vacancy.get(result.vacancy_id, [])
+                if result.topic is None and candidates:
+                    ref = candidates.pop(0)
+                    result.topic = ref.topic_id
+                    result.chat_url = chat_url(ref.chat_id)
+        except (TypeError, ValueError, KeyError, json.JSONDecodeError):
+            logger.warning("SSR topic mapping unavailable; keeping parsed chat URLs")
 
         if not _has_next_page(page, page_num):
             logger.info("Достигнута последняя страница откликов (%d)", page_num)

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -4,7 +4,7 @@ from hhru_bot.negotiations_probe import chat_url, parse_initial_state, topic_ref
 def test_topic_refs_read_ssr_state_without_page_actions():
     html = """
     <template id="HH-Lux-InitialState">
-      {"applicantNegotiations":{"topicList":[{"id":123,"chatId":456}]}}
+      {"applicantNegotiations":{"topicList":[{"id":123,"chatId":456,"vacancyId":789}]}}
     </template>
     """
     assert topic_refs(html)[0].topic_id == "123"

--- a/tests/test_responses_command.py
+++ b/tests/test_responses_command.py
@@ -174,3 +174,54 @@ def test_responses_run_indeterminate_state_is_fail_not_traceback(capsys, tmp_pat
         responses_cmd.run(_args(config, tmp_path / "h.db", since_hours=24.0))
     assert exc.value.code == 1
     assert "список не подтверждён" in capsys.readouterr().err
+
+
+def test_responses_run_skips_upsert_for_ambiguous_topic_cards(capsys, tmp_path, monkeypatch):
+    """Регрессия #186 (round 3): карточка с topic_ambiguous=True (несколько SSR-topic
+    кандидатов на одну вакансию, round-2 guard) НЕ должна персиститься через
+    upsert_response — history матчит существующую строку по (vacancy_id,
+    topic IS NULL), и запись такой карточки наравне с легитимными без-чата
+    ответами слила бы разные переписки одной вакансии в одну строку истории.
+
+    Проверяем: неоднозначная карточка пропущена (не в БД), обычная — записана,
+    и печатается предупреждение с количеством пропущенных.
+    """
+    import contextlib
+
+    from hhru_bot.responses import ResponseItem, ResponseStatus
+
+    config = _write_config(tmp_path, _minimal_config())
+
+    class _FakeContext:
+        def new_page(self):
+            return object()
+
+    @contextlib.contextmanager
+    def _fake_launch_context(*_args, **_kwargs):
+        yield _FakeContext()
+
+    cards = [
+        ResponseItem(vacancy_id="v_ok", status=ResponseStatus.READ, topic="1"),
+        ResponseItem(
+            vacancy_id="v_ambiguous",
+            status=ResponseStatus.READ,
+            topic=None,
+            topic_ambiguous=True,
+        ),
+    ]
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", _fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.commands.responses.fetch_responses", lambda *a, **k: cards, raising=False
+    )
+    monkeypatch.setattr("hhru_bot.responses.fetch_responses", lambda *a, **k: cards, raising=False)
+
+    responses_cmd.run(_args(config, tmp_path / "h.db", since_hours=24.0))
+    out = capsys.readouterr().out
+
+    h = History(tmp_path / "h.db")
+    rows = h.new_responses_since(__import__("datetime").datetime.min)
+    vacancy_ids = {r["vacancy_id"] for r in rows}
+    assert "v_ok" in vacancy_ids
+    assert "v_ambiguous" not in vacancy_ids
+    assert "Пропущено записей с неоднозначным topic: 1" in out

--- a/tests/test_responses_command.py
+++ b/tests/test_responses_command.py
@@ -46,6 +46,7 @@ def _args(config_path, history_path, **overrides) -> argparse.Namespace:
         "max_pages": 5,
         "since_hours": 0.0,
         "headless": False,
+        "detect_external_tests": False,
     }
     base.update(overrides)
     return argparse.Namespace(**base)

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -256,6 +256,39 @@ def test_parse_response_card_unrecognized_legacy_status_falls_through_to_live_se
     assert item.status == ResponseStatus.INVITATION
 
 
+_LIVE_STATUS_HTML = """
+<div data-qa="negotiations-item">
+  <a data-qa="negotiations-item-vacancy" href="/vacancy/444444">Data Engineer</a>
+  <span data-qa="negotiations-tag_negotiations-item-not-viewed">Новое сообщение</span>
+</div>
+<div data-qa="negotiations-item">
+  <a data-qa="negotiations-item-vacancy" href="/vacancy/555555">ML Engineer</a>
+  <span data-qa="negotiations-tag_negotiations-item-viewed">Прочитано</span>
+</div>
+"""
+
+
+def test_parse_response_card_reads_live_not_viewed_status_without_legacy_markup():
+    """Регрессия #186: NEGOTIATION_STATUS был exact-match и НИКОГДА не совпадал
+    с реальной разметкой hh.ru (см. selector_groups/negotiations.py) — карточка
+    без legacy data-qa молча теряла статус (падала в UNKNOWN/READ). Живая
+    разметка (не legacy __state) должна распознаваться prefix-селектором.
+    """
+    page = NegotiationsPage(_LIVE_STATUS_HTML)
+    item = parse_response_card(page.items[0])
+    assert item is not None
+    assert item.status == ResponseStatus.RESPONSE
+    assert item.raw_status == "Новое сообщение"
+
+
+def test_parse_response_card_reads_live_viewed_status_without_legacy_markup():
+    page = NegotiationsPage(_LIVE_STATUS_HTML)
+    item = parse_response_card(page.items[1])
+    assert item is not None
+    assert item.status == ResponseStatus.READ
+    assert item.raw_status == "Прочитано"
+
+
 def test_response_item_dataclass_fields():
     """Контракт dataclass: status обязателен, остальное имеет дефолты."""
     item = ResponseItem(vacancy_id="42", status=ResponseStatus.READ)

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -218,3 +218,62 @@ def test_ssr_topic_recovery_leaves_topic_ambiguous_false_for_genuinely_chatless_
     assert len(results) == 1
     assert results[0].topic is None
     assert results[0].topic_ambiguous is False
+
+
+def test_ssr_topic_recovery_flags_all_cards_when_candidate_pool_is_smaller_than_card_count(
+    monkeypatch, caplog
+):
+    """Регрессия #186 (round 4): две карточки одной вакансии, но SSR-состояние
+    содержит только ОДИН topic-кандидат (напр. неполный/устаревший SSR state).
+    Раньше первая карточка отбирала единственного кандидата через
+    ``candidates.pop(0)`` (ветка ``len==1``), опустошая общий список в
+    ``refs_by_vacancy`` — а вторая карточка того же vacancy_id видела уже пустой
+    список (``len==0``), не попадала ни в "единственный кандидат", ни в "больше
+    одного кандидата" ветку, и молча оставалась ``topic_ambiguous=False`` —
+    как будто у неё легитимно нет чата, хотя на самом деле сопоставление
+    неоднозначно ровно так же, как в случае с избытком кандидатов.
+
+    Фикс группирует карточки по vacancy_id ДО принятия решения (без мутации
+    общего списка кандидатов итеративным pop) — при любом несовпадении числа
+    карточек и кандидатов (не только "кандидатов больше") ВСЕ карточки этой
+    вакансии помечаются ambiguous.
+    """
+    goto_calls: list[str] = []
+
+    def goto(page, url):
+        goto_calls.append(url)
+        page.goto_page(len(goto_calls) - 1)
+
+    def parse_card(card):
+        return card
+
+    item_a = responses.ResponseItem(vacancy_id="800", status=responses.ResponseStatus.READ)
+    item_b = responses.ResponseItem(vacancy_id="800", status=responses.ResponseStatus.READ)
+
+    page = _SSRPage(
+        pages_cards=[[item_a, item_b]],
+        pages_html=[
+            # Only ONE SSR topic for vacancy_id=800, but TWO cards need pairing.
+            _ssr_html([("111", "222", "800")]),
+        ],
+    )
+
+    monkeypatch.setattr(responses, "goto_hh", goto)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", parse_card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with caplog.at_level("WARNING", logger="hhru_bot.responses"):
+        results = responses.fetch_responses(page, max_pages=1)
+
+    assert len(results) == 2
+    # Neither card was guessed at — the mismatch (2 cards, 1 candidate) means
+    # BOTH stay unresolved, not just the second one that would have drained
+    # the shared candidate list under the old pop()-based logic.
+    assert results[0].topic is None
+    assert results[0].chat_url is None
+    assert results[0].topic_ambiguous is True
+    assert results[1].topic is None
+    assert results[1].chat_url is None
+    assert results[1].topic_ambiguous is True
+    assert any("неоднозначно" in message for message in caplog.messages)

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -123,3 +123,57 @@ def test_ssr_topic_recovery_does_not_leak_into_previous_page_when_page_skips_a_c
     # Page 1's item is the only one eligible for this page's SSR topic.
     assert results[1].topic == "999"
     assert results[1].chat_url == "https://chatik.hh.ru/chat/888"
+
+
+def test_ssr_topic_recovery_fails_closed_when_multiple_topics_share_one_vacancy(
+    monkeypatch, caplog
+):
+    """Регрессия #186 (round 2): один работодатель с несколькими переписками по
+    одной вакансии (несколько topic на один vacancy_id) раньше сопоставлялся
+    позиционно (FIFO ``candidates.pop(0)``) — недоказанное допущение, что DOM-
+    порядок карточек совпадает с порядком SSR ``topicList``. Если бы порядок
+    расходился, чужой topic/chat_url присвоился бы не той карточке, испортив
+    identity переписки (`(vacancy_id, topic)` — ключ истории).
+
+    Фикс: при >1 кандидате на vacancy_id — НЕ гадать, оставить обе карточки без
+    topic и залогировать warning. Единственный кандидат по-прежнему сопоставляется
+    (это однозначно — см. соседний тест на странице 1 с одним vacancy=200 topic).
+    """
+    goto_calls: list[str] = []
+
+    def goto(page, url):
+        goto_calls.append(url)
+        page.goto_page(len(goto_calls) - 1)
+
+    def parse_card(card):
+        return card
+
+    item_a = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    item_b = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+
+    page = _SSRPage(
+        pages_cards=[[item_a, item_b]],
+        pages_html=[
+            # Two negotiations for the SAME vacancy_id=700 — reversed order vs
+            # DOM (topic 222 listed first in SSR, but nothing pins it to item_a
+            # specifically) is exactly the ambiguity the guard must reject.
+            _ssr_html([("222", "333", "700"), ("444", "555", "700")]),
+        ],
+    )
+
+    monkeypatch.setattr(responses, "goto_hh", goto)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", parse_card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with caplog.at_level("WARNING", logger="hhru_bot.responses"):
+        results = responses.fetch_responses(page, max_pages=1)
+
+    assert len(results) == 2
+    # Neither card was guessed at — both stay unresolved rather than risking a
+    # cross-assignment between two distinct negotiations for the same employer.
+    assert results[0].topic is None
+    assert results[0].chat_url is None
+    assert results[1].topic is None
+    assert results[1].chat_url is None
+    assert any("неоднозначно" in message for message in caplog.messages)

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -1,0 +1,125 @@
+"""Регрессия #186: SSR topic-recovery не должен захватывать элементы прошлой страницы.
+
+``fetch_responses`` докидывает ``topic``/``chat_url`` из SSR ``topicList`` карточкам,
+у которых их не было (open_chat — кнопка без href). Раньше это делалось срезом
+``results[-count:]``, где ``count`` — число DOM-карточек ТЕКУЩЕЙ страницы; но
+``parse_response_card`` пропускает карточки без vacancy_id (не добавляет их в
+``results``), поэтому за одну итерацию в ``results`` могло добавиться МЕНЬШЕ
+элементов, чем ``count``. Тогда срез ``-count:`` реально захватывал "хвост" из
+результатов ПРЕДЫДУЩЕЙ страницы и мог присвоить им topic из SSR-состояния текущей
+страницы — порча identity уже разобранной переписки. Фикс — считать точную длину
+добавленного за страницу среза (``page_start = len(results)`` до цикла парсинга,
+слайс ``results[page_start:]`` после), не полагаясь на ``count``.
+"""
+
+from __future__ import annotations
+
+import hhru_bot.responses as responses
+from hhru_bot.browser import LOGIN_FORM
+from hhru_bot.selector_groups import negotiations as ns
+
+
+class _CardsLocator:
+    def __init__(self, cards: list[object]):
+        self.cards = cards
+
+    def count(self):
+        return len(self.cards)
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state: str, timeout: int):  # noqa: ARG002
+        return None
+
+    def nth(self, index: int):
+        return self.cards[index]
+
+
+class _SSRPage:
+    """Playwright Page fake с ``content()`` (нужен fetch_responses'у для SSR-mapping)."""
+
+    def __init__(self, pages_cards: list[list[object]], pages_html: list[str]):
+        self.url = "https://hh.ru/applicant/negotiations"
+        self._pages_cards = pages_cards
+        self._pages_html = pages_html
+        self._page_num = -1
+
+    def goto_page(self, page_num: int) -> None:
+        self._page_num = page_num
+
+    def locator(self, selector: str):
+        if selector == LOGIN_FORM:
+            return _CardsLocator([])
+        assert selector == ns.NEGOTIATION_ITEM
+        return _CardsLocator(self._pages_cards[self._page_num])
+
+    def content(self) -> str:
+        return self._pages_html[self._page_num]
+
+
+def _ssr_html(topics: list[tuple[str, str, str]]) -> str:
+    """``topics``: список (topic_id, chat_id, vacancy_id) → embedded SSR JSON."""
+    entries = ",".join(f'{{"id":{t},"chatId":{c},"vacancyId":{v}}}' for t, c, v in topics)
+    return f'<template id="HH-Lux-InitialState">{{"applicantNegotiations":{{"topicList":[{entries}]}}}}</template>'
+
+
+def test_ssr_topic_recovery_does_not_leak_into_previous_page_when_page_skips_a_card(
+    monkeypatch,
+):
+    """Страница 0: 1 DOM-карточка → item(vacancy=100), topic=None (SSR страницы 0
+    ничего для vacancy=100 не даёт — как если бы open_chat ещё не был кликабелен).
+    Страница 1: 2 DOM-карточки, но одна не парсится (vacancy_id отсутствует) →
+    добавляется только item(vacancy=200); DOM count() страницы 1 равен 2. SSR-
+    состояние страницы 1 (единственное, что реально видит parse на этой итерации)
+    содержит topic'и для ОБОИХ vacancy=100 и vacancy=200 — это то, что позволяет
+    отличить баг от фикса.
+
+    Баг (``results[-count:]`` с ``count=2``) захватил бы ОБА результата — item(100)
+    с прошлой страницы и item(200) — и присвоил бы item(100) topic из SSR-состояния
+    страницы 1, хотя реально на этой странице карточки vacancy=100 не было. Фикс
+    (срез по ``page_start``) должен трогать только item(200); item(100) обязан
+    остаться как есть (topic=None), потому что его карточка была разобрана на
+    предыдущей итерации, до того как появилось это SSR-состояние.
+    """
+    goto_calls: list[str] = []
+
+    def goto(page, url):
+        goto_calls.append(url)
+        page.goto_page(len(goto_calls) - 1)
+
+    def parse_card(card):
+        return card  # cards are already ResponseItem-like stand-ins
+
+    page0_item = responses.ResponseItem(vacancy_id="100", status=responses.ResponseStatus.READ)
+    page1_item = responses.ResponseItem(vacancy_id="200", status=responses.ResponseStatus.READ)
+
+    page = _SSRPage(
+        pages_cards=[
+            [page0_item],
+            [None, page1_item],  # first card fails to parse (vacancy_id missing)
+        ],
+        pages_html=[
+            _ssr_html([]),  # page 0's own SSR state has nothing for vacancy 100
+            # page 1's SSR state offers topics for BOTH vacancy 100 and 200 —
+            # only reachable by a card actually rendered on this page load.
+            _ssr_html([("111", "777", "100"), ("999", "888", "200")]),
+        ],
+    )
+
+    monkeypatch.setattr(responses, "goto_hh", goto)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", parse_card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda _page, page_num: page_num == 0)
+
+    results = responses.fetch_responses(page, max_pages=2)
+
+    assert [r.vacancy_id for r in results] == ["100", "200"]
+    # Page 0's item must stay untouched by page 1's SSR state, even though
+    # page 1's SSR state has an entry for the same vacancy_id.
+    assert results[0].topic is None
+    assert results[0].chat_url is None
+    # Page 1's item is the only one eligible for this page's SSR topic.
+    assert results[1].topic == "999"
+    assert results[1].chat_url == "https://chatik.hh.ru/chat/888"

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -177,3 +177,44 @@ def test_ssr_topic_recovery_fails_closed_when_multiple_topics_share_one_vacancy(
     assert results[1].topic is None
     assert results[1].chat_url is None
     assert any("неоднозначно" in message for message in caplog.messages)
+    # Regression #186 (round 3): topic=None alone doesn't distinguish "no chat"
+    # (e.g. discard) from "ambiguous SSR mapping" — callers persisting to
+    # history.upsert_response (keyed on vacancy_id + topic IS NULL) need this
+    # flag to avoid merging distinct negotiations into one history row.
+    assert results[0].topic_ambiguous is True
+    assert results[1].topic_ambiguous is True
+
+
+def test_ssr_topic_recovery_leaves_topic_ambiguous_false_for_genuinely_chatless_card(
+    monkeypatch,
+):
+    """Контроль: карточка без чата вовсе (нет SSR-кандидатов для её vacancy_id,
+    напр. discard) должна остаться topic_ambiguous=False — иначе commands/responses
+    пропускал бы её персистенцию без причины.
+    """
+    goto_calls: list[str] = []
+
+    def goto(page, url):
+        goto_calls.append(url)
+        page.goto_page(len(goto_calls) - 1)
+
+    def parse_card(card):
+        return card
+
+    item = responses.ResponseItem(vacancy_id="900", status=responses.ResponseStatus.DISCARD)
+
+    page = _SSRPage(
+        pages_cards=[[item]],
+        pages_html=[_ssr_html([])],  # no SSR topics at all for this vacancy
+    )
+
+    monkeypatch.setattr(responses, "goto_hh", goto)
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", parse_card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    results = responses.fetch_responses(page, max_pages=1)
+
+    assert len(results) == 1
+    assert results[0].topic is None
+    assert results[0].topic_ambiguous is False


### PR DESCRIPTION
Closes #107

## Summary
- add `probe --negotiations [--topic <topic_id>]` read-only mode
- parse the negotiations SSR `HH-Lux-InitialState` topic/chat mapping
- use the confirmed `https://chatik.hh.ru/chat/<chatId>` route without clicking `open_chat`
- report selector counts, topic/chat routes, message IDs, author markers, and raw HTML fragments as ASCII output
- update verified negotiations selectors and keep legacy parser fixtures compatible

## Verification
- `PYTHONPATH=src pytest -q`
- `ruff check ...`
- `python scripts/gen_cli_docs.py --check`
- live read-only: `probe --negotiations --topic 5503357777` with configured storage state
