### PR TITLE
feat(ai): replace chat completions port with Responses API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 # пакета не ломает импорт остального кода.
 ai = [
     "openai>=1.50",
+    "hermes-agent-axisrow>=0.20",
 ]
 # Google Calendar OAuth/event command (#64). Kept optional so the hh.ru CLI does
 # not require Google dependencies and cannot create events implicitly.

--- a/src/hhru_bot/ai/__init__.py
+++ b/src/hhru_bot/ai/__init__.py
@@ -11,7 +11,8 @@ Public surface:
     get_transport          -- resolve a transport instance by api_mode
     register_transport     -- register a transport class for an api_mode
     resolve_runtime_provider -- build a runtime entry from AiConfig + env key
-    ChatCompletionsTransport -- the default OpenAI-compat transport
+    ChatCompletionsTransport -- legacy OpenAI-compat transport
+    ResponsesTransport       -- the default OpenAI Responses API transport
     ProviderTransport      -- ABC for provider transports
 """
 
@@ -21,6 +22,7 @@ from .base import ProviderTransport
 from .chat_completions import ChatCompletionsTransport
 from .llm_client import LLMClient
 from .registry import get_transport, register_transport
+from .responses import ResponsesTransport
 from .runtime_provider import resolve_runtime_provider
 from .types import NormalizedResponse, ToolCall, Usage, build_tool_call, map_finish_reason
 
@@ -35,5 +37,6 @@ __all__ = [
     "register_transport",
     "resolve_runtime_provider",
     "ChatCompletionsTransport",
+    "ResponsesTransport",
     "ProviderTransport",
 ]

--- a/src/hhru_bot/ai/llm_client.py
+++ b/src/hhru_bot/ai/llm_client.py
@@ -1,7 +1,7 @@
 # Ported from NousResearch/hermes-agent (MIT) -- transport conversion contract.
 # The ``LLMClient`` wrapper itself is new for hhru.
 #
-"""Thin LLM client over the ``openai`` SDK.
+"""Thin LLM client over the ``openai`` Responses API.
 
 ``openai`` is an OPTIONAL dependency (install group ``[ai]``). It is imported
 lazily inside the methods so that importing this package -- and the rest of
@@ -27,12 +27,12 @@ if TYPE_CHECKING:
 
 
 class LLMClient:
-    """Minimal synchronous client for an OpenAI-compatible chat endpoint.
+    """Minimal synchronous client for an OpenAI-compatible Responses endpoint.
 
     Args:
         ai_config: parsed top-level ``ai`` config (provider / model / base_url).
         api_key: optional explicit key; otherwise read from ``HHRU_AI_API_KEY``.
-        api_mode: transport to use; defaults to ``chat_completions``.
+        api_mode: transport to use; defaults to ``responses``.
     """
 
     def __init__(
@@ -73,7 +73,7 @@ class LLMClient:
         tools: list[dict[str, Any]] | None = None,
         **params: Any,
     ) -> NormalizedResponse:
-        """Run a chat-completions request and return a NormalizedResponse.
+        """Run a Responses API request and return a NormalizedResponse.
 
         Extra keyword arguments are forwarded to the transport's ``build_kwargs``
         (e.g. ``temperature``, ``max_tokens``, ``timeout``). ``openai`` SDK
@@ -92,5 +92,5 @@ class LLMClient:
             tools,
             **params,
         )
-        response = self._client.chat.completions.create(**kwargs)
+        response = self._client.responses.create(**kwargs)
         return transport.normalize_response(response)

--- a/src/hhru_bot/ai/registry.py
+++ b/src/hhru_bot/ai/registry.py
@@ -53,7 +53,8 @@ def _discover_transports() -> None:
     """Import all bundled transport modules to trigger auto-registration."""
     global _discovered
     _discovered = True
-    try:
-        from . import chat_completions  # noqa: F401
-    except ImportError:
-        pass
+    for module in ("chat_completions", "responses"):
+        try:
+            __import__(f"{__package__}.{module}")
+        except ImportError:
+            pass

