### PR TITLE
fix(negotiations): paginate topic mapping and record uncertain replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Account-wide ответы в чатах: план из локальной ист
 
 - `--dry-run` — Показать план без отправки
 - `--limit LIMIT` — Максимум чатов за запуск (0 = все)
+- `--max-pages MAX_PAGES` — Максимум страниц negotiations для SSR mapping (по умолчанию 5) (по умолчанию: 5)
 - `--template TEMPLATE` — Текст ответа (по умолчанию cover_letter_default)
 - `--force` — Подтвердить боевой запуск
 

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -503,7 +503,7 @@ def run_negotiations(args: argparse.Namespace) -> bool:
     """Dump negotiations/chat DOM using only GET navigation and reads."""
     from ..browser import launch_context
     from ..config import load_config_or_exit
-    from ..negotiations_probe import chat_url, topic_refs
+    from ..negotiations_probe import chat_url, paginated_topic_refs
     from ..report import _ascii_table
     from ..selector_groups import negotiations
 
@@ -518,9 +518,8 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             items.first.wait_for(state="attached", timeout=10_000)
         except PlaywrightError:
             logger.warning("negotiations: cards did not attach within 10 seconds")
-        list_html = page.content()
         try:
-            refs = topic_refs(list_html)
+            refs = paginated_topic_refs(page, max_pages=getattr(args, "max_pages", 5))
         except (TypeError, ValueError, KeyError, json.JSONDecodeError) as exc:
             print(f"[FAIL] не удалось прочитать SSR state: {exc}")
             return True

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -505,6 +505,7 @@ def run_negotiations(args: argparse.Namespace) -> bool:
     from ..config import load_config_or_exit
     from ..negotiations_probe import chat_url, paginated_topic_refs
     from ..report import _ascii_table
+    from ..responses import NotAuthenticated, ResponsesIndeterminate
     from ..selector_groups import negotiations
 
     config = load_config_or_exit(args.config)
@@ -527,6 +528,9 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             refs = paginated_topic_refs(page, max_pages=getattr(args, "max_pages", 5))
         except (TypeError, ValueError, KeyError, json.JSONDecodeError) as exc:
             print(f"[FAIL] не удалось прочитать SSR state: {exc}")
+            return True
+        except (NotAuthenticated, ResponsesIndeterminate) as exc:
+            print(f"[FAIL] не удалось прочитать SSR chat mapping: {exc}")
             return True
 
         rows = []

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -515,15 +515,12 @@ def run_negotiations(args: argparse.Namespace) -> bool:
         page = context.new_page()
         goto_hh(page, list_url)
         items = page.locator(negotiations.NEGOTIATION_ITEM)
-        try:
-            items.first.wait_for(state="attached", timeout=10_000)
-        except PlaywrightError:
-            logger.warning("negotiations: cards did not attach within 10 seconds")
-        # /review (#201): paginated_topic_refs() re-navigates page 0 with its
-        # own goto_hh() call, so the DOM state just waited on above is
-        # discarded and re-fetched. Both requests hit the same GET URL and
-        # probe is read-only, so this is a harmless extra round-trip, not a
-        # correctness issue — left as-is rather than special-casing page 0.
+        # /review (#201): paginated_topic_refs() re-navigates internally (and,
+        # with max_pages>1, may leave `page` on the LAST visited page, not
+        # this first one) — waiting for cards here before that re-navigation
+        # was pointless dead work for the RAW HTML dump below, which reads
+        # `items` only after pagination finishes. Wait AFTER pagination so the
+        # 10s bounded wait covers the page actually rendered at dump time.
         try:
             refs = paginated_topic_refs(page, max_pages=getattr(args, "max_pages", 5))
         except (TypeError, ValueError, KeyError, json.JSONDecodeError) as exc:
@@ -532,6 +529,10 @@ def run_negotiations(args: argparse.Namespace) -> bool:
         except (NotAuthenticated, ResponsesIndeterminate) as exc:
             print(f"[FAIL] не удалось прочитать SSR chat mapping: {exc}")
             return True
+        try:
+            items.first.wait_for(state="attached", timeout=10_000)
+        except PlaywrightError:
+            logger.warning("negotiations: cards did not attach within 10 seconds")
 
         rows = []
         for name, selector in (

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -518,6 +518,11 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             items.first.wait_for(state="attached", timeout=10_000)
         except PlaywrightError:
             logger.warning("negotiations: cards did not attach within 10 seconds")
+        # /review (#201): paginated_topic_refs() re-navigates page 0 with its
+        # own goto_hh() call, so the DOM state just waited on above is
+        # discarded and re-fetched. Both requests hit the same GET URL and
+        # probe is read-only, so this is a harmless extra round-trip, not a
+        # correctness issue — left as-is rather than special-casing page 0.
         try:
             refs = paginated_topic_refs(page, max_pages=getattr(args, "max_pages", 5))
         except (TypeError, ValueError, KeyError, json.JSONDecodeError) as exc:

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -20,6 +20,12 @@ def register(subparsers) -> None:
     parser.add_argument("--dry-run", action="store_true", help="Показать план без отправки")
     parser.add_argument("--limit", type=int, default=0, help="Максимум чатов за запуск (0 = все)")
     parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=5,
+        help="Максимум страниц negotiations для SSR mapping (по умолчанию 5)",
+    )
+    parser.add_argument(
         "--template", type=str, help="Текст ответа (по умолчанию cover_letter_default)"
     )
     parser.add_argument("--force", action="store_true", help="Подтвердить боевой запуск")
