### PR TITLE
fix(responses): read vacancy href from ancestor anchor, not data-qa span

### DIFF
--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -248,6 +248,30 @@ def _first_locator(item, *selectors):
     return item.locator(selectors[0]).first
 
 
+def _href_or_ancestor_href(link) -> str:
+    """Read ``href`` off ``link``, falling back to its nearest ``<a>`` ancestor.
+
+    #44 live check (2026-08-16): ``negotiations-item-vacancy`` is a ``<span>``
+    with no href of its own; the vacancy link lives on the wrapping ``<a>``.
+    Reading href directly on the data-qa node silently returned "" for every
+    card, so ``parse_response_card`` dropped the whole page ("vacancy_id не
+    извлечён"). Prefer the element's own href when present (covers markup
+    where data-qa IS the anchor, e.g. LEGACY_* fixtures), else walk up to the
+    closest anchor ancestor — same category of DOM-structure assumption as
+    ``_form_scope()`` in apply/questions.py, not yet independently reconfirmed
+    beyond this one live check.
+    """
+    if not link.count():
+        return ""
+    href = link.get_attribute("href")
+    if href:
+        return href
+    ancestor = link.locator("xpath=ancestor::a[1]")
+    if ancestor.count():
+        return ancestor.get_attribute("href") or ""
+    return ""
+
+
 def parse_response_card(item) -> ResponseItem | None:
     """Парсит один locator карточки переписки в ResponseItem, либо None.
 
@@ -255,7 +279,7 @@ def parse_response_card(item) -> ResponseItem | None:
     Чистая относительно Playwright-locator'а: импортирует только типы селекторов.
     """
     link = _first_locator(item, ns.NEGOTIATION_VACANCY_LINK, ns.LEGACY_NEGOTIATION_VACANCY_LINK)
-    vacancy_href = link.get_attribute("href") or "" if link.count() else ""
+    vacancy_href = _href_or_ancestor_href(link)
     vacancy_id = _extract_vacancy_id(vacancy_href)
     if not vacancy_id:
         return None

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 # Карточка одной переписки в списке откликов/приглашений.
 NEGOTIATION_ITEM = "[data-qa='negotiations-item']"
-# Ссылка на вакансию внутри карточки — из её href достаём vacancy_id и chat_url.
+# Вакансия внутри карточки. Живая разметка (#44) — <span> без href, вложенный
+# в <a href="/vacancy/...">; vacancy_id/chat_url достаёт _href_or_ancestor_href()
+# в responses.py, поднимаясь до предка <a>, если у самого узла href нет.
 NEGOTIATION_VACANCY_LINK = "[data-qa='negotiations-item-vacancy']"
 # Название компании-работодода. Опционально (hh.ru иногда прячет для анонимных
 # вакансий) — пустая строка, если элемента нет.

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -24,6 +24,10 @@ _QA_RE = re.compile(r"^\[data-qa=(?:['\"])([A-Za-z0-9_\-]+)(?:['\"])\]$")
 # = "[data-qa^='negotiations-tag']" — без этой ветки _parse_selector вернул бы None,
 # и find_all(qa=None) молча матчил бы ЛЮБОЙ узел вместо ничего).
 _QA_PREFIX_RE = re.compile(r"^\[data-qa\^=(?:['\"])([A-Za-z0-9_\-]+)(?:['\"])\]$")
