### PR TITLE
fix(apply): extend success confirmation timeout

### DIFF
--- a/src/hhru_bot/apply/success.py
+++ b/src/hhru_bot/apply/success.py
@@ -94,9 +94,15 @@ def _sleep(page: Page, ms: float) -> None:
 # Шаг poll-loop между переодпросами сигналов (мс). Меньше — быстрее ловит
 # async-рендер, больше — меньше накладных. 80 мс — баланс для ручного CLI.
 _POLL_INTERVAL_MS = 80
+# Success UI is rendered asynchronously after the submit/navigation completes.
+# Keep this bounded, but allow the same slow hh.ru/DDoS-Guard responses that
+# motivated the 90-second navigation timeout to finish rendering their signal.
+SUCCESS_CONFIRMATION_TIMEOUT_MS = 30_000
 
 
-def wait_success_confirmation(page: Page, timeout_ms: int = 10_000) -> bool:
+def wait_success_confirmation(
+    page: Page, timeout_ms: int = SUCCESS_CONFIRMATION_TIMEOUT_MS
+) -> bool:
     """Подтверждает успех отклика по позитивным сигналам.
 
     Возвращает True, если в пределах timeout_ms появился любой позитивный
@@ -108,8 +114,8 @@ def wait_success_confirmation(page: Page, timeout_ms: int = 10_000) -> bool:
 
     Таймаут намеренно даёт false-negative: неудачно подтверждённый отклик
     записывается как status='failed', чтобы не считать его достоверным успехом.
-    Это осознанный выбор проекта: permanent-дедупликация по success важнее
-    риска повторного отклика, поэтому ждём именно union, а не один маркер.
+    Окно подтверждения — 30 секунд: это снижает false-negative на медленном
+    hh.ru, оставаясь ограниченным и не меняя fail-closed правило для сигналов.
     """
     deadline = time.monotonic() + timeout_ms / 1000
     while True:

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -9,10 +9,20 @@
 
 from __future__ import annotations
 
+import inspect
+
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot.apply import success
 from hhru_bot.apply.locators import first_locator
+
+
+def test_default_confirmation_timeout_is_bounded_and_explicit():
+    """Медленный UI получает больше времени, но не неограниченное ожидание."""
+    default = inspect.signature(success.wait_success_confirmation).parameters[
+        "timeout_ms"
+    ].default
+    assert default == success.SUCCESS_CONFIRMATION_TIMEOUT_MS == 30_000
 
 
 class _FakeLocator:

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -19,9 +19,7 @@ from hhru_bot.apply.locators import first_locator
 
 def test_default_confirmation_timeout_is_bounded_and_explicit():
     """Медленный UI получает больше времени, но не неограниченное ожидание."""
-    default = inspect.signature(success.wait_success_confirmation).parameters[
-        "timeout_ms"
-    ].default
+    default = inspect.signature(success.wait_success_confirmation).parameters["timeout_ms"].default
     assert default == success.SUCCESS_CONFIRMATION_TIMEOUT_MS == 30_000
 
 


### PR DESCRIPTION
Closes #199

## Summary
- increase the bounded success-signal polling window from 10s to 30s for slow hh.ru renders
- add explicit regression coverage for the default timeout
- preserve positive-signal-only, fail-closed success detection

## Tests
- pytest -q tests/test_apply_success.py
- ruff check src/hhru_bot/apply/success.py tests/test_apply_success.py
- git diff --check