### PR TITLE
fix(apply): capture diagnostics on form wait failures

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -160,7 +160,7 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         logger.info("[DRY-RUN] Откликнулся бы на '%s' с письмом:\n%s", ctx.vacancy.title, letter)
         return ctx.ok("dry-run")
 
-    apply_steps.navigate_to_response_form(ctx.page)
+    apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
     ctx.probe("form_loaded")
 
     # #95: detect-only проверка на вопросы/анкету. Делается ДО fill_response_form:

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -186,7 +186,7 @@ def probe_vacancy(
     if not apply_steps.wait_apply_button(page):
         return ProbeResult(vacancy, False, "кнопка отклика не найдена на странице")
 
-    apply_steps.navigate_to_response_form(page)
+    apply_steps.navigate_to_response_form(page, vacancy.vacancy_id)
     logger.info("[PROBE] Дошёл до формы отклика, заполняю письмо (без отправки)")
 
     # #95: detect-only. Если форма требует анкеты — НЕ заполняем и НЕ дампим вопросы,

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from urllib.parse import parse_qs, urlparse
 
 from playwright.sync_api import Error as PlaywrightError
@@ -62,12 +61,14 @@ def _dump_navigation_diagnostics(page: Page, stage: str) -> None:
 
     This is deliberately diagnostic-only: a failure to capture either artifact
     must not change the apply result or interrupt the remaining vacancies.
-    ``time_ns`` keeps artifacts from consecutive retries distinct because this
-    path has no vacancy context.
+    Same idempotent-by-name convention as ``probe.dump_probe_snapshot``:
+    the filename is keyed only by ``stage`` (no vacancy context is available
+    on this path) so a repeated failure overwrites the previous dump instead
+    of accumulating a new pair of files per retry.
     """
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
-        prefix = LOG_DIR / f"apply_{stage}_{time.time_ns()}"
+        prefix = LOG_DIR / f"apply_{stage}"
         screenshot_path = prefix.with_suffix(".png")
         html_path = prefix.with_suffix(".html")
         screenshot_path.write_bytes(page.screenshot(full_page=True))

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from urllib.parse import parse_qs, urlparse
 
 from playwright.sync_api import Error as PlaywrightError
@@ -20,6 +21,7 @@ from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from ..browser import GOTO_TIMEOUT_MS
+from ..logging_setup import LOG_DIR
 from ..selector_groups import vacancy_page
 
 logger = logging.getLogger("hhru_bot.apply.steps")
@@ -53,6 +55,32 @@ class SubmitClickUncertain(Exception):
     def __init__(self, cause: PlaywrightError):
         super().__init__(f"submit-клик упал с исключением ({cause})")
         self.playwright_error = cause
+
+
+def _dump_navigation_diagnostics(page: Page, stage: str) -> None:
+    """Best-effort screenshot and HTML dump after an indeterminate form wait.
+
+    This is deliberately diagnostic-only: a failure to capture either artifact
+    must not change the apply result or interrupt the remaining vacancies.
+    ``time_ns`` keeps artifacts from consecutive retries distinct because this
+    path has no vacancy context.
+    """
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        prefix = LOG_DIR / f"apply_{stage}_{time.time_ns()}"
+        screenshot_path = prefix.with_suffix(".png")
+        html_path = prefix.with_suffix(".html")
+        screenshot_path.write_bytes(page.screenshot(full_page=True))
+        html_path.write_text(page.content(), encoding="utf-8")
+    except (OSError, PlaywrightError) as exc:
+        logger.warning("Диагностический дамп после %s недоступен: %s", stage, exc)
+        return
+    logger.info(
+        "Диагностический дамп после %s сохранён: %s, %s",
+        stage,
+        screenshot_path,
+        html_path,
+    )
 
 
 def wait_apply_button(page: Page) -> bool:
@@ -128,6 +156,7 @@ def navigate_to_response_form(page: Page) -> None:
             "**/applicant/vacancy_response**", wait_until="commit", timeout=GOTO_TIMEOUT_MS
         )
     except PlaywrightError as exc:
+        _dump_navigation_diagnostics(page, "navigation_timeout")
         logger.warning(
             "Навигация на форму отклика не подтвердилась (%s) — "
             "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
@@ -139,6 +168,7 @@ def navigate_to_response_form(page: Page) -> None:
             state="visible", timeout=APPLY_TIMEOUT_MS
         )
     except PlaywrightError as exc:
+        _dump_navigation_diagnostics(page, "form_timeout")
         # Форма не загрузилась — fill_response_form всё равно вернёт причину отказа
         # (submit не найден), логируем для диагностики устаревшего селектора.
         logger.warning("Форма отклика не отрисовалась (%s)", exc)

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -56,19 +56,24 @@ class SubmitClickUncertain(Exception):
         self.playwright_error = cause
 
 
-def _dump_navigation_diagnostics(page: Page, stage: str) -> None:
+def _dump_navigation_diagnostics(page: Page, stage: str, vacancy_id: str | None = None) -> None:
     """Best-effort screenshot and HTML dump after an indeterminate form wait.
 
     This is deliberately diagnostic-only: a failure to capture either artifact
     must not change the apply result or interrupt the remaining vacancies.
     Same idempotent-by-name convention as ``probe.dump_probe_snapshot``:
-    the filename is keyed only by ``stage`` (no vacancy context is available
-    on this path) so a repeated failure overwrites the previous dump instead
-    of accumulating a new pair of files per retry.
+    the filename is keyed by ``stage`` (plus ``vacancy_id`` when the caller has
+    one) so a repeated failure on the SAME vacancy overwrites its own previous
+    dump instead of accumulating a new pair of files per retry, while distinct
+    vacancies in one apply run keep separate artifacts (cycle-review round 2:
+    the pure by-stage key from round 1 fixed unbounded growth but lost the
+    per-vacancy context #192 needs to tell a slow DDoS-Guard load apart from a
+    drifted selector on a specific vacancy).
     """
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
-        prefix = LOG_DIR / f"apply_{stage}"
+        name = f"apply_{stage}" if vacancy_id is None else f"apply_{vacancy_id}_{stage}"
+        prefix = LOG_DIR / name
         screenshot_path = prefix.with_suffix(".png")
         html_path = prefix.with_suffix(".html")
         screenshot_path.write_bytes(page.screenshot(full_page=True))
@@ -93,8 +98,12 @@ def wait_apply_button(page: Page) -> bool:
     return True
 
 
-def navigate_to_response_form(page: Page) -> None:
+def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> None:
     """Кликает кнопку отклика и дожидается навигации на форму отклика.
+
+    ``vacancy_id`` (опционален — probe.py его тоже передаёт, но не обязан) даёт
+    диагностическим дампам таймаутов отдельное имя на вакансию, чтобы не терять
+    контекст при массовом apply-прогоне (см. ``_dump_navigation_diagnostics``).
 
     VACANCY_APPLY_BUTTON — это <a href="/applicant/vacancy_response?..."> (подтверждено
     curl-дампом реальной страницы вакансии), а не триггер модалки на этой же странице.
@@ -157,7 +166,7 @@ def navigate_to_response_form(page: Page) -> None:
             "**/applicant/vacancy_response**", wait_until="commit", timeout=GOTO_TIMEOUT_MS
         )
     except PlaywrightError as exc:
-        _dump_navigation_diagnostics(page, "navigation_timeout")
+        _dump_navigation_diagnostics(page, "navigation_timeout", vacancy_id)
         logger.warning(
             "Навигация на форму отклика не подтвердилась (%s) — "
             "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
@@ -169,7 +178,7 @@ def navigate_to_response_form(page: Page) -> None:
             state="visible", timeout=APPLY_TIMEOUT_MS
         )
     except PlaywrightError as exc:
-        _dump_navigation_diagnostics(page, "form_timeout")
+        _dump_navigation_diagnostics(page, "form_timeout", vacancy_id)
         # Форма не загрузилась — fill_response_form всё равно вернёт причину отказа
         # (submit не найден), логируем для диагностики устаревшего селектора.
         logger.warning("Форма отклика не отрисовалась (%s)", exc)

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -10,6 +10,7 @@ submit даёт отказ при отсутствии.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import pytest
 from playwright.sync_api import Error
@@ -181,6 +182,16 @@ class FakeStepsPage:
         # документа не наступает (тест регрессии на этот баг ниже).
         self.wait_for_url_calls: list[tuple[str, str | None, int | None]] = []
         self.wait_for_url_error: Exception | None = None
+        self.screenshot_calls = 0
+        self.content_calls = 0
+
+    def screenshot(self, **_kwargs) -> bytes:
+        self.screenshot_calls += 1
+        return b"png"
+
+    def content(self) -> str:
+        self.content_calls += 1
+        return "<html>diagnostic</html>"
 
     def _state(self, selector: str) -> _SelectorState:
         return self.states.setdefault(selector, _SelectorState())
@@ -333,6 +344,21 @@ def test_navigate_wait_for_url_timeout_does_not_raise():
     assert apply_state.clicks == 1
 
 
+def test_navigate_wait_for_url_timeout_saves_diagnostics(tmp_path: Path, monkeypatch):
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    page.wait_for_url_error = PlaywrightTimeoutError("navigation timeout")
+    monkeypatch.setattr(steps, "LOG_DIR", tmp_path)
+
+    steps.navigate_to_response_form(page)
+
+    assert page.screenshot_calls == 1
+    assert page.content_calls == 1
+    assert len(list(tmp_path.glob("apply_navigation_timeout_*.png"))) == 1
+    assert len(list(tmp_path.glob("apply_navigation_timeout_*.html"))) == 1
+
+
 def test_navigate_wait_for_url_non_timeout_error_does_not_raise():
     # #179 (code-review): раньше wait_for_url ловил только PlaywrightTimeoutError,
     # хотя non-timeout PlaywrightError (page/context closed, navigation aborted)