+# ``xpath=ancestor::a[1]`` → nearest <a> ancestor (used by responses.py's
+# _href_or_ancestor_href, #44 live fix: negotiations-item-vacancy is a <span>
+# wrapped by the actual <a href=...>).
+_XPATH_ANCESTOR_RE = re.compile(r"^xpath=ancestor::([a-z]+)\[1\]$")
 
 # void-теги без закрывающего.
 _VOID = {"area", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source"}
@@ -32,13 +36,14 @@ _VOID = {"area", "br", "col", "embed", "hr", "img", "input", "link", "meta", "so
 class _DOMNode:
     """Минимальный узел DOM: tag, attrs, дочерние узлы, накопленный текст."""
 
-    __slots__ = ("tag", "attrs", "children", "text")
+    __slots__ = ("tag", "attrs", "children", "text", "parent")
 
     def __init__(self, tag: str, attrs: dict[str, str]):
         self.tag = tag
         self.attrs = attrs
         self.children: list[_DOMNode] = []
         self.text = ""
+        self.parent: _DOMNode | None = None
 
     def find_all(self, tag: str | None, qa_match) -> list[_DOMNode]:  # noqa: ANN001
         out: list[_DOMNode] = []
@@ -68,6 +73,7 @@ class _DOMBuilder(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         node = _DOMNode(tag, {k: (v or "") for k, v in attrs})
+        node.parent = self._stack[-1]
         self._stack[-1].children.append(node)
         if tag not in _VOID:
             self._stack.append(node)
@@ -88,6 +94,15 @@ def _parse_root(html: str) -> _DOMNode:
     b = _DOMBuilder()
     b.feed(html)
     return b.root
+
+
+def _nearest_ancestor(node: _DOMNode, tag: str) -> _DOMNode | None:
+    current = node.parent
+    while current is not None:
+        if current.tag == tag:
+            return current
+        current = current.parent
+    return None
 
 
 class FakeLocator:
@@ -141,6 +156,15 @@ class FakeLocator:
 
         raise PlaywrightTimeoutError("fake locator did not attach")
 
+    def locator(self, selector: str) -> FakeLocator:
+        """Only supports ``xpath=ancestor::<tag>[1]`` (see #44 live fix)."""
+        node = self._resolved()[0] if self._resolved() else _DOMNode("#empty", {})
+        ancestor_match = _XPATH_ANCESTOR_RE.match(selector.strip())
+        if ancestor_match:
+            found = _nearest_ancestor(node, ancestor_match.group(1))
+            return FakeLocator(node, lambda _v: False, matches=[found] if found else [])
+        raise AssertionError(f"FakeLocator.locator unsupported selector: {selector}")
+
 
 class _CardLocator(FakeLocator):
     """Локатор карточки: ``.locator(selector)`` ищет ВНУТРИ этой карточки.
@@ -150,8 +174,13 @@ class _CardLocator(FakeLocator):
     """
 
     def locator(self, selector: str) -> FakeLocator:
-        qa_match = _parse_selector(selector)
         node = self._resolved()[0] if self._resolved() else _DOMNode("#empty", {})
+        ancestor_match = _XPATH_ANCESTOR_RE.match(selector.strip())
+        if ancestor_match:
+            tag = ancestor_match.group(1)
+            found = _nearest_ancestor(node, tag)
+            return FakeLocator(node, lambda _v: False, matches=[found] if found else [])
+        qa_match = _parse_selector(selector)
         return FakeLocator(node, qa_match)
 
 

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -238,6 +238,32 @@ def test_parse_response_card_falls_back_to_live_status_selector():
     assert item.status == ResponseStatus.INVITATION
 
 
+# #44 (2026-08-16): живая сверка /applicant/negotiations показала, что
+# ``negotiations-item-vacancy`` — это <span> БЕЗ href, вложенный в <div> внутри
+# <a href="/vacancy/...">. До фикса это молча ронялось в
+# "vacancy_id не извлечён" на ВСЕХ карточках (headless-прогон дал 0 из 7 живых
+# ответов работодателей). _href_or_ancestor_href должен подняться до ближайшего
+# предка <a>.
+_LIVE_VACANCY_SPAN_HTML = """
+<div data-qa="negotiations-item">
+  <a href="/vacancy/135481754?hhtmFrom=negotiation_list">
+    <div><span data-qa="negotiations-item-vacancy">Senior Python Backend Developer</span></div>
+  </a>
+  <div data-qa="negotiations-item-company">"МТС", Работа в IT</div>
+  <span data-qa="negotiations-tag negotiations-item-not-viewed">Прочитано</span>
+</div>
+"""
+
+
+def test_parse_response_card_reads_vacancy_href_from_ancestor_anchor():
+    """Реальная разметка hh.ru: data-qa на <span> внутри <a>, а не на самом <a>."""
+    page = NegotiationsPage(_LIVE_VACANCY_SPAN_HTML)
+    item = parse_response_card(page.items[0])
+    assert item is not None
+    assert item.vacancy_id == "135481754"
+    assert item.employer == '"МТС", Работа в IT'
+
+
 _UNRECOGNIZED_LEGACY_STATUS_HTML = """
 <div data-qa="negotiations-item">
   <a data-qa="negotiations-item__vacancy-link" href="/vacancy/555555">QA Engineer</a>


### PR DESCRIPTION
## Проблема

Живая проверка `/applicant/negotiations` (issue #44) показала, что команда `responses` полностью сломана: `headless` прогон на реальном аккаунте с 7 карточками переписки (включая настоящий ответ работодателя — вакансия 135481754 «МТС» — и первое живое сообщение авто-скрининг бота «Робот-рекрутер») давал **0 из 7** результатов, каждая карточка молча ронялась с `vacancy_id не извлечён`.

## Причина

`negotiations-item-vacancy` в реальном DOM — это `<span>` без `href`, вложенный через `<div>` в `<a href="/vacancy/...">`:

```html
<a href="/vacancy/135481754?hhtmFrom=negotiation_list">
  <div><span data-qa="negotiations-item-vacancy">Senior Python Backend Developer</span></div>
</a>
```

`parse_response_card` читал `href` напрямую с data-qa узла (span) и получал пустую строку на каждой карточке.

## Фикс

`_href_or_ancestor_href()`: сначала пробует `href` на самом элементе (сохраняет обратную совместимость с `LEGACY_*`-фикстурами, где data-qa — это сам `<a>`), иначе поднимается до ближайшего предка `<a>` через `xpath=ancestor::a[1]` — тот же класс DOM-структурного допущения, что и `_form_scope()` в `apply/questions.py`.

## Тесты

- Новый тест `test_parse_response_card_reads_vacancy_href_from_ancestor_anchor` с фикстурой 1:1 копирующей живой DOM.
- `tests/_fakes.py`: добавлена поддержка `xpath=ancestor::<tag>[1]` (parent-ссылки в узлах + новый вид локатора).
- Полный `pytest` (679 тестов) + `ruff check`/`format --check` — зелёные.

## Живая верификация

`responses --headless` на реальном аккаунте: **до фикса 0/7**, **после фикса 7/7** карточек корректно распознаны и записаны в историю, включая вакансию 135481754 «МТС».

Closes #44 (пп. 1–2 из чек-листа issue: селекторы верифицированы вживую, дедупликация подтверждена на реальных карточках; п.3 — auth-recheck после render-wait — не затронут этим фиксом, может остаться follow-up при необходимости).