@@ -40,7 +46,7 @@ def _letter(template: str, candidate: dict) -> str:
 
 
 def run(args: argparse.Namespace) -> None:
-    from ..browser import goto_hh, launch_context
+    from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..history import History
     from ..negotiations_chat import (
@@ -49,11 +55,15 @@ def run(args: argparse.Namespace) -> None:
         send_reply_current,
         wait_reply_confirmation,
     )
-    from ..negotiations_probe import topic_refs
+    from ..negotiations_probe import paginated_topic_refs
     from ..throttle import LimitReached, Throttle
 
     if args.limit < 0:
         print("[FAIL] --limit не может быть отрицательным", file=sys.stderr)
+        sys.exit(1)
+    max_pages = getattr(args, "max_pages", 5)
+    if max_pages < 1:
+        print(f"[FAIL] --max-pages должен быть >= 1 (получено {max_pages}).", file=sys.stderr)
         sys.exit(1)
     if not args.dry_run and not confirm_write(
         args.force,
@@ -80,8 +90,10 @@ def run(args: argparse.Namespace) -> None:
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
         page = context.new_page()
-        goto_hh(page, "https://hh.ru/applicant/negotiations")
-        topic_list = topic_refs(page.content())
+        # #201: пагинируем SSR chat mapping по всем страницам negotiations
+        # (аналогично --max-pages в других командах), иначе чат, ушедший за
+        # пределы первой страницы, тихо выглядит как empty_chat.
+        topic_list = paginated_topic_refs(page, max_pages=max_pages)
         refs = {ref.topic_id: ref.chat_id for ref in topic_list}
         # #200: SSR отдаёт resumeId для каждой переписки (проверено на живой
         # сессии 2026-08-16, 7/7). Отдельный словарь, а не расширение refs:
@@ -145,19 +157,10 @@ def run(args: argparse.Namespace) -> None:
                     # Клик мог не дойти (отклонение сервером, сетевой сбой) —
                     # success пишем только по позитивному подтверждению
                     # (последнее сообщение в чате стало нашим), как в
-                    # apply/success.py (#7): таймаут даёт false-negative
-                    # (status='failed'), не false-positive success.
+                    # apply/success.py (#7): таймаут не даёт false-positive
+                    # success, но после состоявшегося клика фиксируется как
+                    # uncertain, а не как безопасный для retry failed.
                     #
-                    # Codex-ревью round 2 (#198) отметил, что неподтверждённый
-                    # клик мог реально дойти (DOM просто не успел отрендерить
-                    # сигнал) — тогда 'failed' разрешает retry и риск
-                    # дубликата. #176 в apply/bump решает это статусом
-                    # 'uncertain'; для replies такое расширение НЕ вводим —
-                    # REPLY_STATUS_VALUES сознательно заморожен решением #55
-                    # («без машины состояний»), а issue #110 явно требует
-                    # fail-closed в сторону «лучше пропустить чат, чем
-                    # ответить повторно» — 'uncertain' с недедуплицирующей
-                    # семантикой этому противоречил бы. Follow-up: #201.
                     if wait_reply_confirmation(page):
                         status = "success"
                         reason = None
@@ -165,6 +168,10 @@ def run(args: argparse.Namespace) -> None:
                         print(f"[OK] {label}")
                     else:
                         reason = "отправка не подтверждена: нет сигнала доставки"
+                        # The click completed, but the positive DOM signal may
+                        # have rendered late. Keep this auditable without
+                        # making has_replied deduplicate it.
+                        status = "uncertain"
                         print(f"[FAIL] {label} — {reason}")
                 except Exception as exc:
                     reason = f"отправка не подтверждена: {exc}"

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -57,6 +57,7 @@ def run(args: argparse.Namespace) -> None:
         wait_reply_confirmation,
     )
     from ..negotiations_probe import paginated_topic_refs
+    from ..responses import NotAuthenticated, ResponsesIndeterminate
     from ..throttle import LimitReached, Throttle
 
     if args.limit < 0:
@@ -93,8 +94,15 @@ def run(args: argparse.Namespace) -> None:
         page = context.new_page()
         # #201: пагинируем SSR chat mapping по всем страницам negotiations
         # (аналогично --max-pages в других командах), иначе чат, ушедший за
-        # пределы первой страницы, тихо выглядит как empty_chat.
-        topic_list = paginated_topic_refs(page, max_pages=max_pages)
+        # пределы первой страницы, тихо выглядит как empty_chat. Та же пара
+        # исключений, что и у fetch_responses (её собственный вызывающий код
+        # в responses.py ловит их так же): истёкшая сессия или не
+        # подтверждённая пагинация не должны крашить команду с traceback.
+        try:
+            topic_list = paginated_topic_refs(page, max_pages=max_pages)
+        except (NotAuthenticated, ResponsesIndeterminate) as exc:
+            print(f"[FAIL] не удалось прочитать SSR chat mapping: {exc}", file=sys.stderr)
+            sys.exit(1)
         refs = {ref.topic_id: ref.chat_id for ref in topic_list}
         # #200: SSR отдаёт resumeId для каждой переписки (проверено на живой
         # сессии 2026-08-16, 7/7). Отдельный словарь, а не расширение refs:
@@ -157,7 +165,9 @@ def run(args: argparse.Namespace) -> None:
                     send_reply_current(page, letter)
                 except NoReplyForm as exc:
                     # Форма не найдена ДО какого-либо взаимодействия с DOM —
-                    # чистый pre-action early-exit, на hh.ru следа нет.
+                    # чистый pre-action early-exit, на hh.ru следа нет. Как и
+                    # другие ранние выходы до действия (#163), throttle.wait()
+                    # здесь не нужен: не от чего защищать паузой.
                     reason = f"отправка не выполнена: {exc}"
                     status = "failed"
                     print(f"[FAIL] {label} — {reason}")
@@ -172,6 +182,7 @@ def run(args: argparse.Namespace) -> None:
                     reason = f"клик выполнен, исход неопределён: {exc}"
                     status = "uncertain"
                     print(f"[FAIL] {label} — {reason}")
+                    throttle.wait(f"после ответа в чате {topic}")
                 else:
                     # Клик мог не дойти (отклонение сервером, сетевой сбой) —
                     # success пишем только по позитивному подтверждению
@@ -191,7 +202,8 @@ def run(args: argparse.Namespace) -> None:
                         # making has_replied deduplicate it.
                         status = "uncertain"
                         print(f"[FAIL] {label} — {reason}")
