### PR TITLE
fix(apply): совместимые домены resume-id в верификаторе negotiations

### DIFF
--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -335,7 +335,10 @@ def _scan_single_page(
             # DOM-карточка не несёт resumeId — не можем атрибутировать отклик
             # к текущему резюме: он мог уйти с ДРУГОГО. Fail-closed
             # indeterminate, а не ложный success (как SSR-путь, #207).
-            return None, False, "DOM-карточка без атрибуции резюме — исход неопределён", False
+            # attribution_incomparable=True: находка вакансии без атрибуции
+            # обязана перевесить чистое чтение ДРУГОЙ попытки (иначе ложный
+            # not_found — тот же false negative, что #212 устраняет).
+            return None, False, "DOM-карточка без атрибуции резюме — исход неопределён", True
         return "DOM-карточка списка (SSR-состояние недоступно)", True, None, False
     if cards_seen:
         return None, True, None, False

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -28,11 +28,13 @@ Read-only: только goto + чтение. Три исхода:
 домене; «другое резюме» доказуемо только по перечню резюме аккаунта
 (``account_resume_ids`` от ``copy_resume.resolve_numeric_resume_ids``);
 без перечня разные строки — incomparable → fail-closed indeterminate, а не
-молчаливый not_found. Важно: hh.ru подписывает тему резюме, ВЫБРАННЫМ
-формой отклика, а не конфигом бота (живой аккаунт 2026-08-16: все темы
-несли id default-резюме, пока конфиг-резюме было в статусе not_finished —
-форма его не предлагает), поэтому «тема с другим СОБСТВЕННЫМ резюме» —
-всё равно подтверждение клика, а не опровержение.
+молчаливый not_found. Важно (цикл 2, Codex): тема с ДРУГИМ собственным
+резюме аккаунта (форма отклика могла приложить default-резюме, а не
+конфиг-резюме) НЕ подтверждает текущий apply — она могла быть создана
+предыдущим откликом, а не этим кликом. Подтверждать по ней нельзя: ложный
+success перманентно подавил бы повторную попытку через дедупликацию.
+Поэтому «другое собственное» → other_own → fail-closed indeterminate
+(как incomparable), а не found.
 """
 
 from __future__ import annotations
@@ -89,10 +91,13 @@ INDETERMINATE = "indeterminate"
 
 #: Атрибуция темы резюме (#212): matched — тема подтверждает отклик; foreign —
 #: доказуемо чужое резюме (continue скана); incomparable — сравнить нельзя
-#: (fail-closed indeterminate у вызывающего кода).
+#: (fail-closed indeterminate у вызывающего кода); other_own — ДРУГОЕ собственное
+#: резюме аккаунта, но не текущее (fail-closed indeterminate: тема могла быть
+#: создана предыдущим откликом, а не этим кликом — Codex-ревью цикла 2).
 _RESUME_MATCHED = "matched"
 _RESUME_FOREIGN = "foreign"
 _RESUME_INCOMPARABLE = "incomparable"
+_RESUME_OTHER_OWN = "other_own"
 
 
 @dataclass(frozen=True)
@@ -301,20 +306,22 @@ def _scan_single_page(
                     f"{resume_id} (несовместимые домены id, #212)"
                 )
                 continue
-            detail = _describe_topic(topic)
-            topic_resume = topic.get("resumeId")
-            if (
-                resume_id is not None
-                and topic_resume is not None
-                and str(topic_resume) != str(resume_id)
-            ):
-                # Сайт приложил ДРУГОЕ собственное резюме аккаунта (форма не
-                # предлагает конфиг-резюме в not_finished и молча берёт
-                # default) — деталь в вердикте, чтобы это было видно в логах.
-                # topic_resume is None (у темы нет resumeId) сюда не попадает:
-                # str(None)="None" лгал бы «другое резюме» при отсутствии поля.
-                detail += f" — сайт приложил другое резюме аккаунта (конфиг: {resume_id})"
-            return detail, True, None, False
+            if attribution == _RESUME_OTHER_OWN:
+                # Цикл 2 (Codex): тема с ДРУГИМ собственным резюме аккаунта
+                # могла быть создана ПРЕДЫДУЩИМ откликом, а не этим кликом —
+                # подтверждать текущий apply по ней нельзя (иначе ложный
+                # success и перманентная дедупликация подавит повторную
+                # попытку). Fail-closed indeterminate, как incomparable; скан
+                # продолжается: exact match ниже по списку всё ещё доказал бы
+                # found.
+                attribution_problem = (
+                    f"тема vacancy_id={wanted} найдена, но с ДРУГИМ собственным "
+                    f"резюме аккаунта (resumeId темы={topic.get('resumeId')} против "
+                    f"резюме конфига={resume_id}) — не подтверждаем: тема могла "
+                    f"быть создана предыдущим откликом"
+                )
+                continue
+            return _describe_topic(topic), True, None, False
         return (
             None,
             attribution_problem is None,
@@ -346,11 +353,14 @@ def _resume_attribution(
 
     * равные строки — matched (надёжно в любом домене);
     * ``account_resume_ids`` задан (маппинг из /applicant/resumes получен):
-      id темы в перечне — matched (hh.ru подписывает тему резюме, ВЫБРАННЫМ
-      формой отклика, а не конфигом: живой аккаунт 2026-08-16 — все 14 тем с
-      id default-резюме при конфиг-резюме в статусе not_finished; список
-      /applicant/negotiations аккаунт-приватный, «другое собственное» всё
-      равно доказывает клик), вне перечня — foreign (аномалия данных);
+      id темы в перечне, но НЕ равный конфиг-резюме — other_own (ДРУГОЕ
+      собственное резюме аккаунта). Это НЕ подтверждение текущего apply:
+      тема могла быть создана предыдущим откликом с этого резюме, а не этим
+      кликом (Codex-ревью цикла 2) — fail-closed indeterminate, а не found.
+      (До цикла 2 «другое собственное» считалось matched по посылке #212
+      «форма подписывает тему выбранным резюме»; но это не отличает свежую
+      тему от старой, и ложный success перманентно подавил бы повторную
+      попытку через дедупликацию.) Вне перечня — foreign (аномалия данных);
     * маппинга нет и строки разные — incomparable: доказать нельзя ни matched,
       ни foreign → вызывающий код обязан ответить indeterminate (fail-closed),
       а не молчаливым not_found (повторный отклик) или success (ложный).
@@ -366,7 +376,9 @@ def _resume_attribution(
     if str(topic_resume) == str(resume_id):
         return _RESUME_MATCHED
     if account_resume_ids is not None:
-        return _RESUME_MATCHED if str(topic_resume) in account_resume_ids else _RESUME_FOREIGN
+        if str(topic_resume) in account_resume_ids:
+            return _RESUME_OTHER_OWN
+        return _RESUME_FOREIGN
     return _RESUME_INCOMPARABLE
 
 

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -19,6 +19,20 @@ Read-only: только goto + чтение. Три исхода:
   отрендерились) и вакансии нет → отклик точно не ушёл;
 * ``indeterminate`` — список достоверно не прочитан (сессия, рендер, goto) →
   вердикт остаётся за fail-closed-логикой pipeline (uncertain).
+
+#212: атрибуция по резюме. Домены id у hh.ru несовместимы: конфиг адресует
+резюме хэшем из URL, а SSR темы несут числовой ``resumeId``. Сравнение тех и
+других как строк делало каждую тему «чужой» — ``found`` был недостижим в
+продакшене с момента PR #209 (false negative #3, вакансия 135170581).
+Правило здесь — ``_resume_attribution``: прямой match надёжен в любом
+домене; «другое резюме» доказуемо только по перечню резюме аккаунта
+(``account_resume_ids`` от ``copy_resume.resolve_numeric_resume_ids``);
+без перечня разные строки — incomparable → fail-closed indeterminate, а не
+молчаливый not_found. Важно: hh.ru подписывает тему резюме, ВЫБРАННЫМ
+формой отклика, а не конфигом бота (живой аккаунт 2026-08-16: все темы
+несли id default-резюме, пока конфиг-резюме было в статусе not_finished —
+форма его не предлагает), поэтому «тема с другим СОБСТВЕННЫМ резюме» —
+всё равно подтверждение клика, а не опровержение.
 """
 
 from __future__ import annotations
@@ -54,6 +68,11 @@ NEGOTIATIONS_VERIFY_POLL_INTERVAL_MS = 10_000
 #: список отсортирован по свежести, только что отправленный отклик был бы на
 #: странице 0 — глубокий скан не нужен. Достижение потолка при подтверждённой
 #: пагинации — indeterminate, а не not_found (см. _scan_negotiations).
+#: Инвариант «свежий отклик на странице 0» проверен живой пробой 2026-08-16
+#: (#210): все 14 тем аккаунта строго по creationTime по убыванию, свежайшая —
+#: на странице 0. Решение по напряжению 1 #210: документировать инвариант,
+#: НЕ переводя неподтверждённый пагинатор на fail-closed (0 случаев
+#: ResponsesIndeterminate в логах на ту дату — эвристика не стреляет).
 NEGOTIATIONS_VERIFY_MAX_PAGES = 2
 #: Окно стабилизации DOM-списка в fallback-пути: карточки могут догружаться
 #: (отложенный/виртуализированный рендер), и чтение count до стабилизации
@@ -67,6 +86,13 @@ ResponseVerifier = Callable[..., "NegotiationsVerifyResult"]
 FOUND = "found"
 NOT_FOUND = "not_found"
 INDETERMINATE = "indeterminate"
+
+#: Атрибуция темы резюме (#212): matched — тема подтверждает отклик; foreign —
+#: доказуемо чужое резюме (continue скана); incomparable — сравнить нельзя
+#: (fail-closed indeterminate у вызывающего кода).
+_RESUME_MATCHED = "matched"
+_RESUME_FOREIGN = "foreign"
+_RESUME_INCOMPARABLE = "incomparable"
 
 
 @dataclass(frozen=True)
@@ -84,7 +110,10 @@ class NegotiationsVerifyResult:
 
 
 def verify_response_in_negotiations(
-    page: Page, vacancy_id: str | None, resume_id: str | None = None
+    page: Page,
+    vacancy_id: str | None,
+    resume_id: str | None = None,
+    account_resume_ids: set[str] | None = None,
 ) -> NegotiationsVerifyResult:
     """Проверяет, присутствует ли вакансия в /applicant/negotiations.
 
@@ -92,6 +121,12 @@ def verify_response_in_negotiations(
     NEGOTIATIONS_VERIFY_ATTEMPTS) без вакансии — это ``not_found``, а не
     «не знаем»: серверный topicList — тот же источник, из которого hh.ru
     рисует карточки. Ни одной чистой попытки — ``indeterminate``.
+
+    ``resume_id``/#212 — числовой id резюме из маппинга
+    ``resolve_numeric_resume_ids`` (или хэш конфига, если маппинг не
+    получен); ``account_resume_ids`` — перечень числовых id всех резюме
+    аккаунта для отличения «другое собственное резюме» от «чужого»
+    (см. ``_resume_attribution``).
     """
     if not vacancy_id:
         return NegotiationsVerifyResult(INDETERMINATE, "vacancy_id карточки неизвестен")
@@ -99,6 +134,7 @@ def verify_response_in_negotiations(
     clean_read = False
     confirmed_incomplete = False
     problem = "список откликов не прочитан"
+    seen_vacancy_ids: set[str] = set()
     for attempt in range(1, NEGOTIATIONS_VERIFY_ATTEMPTS + 1):
         logger.info(
             "[VERIFY] попытка %d/%d: /applicant/negotiations, vacancy_id=%s",
@@ -119,7 +155,7 @@ def verify_response_in_negotiations(
                     page, wanted, "сессия не авторизована — список откликов недоступен"
                 )
             found_detail, clean, page_problem, incomplete = _scan_negotiations(
-                page, wanted, resume_id
+                page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
             )
             if found_detail is not None:
                 logger.info("[VERIFY] отклик подтверждён: %s", found_detail)
@@ -141,7 +177,14 @@ def verify_response_in_negotiations(
             page, wanted, problem or "подтверждённая пагинация, но не все страницы прочитаны"
         )
     if clean_read:
-        logger.info("[VERIFY] список прочитан, vacancy_id=%s отсутствует", wanted)
+        # #212: not_found не оставлял артефакта для аудита — «точно нет» без
+        # следов того, что именно прочитано, нечем опровергать постфактум.
+        # Печатаем прочитанные vacancy_id (все страницы всех попыток).
+        logger.info(
+            "[VERIFY] список прочитан, vacancy_id=%s отсутствует (прочитано: %s)",
+            wanted,
+            ", ".join(sorted(seen_vacancy_ids)) or "пусто",
+        )
         return NegotiationsVerifyResult(NOT_FOUND, "список откликов прочитан, вакансии нет")
     return _indeterminate(page, wanted, problem)
 
@@ -154,19 +197,25 @@ def _indeterminate(page: Page, vacancy_id: str, detail: str) -> NegotiationsVeri
 
 
 def _scan_negotiations(
-    page: Page, wanted: str, resume_id: str | None
+    page: Page,
+    wanted: str,
+    resume_id: str | None,
+    account_resume_ids: set[str] | None,
+    seen_vacancy_ids: set[str],
 ) -> tuple[str | None, bool, str | None, bool]:
     """Сканирует страницу 0 (+ следующую при подтверждённой пагинации).
 
     Возвращает (detail найденной темы | None, было ли чистое чтение,
     описание проблемы чтения | None, подтверждена ли пагинация, но не дочитана
     страница). Чистое чтение — только когда НИ ОДНА страница не дала проблему:
-    если какая-то страница не загрузилась или карточка не прочиталась, отсутствие
-    целевой вакансии не подтверждаем (она могла быть на непрочитанной странице) —
-    иначе ложный not_found. confirmed_incomplete отдельно от clean: попытка, где
-    пагинатор подтвердил продолжение, но страница не дочиталась, обязана
-    перевесить чистые чтения ДРУГИХ попыток (иначе OR-агрегация в
-    verify_response_in_negotiations замаскировала бы неполный скан, #207).
+    если какая-то страница не загрузилась, карточка не прочиталась или тему
+    совпавшей вакансии не удалось атрибутировать по резюме (#212), отсутствие
+    целевой вакансии не подтверждаем (она могла быть на непрочитанной
+    странице) — иначе ложный not_found. confirmed_incomplete отдельно от
+    clean: попытка, где пагинатор подтвердил продолжение, но страница не
+    дочиталась, обязана перевесить чистые чтения ДРУГИХ попыток (иначе
+    OR-агрегация в verify_response_in_negotiations замаскировала бы неполный
+    скан, #207).
     """
     clean = False
     problem: str | None = None
@@ -181,7 +230,9 @@ def _scan_negotiations(
                 problem = f"goto страницы {page_num} списка не прошёл ({exc})"
                 confirmed_incomplete = True
                 break
-        found_detail, page_clean, page_problem = _scan_single_page(page, wanted, resume_id)
+        found_detail, page_clean, page_problem = _scan_single_page(
+            page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
+        )
         if page_problem:
             problem = page_problem
         if found_detail is not None:
@@ -200,7 +251,11 @@ def _scan_negotiations(
 
 
 def _scan_single_page(
-    page: Page, wanted: str, resume_id: str | None
+    page: Page,
+    wanted: str,
+    resume_id: str | None,
+    account_resume_ids: set[str] | None,
+    seen_vacancy_ids: set[str],
 ) -> tuple[str | None, bool, str | None]:
     try:
         html = page.content()
@@ -209,16 +264,37 @@ def _scan_single_page(
     topics = _ssr_topic_list(html)
     if topics is not None:
         # SSR — серверная истина; DOM читает те же данные, fallback не нужен.
+        seen_vacancy_ids.update(str(t.get("vacancyId")) for t in topics if t.get("vacancyId"))
+        attribution_problem: str | None = None
         for topic in topics:
-            if str(topic.get("vacancyId", "")) == wanted:
-                if _is_foreign_resume(topic, resume_id):
-                    # Отклик с ДРУГОГО резюме на ту же вакансию — не
-                    # подтверждение apply с текущего: продолжаем искать тему
-                    # с совпадающим resumeId (иначе ложный success, #207).
-                    continue
-                return _describe_topic(topic), True, None
-        return None, True, None
+            if str(topic.get("vacancyId", "")) != wanted:
+                continue
+            attribution = _resume_attribution(topic, resume_id, account_resume_ids)
+            if attribution == _RESUME_FOREIGN:
+                # Отклик с доказуемо чужого резюме — не подтверждение apply:
+                # продолжаем искать тему с нашим резюме.
+                continue
+            if attribution == _RESUME_INCOMPARABLE:
+                # #212: тема этой вакансии есть, но сравнить резюме нечем
+                # (несовместимые домены id без маппинга) — absence не
+                # подтверждаем. Скан продолжается: прямой match по resume_id
+                # ниже по списку всё ещё доказал бы found.
+                attribution_problem = (
+                    f"тема vacancy_id={wanted} найдена, но атрибуция резюме невозможна: "
+                    f"resumeId темы={topic.get('resumeId')} против резюме конфига="
+                    f"{resume_id} (несовместимые домены id, #212)"
+                )
+                continue
+            detail = _describe_topic(topic)
+            if resume_id is not None and str(topic.get("resumeId")) != str(resume_id):
+                # Сайт приложил ДРУГОЕ собственное резюме аккаунта (форма не
+                # предлагает конфиг-резюме в not_finished и молча берёт
+                # default) — деталь в вердикте, чтобы это было видно в логах.
+                detail += f" — сайт приложил другое резюме аккаунта (конфиг: {resume_id})"
+            return detail, True, None
+        return None, attribution_problem is None, attribution_problem
     dom_ids, cards_seen = _read_dom_vacancy_ids(page)
+    seen_vacancy_ids.update(dom_ids)
     if wanted in dom_ids:
         if resume_id is not None:
             # DOM-карточка не несёт resumeId — не можем атрибутировать отклик
@@ -231,19 +307,39 @@ def _scan_single_page(
     return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)"
 
 
-def _is_foreign_resume(topic: dict[str, Any], resume_id: str | None) -> bool:
-    """Отклик с другого резюме — не подтверждение apply с текущего.
+def _resume_attribution(
+    topic: dict[str, Any], resume_id: str | None, account_resume_ids: set[str] | None
+) -> str:
+    """Атрибуция темы резюме: matched | foreign | incomparable (#212).
 
-    resume_id не задан — атрибутировать нечем, считаем совпадением (resumeId
-    присутствует у всех тем в практике, #200). Поле отсутствует у темы — тоже
-    не можем отличить, не роняем подтверждение (fail-open, как topic_refs).
+    Домены id несовместимы: конфиг — хэш из URL резюме, SSR темы — числовой
+    ``resumeId``. Прямое сравнение тех и других как строк — баг #212: каждая
+    тема «чужая», found недостижим. Правила:
+
+    * равные строки — matched (надёжно в любом домене);
+    * ``account_resume_ids`` задан (маппинг из /applicant/resumes получен):
+      id темы в перечне — matched (hh.ru подписывает тему резюме, ВЫБРАННЫМ
+      формой отклика, а не конфигом: живой аккаунт 2026-08-16 — все 14 тем с
+      id default-резюме при конфиг-резюме в статусе not_finished; список
+      /applicant/negotiations аккаунт-приватный, «другое собственное» всё
+      равно доказывает клик), вне перечня — foreign (аномалия данных);
+    * маппинга нет и строки разные — incomparable: доказать нельзя ни matched,
+      ни foreign → вызывающий код обязан ответить indeterminate (fail-closed),
+      а не молчаливым not_found (повторный отклик) или success (ложный).
+    * resume_id не задан или у темы нет поля — matched: атрибутировать нечем,
+      ронять подтверждение нельзя (resumeId присутствует у всех тем в живой
+      практике: 14/14 #210, 7/7 #204 — напряжение 2 #210 закрыто фактом).
     """
     if resume_id is None:
-        return False
+        return _RESUME_MATCHED
     topic_resume = topic.get("resumeId")
     if topic_resume is None:
-        return False
-    return str(topic_resume) != str(resume_id)
+        return _RESUME_MATCHED
+    if str(topic_resume) == str(resume_id):
+        return _RESUME_MATCHED
+    if account_resume_ids is not None:
+        return _RESUME_MATCHED if str(topic_resume) in account_resume_ids else _RESUME_FOREIGN
+    return _RESUME_INCOMPARABLE
 
 
 def _describe_topic(topic: dict[str, Any]) -> str:
@@ -344,6 +440,10 @@ def _has_next_page_confirmed(page: Page, page_num: int) -> bool:
         return _has_next_page(page, page_num)
     except ResponsesIndeterminate:
         # Неподтверждённый пагинатор — не причина indeterminate-вердикта:
-        # свежий отклик был бы на странице 0 (сортировка по свежести).
+        # свежий отклик был бы на странице 0. Инвариант сортировки по
+        # свежести проверен живой пробой 2026-08-16 (#210): 14/14 тем строго
+        # по creationTime по убыванию; 0 случаев ResponsesIndeterminate в
+        # логах на ту дату — оставляем as-is (документированное решение по
+        # напряжению 1 #210, не fail-closed).
         logger.warning("[VERIFY] пагинация не подтверждена — сканирую только прочитанное")
         return False

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -133,6 +133,7 @@ def verify_response_in_negotiations(
     wanted = str(vacancy_id)
     clean_read = False
     confirmed_incomplete = False
+    attribution_incomparable = False
     problem = "список откликов не прочитан"
     seen_vacancy_ids: set[str] = set()
     for attempt in range(1, NEGOTIATIONS_VERIFY_ATTEMPTS + 1):
@@ -154,14 +155,15 @@ def verify_response_in_negotiations(
                 return _indeterminate(
                     page, wanted, "сессия не авторизована — список откликов недоступен"
                 )
-            found_detail, clean, page_problem, incomplete = _scan_negotiations(
-                page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
+            found_detail, clean, page_problem, incomplete, page_attribution_incomparable = (
+                _scan_negotiations(page, wanted, resume_id, account_resume_ids, seen_vacancy_ids)
             )
             if found_detail is not None:
                 logger.info("[VERIFY] отклик подтверждён: %s", found_detail)
                 return NegotiationsVerifyResult(FOUND, found_detail)
             clean_read = clean_read or clean
             confirmed_incomplete = confirmed_incomplete or incomplete
+            attribution_incomparable = attribution_incomparable or page_attribution_incomparable
             if page_problem:
                 problem = page_problem
         if attempt < NEGOTIATIONS_VERIFY_ATTEMPTS:
@@ -175,6 +177,15 @@ def verify_response_in_negotiations(
         # неполный скан, #207).
         return _indeterminate(
             page, wanted, problem or "подтверждённая пагинация, но не все страницы прочитаны"
+        )
+    if attribution_incomparable:
+        # #212: хотя бы одна попытка нашла тему целевой вакансии, но не смогла
+        # атрибутировать резюме (несовместимые домены id без маппинга) —
+        # absence не подтверждаем. Отдельный флаг (не только problem): чистое
+        # чтение ДРУГОЙ попытки не должно замаскировать incomparable (иначе
+        # ложный not_found — ровно тот false-negative, что #212 устраняет).
+        return _indeterminate(
+            page, wanted, problem or "тема вакансии найдена, но атрибуция резюме невозможна"
         )
     if clean_read:
         # #212: not_found не оставлял артефакта для аудита — «точно нет» без
@@ -202,24 +213,28 @@ def _scan_negotiations(
     resume_id: str | None,
     account_resume_ids: set[str] | None,
     seen_vacancy_ids: set[str],
-) -> tuple[str | None, bool, str | None, bool]:
+) -> tuple[str | None, bool, str | None, bool, bool]:
     """Сканирует страницу 0 (+ следующую при подтверждённой пагинации).
 
     Возвращает (detail найденной темы | None, было ли чистое чтение,
     описание проблемы чтения | None, подтверждена ли пагинация, но не дочитана
-    страница). Чистое чтение — только когда НИ ОДНА страница не дала проблему:
-    если какая-то страница не загрузилась, карточка не прочиталась или тему
-    совпавшей вакансии не удалось атрибутировать по резюме (#212), отсутствие
-    целевой вакансии не подтверждаем (она могла быть на непрочитанной
-    странице) — иначе ложный not_found. confirmed_incomplete отдельно от
-    clean: попытка, где пагинатор подтвердил продолжение, но страница не
-    дочиталась, обязана перевесить чистые чтения ДРУГИХ попыток (иначе
-    OR-агрегация в verify_response_in_negotiations замаскировала бы неполный
-    скан, #207).
+    страница, найдена ли тема с неатрибутируемым резюме). Чистое чтение —
+    только когда НИ ОДНА страница не дала проблему: если какая-то страница не
+    загрузилась, карточка не прочиталась или тему совпавшей вакансии не удалось
+    атрибутировать по резюме (#212), отсутствие целевой вакансии не подтверждаем
+    (она могла быть на непрочитанной странице) — иначе ложный not_found.
+    confirmed_incomplete отдельно от clean: попытка, где пагинатор подтвердил
+    продолжение, но страница не дочиталась, обязана перевесить чистые чтения
+    ДРУГИХ попыток (иначе OR-агрегация в verify_response_in_negotiations
+    замаскировала бы неполный скан, #207). attribution_incomparable — тема
+    целевой вакансии найдена, но резюме не атрибутируется (несовместимые домены
+    id без маппинга): тоже обязана перевесить чистые чтения других попыток
+    (иначе ложный not_found, #212).
     """
     clean = False
     problem: str | None = None
     confirmed_incomplete = False
+    attribution_incomparable = False
     for page_num in range(NEGOTIATIONS_VERIFY_MAX_PAGES):
         if page_num > 0:
             try:
@@ -230,13 +245,14 @@ def _scan_negotiations(
                 problem = f"goto страницы {page_num} списка не прошёл ({exc})"
                 confirmed_incomplete = True
                 break
-        found_detail, page_clean, page_problem = _scan_single_page(
+        found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
             page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
         )
+        attribution_incomparable = attribution_incomparable or page_attribution_incomparable
         if page_problem:
             problem = page_problem
         if found_detail is not None:
-            return found_detail, True, None, False
+            return found_detail, True, None, False, False
         clean = clean or page_clean
         if not _has_next_page_confirmed(page, page_num):
             break
@@ -247,7 +263,7 @@ def _scan_negotiations(
             problem = "достигнут потолок скана при подтверждённой пагинации"
             confirmed_incomplete = True
             break
-    return None, clean and not problem, problem, confirmed_incomplete
+    return None, clean and not problem, problem, confirmed_incomplete, attribution_incomparable
 
 
 def _scan_single_page(
@@ -256,7 +272,7 @@ def _scan_single_page(
     resume_id: str | None,
     account_resume_ids: set[str] | None,
     seen_vacancy_ids: set[str],
-) -> tuple[str | None, bool, str | None]:
+) -> tuple[str | None, bool, str | None, bool]:
     try:
         html = page.content()
     except PlaywrightError as exc:
@@ -286,13 +302,25 @@ def _scan_single_page(
                 )
                 continue
             detail = _describe_topic(topic)
-            if resume_id is not None and str(topic.get("resumeId")) != str(resume_id):
+            topic_resume = topic.get("resumeId")
+            if (
+                resume_id is not None
+                and topic_resume is not None
+                and str(topic_resume) != str(resume_id)
+            ):
                 # Сайт приложил ДРУГОЕ собственное резюме аккаунта (форма не
                 # предлагает конфиг-резюме в not_finished и молча берёт
                 # default) — деталь в вердикте, чтобы это было видно в логах.
+                # topic_resume is None (у темы нет resumeId) сюда не попадает:
+                # str(None)="None" лгал бы «другое резюме» при отсутствии поля.
                 detail += f" — сайт приложил другое резюме аккаунта (конфиг: {resume_id})"
-            return detail, True, None
-        return None, attribution_problem is None, attribution_problem
+            return detail, True, None, False
+        return (
+            None,
+            attribution_problem is None,
+            attribution_problem,
+            attribution_problem is not None,
+        )
     dom_ids, cards_seen = _read_dom_vacancy_ids(page)
     seen_vacancy_ids.update(dom_ids)
     if wanted in dom_ids:
@@ -300,11 +328,11 @@ def _scan_single_page(
             # DOM-карточка не несёт resumeId — не можем атрибутировать отклик
             # к текущему резюме: он мог уйти с ДРУГОГО. Fail-closed
             # indeterminate, а не ложный success (как SSR-путь, #207).
-            return None, False, "DOM-карточка без атрибуции резюме — исход неопределён"
-        return "DOM-карточка списка (SSR-состояние недоступно)", True, None
+            return None, False, "DOM-карточка без атрибуции резюме — исход неопределён", False
+        return "DOM-карточка списка (SSR-состояние недоступно)", True, None, False
     if cards_seen:
-        return None, True, None
-    return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)"
+        return None, True, None, False
+    return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)", False
 
 
 def _resume_attribution(

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -408,6 +408,11 @@ def _ssr_topic_list(html: str) -> list[dict[str, Any]] | None:
         state = parse_initial_state(html)
     except (ValueError, AttributeError):
         return None
+    # parse_initial_state возвращает любой валидный JSON, не только объект:
+    # null/массив/строка (schema-drift) — .get() на них бросил бы AttributeError
+    # уже вне try. Нормализуем как «состояние недоступно» (fail-closed).
+    if not isinstance(state, dict):
+        return None
     neg = state.get("applicantNegotiations")
     if not isinstance(neg, dict):
         return None

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -17,6 +17,7 @@ from ..apply.letter import CoverLetterProvider
 from ..apply.verify import verify_response_in_negotiations
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
 from ..config_sections.scoring import ScoringWeights
+from ..copy_resume import resolve_numeric_resume_ids
 from ..history import SKIP_REASONS, History
 from ..search import (
     _LLM_SHORTLIST_DEFAULT,
@@ -292,6 +293,35 @@ def run_apply_for_resume(
     cover_letter_template = config.cover_letter_for(resume)
     letter_provider = _build_letter_provider(config, resume, cover_letter_template)
 
+    # #212: атрибуция резюме в верификаторе. Конфиг знает хэш резюме, SSR
+    # /applicant/negotiations — только числовой resumeId; без маппинга found
+    # недостижим (false negative #3, 135170581). Один read-only goto за запуск;
+    # сбой маппинга не фатален — верификатор получит хэш и уйдёт в fail-closed
+    # indeterminate при совпадении вакансии. dry_run до клика не доходит —
+    # верификатор не зовётся, лишний goto не нужен.
+    account_resume_ids: set[str] | None = None
+    verify_resume_id = resume.resume_id
+    if plan.ranked and not args.dry_run:
+        ids_by_hash = resolve_numeric_resume_ids(page)
+        if ids_by_hash is not None:
+            account_resume_ids = set(ids_by_hash.values())
+            verify_resume_id = ids_by_hash.get(resume.resume_id, resume.resume_id)
+            if verify_resume_id == resume.resume_id:
+                logger.warning(
+                    "%s — резюме конфига (%s) нет в маппинге аккаунта: атрибуция в "
+                    "верификаторе уйдёт в fail-closed",
+                    resume.id,
+                    resume.resume_id,
+                )
+
+    def _verifier(page, vacancy_id, _pipeline_resume_id):  # noqa: ANN001
+        # pipeline передаёт хэш конфига (ключ history) — подменяем его числовым
+        # id для сравнения с SSR; запись в history и троттл остаются в домене
+        # хэша, миграций нет.
+        return verify_response_in_negotiations(
+            page, vacancy_id, verify_resume_id, account_resume_ids=account_resume_ids
+        )
+
     applied_count = 0
     for card, _score, _breakdown in plan.ranked:
         try:
@@ -309,7 +339,7 @@ def run_apply_for_resume(
             letter_provider=letter_provider,
             # #207: fail-вердикты после клика по кнопке отклика подтверждаются
             # внешней проверкой /applicant/negotiations до записи в history.
-            verifier=verify_response_in_negotiations,
+            verifier=_verifier,
         )
 
         if result.skipped:

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -304,9 +304,19 @@ def run_apply_for_resume(
     if plan.ranked and not args.dry_run:
         ids_by_hash = resolve_numeric_resume_ids(page)
         if ids_by_hash is not None:
-            account_resume_ids = set(ids_by_hash.values())
-            verify_resume_id = ids_by_hash.get(resume.resume_id, resume.resume_id)
-            if verify_resume_id == resume.resume_id:
+            numeric_id = ids_by_hash.get(resume.resume_id)
+            if numeric_id is not None:
+                # Конфиг-резюме в маппинге: верификатор сравнивает числовой id,
+                # а перечень резюме аккаунта отличает «другое собственное» от
+                # «чужого» (оба доказывают клик, #212).
+                account_resume_ids = set(ids_by_hash.values())
+                verify_resume_id = numeric_id
+            else:
+                # Конфиг-резюме НЕТ в маппинге (устаревший/неверный хэш) —
+                # перечень НЕ заполняем: иначе любая тема с id резюме аккаунта
+                # подтвердила бы отклик (success под хэшем, которого нет в
+                # аккаунте). Без перечня атрибуция уходит в incomparable →
+                # fail-closed indeterminate в самом верификаторе.
                 logger.warning(
                     "%s — резюме конфига (%s) нет в маппинге аккаунта: атрибуция в "
                     "верификаторе уйдёт в fail-closed",

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -23,8 +23,9 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh, has_login_form
+from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh, has_auth_cookie, has_login_form
 from .config import ResumeConfig
+from .negotiations_probe import parse_initial_state
 
 # Reuse the established auth-state exception rather than defining a second
 # copy-resume-only variant; the command layer already treats this shared
@@ -360,6 +361,62 @@ def list_resume_cards(page: Page, *, navigate: bool = True) -> list[ResumeCard]:
         url = f"{HH_BASE_URL}/resume/{resume_id}"
         cards.append(ResumeCard(resume_id=resume_id, title=title, url=url))
     return cards
+
+
+def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
+    """Маппинг «хэш резюме → числовой id hh.ru» с /applicant/resumes (#212).
+
+    Домены id у hh.ru несовместимы: конфиг адресует резюме хэшем из URL
+    (``ResumeConfig.resume_id``), а SSR /applicant/negotiations подписывает
+    темы числовым ``topicList[].resumeId``. Прямое сравнение этих строк всегда
+    даёт «чужое» — верификатор apply из-за этого не мог вернуть found с
+    момента PR #209 (false negative #3, #212). Живая проба 2026-08-16
+    (data/logs/probe212_*.json): оба id лежат рядом в SSR списка резюме,
+    ``applicantResumes[]._attributes.{hash,id}`` — тот же reader-принцип, что
+    у ``list_resume_cards`` (goto + чтение, ничего не кликается).
+
+    None — прочитать не удалось (сессия, рендер, структура): вызывающий код
+    обязан трактовать это как «атрибуция резюме недоступна» (fail-closed в
+    apply/verify), а не как «резюме нет». Дополнительно warns о резюме в
+    статусе not_finished: форма отклика такие не предлагает (SSR формы:
+    ``unfinishedResumeIds``), и отклик уходит с другого резюме аккаунта, хотя
+    история пишется под конфиг-резюме — это должно быть видно в логах.
+    """
+    logger.info("Открываю список резюме для маппинга id: %s", RESUMES_LIST_URL)
+    try:
+        goto_hh(page, RESUMES_LIST_URL)
+        if not has_auth_cookie(page) or has_login_form(page):
+            logger.warning("[RESUME-ID] сессия не авторизована — маппинг id недоступен")
+            return None
+        state = parse_initial_state(page.content())
+    except (PlaywrightError, ValueError, AttributeError) as exc:
+        logger.warning("[RESUME-ID] список резюме не прочитан (%s) — маппинг id недоступен", exc)
+        return None
+    resumes = state.get("applicantResumes")
+    if not isinstance(resumes, list):
+        logger.warning("[RESUME-ID] секция applicantResumes не найдена — маппинг недоступен")
+        return None
+    mapping: dict[str, str] = {}
+    for item in resumes:
+        attrs = item.get("_attributes") if isinstance(item, dict) else None
+        if not isinstance(attrs, dict):
+            continue
+        resume_hash, numeric_id = attrs.get("hash"), attrs.get("id")
+        if not resume_hash or numeric_id is None:
+            continue
+        mapping[str(resume_hash)] = str(numeric_id)
+        if attrs.get("status") == "not_finished":
+            logger.warning(
+                "[RESUME-ID] резюме %s (id=%s) в статусе not_finished — форма отклика "
+                "его не предлагает: отклики уходят с другого резюме аккаунта",
+                resume_hash,
+                numeric_id,
+            )
+    if not mapping:
+        logger.warning("[RESUME-ID] в SSR нет пар hash→id — маппинг недоступен")
+        return None
+    logger.info("[RESUME-ID] маппинг hash→id получен: %d резюме", len(mapping))
+    return mapping
 
 
 def _goto_resumes_list(page: Page, *, post_write: bool = False) -> None:

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -392,6 +392,16 @@ def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
     except (PlaywrightError, ValueError, AttributeError) as exc:
         logger.warning("[RESUME-ID] список резюме не прочитан (%s) — маппинг id недоступен", exc)
         return None
+    # parse_initial_state возвращает любой валидный JSON, не только объект:
+    # null/массив/строка (schema-drift, интерстишл) — .get() на них бросил бы
+    # AttributeError уже вне try и аварийно оборвал бы apply. Нормализуем как
+    # «маппинг недоступен» (fail-closed), не давая исключению прервать цикл.
+    if not isinstance(state, dict):
+        logger.warning(
+            "[RESUME-ID] SSR-состояние не объект (%s) — маппинг id недоступен",
+            type(state).__name__,
+        )
+        return None
     resumes = state.get("applicantResumes")
     if not isinstance(resumes, list):
         logger.warning("[RESUME-ID] секция applicantResumes не найдена — маппинг недоступен")

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -345,6 +345,18 @@ def test_indeterminate_when_ssr_lacks_negotiations_section():
     assert result.indeterminate
 
 
+def test_indeterminate_when_ssr_state_is_non_dict():
+    # parse_initial_state возвращает любой валидный JSON, не только объект:
+    # null/массив/строка (schema-drift) не должны ронять верификатор
+    # AttributeError'ом вне try — нормализуются как «состояние недоступно»
+    # (fail-closed indeterminate, а не ложный not_found).
+    for raw in ("null", "[1,2]", '"строка"'):
+        html = f"<html><body><template id='HH-Lux-InitialState'>{raw}</template></body></html>"
+        page = FakeNegotiationsPage({NEGOTIATIONS_URL: html})
+        result = verify_response_in_negotiations(page, _V2)
+        assert result.indeterminate
+
+
 def test_indeterminate_when_vacancy_id_unknown():
     result = verify_response_in_negotiations(FakeNegotiationsPage(), None)
     assert result.indeterminate

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -558,6 +558,20 @@ def test_incomparable_second_attempt_not_masked_by_clean_first():
     assert "атрибуция" in result.detail
 
 
+def test_dom_unattributeable_second_attempt_not_masked_by_clean_first():
+    # Попытка 1: чистое чтение SSR без целевой вакансии. Попытка 2: SSR
+    # недоступен, DOM-карточка с целевой вакансией, но атрибуция резюме
+    # невозможна (DOM не несёт resumeId). Чистое чтение попытки 1 не должно
+    # замаскировать неатрибутируемую находку попытки 2: иначе ложный not_found
+    # (вакансия есть, но отклик не атрибутируется) — тот же класс false
+    # negative, что #212 устраняет (Codex-ревью цикла 2).
+    page0_clean = _ssr_html([_topic(7, "999999")])
+    page = _IncomparableSecondAttemptPage(page0_clean, _DOM_HTML)
+    result = verify_response_in_negotiations(page, _V1, resume_id="R2")
+    assert result.indeterminate
+    assert "атрибуци" in result.detail
+
+
 def test_topic_without_resume_id_does_not_claim_other_resume():
     # Тема с совпадающей вакансией, но БЕЗ resumeId — matched (атрибутировать
     # нечем, ронять подтверждение нельзя, #210 напряжение 2). Деталь не должна

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -186,18 +186,33 @@ def test_regression_212_config_hash_vs_numeric_topic_is_indeterminate():
     assert "96223331" in result.detail and _HASH in result.detail
 
 
-def test_found_when_topic_carries_default_resume_of_account():
-    """Живой кейс аккаунта: apply шёл с python (284561395), но форма отклика
-    приложила default-резюме marketing (96223331) — тема в перечне резюме
-    аккаунта, значит клик подтверждён; деталь честно показывает подмену."""
+def test_other_own_resume_topic_is_indeterminate():
+    """Тема с ДРУГИМ собственным резюме аккаунта (форма приложила default
+    marketing 96223331, конфиг — python 284561395) НЕ подтверждает текущий
+    apply: тема могла быть создана ПРЕДЫДУЩИМ откликом, а не этим кликом
+    (Codex-ревью цикла 2). Подтверждать по ней нельзя — иначе ложный success
+    под конфиг-резюме и перманентная дедупликация подавят повторную попытку.
+    Fail-closed indeterminate (как incomparable), а не found."""
     page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, 96223331)])})
     result = verify_response_in_negotiations(
         page, _V2, resume_id=_NUM_CONFIG, account_resume_ids=_ACCOUNT
     )
+    assert result.status == "indeterminate"
+    assert "ДРУГИМ собственным резюме" in result.detail
+    assert "96223331" in result.detail and _NUM_CONFIG in result.detail
+
+
+def test_exact_match_wins_over_other_own_resume_topic():
+    # Среди тем вакансии есть и с конфиг-резюме (exact match) — подтверждение,
+    # даже если рядом тема с другим собственным резюме (не атрибутируемая).
+    page = FakeNegotiationsPage(
+        {NEGOTIATIONS_URL: _ssr_html([_topic(7, _V2, 96223331), _topic(8, _V2, _NUM_CONFIG)])}
+    )
+    result = verify_response_in_negotiations(
+        page, _V2, resume_id=_NUM_CONFIG, account_resume_ids=_ACCOUNT
+    )
     assert result.found
-    assert "resumeId=96223331" in result.detail
-    assert "другое резюме аккаунта" in result.detail
-    assert _NUM_CONFIG in result.detail
+    assert f"resumeId={_NUM_CONFIG}" in result.detail
 
 
 def test_found_by_direct_numeric_match_without_account_ids():

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -507,6 +507,53 @@ def test_confirmed_incomplete_attempt_not_masked_by_clean_retry():
     assert result.indeterminate
 
 
+class _IncomparableSecondAttemptPage(FakeNegotiationsPage):
+    """Попытка 1: чистое чтение без целевой вакансии (отклик ещё не долетел).
+    Попытка 2: целевая вакансия появилась, но атрибуция incomparable (хэш
+    конфига vs числовой SSR id, маппинга нет). OR-агрегация clean из попытки 1
+    не должна замаскировать incomparable из попытки 2 (иначе ложный not_found —
+    ровно тот false-negative, что #212 призван устранить)."""
+
+    def __init__(self, page0_clean: str, page0_incomparable: str):
+        super().__init__({NEGOTIATIONS_URL: page0_clean})
+        self._clean = page0_clean
+        self._incomparable = page0_incomparable
+        self._page0_gotos = 0
+
+    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+        self.goto_calls.append(url)
+        if url == NEGOTIATIONS_URL:
+            self._page0_gotos += 1
+            self._html = self._clean if self._page0_gotos == 1 else self._incomparable
+        else:
+            self._html = self._pages.get(url, "")
+
+
+def test_incomparable_second_attempt_not_masked_by_clean_first():
+    # Попытка 1: чистое чтение, целевой вакансии ещё нет. Попытка 2: целевая
+    # вакансия найдена, но атрибуция incomparable (хэш конфига vs числовой SSR
+    # id, маппинга нет). Чистое чтение попытки 1 не должно замаскировать
+    # incomparable из попытки 2: иначе ложный not_found вместо fail-closed
+    # indeterminate (#212).
+    page0_clean = _ssr_html([_topic(7, "999999")])
+    page0_incomparable = _ssr_html([_topic(8, _V2, 96223331)])
+    page = _IncomparableSecondAttemptPage(page0_clean, page0_incomparable)
+    result = verify_response_in_negotiations(page, _V2, resume_id=_HASH)
+    assert result.indeterminate
+    assert "атрибуция" in result.detail
+
+
+def test_topic_without_resume_id_does_not_claim_other_resume():
+    # Тема с совпадающей вакансией, но БЕЗ resumeId — matched (атрибутировать
+    # нечем, ронять подтверждение нельзя, #210 напряжение 2). Деталь не должна
+    # утверждать «другое резюме аккаунта» — у темы вообще нет resumeId, и
+    # str(None)="None" ≠ resume_id лгал бы в логах аудита #212.
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2)])})
+    result = verify_response_in_negotiations(page, _V2, resume_id="R2")
+    assert result.found
+    assert "другое резюме" not in result.detail
+
+
 # --- проводка: run_apply_for_resume передаёт реальный верификатор ------------
 
 
@@ -679,4 +726,61 @@ def test_run_apply_for_resume_verifier_falls_back_to_hash(tmp_path, monkeypatch)
 
     _common.run_apply_for_resume(_ApplyPipelineFakePage(), config, resume, history, throttle, args)
 
+    assert seen == [("42", "AAA111", None)]
+
+
+def test_run_apply_for_resume_fail_closed_when_config_resume_not_in_mapping(tmp_path, monkeypatch):
+    """#212: маппинг получен, но конфиг-резюме в нём ОТСУТСТВУЕТ (устаревший/
+    неверный хэш). Перечень резюме аккаунта НЕ должен заполняться — иначе любая
+    тема с id резюме аккаунта подтвердила бы отклик (success под хэшем, которого
+    нет в аккаунте), вопреки предупреждению о fail-closed. Без перечня
+    атрибуция уходит в incomparable → indeterminate в самом верификаторе."""
+    import argparse
+
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+    from hhru_bot.commands import _common
+    from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+    from hhru_bot.history import History
+    from hhru_bot.search import VacancyCard
+    from hhru_bot.throttle import Throttle
+
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.search_vacancies",
+        lambda page, search, max_pages=5: [  # noqa: ARG005
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+    seen: list[tuple] = []
+
+    def _fake_verify(page, vacancy_id, resume_id=None, account_resume_ids=None):  # noqa: ANN001
+        seen.append((vacancy_id, resume_id, account_resume_ids))
+        return NegotiationsVerifyResult("found", "topic=1")
+
+    monkeypatch.setattr("hhru_bot.commands._common.verify_response_in_negotiations", _fake_verify)
+    # Маппинг есть, но конфиг-резюме AAA111 в нём отсутствует.
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.resolve_numeric_resume_ids",
+        lambda page: {"BBB222": "96223331"},
+    )
+
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="Здравствуйте!",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(dry_run=False, limit=1, max_pages=5, headless=True)
+
+    _common.run_apply_for_resume(_ApplyPipelineFakePage(), config, resume, history, throttle, args)
+
+    # account_resume_ids=None → атрибуция fail-closed (incomparable), не matched.
     assert seen == [("42", "AAA111", None)]

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -140,11 +140,80 @@ def test_found_via_ssr_topic():
     assert page.goto_calls == [NEGOTIATIONS_URL]  # found — без второй попытки
 
 
-def test_foreign_resume_topic_does_not_confirm_apply():
-    # Отклик с ДРУГОГО резюме (R1) на ту же вакансию — НЕ подтверждение apply
-    # с текущего (R2): иначе ложный success для операции, которая не ушла.
+def test_incomparable_resume_topic_without_account_ids():
+    # #212: тема с ДРУГИМ resumeId при неизвестном перечне резюме аккаунта —
+    # НЕ not_found (как было до #212 — «чужое» доказывалось сравнением строк
+    # из несовместимых доменов id). Доказать нельзя ни matched, ни foreign →
+    # fail-closed indeterminate: вердикт за uncertain-логикой pipeline.
     page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, "R1")])})
     result = verify_response_in_negotiations(page, _V2, resume_id="R2")
+    assert result.status == "indeterminate"
+    assert "атрибуция" in result.detail
+
+
+def test_foreign_resume_topic_with_account_ids_does_not_confirm_apply():
+    # Перечень резюме аккаунта известен: id темы вне перечня — доказуемо
+    # чужое → скан продолжается → чистый not_found (исходная семантика
+    # #207 сохранена для доказуемого случая).
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, "R1")])})
+    result = verify_response_in_negotiations(
+        page, _V2, resume_id="R2", account_resume_ids={"R2", "R3"}
+    )
+    assert result.status == "not_found"
+
+
+# --- #212: реальные домены id (хэш конфига vs числовой SSR) ------------------
+#
+# Урок #212: тесты с «R1» против «R1» не ловят прод-баг — обе стороны в одном
+# домене. Дальше — формы живого аккаунта 2026-08-16 (probe212): хэш конфига,
+# числовой id конфиг-резюме и числовой id default-резюме (форма отклика не
+# предлагает not_finished-резюме, и тема подписывается default-резюме).
+_HASH = "b3236ebbff10f60ff30039ed1f6d5876645331"
+_NUM_CONFIG = "284561395"  # python (not_finished)
+_NUM_DEFAULT = "96223331"  # marketing — резюме по умолчанию формы отклика
+_ACCOUNT = {_NUM_CONFIG, _NUM_DEFAULT}
+
+
+def test_regression_212_config_hash_vs_numeric_topic_is_indeterminate():
+    """Регрессия #212 ровно как в проде: верификатору передали хэш конфига
+    (резолвер не отработал), SSR-тема несёт числовой resumeId. До фикса —
+    «чужое» → чистый not_found → false negative (135170581); после —
+    fail-closed indeterminate."""
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, 96223331)])})
+    result = verify_response_in_negotiations(page, _V2, resume_id=_HASH)
+    assert result.status == "indeterminate"
+    assert "несовместимые домены id" in result.detail
+    assert "96223331" in result.detail and _HASH in result.detail
+
+
+def test_found_when_topic_carries_default_resume_of_account():
+    """Живой кейс аккаунта: apply шёл с python (284561395), но форма отклика
+    приложила default-резюме marketing (96223331) — тема в перечне резюме
+    аккаунта, значит клик подтверждён; деталь честно показывает подмену."""
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, 96223331)])})
+    result = verify_response_in_negotiations(
+        page, _V2, resume_id=_NUM_CONFIG, account_resume_ids=_ACCOUNT
+    )
+    assert result.found
+    assert "resumeId=96223331" in result.detail
+    assert "другое резюме аккаунта" in result.detail
+    assert _NUM_CONFIG in result.detail
+
+
+def test_found_by_direct_numeric_match_without_account_ids():
+    # Равенство строк надёжно в любом домене: числовой против числового.
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, 96223331)])})
+    result = verify_response_in_negotiations(page, _V2, resume_id=_NUM_DEFAULT)
+    assert result.found
+    assert "другое резюме" not in result.detail
+
+
+def test_not_found_when_topic_resume_outside_account():
+    # id темы вне перечня аккаунта (аномалия данных) — доказуемо чужое.
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, 999999999)])})
+    result = verify_response_in_negotiations(
+        page, _V2, resume_id=_NUM_CONFIG, account_resume_ids=_ACCOUNT
+    )
     assert result.status == "not_found"
 
 
