### PR TITLE
feat(report): add reply analytics to stats and funnel

### DIFF
--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -47,7 +47,7 @@ def run(args: argparse.Namespace) -> None:
 
     from ..config import ConfigError, load_config_or_exit
     from ..history import History
-    from ..report import format_actions, format_summary
+    from ..report import format_actions, format_replies, format_summary
 
     # --resume получает slug из конфига (resume.id), но история apply/bump
     # хранится под resume.resume_id (стабильный числовой id hh.ru — см. #2).
@@ -70,3 +70,8 @@ def run(args: argparse.Namespace) -> None:
     else:
         summary = history.summary(resume_id=resume_id, period=args.period)
         print(format_summary(summary, args.format))
+        print(
+            format_replies(
+                history.reply_summary(resume_id=resume_id, period=args.period), args.format
+            )
+        )

--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -70,8 +70,14 @@ def run(args: argparse.Namespace) -> None:
     else:
         summary = history.summary(resume_id=resume_id, period=args.period)
         print(format_summary(summary, args.format))
-        print(
-            format_replies(
-                history.reply_summary(resume_id=resume_id, period=args.period), args.format
+        # CSV — экспорт для машин: один документ, одна схема колонок (см. #112
+        # ревью). Reply-сводка имеет другую схему (metric,value), поэтому в csv
+        # её печатать вторым документом в тот же stdout-поток нельзя — консьюмер,
+        # парсящий вывод одним csv.reader, получит смешение схем. Показываем её
+        # только в человекочитаемых форматах.
+        if args.format != "csv":
+            print(
+                format_replies(
+                    history.reply_summary(resume_id=resume_id, period=args.period), args.format
+                )
             )
-        )

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -439,6 +439,47 @@ class History:
             result["total"] += cnt
         return result
 
+    def reply_summary(self, resume_id: str | None, period: str) -> dict:
+        """Сводка наших ответов из локальной таблицы ``replies``.
+
+        Успешные ответы считаются отправленными; ``dry_run`` в отправки не
+        входит. Счётчики вариантов относятся к выбранному периоду.
+        """
+        filters: list[str] = []
+        params: list = []
+        if resume_id is not None:
+            filters.append("resume_id = ?")
+            params.append(resume_id)
+        since = self._period_since(period)
+        period_filters = [*filters]
+        period_params = [*params]
+        if since is not None:
+            period_filters.append("created_at >= ?")
+            period_params.append(since)
+        period_clause = " WHERE " + " AND ".join(period_filters) if period_filters else ""
+        total_filters = [*filters, "status = 'success'"]
+        total_clause = " WHERE " + " AND ".join(total_filters)
+        with self._connect() as conn:
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM replies{total_clause}", params
+            ).fetchone()[0]
+            rows = conn.execute(
+                f"SELECT status, letter_variant, COUNT(*) AS cnt FROM replies{period_clause} "
+                "GROUP BY status, letter_variant",
+                period_params,
+            ).fetchall()
+        result = {"total": total, "period": {"success": 0, "failed": 0}, "letter_variants": {}}
+        for row in rows:
+            if row["status"] == "success":
+                result["period"]["success"] += row["cnt"]
+                variant = row["letter_variant"] or "unknown"
+                result["letter_variants"][variant] = (
+                    result["letter_variants"].get(variant, 0) + row["cnt"]
+                )
+            elif row["status"] == "failed":
+                result["period"]["failed"] += row["cnt"]
+        return result
+
     def list_actions(self, resume_id: str | None, period: str, limit: int = 50) -> list[dict]:
         """Последние действия (свежие первыми) для таблицы stats.
 
@@ -692,6 +733,11 @@ class History:
                         SELECT 1 FROM manual_offers m
                         WHERE m.resume_id = a.resume_id AND m.vacancy_id = a.vacancy_id
                     ) THEN a.vacancy_id END) AS offer
+                    ,COUNT(DISTINCT CASE WHEN EXISTS (
+                        SELECT 1 FROM responses r
+                        JOIN replies p ON p.topic = r.topic AND p.status = 'success'
+                        WHERE r.vacancy_id = a.vacancy_id
+                    ) THEN a.vacancy_id END) AS replied
                 FROM actions AS a
                 {clause}
                 GROUP BY a.resume_id
@@ -702,16 +748,19 @@ class History:
 
         funnel: list[dict] = []
         for row in rows:
-            sent, viewed, invited, offer = row["sent"], row["viewed"], row["invited"], row["offer"]
+            sent, viewed, invited = row["sent"], row["viewed"], row["invited"]
+            replied, offer = row["replied"], row["offer"]
             funnel.append(
                 {
                     "resume_id": row["resume_id"],
                     "sent": sent,
                     "viewed": viewed,
                     "invited": invited,
+                    "replied": replied,
                     "offer": offer,
                     "view_rate": self._pct(viewed, sent),
                     "invite_rate": self._pct(invited, viewed),
+                    "reply_rate": self._pct(replied, invited),
                     "offer_rate": self._pct(offer, invited),
                 }
             )

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -440,10 +440,12 @@ class History:
         return result
 
     def reply_summary(self, resume_id: str | None, period: str) -> dict:
-        """Сводка наших ответов из локальной таблицы ``replies``.
+        """Сводка наших ответов из локальной таблицы ``replies`` за период.
 
         Успешные ответы считаются отправленными; ``dry_run`` в отправки не
-        входит. Счётчики вариантов относятся к выбранному периоду.
+        входит. ``total`` и ``period``/``letter_variants`` уважают один и тот
+        же ``period`` (как ``summary().total`` — #112 review), а не только
+        ``resume_id``.
         """
         filters: list[str] = []
         params: list = []