-                finally:
+                    # Клик состоялся (успешно или uncertain) — реальное
+                    # действие на hh.ru, пауза нужна (#163).
                     throttle.wait(f"после ответа в чате {topic}")
             history.record_reply_and_action(
                 topic,

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -50,6 +50,7 @@ def run(args: argparse.Namespace) -> None:
     from ..config import load_config_or_exit
     from ..history import History
     from ..negotiations_chat import (
+        NoReplyForm,
         needs_reply,
         read_chat,
         send_reply_current,
@@ -154,13 +155,30 @@ def run(args: argparse.Namespace) -> None:
                 inbound_marker = live_chat.inbound_marker or ""
                 try:
                     send_reply_current(page, letter)
+                except NoReplyForm as exc:
+                    # Форма не найдена ДО какого-либо взаимодействия с DOM —
+                    # чистый pre-action early-exit, на hh.ru следа нет.
+                    reason = f"отправка не выполнена: {exc}"
+                    status = "failed"
+                    print(f"[FAIL] {label} — {reason}")
+                except Exception as exc:
+                    # Исключение уже ПОСЛЕ начала клика (Codex #201, по
+                    # аналогии с #176 в apply/bump): fill()/click() могли
+                    # частично выполниться и сообщение — уйти на hh.ru,
+                    # несмотря на исключение. fail-closed в сторону «действие
+                    # могло случиться»: status='uncertain' (не дедуплицирует
+                    # has_replied), а не 'failed' (который бы разрешил тихий
+                    # повторный retry поверх реально ушедшего сообщения).
+                    reason = f"клик выполнен, исход неопределён: {exc}"
+                    status = "uncertain"
+                    print(f"[FAIL] {label} — {reason}")
+                else:
                     # Клик мог не дойти (отклонение сервером, сетевой сбой) —
                     # success пишем только по позитивному подтверждению
                     # (последнее сообщение в чате стало нашим), как в
                     # apply/success.py (#7): таймаут не даёт false-positive
                     # success, но после состоявшегося клика фиксируется как
                     # uncertain, а не как безопасный для retry failed.
-                    #
                     if wait_reply_confirmation(page):
                         status = "success"
                         reason = None
@@ -173,9 +191,6 @@ def run(args: argparse.Namespace) -> None:
                         # making has_replied deduplicate it.
                         status = "uncertain"
                         print(f"[FAIL] {label} — {reason}")
-                except Exception as exc:
-                    reason = f"отправка не подтверждена: {exc}"
-                    print(f"[FAIL] {label} — {reason}")
                 finally:
                     throttle.wait(f"после ответа в чате {topic}")
             history.record_reply_and_action(

--- a/src/hhru_bot/commands/responses.py
+++ b/src/hhru_bot/commands/responses.py
@@ -148,16 +148,16 @@ def run(args: argparse.Namespace) -> None:
                 # fetch_responses performs its own navigation. Re-open the
                 # list read-only so SSR topicList is captured from the actual
                 # negotiations page, then use the confirmed chatId route.
-                from ..browser import goto_hh
                 from ..negotiations_chat import (
                     extract_external_test_link,
                     read_employer_messages,
                 )
-                from ..negotiations_probe import topic_refs
+                from ..negotiations_probe import paginated_topic_refs
 
-                goto_hh(page, "https://hh.ru/applicant/negotiations")
-                list_html = page.content()
-                refs = {ref.topic_id: ref.chat_id for ref in topic_refs(list_html)}
+                refs = {
+                    ref.topic_id: ref.chat_id
+                    for ref in paginated_topic_refs(page, max_pages=args.max_pages)
+                }
                 detected = 0
                 for card in cards:
                     if not card.topic or card.topic not in refs:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -138,8 +138,8 @@ CREATE TABLE IF NOT EXISTS skipped (
 -- источник правды об отправке. Перед боевой отправкой pipeline обязан свериться
 -- с ЖИВЫМ чатом: пользователь мог ответить вручную с телефона, и БД об этом не
 -- знает. has_replied отсекает заведомо отвеченные, живой чат подтверждает финально.
--- status — те же значения, что в actions (success/failed/dry_run), НЕ новый
--- словарь состояний: машины состояний (pending/in_flight/sent) по решению #55 нет.
+-- status — success/failed/dry_run/uncertain (#201); uncertain означает клик без
+-- пойманного позитивного сигнала за таймаут и не дедуплицирует чат.
 -- resume_id опционален и НЕ в ключе. ВАЖНО (#200): это НЕ значит «привязки к
 -- резюме не существует» — прежняя формулировка («/applicant/negotiations не даёт
 -- достоверной привязки чата к резюме») опровергнута живой проверкой 2026-08-16:
@@ -162,7 +162,7 @@ CREATE TABLE IF NOT EXISTS replies (
 
 -- Ключ PARTIAL-UNIQUE только по успешным ответам (тот же приём, что
 -- idx_resume_vacancy_apply у actions). Так одно входящее не может получить два
--- успешных ответа, а dry_run/failed ключ НЕ занимают. Table-level
+-- успешных ответа, а dry_run/failed/uncertain ключ НЕ занимают. Table-level
 -- UNIQUE(topic, inbound_marker) здесь был бы багом: штатный сценарий «сначала
 -- --dry-run, потом боевая отправка» (и ретрай после failed) молча терял бы
 -- success под INSERT OR IGNORE — has_replied навсегда остался бы False, а
@@ -254,15 +254,15 @@ SKIP_REASON_VALUES = (
 )
 
 
-#: Допустимые значения ``replies.status`` (#108). Тот же словарь, что у actions
-#: — новых состояний не вводим (решение #55: без машины состояний). Кортеж, не
+#: Допустимые значения ``replies.status`` (#108, #201). ``uncertain`` означает,
+#: что клик состоялся, но позитивный сигнал не был пойман за таймаут. Кортеж, не
 #: set: порядок стабилен для сообщений об ошибке.
 #:
 #: Валидируется в record_reply намеренно (в отличие от record_action): опечатка
 #: или синоним (``"SUCCESS"``, ``"sent"``) прошли бы в БД молча, has_replied
 #: навсегда вернул бы False, и бот отправил бы работодателю ВТОРОЕ сообщение.
 #: В actions такая же ошибка лишь искажает статистику, здесь — видна человеку.
-REPLY_STATUS_VALUES = ("success", "failed", "dry_run")
+REPLY_STATUS_VALUES = ("success", "failed", "dry_run", "uncertain")
 
 
 class History:
@@ -476,7 +476,11 @@ class History:
                 "GROUP BY status, letter_variant",
                 period_params,
             ).fetchall()
-        result = {"total": total, "period": {"success": 0, "failed": 0}, "letter_variants": {}}
+        result = {
+            "total": total,
+            "period": {"success": 0, "failed": 0, "uncertain": 0},
+            "letter_variants": {},
+        }
         for row in rows:
             if row["status"] == "success":
                 result["period"]["success"] += row["cnt"]
@@ -486,6 +490,8 @@ class History:
                 )
             elif row["status"] == "failed":
                 result["period"]["failed"] += row["cnt"]
+            elif row["status"] == "uncertain":
+                result["period"]["uncertain"] += row["cnt"]
         return result
 
     def list_actions(self, resume_id: str | None, period: str, limit: int = 50) -> list[dict]:
@@ -1476,7 +1482,7 @@ class History:
     # negotiations, отдельно от перезаписываемой responses (#12). Ключ —
     # partial-UNIQUE(topic, inbound_marker) WHERE status='success': одно входящее
     # не получит двух успешных ответов, повторный success — no-op (INSERT OR
-    # IGNORE), а dry_run/failed ключ не занимают и копятся для аналитики.
+    # IGNORE), а dry_run/failed/uncertain ключ не занимают и копятся для аналитики.
     # Account-scope: resume_id опционален и не в ключе.
     #
     # ГРАНИЦА ОТВЕТСТВЕННОСТИ (#55): этот слой отвечает «мы уже писали ответ на
@@ -1500,13 +1506,13 @@ class History:
 
         ``inbound_marker`` — непрозрачный признак входящего: реальный message_id
         либо суррогат (дата + хеш текста), см. комментарий к таблице. ``status``
-        — из словаря actions (``success``/``failed``/``dry_run``), новых состояний
-        не вводим (#55).
+        — из :data:`REPLY_STATUS_VALUES`; ``uncertain`` означает, что клик был
+        выполнен, но подтверждение не поймано за таймаут.
 
         Идемпотентность — по partial-UNIQUE, то есть только по УСПЕШНЫМ ответам:
         повторный ``success`` на ту же (topic, inbound_marker) — no-op (INSERT OR
         IGNORE), первая успешная запись не перезаписывается. Неуспешные попытки
-        (``dry_run``/``failed``) ключ не занимают: они копятся строками для
+        (``dry_run``/``failed``/``uncertain``) ключ не занимают: они копятся строками для
         аналитики и НЕ блокируют последующий ``success`` — иначе штатный сценарий
         «сначала --dry-run, потом боевая отправка» терял бы факт отправки. Разные
         входящие в одном чате — разные строки (диалог продолжается).
@@ -1541,7 +1547,7 @@ class History:
     def has_replied(self, topic: str, inbound_marker: str) -> bool:
         """True, если мы УСПЕШНО ответили на это входящее (для планирования).
 
-        Только ``status='success'``: ``dry_run`` и ``failed`` отправкой не
+        Только ``status='success'``: ``dry_run``, ``failed`` и ``uncertain`` отправкой не
         считаются. Это намеренно ИНАЧЕ, чем в :meth:`has_applied` (#3), где
         dry_run дедуплицирует отклик: там повторный отклик безвреден, а здесь
         холостой прогон навсегда заблокировал бы боевой ответ на живое входящее.
@@ -1631,7 +1637,8 @@ class History:
     def replies_since(self, since: datetime) -> list[dict]:
         """Наши ответы, записанные после ``since`` — для аналитики и отчётов.
 
-        Свежие первыми. Возвращает ВСЕ статусы (включая ``dry_run``/``failed``):
+        Свежие первыми. Возвращает ВСЕ статусы (включая ``dry_run``/``failed``/
+        ``uncertain``):
         журнал полный, фильтр «успешных» — задача вызывающего. Ключи словарей:
         topic/inbound_marker/vacancy_id/resume_id/status/letter_variant/note/
         created_at.

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -29,6 +29,17 @@ from .selector_groups.negotiations import (
 
 logger = logging.getLogger("hhru_bot.negotiations_chat")
 
+
+class NoReplyForm(RuntimeError):
+    """Форма ответа не найдена (#201): чистый pre-action early-exit.
+
+    Бросается ДО какого-либо взаимодействия с DOM формы (до ``fill``/``click``),
+    поэтому вызывающий код может отличить его от исключения, случившегося уже
+    после начала клика (см. ``send_reply_current``) — на hh.ru в этом случае
+    следа нет, повторная попытка безопасна как ``status='failed'``.
+    """
+
+
 # A URL is deliberately restricted to HTTP(S).  This avoids treating email
 # addresses, javascript: values, and arbitrary punctuation as test links.
 _URL_RE = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
@@ -178,7 +189,7 @@ def send_reply_current(page: Page, text: str) -> None:
     input_loc = page.locator(CHAT_MESSAGE_INPUT)
     send_loc = page.locator(CHAT_MESSAGE_SEND)
     if input_loc.count() != 1 or send_loc.count() != 1:
-        raise RuntimeError("не удалось однозначно найти форму ответа в чате")
+        raise NoReplyForm("не удалось однозначно найти форму ответа в чате")
     input_loc.fill(text)
     send_loc.click()
 

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -82,13 +82,29 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         raise ValueError("max_pages must be >= 1")
 
     # Lazy imports avoid a module cycle while responses.py recovers topics.
-    from .browser import goto_hh
-    from .responses import NEGOTIATIONS_URL, _has_next_page
+    from .browser import goto_hh, has_auth_cookie, has_login_form
+    from .responses import NEGOTIATIONS_URL, NotAuthenticated, _has_next_page
 
     refs: list[TopicRef] = []
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         goto_hh(page, url)
+        # Codex-ревью (#201, по аналогии с fetch_responses в responses.py):
+        # проверяем auth-маркер ДО чтения SSR-состояния. Без этой проверки
+        # рендер login-страницы вместо negotiations (истёкшая сессия) даёт
+        # topic_refs() ValueError («HH-Lux-InitialState not found») вместо
+        # диагностируемого NotAuthenticated — тот же класс ошибки, что и
+        # пустой inbox, но с другой причиной, которую вызывающий код не
+        # должен путать с завершённой пагинацией.
+        if not has_auth_cookie(page):
+            raise NotAuthenticated(
+                "cookie hhtoken не найден — сессия истекла (запустите `login`, затем повторите)"
+            )
+        if has_login_form(page):
+            raise NotAuthenticated(
+                "страница содержит форму входа при наличии hhtoken — сессия отвергнута "
+                "сервером (запустите `login`, затем повторите)"
+            )
         refs.extend(topic_refs(page.content()))
         try:
             has_next = _has_next_page(page, page_num)

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -71,6 +71,36 @@ def topic_refs(html: str) -> list[TopicRef]:
     return refs
 
 
+def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
+    """Read SSR topic mappings from every available negotiations page.
+
+    ``topicList`` is paginated with the cards, so reading only page zero makes
+    chats on later pages look unavailable. Navigation is GET-only and uses the
+    same confirmed pager contract as ``fetch_responses``.
+    """
+    if max_pages < 1:
+        raise ValueError("max_pages must be >= 1")
+
+    # Lazy imports avoid a module cycle while responses.py recovers topics.
+    from .browser import goto_hh
+    from .responses import NEGOTIATIONS_URL, _has_next_page
+
+    refs: list[TopicRef] = []
+    for page_num in range(max_pages):
+        url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
+        goto_hh(page, url)
+        refs.extend(topic_refs(page.content()))
+        try:
+            has_next = _has_next_page(page, page_num)
+        except AttributeError:
+            # Lightweight read-only fakes may expose content() but not the
+            # pagination locators; they represent a single page.
+            has_next = False
+        if not has_next:
+            break
+    return refs
+
+
 def chat_url(chat_id: str, chatik_origin: str = "https://chatik.hh.ru") -> str:
     """Build the route used by hh.ru's ``open_chat`` button."""
     return f"{chatik_origin.rstrip('/')}/chat/{chat_id}"

--- a/tests/test_history_replies.py
+++ b/tests/test_history_replies.py
@@ -275,6 +275,13 @@ def test_has_replied_true_only_for_successful_send(tmp_path):
     assert h.has_replied("t3", "m3")
 
 
+def test_uncertain_reply_is_recorded_but_does_not_deduplicate(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_reply("t1", "m1", status="uncertain", note="таймаут подтверждения")
+    assert not h.has_replied("t1", "m1")
+    assert h.replies_since(datetime(2000, 1, 1))[0]["status"] == "uncertain"
+
+
 def test_replies_are_recorded_for_all_statuses(tmp_path):
     # Append-only журнал: dry_run/failed пишутся (нужны для аналитики),
     # просто не считаются отправкой в has_replied.
@@ -329,7 +336,7 @@ def test_reply_summary_excludes_dry_run_and_groups_variants(tmp_path):
 
     summary = h.reply_summary(None, "all")
     assert summary["total"] == 2
-    assert summary["period"] == {"success": 2, "failed": 1}
+    assert summary["period"] == {"success": 2, "failed": 1, "uncertain": 0}
     assert summary["letter_variants"] == {"ai": 1, "template": 1}
 
 
@@ -355,8 +362,7 @@ def test_reply_summary_total_respects_period_like_summary_does(tmp_path):
 
 
 def test_reply_status_values_match_actions_vocabulary():
-    # Словарь тот же, что у actions (#55): без новых состояний.
-    assert set(REPLY_STATUS_VALUES) == {"success", "failed", "dry_run"}
+    assert set(REPLY_STATUS_VALUES) == {"success", "failed", "dry_run", "uncertain"}
 
 
 # --- replies_since ---------------------------------------------------------

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -72,11 +72,7 @@ def test_paginated_topic_refs_collects_all_pages(monkeypatch):
                     ]
                 }
             }
-            return (
-                '<template id="HH-Lux-InitialState">'
-                + json.dumps(state)
-                + "</template>"
-            )
+            return '<template id="HH-Lux-InitialState">' + json.dumps(state) + "</template>"
 
     page = Page()
     urls = []

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -1,11 +1,14 @@
 import json
 
+import pytest
+
 from hhru_bot.negotiations_probe import (
     chat_url,
     paginated_topic_refs,
     parse_initial_state,
     topic_refs,
 )
+from hhru_bot.responses import NotAuthenticated
 
 
 def test_topic_refs_read_ssr_state_without_page_actions():
@@ -82,6 +85,8 @@ def test_paginated_topic_refs_collects_all_pages(monkeypatch):
         page.page_num = len(urls) - 1
 
     monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
     monkeypatch.setattr("hhru_bot.responses._has_next_page", lambda _page, n: n < 2)
 
     refs = paginated_topic_refs(page, max_pages=3)
@@ -92,6 +97,43 @@ def test_paginated_topic_refs_collects_all_pages(monkeypatch):
         "https://hh.ru/applicant/negotiations?page=1",
         "https://hh.ru/applicant/negotiations?page=2",
     ]
+
+
+# --- Codex review (#201): expired session must not surface as a raw ValueError
+
+
+def test_paginated_topic_refs_raises_not_authenticated_without_cookie(monkeypatch):
+    """No hhtoken cookie must fail as NotAuthenticated, not crash inside
+    topic_refs() with a ValueError about a missing SSR template — same
+    contract fetch_responses() already enforces.
+    """
+
+    class Page:
+        def content(self):
+            raise AssertionError("must not read SSR state before the auth check")
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url: None)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: False)
+
+    with pytest.raises(NotAuthenticated):
+        paginated_topic_refs(Page(), max_pages=1)
+
+
+def test_paginated_topic_refs_raises_not_authenticated_on_login_form(monkeypatch):
+    """A server-rendered login form (rejected/stale hhtoken) must also fail
+    as NotAuthenticated, not as topic_refs()'s missing-SSR-template ValueError.
+    """
+
+    class Page:
+        def content(self):
+            raise AssertionError("must not read SSR state before the auth check")
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url: None)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: True)
+
+    with pytest.raises(NotAuthenticated):
+        paginated_topic_refs(Page(), max_pages=1)
 
 
 def test_chat_url_matches_hh_open_chat_route():

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -1,4 +1,11 @@
-from hhru_bot.negotiations_probe import chat_url, parse_initial_state, topic_refs
+import json
+
+from hhru_bot.negotiations_probe import (
+    chat_url,
+    paginated_topic_refs,
+    parse_initial_state,
+    topic_refs,
+)
 
 
 def test_topic_refs_read_ssr_state_without_page_actions():
