### PR TITLE
fix(apply): fail closed on incomparable resume ids

### DIFF
--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -23,7 +23,9 @@ Read-only: только goto + чтение. Три исхода:
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -32,6 +34,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from ..browser import goto_hh, has_auth_cookie, has_login_form
+from ..logging_setup import LOG_DIR
 from ..negotiations_probe import parse_initial_state
 from ..responses import (
     NEGOTIATIONS_URL,
@@ -142,6 +145,7 @@ def verify_response_in_negotiations(
         )
     if clean_read:
         logger.info("[VERIFY] список прочитан, vacancy_id=%s отсутствует", wanted)
+        _dump_not_found_diagnostics(page, wanted)
         return NegotiationsVerifyResult(NOT_FOUND, "список откликов прочитан, вакансии нет")
     return _indeterminate(page, wanted, problem)
 
@@ -151,6 +155,22 @@ def _indeterminate(page: Page, vacancy_id: str, detail: str) -> NegotiationsVeri
     # для посмертной диагностики (селектор — первый подозреваемый, CLAUDE.md).
     _dump_navigation_diagnostics(page, "verify_indeterminate", vacancy_id)
     return NegotiationsVerifyResult(INDETERMINATE, detail)
+
+
+def _dump_not_found_diagnostics(page: Page, vacancy_id: str) -> None:
+    """Сохраняет прочитанный SSR-набор тем вместе с обычным дампом страницы."""
+    _dump_navigation_diagnostics(page, "verify_not_found", vacancy_id)
+    try:
+        topics = _ssr_topic_list(page.content())
+        ids = [] if topics is None else [topic.get("vacancyId") for topic in topics]
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        path = LOG_DIR / f"apply_{vacancy_id}_verify_not_found.json"
+        path.write_text(
+            json.dumps({"vacancy_id": vacancy_id, "topic_vacancy_ids": ids}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except (OSError, PlaywrightError, TypeError, ValueError) as exc:
+        logger.warning("Дамп vacancy_id тем после not_found недоступен: %s", exc)
 
 
 def _scan_negotiations(
@@ -211,7 +231,14 @@ def _scan_single_page(
         # SSR — серверная истина; DOM читает те же данные, fallback не нужен.
         for topic in topics:
             if str(topic.get("vacancyId", "")) == wanted:
-                if _is_foreign_resume(topic, resume_id):
+                resume_match = _is_foreign_resume(topic, resume_id)
+                if resume_match is None:
+                    return (
+                        None,
+                        False,
+                        "resumeId темы и resume_id конфигурации имеют несравнимые форматы",
+                    )
+                if resume_match:
                     # Отклик с ДРУГОГО резюме на ту же вакансию — не
                     # подтверждение apply с текущего: продолжаем искать тему
                     # с совпадающим resumeId (иначе ложный success, #207).
@@ -231,7 +258,7 @@ def _scan_single_page(
     return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)"
 
 
-def _is_foreign_resume(topic: dict[str, Any], resume_id: str | None) -> bool:
+def _is_foreign_resume(topic: dict[str, Any], resume_id: str | None) -> bool | None:
     """Отклик с другого резюме — не подтверждение apply с текущего.
 
     resume_id не задан — атрибутировать нечем, считаем совпадением (resumeId
@@ -243,7 +270,25 @@ def _is_foreign_resume(topic: dict[str, Any], resume_id: str | None) -> bool:
     topic_resume = topic.get("resumeId")
     if topic_resume is None:
         return False
-    return str(topic_resume) != str(resume_id)
+    topic_value = str(topic_resume)
+    configured_value = str(resume_id)
+    topic_domain = _resume_id_domain(topic_value)
+    configured_domain = _resume_id_domain(configured_value)
+    if {topic_domain, configured_domain} == {"numeric", "hash"}:
+        # SSR exposes hh's numeric resume id, while config/actions currently
+        # carry the opaque id from the resume URL.  They cannot be compared:
+        # treating this as foreign makes a real response look absent.
+        return None
+    return topic_value != configured_value
+
+
+def _resume_id_domain(value: str) -> str:
+    """Classify the two resume-id formats that are known to be incomparable."""
+    if re.fullmatch(r"\d+", value):
+        return "numeric"
+    if re.fullmatch(r"[0-9a-fA-F]{32,64}", value):
+        return "hash"
+    return "other"
 
 
 def _describe_topic(topic: dict[str, Any]) -> str:

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 
 from playwright.sync_api import Error as PlaywrightError
 
+import hhru_bot.apply.verify as verify_module
 from _fakes import FakeLocator, _CardLocator, _parse_root, _parse_selector
 from hhru_bot.apply.verify import verify_response_in_negotiations
 from hhru_bot.responses import NEGOTIATIONS_URL
@@ -146,6 +147,33 @@ def test_foreign_resume_topic_does_not_confirm_apply():
     page = FakeNegotiationsPage({NEGOTIATIONS_URL: _ssr_html([_topic(8, _V2, "R1")])})
     result = verify_response_in_negotiations(page, _V2, resume_id="R2")
     assert result.status == "not_found"
+
+
+def test_incomparable_numeric_ssr_and_hashed_config_resume_ids_are_indeterminate():
+    """Live format pair from #212 must not become a false not_found."""
+    page = FakeNegotiationsPage(
+        {NEGOTIATIONS_URL: _ssr_html([_topic(5503922709, "135170581", "96223331")])}
+    )
+    result = verify_response_in_negotiations(
+        page,
+        "135170581",
+        resume_id="b3236ebbff10f60ff30039ed1f6d5876645331",
+    )
+    assert result.indeterminate
+    assert "несравнимые форматы" in result.detail
+
+
+def test_not_found_dumps_read_topic_vacancy_ids(tmp_path, monkeypatch):
+    monkeypatch.setattr(verify_module, "LOG_DIR", tmp_path)
+    page = FakeNegotiationsPage(
+        {NEGOTIATIONS_URL: _ssr_html([_topic(7, "999999"), _topic(8, "888888")])}
+    )
+    result = verify_response_in_negotiations(page, _V2)
+    assert result.status == "not_found"
+    artifact = json.loads(
+        (tmp_path / f"apply_{_V2}_verify_not_found.json").read_text(encoding="utf-8")
+    )
+    assert artifact["topic_vacancy_ids"] == ["999999", "888888"]
 
 
 def test_found_matching_resume_has_no_mismatch_note():


### PR DESCRIPTION
Closes #212

## Summary
- classify numeric SSR resume IDs versus hashed config IDs as indeterminate instead of foreign
- persist read SSR vacancy IDs for not_found diagnostics
- add realistic regression and artifact tests

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`

## Known limitation
- Numeric HH resume-ID mapping is not added; this PR implements the minimal fail-closed fix.