@@ -457,12 +459,12 @@ class History:
             period_filters.append("created_at >= ?")
             period_params.append(since)
         period_clause = " WHERE " + " AND ".join(period_filters) if period_filters else ""
-        total_filters = [*filters, "status = 'success'"]
+        total_filters = [*period_filters, "status = 'success'"]
         total_clause = " WHERE " + " AND ".join(total_filters)
         with self._connect() as conn:
-            total = conn.execute(f"SELECT COUNT(*) FROM replies{total_clause}", params).fetchone()[
-                0
-            ]
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM replies{total_clause}", period_params
+            ).fetchone()[0]
             rows = conn.execute(
                 f"SELECT status, letter_variant, COUNT(*) AS cnt FROM replies{period_clause} "
                 "GROUP BY status, letter_variant",

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -460,9 +460,9 @@ class History:
         total_filters = [*filters, "status = 'success'"]
         total_clause = " WHERE " + " AND ".join(total_filters)
         with self._connect() as conn:
-            total = conn.execute(
-                f"SELECT COUNT(*) FROM replies{total_clause}", params
-            ).fetchone()[0]
+            total = conn.execute(f"SELECT COUNT(*) FROM replies{total_clause}", params).fetchone()[
+                0
+            ]
             rows = conn.execute(
                 f"SELECT status, letter_variant, COUNT(*) AS cnt FROM replies{period_clause} "
                 "GROUP BY status, letter_variant",

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -675,23 +675,30 @@ class History:
     ) -> list[dict]:
         """Воронка отправлено → просмотрено → приглашение → оффер по резюме.
 
-        Этапы КУМУЛЯТИВНЫЕ (sent ⊇ viewed ⊇ invited ⊇ offer): вакансия, до которой
-        дошло приглашение, считается и просмотренной; оффер — и просмотренным, и
-        приглашённым. Это необходимо, т.к. #12 хранит в responses только ТЕКУЩИЙ
-        статус переписки (после read→invitation прежний read уже не виден) —
-        некумулятивный подсчёт давал бы viewed=0 после перехода. «Просмотрено» =
-        любой ответ работодателя (#12: read/response/invitation/discard/offer) —
-        отказ или письмо тоже означают, что резюме видели.
+        Этапы КУМУЛЯТИВНЫЕ (sent ⊇ viewed ⊇ invited ⊇ replied ⊇ offer): вакансия,
+        до которой дошло приглашение, считается и просмотренной; оффер — и
+        просмотренным, и приглашённым, и отвеченным нами. Это необходимо, т.к.
+        #12 хранит в responses только ТЕКУЩИЙ статус переписки (после
+        read→invitation прежний read уже не виден) — некумулятивный подсчёт
+        давал бы viewed=0 после перехода. «Просмотрено» = любой ответ
+        работодателя (#12: read/response/invitation/discard/offer) — отказ или
+        письмо тоже означают, что резюме видели. «Наш ответ» (replied, #112) =
+        залогированный успешный ``replies``-ответ на invitation/offer, ИЛИ сам
+        факт оффера (responses status='offer' или ручная пометка manual_offers)
+        — оффер невозможен без нашего ответа, даже если сам факт ответа не
+        попал в локальный журнал (ручной оффер, сбой логирования).
 
-        Ответы берутся из responses (#12, account-scope по vacancy_id) плюс липкие
-        ручные пометки из manual_offers (per-resume). Группировка по actions.resume_id.
-        Пер-резюме точность ограничена account-scope responses (ответ одной вакансии
-        зачтётся всем резюме, откликнувшимся в неё) — это ограничение источника
-        данных #12 (нет достоверного связывания ответ→резюме).
+        Ответы берутся из responses (#12, account-scope по vacancy_id) и
+        replies (#108, account-scope по topic) плюс липкие ручные пометки из
+        manual_offers (per-resume). Группировка по actions.resume_id. Пер-резюме
+        точность ограничена account-scope responses/replies (ответ одной
+        вакансии зачтётся всем резюме, откликнувшимся в неё) — это ограничение
+        источника данных #12/#108 (нет достоверного связывания ответ→резюме).
 
-        Конверсии: view_rate=viewed/sent, invite_rate=invited/viewed, offer_rate=
-        offer/invited; 0% при пустом знаменателе. Возвращает список словарей (по
-        строке на resume_id, отсортированных по убыванию отправленных). Пусто → [].
+        Конверсии: view_rate=viewed/sent, invite_rate=invited/viewed, reply_rate=
+        replied/invited, offer_rate=offer/invited; 0% при пустом знаменателе.
+        Возвращает список словарей (по строке на resume_id, отсортированных по
+        убыванию отправленных). Пусто → [].
         """
         where = ["a.action = 'apply'", "a.status = 'success'"]
         params: list = []
@@ -740,6 +747,12 @@ class History:
                         JOIN replies p ON p.topic = r.topic AND p.status = 'success'
                         WHERE r.vacancy_id = a.vacancy_id
                           AND r.status IN ('invitation', 'offer')
+                    ) OR EXISTS (
+                        SELECT 1 FROM responses r
+                        WHERE r.vacancy_id = a.vacancy_id AND r.status = 'offer'
+                    ) OR EXISTS (
+                        SELECT 1 FROM manual_offers m
+                        WHERE m.resume_id = a.resume_id AND m.vacancy_id = a.vacancy_id
                     ) THEN a.vacancy_id END) AS replied
                 FROM actions AS a
                 {clause}

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -739,6 +739,7 @@ class History:
                         SELECT 1 FROM responses r
                         JOIN replies p ON p.topic = r.topic AND p.status = 'success'
                         WHERE r.vacancy_id = a.vacancy_id
