### PR TITLE
chore(negotiations): unify selector fallbacks

### DIFF
--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -572,8 +572,7 @@ def run_negotiations(args: argparse.Namespace) -> bool:
                         str(i + 1),
                         loc.get_attribute("data-qa") or "-",
                         "own"
-                        if negotiations.CHAT_MESSAGE_MY_MARKER
-                        in parent_class.split()
+                        if negotiations.CHAT_MESSAGE_MY_MARKER in parent_class.split()
                         else "other",
                         loc.inner_text().replace("\n", " ")[:160],
                     ]

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -562,15 +562,19 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             for i in range(messages.count()):
                 loc = messages.nth(i)
                 parent_class = loc.evaluate(
-                    "el => { for (let n = el; n; n = n.parentElement) "
-                    "if (String(n.className).includes('message_my')) return n.className; "
-                    "return ''; }"
+                    "(el, marker) => { for (let n = el; n; n = n.parentElement) "
+                    "if (String(n.className).split(/\\s+/).includes(marker)) "
+                    "return n.className; return ''; }",
+                    negotiations.CHAT_MESSAGE_MY_MARKER,
                 )
                 message_rows.append(
                     [
                         str(i + 1),
                         loc.get_attribute("data-qa") or "-",
-                        "own" if "message_my" in parent_class else "other",
+                        "own"
+                        if negotiations.CHAT_MESSAGE_MY_MARKER
+                        in parent_class.split()
+                        else "other",
                         loc.inner_text().replace("\n", " ")[:160],
                     ]
                 )

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -214,11 +214,22 @@ def _optional_text(item, *selectors: str) -> str:
     None → пустая строка (для responses пустота нормальна и удобнее в dataclass).
     Selectors are ordered live-first, with legacy markup as a fallback.
     """
-    loc = _first_locator(item, *selectors)
-    if not loc.count():
-        return ""
-    text = loc.inner_text().strip()
-    return text or ""
+    for selector in selectors:
+        loc = item.locator(selector).first
+        if loc.count():
+            text = loc.inner_text().strip()
+            if text:
+                return text
+    return ""
+
+
+def _status_text(item, *selectors: str) -> str:
+    """Return the first non-empty, recognized status from ordered selectors."""
+    for selector in selectors:
+        text = _optional_text(item, selector)
+        if text and normalize_status(text) != ResponseStatus.UNKNOWN:
+            return text
+    return ""
 
 
 def _first_locator(item, *selectors):
@@ -244,9 +255,7 @@ def parse_response_card(item) -> ResponseItem | None:
 
     # Prefer confirmed live selectors consistently; old saved markup remains a
     # fallback for fixtures and previously captured pages.
-    raw_status = _optional_text(item, ns.NEGOTIATION_STATUS, ns.LEGACY_NEGOTIATION_STATUS)
-    if normalize_status(raw_status) == ResponseStatus.UNKNOWN:
-        raw_status = ""
+    raw_status = _status_text(item, ns.NEGOTIATION_STATUS, ns.LEGACY_NEGOTIATION_STATUS)
     employer = _optional_text(item, ns.NEGOTIATION_EMPLOYER, ns.LEGACY_NEGOTIATION_EMPLOYER)
     date = _optional_text(item, ns.NEGOTIATION_DATE, ns.LEGACY_NEGOTIATION_DATE)
 

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -207,13 +207,14 @@ def _absolute_url(href: str, *, keep_query: bool = False) -> str:
     return f"{HH_BASE_URL}{href.split('?')[0]}"
 
 
-def _optional_text(item, selector: str) -> str:
-    """Текст первого элемента карточки по selector, либо пустая строка.
+def _optional_text(item, *selectors: str) -> str:
+    """Текст первого найденного элемента карточки, либо пустая строка.
 
     Опциональные поля (работодатель, статус). Как search._optional_text, но без
     None → пустая строка (для responses пустота нормальна и удобнее в dataclass).
+    Selectors are ordered live-first, with legacy markup as a fallback.
     """
-    loc = item.locator(selector).first
+    loc = _first_locator(item, *selectors)
     if not loc.count():
         return ""
     text = loc.inner_text().strip()
@@ -241,24 +242,17 @@ def parse_response_card(item) -> ResponseItem | None:
     if not vacancy_id:
         return None
 
