### PR TITLE
fix: scope response questions to associated form

### DIFF
--- a/src/hhru_bot/apply/questions.py
+++ b/src/hhru_bot/apply/questions.py
@@ -154,9 +154,7 @@ def _form_scope(page: Page) -> Locator | None:
         return None
     linked_scope = page.locator(f"form#{form_id}")
     return (
-        linked_scope
-        if _wait_present(linked_scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS)
-        else None
+        linked_scope if _wait_present(linked_scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS) else None
     )
 
 

--- a/src/hhru_bot/apply/questions.py
+++ b/src/hhru_bot/apply/questions.py
@@ -94,7 +94,9 @@ class QuestionDetection:
         return cls(True, reason, indeterminate=True)
 
 
-_SCOPE_NOT_FOUND_REASON = "не удалось определить границы формы отклика (нет <form>-предка у submit)"
+_SCOPE_NOT_FOUND_REASON = (
+    "не удалось определить границы формы отклика (нет связанного <form> у submit)"
+)
 _RUNTIME_ERROR_REASON = (
     "ошибка при проверке анкеты формы отклика — отправка отменена (нестабильная страница)"
 )
@@ -121,7 +123,7 @@ def _wait_present(locator: Locator, *, timeout_ms: int) -> bool | None:
 
 
 def _form_scope(page: Page) -> Locator | None:
-    """Ищет ближайший предок-<form> кнопки submit — граница heuristic-поиска
+    """Ищет связанную с кнопкой submit форму — граница heuristic-поиска
     (#95 round-1 fix). Возвращает Locator при успехе, None если <form>-предок
     не найден — НЕТ fallback на весь page (round-2 fix): без надёжной границы
     heuristic не выполняется вовсе, чтобы посторонний page-level
@@ -136,9 +138,26 @@ def _form_scope(page: Page) -> Locator | None:
     гарантию для дочерних локаторов (``scope.locator(...)`` ниже в
     detect_questions), каждый из них дожидается своего состояния независимо.
     """
+    submit = page.locator(apply_form.APPLY_SUBMIT_BUTTON).first
     scope = page.locator(f"{apply_form.APPLY_SUBMIT_BUTTON} >> xpath=ancestor::form[1]")
     present = _wait_present(scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS)
-    return scope if present else None
+    if present:
+        return scope
+
+    # The response modal renders its footer button outside the form and links
+    # it with the HTML ``form`` attribute (for example, RESPONSE_MODAL_FORM_ID).
+    try:
+        form_id = submit.get_attribute("form")
+    except PlaywrightError:
+        return None
+    if not form_id:
+        return None
+    linked_scope = page.locator(f"form#{form_id}")
+    return (
+        linked_scope
+        if _wait_present(linked_scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS)
+        else None
+    )
 
 
 def detect_questions(page: Page) -> QuestionDetection:

--- a/tests/test_apply_questions.py
+++ b/tests/test_apply_questions.py
@@ -62,9 +62,12 @@ _TAG_RE = re.compile(r"^([a-zA-Z]+)$")
 _TYPE_RE = re.compile(r"^input\[type=[\"'](\w+)[\"']\]$")
 _QA_RE = re.compile(r"^\[data-qa=[\"']([\w\-]+)[\"']\]$")
 _TAG_QA_RE = re.compile(r"^([a-zA-Z]+)\[data-qa=[\"']([\w\-]+)[\"']\]$")
+_ID_RE = re.compile(r"^([a-zA-Z]+)#([\w\-]+)$")
 
 
 def _match(node, sel):
+    if m := _ID_RE.match(sel):
+        return node.tag == m.group(1) and node.attrs.get("id") == m.group(2)
     if m := _TAG_RE.match(sel):
         return node.tag == m.group(1)
     if m := _TYPE_RE.match(sel):
@@ -152,6 +155,9 @@ class _Loc:
             # Немедленное чтение без ожидания — застаёт непрогрузившийся DOM.
             return 0
         return len(self._n)
+
+    def get_attribute(self, name):
+        return self._n[0].attrs.get(name) if self._n else None
 
     def locator(self, sel):
         # Вложенный locator() внутри scope (напр. scope.locator(_RADIO)) решает
@@ -369,6 +375,24 @@ def test_detect_indeterminate_when_submit_not_in_form():
     result = detect_questions(page)
     assert result.has_questions is True
     assert result.indeterminate is True
+
+
+def test_detect_scope_when_submit_is_associated_with_form_by_id():
+    """HH.ru modal places submit outside ``form`` and links it with ``form``."""
+    html = """
+        <form id='RESPONSE_MODAL_FORM_ID'>
+            <textarea data-qa='vacancy-response-popup-form-letter-input'></textarea>
+            <input type='radio' name='q1' value='a'>
+        </form>
+        <div class='modal-footer'>
+            <button data-qa='vacancy-response-submit-popup'
+                    type='submit' form='RESPONSE_MODAL_FORM_ID'>Откликнуться</button>
+        </div>
+    """
+    result = detect_questions(_Page(html))
+    assert result.has_questions is True
+    assert result.indeterminate is False
+    assert "radio/checkbox" in result.reason
 
 
 def test_detect_indeterminate_when_submit_missing():


### PR DESCRIPTION
Closes #188

## Summary
- use the submit button's HTML `form` association when it is rendered outside the `<form>` ancestor
- add a regression test matching the live HH.ru response modal DOM

## Verification
- `pytest -q tests/test_apply_questions.py tests/test_apply_pipeline.py tests/test_apply_probe.py`
- `ruff check src/hhru_bot/apply/questions.py tests/test_apply_questions.py`
- `git diff --check`

Live probe evidence: vacancy 135481754 rendered `<form id="RESPONSE_MODAL_FORM_ID">` with the submit button outside it and `form="RESPONSE_MODAL_FORM_ID"`; the old ancestor XPath consequently returned no scope.