+                          AND r.status IN ('invitation', 'offer')
                     ) THEN a.vacancy_id END) AS replied
                 FROM actions AS a
                 {clause}

--- a/src/hhru_bot/report.py
+++ b/src/hhru_bot/report.py
@@ -101,6 +101,30 @@ def format_summary(summary: dict, fmt: str) -> str:
     return _ascii_table(header, rows, footer=["Итого", str(total)] + [""] * (len(header) - 2))
 
 
+def format_replies(summary: dict, fmt: str) -> str:
+    """Отрисовать сводку наших ответов работодателям."""
+    _check_format(fmt)
+    variants = summary.get("letter_variants", {})
+    rows = [
+        ["Всего отправлено", str(summary.get("total", 0))],
+        ["За период", str(summary.get("period", {}).get("success", 0))],
+        ["Провалено за период", str(summary.get("period", {}).get("failed", 0))],
+    ]
+    rows.extend([f"Шаблон: {variant}", str(count)] for variant, count in sorted(variants.items()))
+    header = ["Метрика", "Значение"]
+    if fmt == "csv":
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(["metric", "value"])
+        writer.writerows(rows)
+        return out.getvalue().rstrip("\n")
+    if fmt == "md":
+        return "| Метрика | Значение |\n| --- | --- |\n" + "\n".join(
+            f"| {label} | {value} |" for label, value in rows
+        )
+    return _ascii_table(header, rows)
+
+
 # --- actions ----------------------------------------------------------------
 
 

