### PR TITLE
feat(negotiations): detect whether chat needs reply

### DIFF
--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -9,18 +9,102 @@ not perform any navigation (in particular, it never follows the external URL).
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
+from dataclasses import dataclass
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Page
 
 from .browser import goto_hh
-from .selector_groups.negotiations import CHAT_MESSAGE_MY_MARKER, CHAT_MESSAGE_TEXT
+from .negotiations_probe import chat_url
+from .selector_groups.negotiations import (
+    CHAT_MESSAGE_MY_MARKER,
+    CHAT_MESSAGE_OTHER_MARKER,
+    CHAT_MESSAGE_TEXT,
+)
 
 # A URL is deliberately restricted to HTTP(S).  This avoids treating email
 # addresses, javascript: values, and arbitrary punctuation as test links.
 _URL_RE = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
 _TRAILING_URL_PUNCTUATION = ".,;:!?)]}>\"'»"
 _HH_DOMAINS = ("hh.ru", "hhcdn.ru")
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """The small, browser-independent part of the latest chat message."""
+
+    author: str | None
+    inbound_marker: str | None
+
+
+@dataclass(frozen=True)
+class ReplyDecision:
+    """Result of the fail-closed reply decision."""
+
+    should_reply: bool
+    reason: str
+
+
+def needs_reply(chat: ChatMessage | None) -> ReplyDecision:
+    """Decide whether the latest message permits a reply.
+
+    ``author`` is deliberately normalized by the DOM reader to ``employer`` or
+    ``me``.  A missing message, author, or marker is never treated as an
+    employer message: sending on incomplete DOM data would create a duplicate.
+    """
+    if chat is None:
+        return ReplyDecision(False, "empty_chat")
+    if not chat.inbound_marker:
+        return ReplyDecision(False, "inbound_marker_unknown")
+    if chat.author == "employer":
+        return ReplyDecision(True, "last_message_from_employer")
+    if chat.author == "me":
+        return ReplyDecision(False, "last_message_from_us")
+    return ReplyDecision(False, "author_unknown")
+
+
+def _message_id(data_qa: str | None) -> str | None:
+    if not data_qa or not data_qa.startswith("chatik-chat-message-"):
+        return None
+    value = data_qa[len("chatik-chat-message-") :]
+    if not value.endswith("-text"):
+        return None
+    marker = value[: -len("-text")]
+    return marker or None
+
+
+def read_last_message(page: Page, chat_id: str) -> ChatMessage | None:
+    """Read the latest message from the confirmed chat route, without writes."""
+    goto_hh(page, chat_url(chat_id))
+    messages = page.locator(CHAT_MESSAGE_TEXT)
+    if not messages.count():
+        return None
+    message = messages.nth(messages.count() - 1)
+    marker = _message_id(message.get_attribute("data-qa"))
+    author = message.evaluate(
+        """(el, ownMarker, otherMarker) => {
+            for (let node = el; node; node = node.parentElement) {
+                const classes = String(node.className).split(/\\s+/);
+                if (classes.includes(ownMarker)) return 'me';
+                if (classes.includes(otherMarker)) return 'employer';
+            }
+            return null;
+        }""",
+        CHAT_MESSAGE_MY_MARKER,
+        CHAT_MESSAGE_OTHER_MARKER,
+    )
+    return ChatMessage(author, marker)
+
+
+def read_chat(
+    page: Page, topic: str, topic_to_chat_id: Mapping[str, str]
+) -> ChatMessage | None:
+    """Resolve a topic from the #107 SSR mapping and read its latest message."""
+    chat_id = topic_to_chat_id.get(str(topic))
+    if not chat_id:
+        return None
+    return read_last_message(page, str(chat_id))
 
 
 def _is_hh_domain(hostname: str | None) -> bool:
@@ -57,7 +141,7 @@ def read_employer_messages(page: Page, chat_id: str) -> list[str]:
     in an earlier message even if the employer's most recent message is a
     URL-free follow-up.
     """
-    goto_hh(page, f"https://chatik.hh.ru/chat/{chat_id}")
+    goto_hh(page, chat_url(chat_id))
     messages = page.locator(CHAT_MESSAGE_TEXT)
     texts: list[str] = []
     for index in range(messages.count() - 1, -1, -1):

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -83,16 +83,15 @@ def read_last_message(page: Page, chat_id: str) -> ChatMessage | None:
     message = messages.nth(messages.count() - 1)
     marker = _message_id(message.get_attribute("data-qa"))
     author = message.evaluate(
-        """(el, ownMarker, otherMarker) => {
+        """(el, markers) => {
             for (let node = el; node; node = node.parentElement) {
                 const classes = String(node.className).split(/\\s+/);
-                if (classes.includes(ownMarker)) return 'me';
-                if (classes.includes(otherMarker)) return 'employer';
+                if (classes.includes(markers.own)) return 'me';
+                if (classes.includes(markers.other)) return 'employer';
             }
             return null;
         }""",
-        CHAT_MESSAGE_MY_MARKER,
-        CHAT_MESSAGE_OTHER_MARKER,
+        {"own": CHAT_MESSAGE_MY_MARKER, "other": CHAT_MESSAGE_OTHER_MARKER},
     )
     return ChatMessage(author, marker)
 

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -8,6 +8,7 @@ not perform any navigation (in particular, it never follows the external URL).
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -22,6 +23,8 @@ from .selector_groups.negotiations import (
     CHAT_MESSAGE_OTHER_MARKER,
     CHAT_MESSAGE_TEXT,
 )