@@ -46,6 +53,49 @@ def test_topic_refs_keep_mapping_when_resume_id_absent():
     ref = topic_refs(html)[0]
     assert ref.resume_id is None
     assert (ref.topic_id, ref.chat_id) == ("123", "456")
+
+
+def test_paginated_topic_refs_collects_all_pages(monkeypatch):
+    class Page:
+        def __init__(self):
+            self.page_num = 0
+
+        def content(self):
+            state = {
+                "applicantNegotiations": {
+                    "topicList": [
+                        {
+                            "id": self.page_num + 1,
+                            "chatId": self.page_num + 11,
+                            "vacancyId": self.page_num + 21,
+                        }
+                    ]
+                }
+            }
+            return (
+                '<template id="HH-Lux-InitialState">'
+                + json.dumps(state)
+                + "</template>"
+            )
+
+    page = Page()
+    urls = []
+
+    def goto(_page, url):
+        urls.append(url)
+        page.page_num = len(urls) - 1
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.responses._has_next_page", lambda _page, n: n < 2)
+
+    refs = paginated_topic_refs(page, max_pages=3)
+
+    assert [ref.topic_id for ref in refs] == ["1", "2", "3"]
+    assert urls == [
+        "https://hh.ru/applicant/negotiations",
+        "https://hh.ru/applicant/negotiations?page=1",
+        "https://hh.ru/applicant/negotiations?page=2",
+    ]
 
 
 def test_chat_url_matches_hh_open_chat_route():

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -162,6 +162,32 @@ def test_no_candidates_prints_info_and_returns(tmp_path, monkeypatch, capsys):
     assert "[INFO]" in capsys.readouterr().out
 
 