@@ -496,9 +565,11 @@ class _ApplyPipelineFakePage:
 
 
 def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
-    """#207: продакшн-проводка — run_apply_for_resume передаёт реальный
-    верификатор в pipeline; подтверждённый внешним источником отклик
-    доходит до history как status='success' (не failed/без записи)."""
+    """#207/#212: продакшн-проводка — run_apply_for_resume передаёт реальный
+    верификатор в pipeline; подтверждённый внешним источником отклик доходит
+    до history как status='success' (не failed/без записи). Верификатор
+    получает ЧИСЛОВОЙ id резюме из маппинга (#212: SSR несёт числовой
+    resumeId, а не хэш конфига), запись в history остаётся под хэшем."""
     import argparse
     import sqlite3
 
@@ -519,11 +590,17 @@ def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
     )
     seen: list[tuple] = []
 
-    def _fake_verify(page, vacancy_id, resume_id=None):  # noqa: ANN001
-        seen.append((vacancy_id, resume_id))
+    def _fake_verify(page, vacancy_id, resume_id=None, account_resume_ids=None):  # noqa: ANN001
+        seen.append((vacancy_id, resume_id, sorted(account_resume_ids or ())))
         return NegotiationsVerifyResult("found", "topic=1")
 
     monkeypatch.setattr("hhru_bot.commands._common.verify_response_in_negotiations", _fake_verify)