@@ -364,6 +390,19 @@ def test_navigate_apply_button_click_error_does_not_raise():
     steps.navigate_to_response_form(page)  # не должен бросать
 
     assert page.navigation_entered == 0  # wait_for_url не вызывался после сбойного клика
+
+
+def test_navigate_missing_submit_saves_diagnostics(tmp_path: Path, monkeypatch):
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    monkeypatch.setattr(steps, "LOG_DIR", tmp_path)
+
+    steps.navigate_to_response_form(page)
+
+    assert page.screenshot_calls == 1
+    assert page.content_calls == 1
+    assert len(list(tmp_path.glob("apply_form_timeout_*.png"))) == 1
+    assert len(list(tmp_path.glob("apply_form_timeout_*.html"))) == 1
 
 
 def test_navigate_clicks_apply_button_with_no_wait_after():

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -358,13 +358,32 @@ def test_navigate_wait_for_url_timeout_saves_diagnostics(tmp_path: Path, monkeyp
     assert (tmp_path / "apply_navigation_timeout.png").exists()
     assert (tmp_path / "apply_navigation_timeout.html").exists()
 
-    # Повторный таймаут перезаписывает те же файлы (идемпотентно по stage,
-    # как probe.dump_probe_snapshot), а не копит файл на каждый retry.
+    # Повторный таймаут БЕЗ vacancy_id перезаписывает те же файлы (идемпотентно
+    # по stage, как probe.dump_probe_snapshot), а не копит файл на каждый retry.
     steps.navigate_to_response_form(page)
 
     assert page.screenshot_calls == 2
     assert len(list(tmp_path.glob("apply_navigation_timeout*.png"))) == 1
     assert len(list(tmp_path.glob("apply_navigation_timeout*.html"))) == 1
+
+
+def test_navigate_wait_for_url_timeout_keeps_diagnostics_per_vacancy(tmp_path: Path, monkeypatch):
+    # cycle-review round 2: round-1 fix сделал имя чисто по stage и потерял
+    # контекст вакансии — при массовом apply-прогоне дамп одной вакансии
+    # затирался следующей, что противоречит цели #192 (сравнить артефакты
+    # разных вакансий). vacancy_id в имени разделяет их, оставаясь idempotent
+    # per-vacancy.
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+    page.wait_for_url_error = PlaywrightTimeoutError("navigation timeout")
+    monkeypatch.setattr(steps, "LOG_DIR", tmp_path)
+
+    steps.navigate_to_response_form(page, "111")
+    steps.navigate_to_response_form(page, "222")
+
+    assert (tmp_path / "apply_111_navigation_timeout.png").exists()
+    assert (tmp_path / "apply_222_navigation_timeout.png").exists()
 
 
 def test_navigate_wait_for_url_non_timeout_error_does_not_raise():

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -355,8 +355,16 @@ def test_navigate_wait_for_url_timeout_saves_diagnostics(tmp_path: Path, monkeyp
 
     assert page.screenshot_calls == 1
     assert page.content_calls == 1
-    assert len(list(tmp_path.glob("apply_navigation_timeout_*.png"))) == 1
-    assert len(list(tmp_path.glob("apply_navigation_timeout_*.html"))) == 1
+    assert (tmp_path / "apply_navigation_timeout.png").exists()
+    assert (tmp_path / "apply_navigation_timeout.html").exists()
+
+    # Повторный таймаут перезаписывает те же файлы (идемпотентно по stage,
+    # как probe.dump_probe_snapshot), а не копит файл на каждый retry.
+    steps.navigate_to_response_form(page)
+
+    assert page.screenshot_calls == 2
+    assert len(list(tmp_path.glob("apply_navigation_timeout*.png"))) == 1
+    assert len(list(tmp_path.glob("apply_navigation_timeout*.html"))) == 1
 
 
 def test_navigate_wait_for_url_non_timeout_error_does_not_raise():
@@ -401,8 +409,8 @@ def test_navigate_missing_submit_saves_diagnostics(tmp_path: Path, monkeypatch):
 
     assert page.screenshot_calls == 1
     assert page.content_calls == 1
-    assert len(list(tmp_path.glob("apply_form_timeout_*.png"))) == 1
-    assert len(list(tmp_path.glob("apply_form_timeout_*.html"))) == 1
+    assert (tmp_path / "apply_form_timeout.png").exists()
+    assert (tmp_path / "apply_form_timeout.html").exists()
 
 
 def test_navigate_clicks_apply_button_with_no_wait_after():


### PR DESCRIPTION
Closes #192

## Summary
- capture best-effort screenshot and HTML artifacts in data/logs after response navigation or form-render wait failures
- keep diagnostics fail-safe so capture errors do not interrupt apply
- add focused tests for both timeout paths

## Tests
- ruff check src/hhru_bot/apply/steps.py tests/test_apply_steps.py
- python -m pytest -q tests/test_apply_steps.py tests/test_apply_probe.py

Known warning: pytest emits the existing pytest-asyncio loop-scope deprecation warning.