+# --- /review (#201): indeterminate SSR pagination is fail-closed, not a crash
+
+
+def test_indeterminate_pagination_exits_cleanly(tmp_path, monkeypatch, capsys):
+    """paginated_topic_refs() can raise the same exceptions as fetch_responses
+    (expired session, unconfirmed pager DOM) — reply-employers must handle
+    them the same way responses.py does: a clean [FAIL] + exit, not an
+    uncaught traceback.
+    """
+    from hhru_bot.responses import ResponsesIndeterminate
+
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    _patch_common(monkeypatch, history)
+
+    def _boom(page, max_pages=5):
+        raise ResponsesIndeterminate("пагинация не подтверждена")
+
+    monkeypatch.setattr("hhru_bot.negotiations_probe.paginated_topic_refs", _boom)
+
+    with pytest.raises(SystemExit) as exc:
+        command.run(_args(force=True))
+    assert exc.value.code == 1
+    assert "[FAIL]" in capsys.readouterr().err
+
+
 # --- --limit is respected ----------------------------------------------
 
 
@@ -325,6 +351,78 @@ def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
         assert row[0] == "failed"
     # A failed send does not count as replied — retry must remain possible.
     assert history.has_replied("tp1", "m1") is False
+
+
+# --- /review (#201): NoReplyForm is pre-action, must not pay the throttle --
+
+
+def test_no_reply_form_does_not_wait_throttle(tmp_path, monkeypatch, capsys):
+    """NoReplyForm fires before fill()/click() — no trace was left on hh.ru,
+    so per #163 (early exits before an action skip the pause) throttle.wait()
+    must not run. A click that begins (uncertain or success) is a real action
+    and must still pay the pause.
+    """
+    from hhru_bot import throttle as throttle_module
+
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+
+    Ref = TopicRef("tp1", "c1", None, "96223331")
+
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _send(page, text):
+        raise NoReplyForm("не удалось однозначно найти форму ответа в чате")
+
+    waited = []
+    monkeypatch.setattr(
+        throttle_module.Throttle, "wait", lambda self, reason="": waited.append(reason)
+    )
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+        send=_send,
+    )
+
+    command.run(_args(force=True))
+    assert "[FAIL]" in capsys.readouterr().out
+    assert waited == []
+
+
+def test_click_exception_waits_throttle(tmp_path, monkeypatch, capsys):
+    """An exception after the click begins is a real action attempt — the
+    throttle pause must still run, same as a confirmed success (#163)."""
+    from hhru_bot import throttle as throttle_module
+
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+
+    Ref = TopicRef("tp1", "c1", None, "96223331")
+
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _send(page, text):
+        raise TimeoutError("network hiccup after click().click()")
+
+    waited = []
+    monkeypatch.setattr(
+        throttle_module.Throttle, "wait", lambda self, reason="": waited.append(reason)
+    )
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+        send=_send,
+    )
+
+    command.run(_args(force=True))
+    assert "[FAIL]" in capsys.readouterr().out
+    assert len(waited) == 1
 
 
 # --- Codex review (#201): exception after click begins is uncertain --------

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -78,6 +78,10 @@ def _patch_common(
         "hhru_bot.browser.launch_context", lambda *a, **k: _Context(page or _Page())
     )
     monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *a, **k: None)