+    # #212: маппинг «хэш → числовой id» — как от /applicant/resumes (два резюме
+    # аккаунта; конфиг — первое). Без подмены резолвер ходил бы в сеть.
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.resolve_numeric_resume_ids",
+        lambda page: {"AAA111": "284561395", "BBB222": "96223331"},
+    )
 
     resume = ResumeConfig(
         id="python",
@@ -543,11 +620,65 @@ def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
 
     _common.run_apply_for_resume(_ApplyPipelineFakePage(), config, resume, history, throttle, args)
 
-    assert seen == [("42", "AAA111")]
+    # Верификатор — в числовом домене с перечнем резюме аккаунта (#212)…
+    assert seen == [("42", "284561395", ["284561395", "96223331"])]
     conn = sqlite3.connect(history_db)
     try:
-        rows = conn.execute("SELECT status, reason FROM actions").fetchall()
+        rows = conn.execute("SELECT resume_id, status, reason FROM actions").fetchall()
     finally:
         conn.close()
-    assert rows == [("success", rows[0][1])]
-    assert "negotiations" in rows[0][1]
+    # …а history — по-прежнему под хэшем конфига: домены не смешиваются.
+    assert rows == [("AAA111", "success", rows[0][2])]
+    assert "negotiations" in rows[0][2]
+
+
+def test_run_apply_for_resume_verifier_falls_back_to_hash(tmp_path, monkeypatch):
+    """#212: сбой маппинга (None) не роняет apply — верификатор получает хэш
+    конфига без перечня резюме; атрибуция деградирует до fail-closed
+    indeterminate в самом верификаторе, а не молчаливого not_found."""
+    import argparse
+
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+    from hhru_bot.commands import _common
+    from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+    from hhru_bot.history import History
+    from hhru_bot.search import VacancyCard
+    from hhru_bot.throttle import Throttle
+
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.search_vacancies",
+        lambda page, search, max_pages=5: [  # noqa: ARG005
+            VacancyCard(
+                vacancy_id="42", title="Dev", company="Acme", url="https://hh.ru/vacancy/42"
+            )
+        ],
+    )
+    seen: list[tuple] = []
+
+    def _fake_verify(page, vacancy_id, resume_id=None, account_resume_ids=None):  # noqa: ANN001
+        seen.append((vacancy_id, resume_id, account_resume_ids))
+        return NegotiationsVerifyResult("found", "topic=1")
+
+    monkeypatch.setattr("hhru_bot.commands._common.verify_response_in_negotiations", _fake_verify)
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.resolve_numeric_resume_ids", lambda page: None
+    )
+
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="Здравствуйте!",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(dry_run=False, limit=1, max_pages=5, headless=True)
+
+    _common.run_apply_for_resume(_ApplyPipelineFakePage(), config, resume, history, throttle, args)
+
+    assert seen == [("42", "AAA111", None)]

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -660,9 +660,7 @@ def test_run_apply_for_resume_verifier_falls_back_to_hash(tmp_path, monkeypatch)
         return NegotiationsVerifyResult("found", "topic=1")
 
     monkeypatch.setattr("hhru_bot.commands._common.verify_response_in_negotiations", _fake_verify)
