### PR TITLE
fix(probe): preserve partial dumps on indeterminate forms

### DIFF
--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from ..browser import PAGE_STATE, goto_hh, has_login_form
@@ -73,7 +74,9 @@ class ProbeResult:
         return ProbeResult(self.vacancy, True, reason, dump_paths)
 
 
-def dump_probe_snapshot(page: Page, ctx: ProbeContext) -> dict[str, Path]:
+def dump_probe_snapshot(
+    page: Page, ctx: ProbeContext, *, best_effort: bool = False
+) -> dict[str, Path]:
     """Снимает screenshot + HTML текущего состояния страницы в data/logs/.
 
     Идемпотентно по имени (vacancy_id + stage): повторный вызов перезаписывает
@@ -85,11 +88,29 @@ def dump_probe_snapshot(page: Page, ctx: ProbeContext) -> dict[str, Path]:
     png_path = ctx.logs_dir / f"probe_{slug}.png"
     html_path = ctx.logs_dir / f"probe_{slug}.html"
 
-    png_path.write_bytes(page.screenshot(full_page=True))
-    html_path.write_text(page.content(), encoding="utf-8")
+    paths: dict[str, Path] = {}
+    try:
+        png_path.write_bytes(page.screenshot(full_page=True))
+        paths["screenshot"] = png_path
+    except PlaywrightError as exc:
+        if not best_effort:
+            raise
+        logger.warning("probe[%s]: screenshot недоступен: %s", ctx.stage, exc)
+    try:
+        html_path.write_text(page.content(), encoding="utf-8")
+        paths["html"] = html_path
+    except PlaywrightError as exc:
+        if not best_effort:
+            raise
+        logger.warning("probe[%s]: HTML недоступен: %s", ctx.stage, exc)
 
-    logger.info("probe[%s]: дамп сохранён — %s, %s", ctx.stage, png_path.name, html_path.name)
-    return {"screenshot": png_path, "html": html_path}
+    if paths:
+        logger.info(
+            "probe[%s]: дамп сохранён — %s",
+            ctx.stage,
+            ", ".join(p.name for p in paths.values()),
+        )
+    return paths
 
 
 def _fill_cover_letter_only(page: Page, resume_id: str, letter: str) -> None:
@@ -175,6 +196,18 @@ def probe_vacancy(
     questions = detect_questions(page)
     if questions.has_questions:
         marker = f"[WARN {PAGE_STATE['indeterminate']}]" if questions.indeterminate else "[INFO]"
+        if questions.indeterminate:
+            # Keep the DOM that survived a navigation/render timeout.  This is
+            # diagnostic-only: a closed context may yield no artifact, while a
+            # partially rendered page can still provide the evidence needed to
+            # correct selectors without guessing.
+            partial_ctx = ProbeContext(
+                vacancy_id=vacancy.vacancy_id,
+                vacancy_url=vacancy.url,
+                stage="form_indeterminate",
+                logs_dir=ctx_dir.logs_dir,
+            )
+            dump_probe_snapshot(page, partial_ctx, best_effort=True)
         logger.info("%s %s — %s", marker, vacancy.title, questions.reason)
         return ProbeResult(vacancy, success=False, reason=questions.reason, skipped=True)
 

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -237,6 +237,20 @@ def test_probe_no_apply_button_fails(tmp_path: Path):
     assert page.screenshot_calls == 0
 
 
+def test_probe_indeterminate_saves_partial_dump(tmp_path: Path):
+    """A form-scope timeout leaves a diagnostic DOM artifact when possible."""
+    page = FakeProbePage(submit=False)
+
+    result = probe_vacancy(page, _vacancy(), "RID", "x", tmp_path)
+
+    assert result.success is False
+    assert result.skipped is True
+    assert "не удалось определить" in result.reason
+    partial_html = tmp_path / "probe_42_form_indeterminate.html"
+    assert partial_html.exists()
+    assert "probe dump" in partial_html.read_text(encoding="utf-8")
+
+
 def test_probe_login_form_is_checked_after_navigation(tmp_path: Path, monkeypatch):
     page = FakeProbePage()
     events: list[str] = []


### PR DESCRIPTION
## Summary

- preserve best-effort HTML/screenshot artifacts when probe question detection is indeterminate
- save partial artifacts under `probe_<vacancy>_form_indeterminate.*` without changing fail-closed behavior
- keep normal probe dumps strict, while allowing closed/unstable pages to yield any artifact still available

This is a diagnostic improvement for follow-up investigation of #188; it does not claim to fix `_form_scope`.

Refs #188

## Verification

- `pytest -q tests/test_apply_probe.py tests/test_apply_questions.py`
- `ruff check src/hhru_bot/apply/probe.py tests/test_apply_probe.py`
- `git diff --check`