--- a/src/hhru_bot/report_funnel.py
+++ b/src/hhru_bot/report_funnel.py
@@ -3,7 +3,7 @@
 Отдельный файл от report.py — конвенция CLAUDE.md: «один report-топик на файл»
 (report.py владеет #11/stats, здесь — воронка/фаннел #13).
 
-Воронка: отправлено → просмотрено → приглашение → оффер, с конверсиями между
+Воронка: отправлено → просмотрено → приглашение → наш ответ → оффер, с конверсиями между
 шагами. Плюс «мёртвая зона» (отклики без ответа старше N дней). Форматы table/md
 (как в теле #13). Только текст/ASCII — НИКАКИХ эмодзи (правило CLI-вывода).
 """
@@ -30,9 +30,11 @@ _FUNNEL_COLUMNS = (
     "sent",
     "viewed",
     "invited",
+    "replied",
     "offer",
     "view_rate",
     "invite_rate",
+    "reply_rate",
     "offer_rate",
 )
 
@@ -41,9 +43,11 @@ _FUNNEL_HEADERS = {
     "sent": "Отправлено",
     "viewed": "Просмотрено",
     "invited": "Приглашение",
+    "replied": "Наш ответ",
     "offer": "Оффер",
     "view_rate": "Просмотры %",
     "invite_rate": "Приглаш. %",
+    "reply_rate": "Наш ответ %",
     "offer_rate": "Оффер %",
 }
 
@@ -67,9 +71,11 @@ def _funnel_rows(funnel: Iterable[dict]) -> list[list[str]]:
                 str(r.get("sent", 0)),
                 str(r.get("viewed", 0)),
                 str(r.get("invited", 0)),
+                str(r.get("replied", 0)),
                 str(r.get("offer", 0)),
                 _fmt_rate(r.get("view_rate", 0.0)),
                 _fmt_rate(r.get("invite_rate", 0.0)),
+                _fmt_rate(r.get("reply_rate", 0.0)),
                 _fmt_rate(r.get("offer_rate", 0.0)),
             ]
         )

--- a/tests/test_history_funnel.py
+++ b/tests/test_history_funnel.py
@@ -296,3 +296,18 @@ def test_mark_offer_creates_record_even_without_action(tmp_path):
             ("r1", "v1"),
         ).fetchone()
     assert row is not None
+
+
+def test_funnel_counts_successful_reply_by_response_topic(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.record_action("r1", "v2", "apply", "success")
+    h.upsert_response("v1", "Acme", "invitation", "/chat/1", topic="t1")
+    h.upsert_response("v2", "Acme", "invitation", "/chat/2", topic="t2")
+    h.record_reply("t1", "m1", status="success")
+    h.record_reply("t2", "m2", status="dry_run")
+
+    row = h.funnel_by_resume(since=None)[0]
+    assert row["invited"] == 2
+    assert row["replied"] == 1
+    assert row["reply_rate"] == 50.0

--- a/tests/test_history_funnel.py
+++ b/tests/test_history_funnel.py
@@ -311,3 +311,26 @@ def test_funnel_counts_successful_reply_by_response_topic(tmp_path):
     assert row["invited"] == 2
     assert row["replied"] == 1
     assert row["reply_rate"] == 50.0
+
+
+def test_funnel_reply_rate_cannot_exceed_invited_count(tmp_path):
+    """reply_rate не должен превышать 100% (#112 review, cycle 2).
+
+    replied должен быть подмножеством invited: успешный ответ на переписку,
+    НЕ дошедшую до приглашения (status='read'/'response'), не должен
+    засчитываться в replied — иначе replied может превысить invited и
+    reply_rate станет невалидным (>100%)."""
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "vA", "apply", "success")
+    h.record_action("r1", "vB", "apply", "success")
+    h.record_action("r1", "vC", "apply", "success")
+    h.upsert_response("vA", "Acme", "invitation", "/chat/a", topic="tA")
+    h.upsert_response("vB", "Acme", "read", "/chat/b", topic="tB")
+    h.upsert_response("vC", "Acme", "response", "/chat/c", topic="tC")
+    h.record_reply("tB", "m-b", status="success")
+    h.record_reply("tC", "m-c", status="success")
+
+    row = h.funnel_by_resume(since=None)[0]
+    assert row["invited"] == 1
+    assert row["replied"] == 0
+    assert row["reply_rate"] <= 100.0

--- a/tests/test_history_funnel.py
+++ b/tests/test_history_funnel.py
@@ -141,6 +141,24 @@ def test_funnel_offer_counted_from_mark(tmp_path):
     # кумулятивно: offer → и viewed, и invited тоже
     assert row["viewed"] == 1
     assert row["invited"] == 1
+    # РЕГРЕССИЯ (#112 review, cycle 3): offer ⊆ replied тоже, даже когда оффер
+    # пришёл через ручную пометку mark_offer без залогированного replies-ответа.
+    assert row["replied"] == 1
+
+
+def test_funnel_offer_via_responses_counts_as_replied_without_logged_reply(tmp_path):
+    """РЕГРЕССИЯ (#112 review, cycle 3): responses.status='offer' без replies-строки.
+
+    Оффер физически невозможен без нашего ответа работодателю, даже если сам
+    факт ответа не попал в локальный журнал replies (сбой логирования,
+    ответили не через бота). offer=1 должен подразумевать replied=1."""
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+    h.upsert_response("v1", "Acme", "offer", "/chat/1", topic="t1")
+
+    row = h.funnel_by_resume(since=None)[0]
+    assert row["offer"] == 1
+    assert row["replied"] == 1
 
 
 def test_funnel_multi_topic_vacancy_no_inflation(tmp_path):

--- a/tests/test_history_replies.py
+++ b/tests/test_history_replies.py
@@ -316,6 +316,19 @@ def test_record_reply_accepts_known_statuses(tmp_path):
     assert len(h.replies_since(datetime(2000, 1, 1))) == len(REPLY_STATUS_VALUES)
 
 
+def test_reply_summary_excludes_dry_run_and_groups_variants(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="success", letter_variant="template")
+    h.record_reply("t2", "m2", status="success", letter_variant="ai")
+    h.record_reply("t3", "m3", status="dry_run", letter_variant="ai")
+    h.record_reply("t4", "m4", status="failed", letter_variant="template")
+
+    summary = h.reply_summary(None, "all")
+    assert summary["total"] == 2
+    assert summary["period"] == {"success": 2, "failed": 1}
+    assert summary["letter_variants"] == {"ai": 1, "template": 1}
+
+
 def test_reply_status_values_match_actions_vocabulary():
     # Словарь тот же, что у actions (#55): без новых состояний.
     assert set(REPLY_STATUS_VALUES) == {"success", "failed", "dry_run"}

--- a/tests/test_history_replies.py
+++ b/tests/test_history_replies.py
@@ -329,6 +329,27 @@ def test_reply_summary_excludes_dry_run_and_groups_variants(tmp_path):
     assert summary["letter_variants"] == {"ai": 1, "template": 1}
 
 
+def test_reply_summary_total_respects_period_like_summary_does(tmp_path):
+    """total должен уважать --period так же, как соседний summary().total (#112 review).
+
+    Старая (400 дней назад) и свежая успешные записи: period='today' должен
+    видеть только свежую и в total, и в period.success — иначе «Всего
+    отправлено» вводит в заблуждение рядом со «За период» на том же экране."""
+    h = History(tmp_path / "h.db")
+    old_ts = (datetime.now() - timedelta(days=400)).isoformat()
+    with h._connect() as conn:
+        conn.execute(
+            "INSERT INTO replies (topic, inbound_marker, status, created_at) "
+            "VALUES (?, ?, 'success', ?)",
+            ("t-old", "m-old", old_ts),
+        )
+    h.record_reply("t-new", "m-new", status="success")
+
+    summary = h.reply_summary(None, "today")
+    assert summary["total"] == 1
+    assert summary["period"]["success"] == 1
+
+
 def test_reply_status_values_match_actions_vocabulary():
     # Словарь тот же, что у actions (#55): без новых состояний.
     assert set(REPLY_STATUS_VALUES) == {"success", "failed", "dry_run"}

--- a/tests/test_stats_command.py
+++ b/tests/test_stats_command.py
@@ -8,6 +8,7 @@ run() — с минимальным конфигом и seeded SQLite-истор
 from __future__ import annotations
 
 import argparse
+import io
 import textwrap
 
 from hhru_bot.commands import stats as stats_cmd
@@ -93,6 +94,32 @@ def test_stats_run_csv_export_machine_readable(capsys, tmp_path):
     # машиночитаемые имена колонок сводки (#176: добавлена колонка uncertain —
     # действие могло выполниться при упавшем посреди клика Playwright)
     assert out.splitlines()[0] == "action,success,dry_run,failed,uncertain"
+
+
+def test_stats_run_csv_export_is_single_valid_csv_document(capsys, tmp_path):
+    """CSV-режим — экспорт для машин: один документ, одна схема колонок.
+
+    Регрессия #112 (reply-аналитика в stats): второй печатаемый блок
+    (format_replies) не должен начинать в том же stdout-потоке новый
+    CSV-документ с другим набором колонок (metric,value) — консьюмер,
+    парсящий stdout одним csv.reader, увидит смешение схем и упадёт/
+    получит битые данные."""
+    import csv as csv_module
+
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success")
+
+    stats_cmd.run(_args(config, tmp_path / "h.db", format="csv"))
+    out = capsys.readouterr().out
+
+    rows = list(csv_module.reader(io.StringIO(out)))
+    header = rows[0]
+    for row in rows[1:]:
+        assert len(row) == len(header), (
+            f"CSV-строка {row!r} не соответствует схеме заголовка {header!r} — "
+            "второй документ (reply-сводка) не должен ломать единую CSV-схему"
+        )
 
 
 def test_stats_run_resume_filter(capsys, tmp_path):


### PR DESCRIPTION
Closes #112

## Summary
- add local replies analytics to `stats` (sent totals, period success/failed, letter variants)
- add successful employer-topic replies as a funnel stage
- exclude `dry_run` replies from sent/replied counts

## Tests
- `ruff check ...`
- focused pytest suites for replies, funnel, reports, and commands