-    # Prefer the legacy exact selector first: it also keeps old saved fixtures
-    # deterministic while the live selector is verified on the real DOM. Fall
-    # through to the confirmed selector whenever the legacy one is empty OR
-    # unrecognized — normalize_status("") is READ (not UNKNOWN) by design, so
-    # "empty" and "unrecognized" are checked separately; an unrecognized
-    # legacy match must not shadow a live selector that could still resolve
-    # to a known status.
-    raw_status = _optional_text(item, ns.LEGACY_NEGOTIATION_STATUS)
-    if not raw_status or normalize_status(raw_status) == ResponseStatus.UNKNOWN:
-        raw_status = _optional_text(item, ns.NEGOTIATION_STATUS)
+    # Prefer confirmed live selectors consistently; old saved markup remains a
+    # fallback for fixtures and previously captured pages.
+    raw_status = _optional_text(
+        item, ns.NEGOTIATION_STATUS, ns.LEGACY_NEGOTIATION_STATUS
+    )
     if normalize_status(raw_status) == ResponseStatus.UNKNOWN:
         raw_status = ""
-    employer = _optional_text(item, ns.NEGOTIATION_EMPLOYER)
-    if not employer:
-        employer = _optional_text(item, ns.LEGACY_NEGOTIATION_EMPLOYER)
-    date = _optional_text(item, ns.NEGOTIATION_DATE)
-    if not date:
-        date = _optional_text(item, ns.LEGACY_NEGOTIATION_DATE)
+    employer = _optional_text(
+        item, ns.NEGOTIATION_EMPLOYER, ns.LEGACY_NEGOTIATION_EMPLOYER
+    )
+    date = _optional_text(item, ns.NEGOTIATION_DATE, ns.LEGACY_NEGOTIATION_DATE)
 
     chat_link = _first_locator(item, ns.NEGOTIATION_CHAT_LINK, ns.LEGACY_NEGOTIATION_CHAT_LINK)
     chat_href = chat_link.get_attribute("href") or "" if chat_link.count() else ""

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -224,10 +224,17 @@ def _optional_text(item, *selectors: str) -> str:
 
 
 def _status_text(item, *selectors: str) -> str:
-    """Return the first non-empty, recognized status from ordered selectors."""
+    """Return the first non-empty status from ordered selectors.
+
+    A present live status is authoritative even when unrecognized by
+    normalize_status() — only an EMPTY selector falls through to the next
+    one. Falling through on "unrecognized" instead of "empty" would let a
+    stale legacy status silently override a real (if unmapped) live status
+    whenever both markup variants happen to be present in the same card.
+    """
     for selector in selectors:
         text = _optional_text(item, selector)
-        if text and normalize_status(text) != ResponseStatus.UNKNOWN:
+        if text:
             return text
     return ""
 

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -244,14 +244,10 @@ def parse_response_card(item) -> ResponseItem | None:
 
     # Prefer confirmed live selectors consistently; old saved markup remains a
     # fallback for fixtures and previously captured pages.
-    raw_status = _optional_text(
-        item, ns.NEGOTIATION_STATUS, ns.LEGACY_NEGOTIATION_STATUS
-    )
+    raw_status = _optional_text(item, ns.NEGOTIATION_STATUS, ns.LEGACY_NEGOTIATION_STATUS)
     if normalize_status(raw_status) == ResponseStatus.UNKNOWN:
         raw_status = ""
-    employer = _optional_text(
-        item, ns.NEGOTIATION_EMPLOYER, ns.LEGACY_NEGOTIATION_EMPLOYER
-    )
+    employer = _optional_text(item, ns.NEGOTIATION_EMPLOYER, ns.LEGACY_NEGOTIATION_EMPLOYER)
     date = _optional_text(item, ns.NEGOTIATION_DATE, ns.LEGACY_NEGOTIATION_DATE)
 
     chat_link = _first_locator(item, ns.NEGOTIATION_CHAT_LINK, ns.LEGACY_NEGOTIATION_CHAT_LINK)

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -287,6 +287,28 @@ def test_parse_response_card_reads_live_viewed_status_without_legacy_markup():
     assert item is not None
     assert item.status == ResponseStatus.READ
     assert item.raw_status == "Прочитано"
+def test_parse_response_card_prefers_live_fields_when_both_markups_exist():
+    """Confirmed selectors win consistently over compatibility selectors."""
+    page = NegotiationsPage(
+        """
+        <div data-qa="negotiations-item">
+          <a data-qa="negotiations-item-vacancy" href="/vacancy/666666">Live</a>
+          <a data-qa="negotiations-item__vacancy-link" href="/vacancy/777777">Legacy</a>
+          <span data-qa="negotiations-tag">Новое сообщение</span>
+          <span data-qa="negotiations-item__state">Отказ</span>
+          <span data-qa="negotiations-item-company">Live Corp</span>
+          <span data-qa="negotiations-item__employer">Legacy Corp</span>
+          <span data-qa="negotiations-item-date">сегодня</span>
+          <span data-qa="negotiations-item__date">вчера</span>
+        </div>
+        """
+    )
+    item = parse_response_card(page.items[0])
+    assert item is not None
+    assert item.vacancy_id == "666666"
+    assert item.status == ResponseStatus.RESPONSE
+    assert item.employer == "Live Corp"
+    assert item.date == "сегодня"
 
 
 def test_response_item_dataclass_fields():

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -313,6 +313,28 @@ def test_parse_response_card_prefers_live_fields_when_both_markups_exist():
     assert item.date == "сегодня"
 
 