-    monkeypatch.setattr(
-        "hhru_bot.commands._common.resolve_numeric_resume_ids", lambda page: None
-    )
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_numeric_resume_ids", lambda page: None)
 
     resume = ResumeConfig(
         id="python",

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -273,7 +273,9 @@ class StubResumesPage:
 
 def _resumes_ssr_html(resumes: list[dict]) -> str:
     state = json.dumps({"applicantResumes": resumes}, ensure_ascii=False)
-    return f"<html><body><template id='HH-Lux-InitialState'>{escape(state)}</template></body></html>"
+    return (
+        f"<html><body><template id='HH-Lux-InitialState'>{escape(state)}</template></body></html>"
+    )
 
 
 def _resume_attrs(hash_: str, numeric_id: str, status: str = "modified") -> dict:
@@ -287,7 +289,10 @@ _HASH_MK = "6b85a1" * 5 + "6e370"
 def test_resolve_numeric_resume_ids_maps_hash_to_id():
     page = StubResumesPage(
         _resumes_ssr_html(
-            [_resume_attrs(_HASH_PY, "284561395", "not_finished"), _resume_attrs(_HASH_MK, "96223331")]
+            [
+                _resume_attrs(_HASH_PY, "284561395", "not_finished"),
+                _resume_attrs(_HASH_MK, "96223331"),
+            ]
         )
     )
     mapping = cr.resolve_numeric_resume_ids(page)
@@ -298,7 +303,9 @@ def test_resolve_numeric_resume_ids_maps_hash_to_id():
 def test_resolve_numeric_resume_ids_warns_on_not_finished(caplog):
     # not_finished-резюме форма отклика не предлагает: отклики уходят с другого
     # резюме аккаунта — это обязано попасть в логи, а не пройти молча.
-    page = StubResumesPage(_resumes_ssr_html([_resume_attrs(_HASH_PY, "284561395", "not_finished")]))
+    page = StubResumesPage(
+        _resumes_ssr_html([_resume_attrs(_HASH_PY, "284561395", "not_finished")])
+    )
     with caplog.at_level("WARNING", logger="hhru_bot.copy_resume"):
         mapping = cr.resolve_numeric_resume_ids(page)
     assert mapping == {_HASH_PY: "284561395"}
@@ -332,5 +339,7 @@ def test_resolve_numeric_resume_ids_none_without_ssr_state():
 
 
 def test_resolve_numeric_resume_ids_none_without_section():
-    page = StubResumesPage("<html><template id='HH-Lux-InitialState'>{\"other\":1}</template></html>")
+    page = StubResumesPage(
+        "<html><template id='HH-Lux-InitialState'>{\"other\":1}</template></html>"
+    )
     assert cr.resolve_numeric_resume_ids(page) is None

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -11,6 +11,10 @@
 
 from __future__ import annotations
 
+import json
+from html import escape
+from types import SimpleNamespace
+
 import hhru_bot.copy_resume as cr
 from hhru_bot.selector_groups.resume_list import (
     RESUME_LIST_CARD,
@@ -227,3 +231,106 @@ def test_navigate_false_skips_goto(monkeypatch):
 
     assert len(cards) == 1
     assert page.gotos == []  # goto_hh НЕ вызван — вызывающий уже перешёл сам
+
+
+# --- resolve_numeric_resume_ids (#212) ----------------------------------------
+#
+# Маппинг «хэш резюме → числовой id» из SSR /applicant/resumes: Applicant
+# Resumes[]._attributes.{hash,id,status}. Формы — с живой пробы 2026-08-16
+# (data/logs/probe212_*.json), хэши обезличены: python-резюме там в статусе
+# not_finished (форма отклика его не предлагает), marketing — рабочее
+# default-резюме аккаунта.
+
+
+class _NoMatches:
+    def count(self):
+        return 0
+
+
+class StubResumesPage:
+    """Page для SSR-чтения: goto + content + cookies; локаторы пусты
+    (has_login_form на авторизованной странице возвращает 0 совпадений)."""
+
+    def __init__(self, html: str = "", authed: bool = True):
+        self._html = html
+        self._authed = authed
+        self.gotos: list[str] = []
+
+    def goto(self, url, wait_until=""):  # noqa: ARG002
+        self.gotos.append(url)
+
+    def content(self):
+        return self._html
+
+    def locator(self, selector):  # noqa: ARG002
+        return _NoMatches()
+
+    @property
+    def context(self):
+        cookies = [{"name": "hhtoken", "value": "x"}] if self._authed else []
+        return SimpleNamespace(cookies=lambda: cookies)
+
+
+def _resumes_ssr_html(resumes: list[dict]) -> str:
+    state = json.dumps({"applicantResumes": resumes}, ensure_ascii=False)
+    return f"<html><body><template id='HH-Lux-InitialState'>{escape(state)}</template></body></html>"
+
+
+def _resume_attrs(hash_: str, numeric_id: str, status: str = "modified") -> dict:
+    return {"_attributes": {"hash": hash_, "id": numeric_id, "status": status}}
+
+
+_HASH_PY = "c0ffee" * 5 + "b3236e"
+_HASH_MK = "6b85a1" * 5 + "6e370"
+
+
+def test_resolve_numeric_resume_ids_maps_hash_to_id():
+    page = StubResumesPage(
+        _resumes_ssr_html(
+            [_resume_attrs(_HASH_PY, "284561395", "not_finished"), _resume_attrs(_HASH_MK, "96223331")]
+        )
+    )
+    mapping = cr.resolve_numeric_resume_ids(page)
+    assert mapping == {_HASH_PY: "284561395", _HASH_MK: "96223331"}
+    assert page.gotos == [cr.RESUMES_LIST_URL]  # один goto за вызов
+
+
+def test_resolve_numeric_resume_ids_warns_on_not_finished(caplog):
+    # not_finished-резюме форма отклика не предлагает: отклики уходят с другого
+    # резюме аккаунта — это обязано попасть в логи, а не пройти молча.
+    page = StubResumesPage(_resumes_ssr_html([_resume_attrs(_HASH_PY, "284561395", "not_finished")]))
+    with caplog.at_level("WARNING", logger="hhru_bot.copy_resume"):
+        mapping = cr.resolve_numeric_resume_ids(page)
+    assert mapping == {_HASH_PY: "284561395"}
+    assert any("not_finished" in r.message for r in caplog.records)
+
+
+def test_resolve_numeric_resume_ids_skips_entries_without_ids():
+    page = StubResumesPage(
+        _resumes_ssr_html(
+            [
+                {"no_attributes": True},
+                _resume_attrs(_HASH_PY, "284561395"),
+                {"_attributes": {"hash": _HASH_MK}},  # без id
+                {"_attributes": {"id": "111"}},  # без hash
+            ]
+        )
+    )
+    assert cr.resolve_numeric_resume_ids(page) == {_HASH_PY: "284561395"}
+
+
+def test_resolve_numeric_resume_ids_none_without_session():
+    # Сессия истекла — «атрибуция недоступна» (None), не «резюме нет».
+    page = StubResumesPage(_resumes_ssr_html([_resume_attrs(_HASH_PY, "284561395")]), authed=False)
+    assert cr.resolve_numeric_resume_ids(page) is None
+
+
+def test_resolve_numeric_resume_ids_none_without_ssr_state():
+    # Страница без HH-Lux-InitialState (анти-бот/интерстишл) — None, не пустой
+    # маппинг: пустой dict лгал бы «у аккаунта нет резюме».
+    assert cr.resolve_numeric_resume_ids(StubResumesPage("<html>proxy check</html>")) is None
+
+
+def test_resolve_numeric_resume_ids_none_without_section():
+    page = StubResumesPage("<html><template id='HH-Lux-InitialState'>{\"other\":1}</template></html>")
+    assert cr.resolve_numeric_resume_ids(page) is None

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -343,3 +343,12 @@ def test_resolve_numeric_resume_ids_none_without_section():
         "<html><template id='HH-Lux-InitialState'>{\"other\":1}</template></html>"
     )
     assert cr.resolve_numeric_resume_ids(page) is None
+
+
+def test_resolve_numeric_resume_ids_none_on_non_dict_ssr_state():
+    # parse_initial_state возвращает любой валидный JSON, не только объект:
+    # null/массив/строка (schema-drift, интерстишл) не должны ронять apply
+    # AttributeError'ом вне try — нормализуются как «маппинг недоступен».
+    for raw in ("null", "[1,2]", '"строка"'):
+        page = StubResumesPage(f"<html><template id='HH-Lux-InitialState'>{raw}</template></html>")
+        assert cr.resolve_numeric_resume_ids(page) is None


### PR DESCRIPTION
## Суть

`found` недостижим в продакшене с момента PR #209: верификатор сравнивал хэш резюме из конфига с числовым `topicList[].resumeId` из SSR — разные домены id, каждая тема «чужая», чистый `not_found`. False negative #3 (135170581): тема существовала, записи в actions нет, риск повторного отклика.

## Что сделано

- **`copy_resume.resolve_numeric_resume_ids`** — read-only маппинг «хэш → числовой id» из SSR `/applicant/resumes` (`applicantResumes[]._attributes.{hash,id}`, источник подтверждён живой пробой `probe212`). Один goto за запуск; сбой → `None` + warn, не фатально.
- **`_resume_attribution`** (вместо `_is_foreign_resume`): равные строки — matched (надёжно в любом домене); id темы в перечне резюме аккаунта — matched; вне перечня — foreign; без перечня разные строки — **incomparable → fail-closed indeterminate**, а не молчаливый not_found.
- **Врезка в `_common`**: верификатор получает числовой id + перечень аккаунта; history и троттл остаются в домене хэша (миграций нет). dry_run резолвер не зовёт.
- **Аудит not_found**: при чистом «точно нет» логируются прочитанные vacancy_id (все страницы всех попыток).
- **#210, оба напряжения закрыты фактом без изменения поведения**: инвариант свежести (creationTime строго desc, 14/14) и стабильное наличие resumeId (14/14 + 7/7 #204) задокументированы в коде.

## Ключевая находка пробы (меньше теории, чем предполагал #212)

hh.ru подписывает тему резюме, **выбранным формой отклика**, а не конфигом бота: на живом аккаунте все 14 тем несли id default-резюме (`96223331`), пока конфиг-резюме в статусе `not_finished` (форма его не предлагает — `unfinishedResumeIds` в SSR формы). Поэтому строгая атрибуция «тема = конфиг-резюме» провалила бы собственный дрилл; принятое правило — «другое **собственное** резюме аккаунта тоже доказывает клик» (список переговоров аккаунт-приватный). Деталь вердикта честно показывает подмену: `resumeId=96223331 — сайт приложил другое резюме аккаунта (конфиг: 284561395)`.

## Тесты

Регрессия #212 ровно как в проде (хэш конфига vs числовой resumeId → indeterminate, не not_found); found через default-резюме; foreign только при известном перечне; резолвер — 6 сценариев (маппинг, warn о not_finished, пропуск битых записей, None без сессии/SSR/секции); врезка — числовой id доходит до верификатора, хэш остаётся ключом history; fallback при сбое маппинга. Полный pytest (1067) и ruff — зелёные.

## Доказательство (стандарт багфиксов)

Живой read-only дрилл-реплей инцидента (`data/logs/drill212_*.txt`, goto+чтение, без кликов):

```
[DRILL] инцидент 135170581: found | topic=5503922709, resumeId=96223331 — сайт приложил другое резюме аккаунта (конфиг: 284561395)
[DRILL] контроль 42: not_found | список откликов прочитан, вакансии нет (аудит: 18 прочитанных vacancy_id)
[DRILL] итог: PROVEN
```

До фикса тот же вызов возвращал `not_found` (лог 2026-08-16 19:47:47).

Closes #212
Closes #210