+    # #201: paginated_topic_refs() checks the auth marker before reading SSR
+    # state (same pattern fetch_responses uses, see test_responses_*.py).
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda *a, **k: _Cfg())
     monkeypatch.setattr("hhru_bot.history.History", lambda *a, **k: history)
     monkeypatch.setattr("hhru_bot.negotiations_probe.topic_refs", lambda html: refs or [])

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -327,10 +327,10 @@ def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
 # --- Codex review (PR #198): click confirmed but delivery unverified -------
 
 
-def test_click_without_delivery_confirmation_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
+def test_click_without_delivery_confirmation_is_recorded_as_uncertain(tmp_path, monkeypatch, capsys):
     """send_reply_current only clicks; a click with no delivery signal must
-    not be journaled as success — otherwise has_replied() would permanently
-    suppress a retry for a reply that never actually reached the employer.
+    not be journaled as success.  The click may have reached hh.ru even when
+    the positive DOM signal was not observed, so the outcome is uncertain.
     """
     history = History(tmp_path / "history.db")
     _seed_response(history, vacancy_id="1", topic="tp1")
@@ -359,7 +359,7 @@ def test_click_without_delivery_confirmation_is_recorded_as_failed(tmp_path, mon
     assert "[OK]" not in out
     with history._connect() as conn:
         row = conn.execute("SELECT status FROM replies").fetchone()
-        assert row[0] == "failed"
+        assert row[0] == "uncertain"
     # Not journaled as replied — retry must remain possible.
     assert history.has_replied("tp1", "m1") is False
 

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -327,7 +327,9 @@ def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
 # --- Codex review (PR #198): click confirmed but delivery unverified -------
 
 
-def test_click_without_delivery_confirmation_is_recorded_as_uncertain(tmp_path, monkeypatch, capsys):
+def test_click_without_delivery_confirmation_is_recorded_as_uncertain(
+    tmp_path, monkeypatch, capsys
+):
     """send_reply_current only clicks; a click with no delivery signal must
     not be journaled as success.  The click may have reached hh.ru even when
     the positive DOM signal was not observed, so the outcome is uncertain.

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -6,7 +6,7 @@ import pytest
 
 from hhru_bot.commands import reply_employers as command
 from hhru_bot.history import History
-from hhru_bot.negotiations_chat import ChatMessage
+from hhru_bot.negotiations_chat import ChatMessage, NoReplyForm
 from hhru_bot.negotiations_probe import TopicRef
 
 
@@ -297,6 +297,9 @@ def test_successful_send_records_reply_and_action(tmp_path, monkeypatch, capsys)
 
 
 def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
+    """NoReplyForm is a pre-action guard — send_reply_current raises it before
+    any DOM interaction (fill/click), so hh.ru sees no trace and retry is safe.
+    """
     history = History(tmp_path / "history.db")
     _seed_response(history, vacancy_id="1", topic="tp1")
 
@@ -305,7 +308,7 @@ def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
     chat = ChatMessage(author="employer", inbound_marker="m1")
 
     def _send(page, text):
-        raise RuntimeError("не удалось однозначно найти форму ответа в чате")
+        raise NoReplyForm("не удалось однозначно найти форму ответа в чате")
 
     _patch_common(
         monkeypatch,
@@ -321,6 +324,45 @@ def test_send_failure_is_recorded_as_failed(tmp_path, monkeypatch, capsys):
         row = conn.execute("SELECT status FROM replies").fetchone()
         assert row[0] == "failed"
     # A failed send does not count as replied — retry must remain possible.
+    assert history.has_replied("tp1", "m1") is False
+
+
+# --- Codex review (#201): exception after click begins is uncertain --------
+
+
+def test_send_exception_after_click_is_recorded_as_uncertain(tmp_path, monkeypatch, capsys):
+    """Any exception other than NoReplyForm means fill()/click() may already
+    have run — the message could have reached hh.ru despite the exception.
+    fail-closed: status='uncertain' (not deduplicating), never 'failed'
+    (which would let a later run silently resend on top of a delivered
+    message), by analogy with apply/bump (#176).
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+
+    Ref = TopicRef("tp1", "c1", None, "96223331")
+
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _send(page, text):
+        raise TimeoutError("network hiccup after click().click()")
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+        send=_send,
+    )
+
+    command.run(_args(force=True))
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "[OK]" not in out
+    with history._connect() as conn:
+        row = conn.execute("SELECT status FROM replies").fetchone()
+        assert row[0] == "uncertain"
+    # Not journaled as replied — retry must remain possible.
     assert history.has_replied("tp1", "m1") is False
 
 


### PR DESCRIPTION
## Summary

Реализует оба пункта из issue #201:

1. **Пагинация SSR chat mapping (topic_refs)** — сбор маппинга topic_refs по `/applicant/negotiations` теперь проходит по всем страницам (аналогично `--max-pages` в других командах), а не только по первой странице.
2. **Uncertain-статус для reply-детекции** — добавлен `uncertain` в `REPLY_STATUS_VALUES` (`history.py`), по аналогии с #176 (apply/bump). Используется, когда клик по ответу прошёл, но `wait_reply_confirmation()` не поймала позитивный сигнал за таймаут — раньше в этом случае писался `failed`, что вводило в заблуждение (клик мог реально уйти).

## Test plan

- Обновлены/добавлены unit-тесты: `tests/test_negotiations_probe.py`, `tests/test_history_replies.py`, `tests/test_reply_employers_command.py`.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)