+def test_parse_response_card_uses_legacy_text_when_live_fields_are_empty_or_unknown():
+    page = NegotiationsPage(
+        """
+        <div data-qa="negotiations-item">
+          <a data-qa="negotiations-item-vacancy" href="/vacancy/888888">Live</a>
+          <span data-qa="negotiations-tag">Unknown live status</span>
+          <span data-qa="negotiations-item__state">Приглашение</span>
+          <span data-qa="negotiations-item-company"></span>
+          <span data-qa="negotiations-item__employer">Legacy Corp</span>
+          <span data-qa="negotiations-item-date"> </span>
+          <span data-qa="negotiations-item__date">вчера</span>
+        </div>
+        """
+    )
+    item = parse_response_card(page.items[0])
+    assert item is not None
+    assert item.status == ResponseStatus.INVITATION
+    assert item.raw_status == "Приглашение"
+    assert item.employer == "Legacy Corp"
+    assert item.date == "вчера"
+
+
 def test_response_item_dataclass_fields():
     """Контракт dataclass: status обязателен, остальное имеет дефолты."""
     item = ResponseItem(vacancy_id="42", status=ResponseStatus.READ)

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -313,12 +313,11 @@ def test_parse_response_card_prefers_live_fields_when_both_markups_exist():
     assert item.date == "сегодня"
 
 
-def test_parse_response_card_uses_legacy_text_when_live_fields_are_empty_or_unknown():
+def test_parse_response_card_uses_legacy_text_when_live_fields_are_empty():
     page = NegotiationsPage(
         """
         <div data-qa="negotiations-item">
           <a data-qa="negotiations-item-vacancy" href="/vacancy/888888">Live</a>
-          <span data-qa="negotiations-tag">Unknown live status</span>
           <span data-qa="negotiations-item__state">Приглашение</span>
           <span data-qa="negotiations-item-company"></span>
           <span data-qa="negotiations-item__employer">Legacy Corp</span>
@@ -333,6 +332,24 @@ def test_parse_response_card_uses_legacy_text_when_live_fields_are_empty_or_unkn
     assert item.raw_status == "Приглашение"
     assert item.employer == "Legacy Corp"
     assert item.date == "вчера"
+
+
+def test_parse_response_card_keeps_unrecognized_live_status_over_recognized_legacy():
+    """Присутствующий live-статус авторитетен даже если normalize_status его не знает —
+    легаси-статус не должен маскировать реальный (пусть и нераспознанный) live-статус."""
+    page = NegotiationsPage(
+        """
+        <div data-qa="negotiations-item">
+          <a data-qa="negotiations-item-vacancy" href="/vacancy/888888">Live</a>
+          <span data-qa="negotiations-tag">Unknown live status</span>
+          <span data-qa="negotiations-item__state">Приглашение</span>
+        </div>
+        """
+    )
+    item = parse_response_card(page.items[0])
+    assert item is not None
+    assert item.status == ResponseStatus.UNKNOWN
+    assert item.raw_status == "Unknown live status"
 
 
 def test_response_item_dataclass_fields():

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -287,6 +287,8 @@ def test_parse_response_card_reads_live_viewed_status_without_legacy_markup():
     assert item is not None
     assert item.status == ResponseStatus.READ
     assert item.raw_status == "Прочитано"
+
+
 def test_parse_response_card_prefers_live_fields_when_both_markups_exist():
     """Confirmed selectors win consistently over compatibility selectors."""
     page = NegotiationsPage(


### PR DESCRIPTION
## Summary
- prefer confirmed live negotiation selectors consistently, retaining legacy markup as fallback
- align probe own-message detection with exact class-token matching
- add regression coverage for live-over-legacy precedence

## Scope
This closes issue #187 items 1 and 3. Item 2 (legacy status selector cleanup) and item 4 (external-link classification) remain explicitly optional follow-up work.

## Verification
- `PYTHONPATH=src pytest -q`
- `ruff format --check src tests`

Closes #187