### PR TITLE
fix(apply): fail closed for unfinished resume

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -279,18 +279,31 @@ def run_apply_for_resume(
     if not args.dry_run:
         ids_by_hash = resolve_numeric_resume_ids(page)
         if ids_by_hash is not None:
-            resume_status = getattr(ids_by_hash, "statuses", {}).get(resume.resume_id)
-            if resume_status == "not_finished":
-                print(
-                    f"[FAIL] {resume.id} — резюме имеет статус not_finished на hh.ru; "
-                    "сначала завершите/опубликуйте его вручную"
-                )
-                return True
             numeric_id = ids_by_hash.get(resume.resume_id)
             if numeric_id is not None:
+                # Хэш конфига есть в маппинге аккаунта — SSR прочитан успешно
+                # именно для этого резюме. not_finished фейлится явно (#216).
+                # Отсутствие поля status в SSR для присутствующего в маппинге
+                # хэша (schema drift) трактуем так же: мы прочитали резюме
+                # аккаунта, но не можем подтвердить его готовность к откликам
+                # — здесь, в отличие от отсутствия самого хэша (#212, домен
+                # верификатора), у нас есть основания фейлиться до отправки,
+                # а не полагаться на пост-клик verify.
+                resume_status = getattr(ids_by_hash, "statuses", {}).get(resume.resume_id)
+                if resume_status is None or resume_status == "not_finished":
+                    print(
+                        f"[FAIL] {resume.id} — статус резюме на hh.ru не подтверждён как "
+                        f"готовый к отклику (status={resume_status!r}); завершите/опубликуйте "
+                        "его вручную"
+                    )
+                    return True
                 account_resume_ids = set(ids_by_hash.values())
                 verify_resume_id = numeric_id
             else:
+                # Конфиг-хэш отсутствует в маппинге аккаунта (устаревший/
+                # неверный хэш, #212) — не наш домен: перечень НЕ заполняем,
+                # атрибуция уходит в incomparable → fail-closed indeterminate
+                # в самом верификаторе, апробировано тестами #212.
                 logger.warning(
                     "%s — резюме конфига (%s) нет в маппинге аккаунта: атрибуция в "
                     "верификаторе уйдёт в fail-closed",

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -270,6 +270,34 @@ def run_apply_for_resume(
         print(f"Пропуск: {e}")
         return False
 
+    # #216: hh.ru silently substitutes another account resume when the
+    # configured one is not_finished. Check this before searching or any
+    # possible submit, and fail closed rather than creating a misleading
+    # history entry under the configured resume.
+    account_resume_ids: set[str] | None = None
+    verify_resume_id = resume.resume_id
+    if not args.dry_run:
+        ids_by_hash = resolve_numeric_resume_ids(page)
+        if ids_by_hash is not None:
+            resume_status = getattr(ids_by_hash, "statuses", {}).get(resume.resume_id)
+            if resume_status == "not_finished":
+                print(
+                    f"[FAIL] {resume.id} — резюме имеет статус not_finished на hh.ru; "
+                    "сначала завершите/опубликуйте его вручную"
+                )
+                return True
+            numeric_id = ids_by_hash.get(resume.resume_id)
+            if numeric_id is not None:
+                account_resume_ids = set(ids_by_hash.values())
+                verify_resume_id = numeric_id
+            else:
+                logger.warning(
+                    "%s — резюме конфига (%s) нет в маппинге аккаунта: атрибуция в "
+                    "верификаторе уйдёт в fail-closed",
+                    resume.id,
+                    resume.resume_id,
+                )
+
     try:
         cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
     except VacancySearchIndeterminate as e:
@@ -299,31 +327,6 @@ def run_apply_for_resume(
     # сбой маппинга не фатален — верификатор получит хэш и уйдёт в fail-closed
     # indeterminate при совпадении вакансии. dry_run до клика не доходит —
     # верификатор не зовётся, лишний goto не нужен.
-    account_resume_ids: set[str] | None = None
-    verify_resume_id = resume.resume_id
-    if plan.ranked and not args.dry_run:
-        ids_by_hash = resolve_numeric_resume_ids(page)
-        if ids_by_hash is not None:
-            numeric_id = ids_by_hash.get(resume.resume_id)
-            if numeric_id is not None:
-                # Конфиг-резюме в маппинге: верификатор сравнивает числовой id,
-                # а перечень резюме аккаунта отличает «другое собственное» от
-                # «чужого» (оба доказывают клик, #212).
-                account_resume_ids = set(ids_by_hash.values())
-                verify_resume_id = numeric_id
-            else:
-                # Конфиг-резюме НЕТ в маппинге (устаревший/неверный хэш) —
-                # перечень НЕ заполняем: иначе любая тема с id резюме аккаунта
-                # подтвердила бы отклик (success под хэшем, которого нет в
-                # аккаунте). Без перечня атрибуция уходит в incomparable →
-                # fail-closed indeterminate в самом верификаторе.
-                logger.warning(
-                    "%s — резюме конфига (%s) нет в маппинге аккаунта: атрибуция в "
-                    "верификаторе уйдёт в fail-closed",
-                    resume.id,
-                    resume.resume_id,
-                )
-
     def _verifier(page, vacancy_id, _pipeline_resume_id):  # noqa: ANN001
         # pipeline передаёт хэш конфига (ключ history) — подменяем его числовым
         # id для сравнения с SSR; запись в history и троттл остаются в домене

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -363,7 +363,15 @@ def list_resume_cards(page: Page, *, navigate: bool = True) -> list[ResumeCard]:
     return cards
 
 
-def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
+class ResumeIdMapping(dict[str, str]):
+    """Hash-to-numeric-id mapping with the status read from the same SSR."""
+
+    def __init__(self, *args, statuses: dict[str, str], **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.statuses = statuses
+
+
+def resolve_numeric_resume_ids(page: Page) -> ResumeIdMapping | None:
     """Маппинг «хэш резюме → числовой id hh.ru» с /applicant/resumes (#212).
 
     Домены id у hh.ru несовместимы: конфиг адресует резюме хэшем из URL
@@ -407,6 +415,7 @@ def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
         logger.warning("[RESUME-ID] секция applicantResumes не найдена — маппинг недоступен")
         return None
     mapping: dict[str, str] = {}
+    statuses: dict[str, str] = {}
     for item in resumes:
         attrs = item.get("_attributes") if isinstance(item, dict) else None
         if not isinstance(attrs, dict):
@@ -415,6 +424,8 @@ def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
         if not resume_hash or numeric_id is None:
             continue
         mapping[str(resume_hash)] = str(numeric_id)
+        if attrs.get("status") is not None:
+            statuses[str(resume_hash)] = str(attrs["status"])
         if attrs.get("status") == "not_finished":
             logger.warning(
                 "[RESUME-ID] резюме %s (id=%s) в статусе not_finished — форма отклика "
@@ -426,7 +437,7 @@ def resolve_numeric_resume_ids(page: Page) -> dict[str, str] | None:
         logger.warning("[RESUME-ID] в SSR нет пар hash→id — маппинг недоступен")
         return None
     logger.info("[RESUME-ID] маппинг hash→id получен: %d резюме", len(mapping))
-    return mapping
+    return ResumeIdMapping(mapping, statuses=statuses)
 
 
 def _goto_resumes_list(page: Page, *, post_write: bool = False) -> None:

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -424,9 +424,10 @@ def resolve_numeric_resume_ids(page: Page) -> ResumeIdMapping | None:
         if not resume_hash or numeric_id is None:
             continue
         mapping[str(resume_hash)] = str(numeric_id)
-        if attrs.get("status") is not None:
-            statuses[str(resume_hash)] = str(attrs["status"])
-        if attrs.get("status") == "not_finished":
+        status = attrs.get("status")
+        if status is not None:
+            statuses[str(resume_hash)] = str(status)
+        if status == "not_finished":
             logger.warning(
                 "[RESUME-ID] резюме %s (id=%s) в статусе not_finished — форма отклика "
                 "его не предлагает: отклики уходят с другого резюме аккаунта",

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -667,6 +667,7 @@ def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
     from hhru_bot.apply.verify import NegotiationsVerifyResult
     from hhru_bot.commands import _common
     from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+    from hhru_bot.copy_resume import ResumeIdMapping
     from hhru_bot.history import History
     from hhru_bot.search import VacancyCard
     from hhru_bot.throttle import Throttle
@@ -688,9 +689,14 @@ def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
     monkeypatch.setattr("hhru_bot.commands._common.verify_response_in_negotiations", _fake_verify)
     # #212: маппинг «хэш → числовой id» — как от /applicant/resumes (два резюме
     # аккаунта; конфиг — первое). Без подмены резолвер ходил бы в сеть.
+    # #216: статус конфиг-резюме должен быть подтверждён (не not_finished,
+    # не отсутствовать) — иначе run_apply_for_resume фейлится до поиска.
     monkeypatch.setattr(
         "hhru_bot.commands._common.resolve_numeric_resume_ids",
-        lambda page: {"AAA111": "284561395", "BBB222": "96223331"},
+        lambda page: ResumeIdMapping(
+            {"AAA111": "284561395", "BBB222": "96223331"},
+            statuses={"AAA111": "modified", "BBB222": "modified"},
+        ),
     )
 
     resume = ResumeConfig(
@@ -740,6 +746,50 @@ def test_run_apply_for_resume_fails_before_search_for_unfinished_resume(tmp_path
     monkeypatch.setattr(
         "hhru_bot.commands._common.resolve_numeric_resume_ids",
         lambda page: ResumeIdMapping({"AAA111": "284561395"}, statuses={"AAA111": "not_finished"}),
+    )
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="Здравствуйте!",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(dry_run=False, limit=1, max_pages=5, headless=True)
+
+    assert (
+        _common.run_apply_for_resume(
+            _ApplyPipelineFakePage(), config, resume, history, throttle, args
+        )
+        is True
+    )
+
+
+def test_run_apply_for_resume_fails_before_search_when_status_unknown(tmp_path, monkeypatch):
+    """#216: конфиг-хэш присутствует в маппинге (SSR прочитан успешно для
+    этого резюме), но поле status для него отсутствует (schema drift) — мы
+    объективно не можем подтвердить готовность резюме к откликам, поэтому
+    фейлимся так же, как при not_finished, а не молча продолжаем."""
+    import argparse
+
+    from hhru_bot.commands import _common
+    from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+    from hhru_bot.copy_resume import ResumeIdMapping
+    from hhru_bot.history import History
+    from hhru_bot.throttle import Throttle
+
+    def _unexpected_search(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("resume with unknown status must fail before vacancy search")
+
+    monkeypatch.setattr("hhru_bot.commands._common.search_vacancies", _unexpected_search)
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.resolve_numeric_resume_ids",
+        lambda page: ResumeIdMapping({"AAA111": "284561395"}, statuses={}),
     )
     resume = ResumeConfig(
         id="python",

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -739,9 +739,7 @@ def test_run_apply_for_resume_fails_before_search_for_unfinished_resume(tmp_path
     monkeypatch.setattr("hhru_bot.commands._common.search_vacancies", _unexpected_search)
     monkeypatch.setattr(
         "hhru_bot.commands._common.resolve_numeric_resume_ids",
-        lambda page: ResumeIdMapping(
-            {"AAA111": "284561395"}, statuses={"AAA111": "not_finished"}
-        ),
+        lambda page: ResumeIdMapping({"AAA111": "284561395"}, statuses={"AAA111": "not_finished"}),
     )
     resume = ResumeConfig(
         id="python",
@@ -758,9 +756,12 @@ def test_run_apply_for_resume_fails_before_search_for_unfinished_resume(tmp_path
     throttle = Throttle(config.throttle, history)
     args = argparse.Namespace(dry_run=False, limit=1, max_pages=5, headless=True)
 
-    assert _common.run_apply_for_resume(
-        _ApplyPipelineFakePage(), config, resume, history, throttle, args
-    ) is True
+    assert (
+        _common.run_apply_for_resume(
+            _ApplyPipelineFakePage(), config, resume, history, throttle, args
+        )
+        is True
+    )
 
 
 def test_run_apply_for_resume_verifier_falls_back_to_hash(tmp_path, monkeypatch):

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -723,6 +723,46 @@ def test_run_apply_for_resume_wires_verifier(tmp_path, monkeypatch):
     assert "negotiations" in rows[0][2]
 
 
+def test_run_apply_for_resume_fails_before_search_for_unfinished_resume(tmp_path, monkeypatch):
+    """#216: an unfinished configured resume must never reach the apply plan."""
+    import argparse
+
+    from hhru_bot.commands import _common
+    from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+    from hhru_bot.copy_resume import ResumeIdMapping
+    from hhru_bot.history import History
+    from hhru_bot.throttle import Throttle
+
+    def _unexpected_search(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("unfinished resume must fail before vacancy search")
+
+    monkeypatch.setattr("hhru_bot.commands._common.search_vacancies", _unexpected_search)
+    monkeypatch.setattr(
+        "hhru_bot.commands._common.resolve_numeric_resume_ids",
+        lambda page: ResumeIdMapping(
+            {"AAA111": "284561395"}, statuses={"AAA111": "not_finished"}
+        ),
+    )
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python developer"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="Здравствуйте!",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(dry_run=False, limit=1, max_pages=5, headless=True)
+
+    assert _common.run_apply_for_resume(
+        _ApplyPipelineFakePage(), config, resume, history, throttle, args
+    ) is True
+
+
 def test_run_apply_for_resume_verifier_falls_back_to_hash(tmp_path, monkeypatch):
     """#212: сбой маппинга (None) не роняет apply — верификатор получает хэш
     конфига без перечня резюме; атрибуция деградирует до fail-closed

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -299,6 +299,7 @@ def test_resolve_numeric_resume_ids_maps_hash_to_id():
     )
     mapping = cr.resolve_numeric_resume_ids(page)
     assert mapping == {_HASH_PY: "284561395", _HASH_MK: "96223331"}
+    assert mapping.statuses == {_HASH_PY: "not_finished", _HASH_MK: "modified"}
     assert page.gotos == [cr.RESUMES_LIST_URL]  # один goto за вызов
 
 


### PR DESCRIPTION
Closes #216

## Summary
- preserve resume statuses alongside hash-to-numeric-id mapping
- reject `not_finished` configured resumes before vacancy search or any submit
- add regression coverage for fail-closed behavior

## Tests
- `pytest -q tests/test_list_resume_cards.py tests/test_apply_verify.py`
- `pytest -q tests/test_apply_pipeline.py tests/test_apply_placeholder.py tests/test_apply_steps.py`
- `python -m ruff check src/hhru_bot/copy_resume.py src/hhru_bot/commands/_common.py tests/test_apply_verify.py tests/test_list_resume_cards.py`