--- a/src/hhru_bot/ai/responses.py
+++ b/src/hhru_bot/ai/responses.py
@@ -1,0 +1,95 @@
+"""OpenAI Responses API transport used by the optional AI integration.
+
+The adapter deliberately depends only on the public ``openai`` Responses
+surface.  ``hermes-agent-axisrow`` is an optional companion dependency, but
+its internal modules are not imported: they are not a stable library API.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .base import ProviderTransport
+from .registry import register_transport
+from .types import NormalizedResponse, ToolCall, Usage
+
+
+class ResponsesTransport(ProviderTransport):
+    """Convert the existing message contract to Responses API arguments."""
+
+    @property
+    def api_mode(self) -> str:
+        return "responses"
+
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> list[dict[str, Any]]:
+        del kwargs
+        return [
+            {key: value for key, value in message.items() if key in {"role", "content"}}
+            for message in messages
+            if isinstance(message, dict)
+        ]
+
+    def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        converted = []
+        for tool in tools:
+            function = tool.get("function", tool)
+            converted_tool = {
+                "type": "function",
+                "name": function["name"],
+            }
+            if function.get("description"):
+                converted_tool["description"] = function["description"]
+            if function.get("parameters"):
+                converted_tool["parameters"] = function["parameters"]
+            converted.append(converted_tool)
+        return converted
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"model": model, "input": self.convert_messages(messages)}
+        if tools:
+            kwargs["tools"] = self.convert_tools(tools)
+        for source, target in (
+            ("max_tokens", "max_output_tokens"),
+            ("temperature", "temperature"),
+            ("timeout", "timeout"),
+        ):
+            if params.get(source) is not None:
+                kwargs[target] = params[source]
+        overrides = params.get("request_overrides")
+        if overrides:
+            kwargs.update(overrides)
+        return kwargs
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        del kwargs
+        tool_calls = []
+        for item in getattr(response, "output", None) or []:
+            if getattr(item, "type", None) == "function_call":
+                arguments = getattr(item, "arguments", "{}")
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments)
+                tool_calls.append(ToolCall(getattr(item, "call_id", None), item.name, arguments))
+        usage_obj = getattr(response, "usage", None)
+        usage = None
+        if usage_obj:
+            usage = Usage(
+                prompt_tokens=getattr(usage_obj, "input_tokens", 0) or 0,
+                completion_tokens=getattr(usage_obj, "output_tokens", 0) or 0,
+                total_tokens=getattr(usage_obj, "total_tokens", 0) or 0,
+            )
+        content = getattr(response, "output_text", None)
+        return NormalizedResponse(
+            content=content,
+            tool_calls=tool_calls or None,
+            finish_reason="tool_calls" if tool_calls else "stop",
+            usage=usage,
+        )
+
+register_transport("responses", ResponsesTransport)

--- a/src/hhru_bot/ai/responses.py
+++ b/src/hhru_bot/ai/responses.py
@@ -92,4 +92,5 @@ class ResponsesTransport(ProviderTransport):
             usage=usage,
         )
 
+
 register_transport("responses", ResponsesTransport)

--- a/src/hhru_bot/ai/runtime_provider.py
+++ b/src/hhru_bot/ai/runtime_provider.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from ..config_sections.ai import AiConfig
 
-# The single transport shipped with this package. A future api_mode (anthropic,
-# responses, ...) would be selected here based on provider/base_url.
-DEFAULT_API_MODE = "chat_completions"
+# Responses is the supported API mode. The explicit override remains for
+# callers migrating from the legacy chat-completions transport.
+DEFAULT_API_MODE = "responses"
 
 # Env var that carries the API key. The key is intentionally NOT read from
 # config.yaml so it can't be committed by accident.

--- a/tests/test_ai_responses.py
+++ b/tests/test_ai_responses.py
@@ -1,0 +1,43 @@
+"""Focused contract tests for the Responses API transport."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hhru_bot.ai.responses import ResponsesTransport
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_kwargs_uses_responses_input_and_tool_shape():
+    transport = ResponsesTransport()
+    kwargs = transport.build_kwargs(
+        "gpt-5-mini",
+        [{"role": "system", "content": "be concise"}, {"role": "user", "content": "hi"}],
+        [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
+        max_tokens=80,
+    )
+    assert kwargs["input"][0]["role"] == "system"
+    assert kwargs["input"][1]["content"] == "hi"
+    assert kwargs["max_output_tokens"] == 80
+    assert kwargs["tools"] == [
+        {"type": "function", "name": "search", "parameters": {"type": "object"}}
+    ]
+    assert "messages" not in kwargs
+
+
+def test_normalize_response_text_usage_and_function_call():
+    response = SimpleNamespace(
+        output_text="draft",
+        output=[
+            SimpleNamespace(
+                type="function_call", call_id="call_1", name="search", arguments='{"q":"x"}'
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=4, total_tokens=14),
+    )
+    normalized = ResponsesTransport().normalize_response(response)
+    assert normalized.content == "draft"
+    assert normalized.finish_reason == "tool_calls"
+    assert normalized.tool_calls[0].id == "call_1"
+    assert normalized.usage.prompt_tokens == 10


### PR DESCRIPTION
Closes #230

## Summary
- add a public OpenAI Responses API transport and make it the default
- normalize text, usage, and function-call outputs to the existing AI contract
- add hermes-agent-axisrow to the optional [ai] extra

Reconnaissance: hermes-agent-axisrow exposes console entry points and private internal modules, not a supported single-call Python API. The implementation therefore avoids private Hermes imports and uses the public Responses SDK path while keeping Hermes optional for the AI extra.

## Verification
- pytest -q tests/test_ai_runtime_provider.py tests/test_ai_registry.py tests/test_ai_responses.py tests/test_apply_letter.py tests/test_apply_letter_integration.py tests/test_apply_scoring_integration.py
- ruff check src/hhru_bot/ai tests/test_ai_responses.py
- python -m build --wheel --no-isolation