### PR TITLE
fix(apply): resolve externally associated response form

### DIFF
--- a/src/hhru_bot/apply/questions.py
+++ b/src/hhru_bot/apply/questions.py
@@ -13,18 +13,10 @@ textarea за вычетом известных cover-letter textareas → True;
 
 Чистая функция поверх page.locator().count() — без браузера тестируется на HTML-фикстуре.
 
-ИЗВЕСТНОЕ ОГРАНИЧЕНИЕ (round 3, НЕ подтверждено на живом hh.ru): heuristic-путь
-(2) скоупится через ближайший <form>-предок APPLY_SUBMIT_BUTTON (см. _form_scope).
-konard-референс подтверждает только наличие data-qa атрибутов, а НЕ то, что кнопка
-submit обёрнута именно в семантический <form>-тег — этот факт нигде не проверен
-живым дампом (форма отклика в CLAUDE.md сама помечена «НЕ подтверждено»). Если
-допущение неверно (SPA без <form>, submit через onClick — обычная практика для
-React), _form_scope() будет систематически возвращать None → detect_questions()
-всегда вернёт indeterminate=True → pipeline будет fail'ить КАЖДЫЙ non-dry-run
-apply ещё до fill_response_form, независимо от наличия вопросов в форме.
-ОБЯЗАТЕЛЬНО перед первым боевым apply/bump: прогнать `probe` на реальной вакансии
-и проверить лог на "[WARN indeterminate]" — если он появляется на форме БЕЗ
-вопросов, admission `<form>`-скоупинга неверно и требует ревизии (см. #95).
+Живой дамп формы отклика (issue #188) показывает, что submit-кнопка может находиться
+вне `<form>`, но иметь атрибут `form="RESPONSE_MODAL_FORM_ID"`. Поэтому
+_form_scope() сначала разрешает связанный по атрибуту `<form>`, а для старой
+разметки сохраняет fallback на ближайшего `<form>`-предка.
 """
 
 from __future__ import annotations
@@ -121,9 +113,12 @@ def _wait_present(locator: Locator, *, timeout_ms: int) -> bool | None:
 
 
 def _form_scope(page: Page) -> Locator | None:
-    """Ищет ближайший предок-<form> кнопки submit — граница heuristic-поиска
-    (#95 round-1 fix). Возвращает Locator при успехе, None если <form>-предок
-    не найден — НЕТ fallback на весь page (round-2 fix): без надёжной границы
+    """Ищет форму, связанную с submit-кнопкой, — границу heuristic-поиска.
+
+    HTML допускает submit-кнопку вне формы, связанную через атрибут ``form``
+    (#188), поэтому сначала используем этот явный идентификатор. Для старой
+    разметки сохраняем fallback на ближайшего ``<form>``-предка. Возвращает
+    None если надёжная граница не найдена — НЕТ fallback на весь page: без надёжной границы
     heuristic не выполняется вовсе, чтобы посторонний page-level
     radio/checkbox/textarea не порождал ложный persistent skip.
 
@@ -136,9 +131,21 @@ def _form_scope(page: Page) -> Locator | None:
     гарантию для дочерних локаторов (``scope.locator(...)`` ниже в
     detect_questions), каждый из них дожидается своего состояния независимо.
     """
+    submit = page.locator(apply_form.APPLY_SUBMIT_BUTTON).first
+    if _wait_present(submit, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS) is not True:
+        return None
+
+    try:
+        form_id = submit.get_attribute("form")
+    except PlaywrightError:
+        form_id = None
+    if form_id:
+        linked_scope = page.locator(f"form#{form_id}")
+        if _wait_present(linked_scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS) is True:
+            return linked_scope
+
     scope = page.locator(f"{apply_form.APPLY_SUBMIT_BUTTON} >> xpath=ancestor::form[1]")
-    present = _wait_present(scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS)
-    return scope if present else None
+    return scope if _wait_present(scope, timeout_ms=_QUESTION_WAIT_TIMEOUT_MS) else None
 
 
 def detect_questions(page: Page) -> QuestionDetection:

--- a/tests/test_apply_questions.py
+++ b/tests/test_apply_questions.py
@@ -62,6 +62,7 @@ _TAG_RE = re.compile(r"^([a-zA-Z]+)$")
 _TYPE_RE = re.compile(r"^input\[type=[\"'](\w+)[\"']\]$")
 _QA_RE = re.compile(r"^\[data-qa=[\"']([\w\-]+)[\"']\]$")
 _TAG_QA_RE = re.compile(r"^([a-zA-Z]+)\[data-qa=[\"']([\w\-]+)[\"']\]$")
+_FORM_ID_RE = re.compile(r"^form#([\w\-]+)$")
 
 
 def _match(node, sel):
@@ -162,6 +163,11 @@ class _Loc:
         nodes = [] if scope is None else [n for n in _all(scope) if _match(n, sel)]
         return self._page._make_locator(sel, nodes)
 
+    def get_attribute(self, name):
+        if name != "form" or not self._n:
+            return None
+        return self._n[0].attrs.get("form")
+
 
 class _Page:
     def __init__(self, html, *, render_delayed_selectors=(), wait_error_selectors=()):
@@ -180,6 +186,11 @@ class _Page:
         return loc
 
     def locator(self, sel):
+        if m := _FORM_ID_RE.match(sel):
+            return self._make_locator(
+                sel,
+                [n for n in _all(self._tree) if n.tag == "form" and n.attrs.get("id") == m.group(1)],
+            )
         if ">> xpath=ancestor::form" in sel:
             base_sel = sel.split(" >> xpath=ancestor::form")[0]
             submit = next((n for n in _all(self._tree) if _match(n, base_sel)), None)
@@ -188,6 +199,19 @@ class _Page:
             form = _ancestor_form(self._tree, submit)
             return self._make_locator(sel, [form] if form is not None else [])
         return self._make_locator(sel, [n for n in _all(self._tree) if _match(n, sel)])
+
+
+def test_detect_uses_form_attribute_when_submit_is_outside_form():
+    """HH.ru's modal keeps submit outside its form and links it with form=ID."""
+    html = """
+        <form id='RESPONSE_MODAL_FORM_ID'>
+            <textarea data-qa='vacancy-response-popup-form-letter-input'></textarea>
+        </form>
+        <div><input type='checkbox'><button form='RESPONSE_MODAL_FORM_ID'
+            data-qa='vacancy-response-submit-popup'>Откликнуться</button></div>
+    """
+    result = detect_questions(_Page(html))
+    assert result == QuestionDetection.no()
 
 
 def test_detect_no_questions_clean_form():

--- a/tests/test_apply_questions.py
+++ b/tests/test_apply_questions.py
@@ -189,7 +189,11 @@ class _Page:
         if m := _FORM_ID_RE.match(sel):
             return self._make_locator(
                 sel,
-                [n for n in _all(self._tree) if n.tag == "form" and n.attrs.get("id") == m.group(1)],
+                [
+                    n
+                    for n in _all(self._tree)
+                    if n.tag == "form" and n.attrs.get("id") == m.group(1)
+                ],
             )
         if ">> xpath=ancestor::form" in sel:
             base_sel = sel.split(" >> xpath=ancestor::form")[0]


### PR DESCRIPTION
## Summary
- inspect a live probe dump from vacancy 135481754
- resolve response form via submit button's `form` attribute when the button is outside the form
- retain ancestor-form fallback and add regression coverage

## Verification
- `pytest -q tests/test_apply_questions.py tests/test_apply_pipeline.py tests/test_apply_probe.py`
- `ruff check src/hhru_bot/apply/questions.py tests/test_apply_questions.py`
- live `probe --resume python --vacancy-id 135481754` saved HTML/screenshot without sending

Closes #188