+
+logger = logging.getLogger("hhru_bot.negotiations_chat")
 
 # A URL is deliberately restricted to HTTP(S).  This avoids treating email
 # addresses, javascript: values, and arbitrary punctuation as test links.
@@ -97,9 +100,17 @@ def read_last_message(page: Page, chat_id: str) -> ChatMessage | None:
 
 
 def read_chat(page: Page, topic: str, topic_to_chat_id: Mapping[str, str]) -> ChatMessage | None:
-    """Resolve a topic from the #107 SSR mapping and read its latest message."""
+    """Resolve a topic from the #107 SSR mapping and read its latest message.
+
+    A topic missing from ``topic_to_chat_id`` is a mapping problem (possible
+    #107 SSR drift), not a chat that legitimately has no messages. Both cases
+    fail-closed to ``None`` (``needs_reply`` reports them identically as
+    ``empty_chat``, per #109), but the mapping miss is logged so it is
+    diagnosable instead of silently masquerading as a normal empty chat.
+    """
     chat_id = topic_to_chat_id.get(str(topic))
     if not chat_id:
+        logger.warning("negotiations: topic %s not found in SSR chat mapping", topic)
         return None
     return read_last_message(page, str(chat_id))
 

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -97,9 +97,7 @@ def read_last_message(page: Page, chat_id: str) -> ChatMessage | None:
     return ChatMessage(author, marker)
 
 
-def read_chat(
-    page: Page, topic: str, topic_to_chat_id: Mapping[str, str]
-) -> ChatMessage | None:
+def read_chat(page: Page, topic: str, topic_to_chat_id: Mapping[str, str]) -> ChatMessage | None:
     """Resolve a topic from the #107 SSR mapping and read its latest message."""
     chat_id = topic_to_chat_id.get(str(topic))
     if not chat_id:

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -63,3 +63,4 @@ CHAT_MESSAGE_TEXT = (
     ':not([data-qa="chatik-chat-message-applicant-action-text"])'
 )
 CHAT_MESSAGE_MY_MARKER = "message_my"
+CHAT_MESSAGE_OTHER_MARKER = "message_other"

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -1,4 +1,14 @@
-from hhru_bot.negotiations_chat import ChatMessage, extract_external_test_link, needs_reply
+import logging
+from typing import cast
+
+from playwright.sync_api import Page
+
+from hhru_bot.negotiations_chat import (
+    ChatMessage,
+    extract_external_test_link,
+    needs_reply,
+    read_chat,
+)
 
 
 def test_needs_reply_when_last_message_is_from_employer():
@@ -20,6 +30,17 @@ def test_needs_reply_is_fail_closed_for_empty_chat():
 def test_needs_reply_is_fail_closed_for_unknown_author_or_marker():
     assert needs_reply(ChatMessage(None, "message-1")).should_reply is False
     assert needs_reply(ChatMessage("employer", None)).reason == "inbound_marker_unknown"
+
+
+def test_read_chat_logs_and_fails_closed_for_unmapped_topic(caplog):
+    # An unmapped topic returns before ``page`` is touched, so a typed stand-in
+    # is enough — no real Playwright Page is needed for this branch.
+    fake_page = cast(Page, object())
+    with caplog.at_level(logging.WARNING, logger="hhru_bot.negotiations_chat"):
+        result = read_chat(fake_page, topic="unknown-topic", topic_to_chat_id={})
+
+    assert result is None
+    assert any("unknown-topic" in record.message for record in caplog.records)
 
 
 def test_extracts_external_link_from_message():

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -1,4 +1,25 @@
-from hhru_bot.negotiations_chat import extract_external_test_link
+from hhru_bot.negotiations_chat import ChatMessage, extract_external_test_link, needs_reply
+
+
+def test_needs_reply_when_last_message_is_from_employer():
+    decision = needs_reply(ChatMessage("employer", "message-1"))
+    assert decision.should_reply is True
+    assert decision.reason == "last_message_from_employer"
+
+
+def test_needs_reply_skips_our_last_message():
+    decision = needs_reply(ChatMessage("me", "message-1"))
+    assert decision.should_reply is False
+    assert decision.reason == "last_message_from_us"
+
+
+def test_needs_reply_is_fail_closed_for_empty_chat():
+    assert needs_reply(None).reason == "empty_chat"
+
+
+def test_needs_reply_is_fail_closed_for_unknown_author_or_marker():
+    assert needs_reply(ChatMessage(None, "message-1")).should_reply is False
+    assert needs_reply(ChatMessage("employer", None)).reason == "inbound_marker_unknown"
 
 
 def test_extracts_external_link_from_message():


### PR DESCRIPTION
Closes #109

## Summary
- add pure fail-closed `needs_reply` decision for the latest chat message
- read the latest message via the confirmed `chatik.hh.ru/chat/<chatId>` route and `message_my`/`message_other` markers
- resolve topic to chat ID through the existing #107 SSR mapping infrastructure
- keep the feature read-only; no send or click actions

## Verification
- `PYTHONPATH=src pytest -q`
- `ruff check --fix src/hhru_bot/negotiations_chat.py tests/test_negotiations_chat.py`

Depends on the selector/chat probe infrastructure from #107 (PR #186). No live account action was performed.