### PR TITLE
fix(apply): handle transitional responded markers

### DIFF
--- a/src/hhru_bot/apply/dedup.py
+++ b/src/hhru_bot/apply/dedup.py
@@ -27,9 +27,7 @@ logger = logging.getLogger("hhru_bot.apply.dedup")
 _VISIBILITY_CHECK_TIMEOUT_MS = 1_500
 
 
-def check_already_responded(
-    page: Page, vacancy: VacancyCard, *, blocking: bool = True
-) -> str | None:
+def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
     """Возвращает причину отказа, если вакансия уже откликнута.
 
     Дедупликация идёт через history.has_applied() в filter_candidates() (см.
@@ -44,23 +42,26 @@ def check_already_responded(
     или устаревшая SPA-копия маркера, засчитанная как attached, дала бы
     ложноположительный и практически необратимый пропуск валидной вакансии.
 
-    #241 cycle-review round 1 (codex): blocking=True (по умолчанию, ветка
-    "кнопка не найдена" в pipeline._run) ждёт видимость с полным таймаутом —
-    транзитное SPA-состояние ещё может дорендерить маркер. blocking=False
-    (ветка "кнопка уже подтверждена wait_apply_button") проверяет видимость
-    БЕЗ ожидания: комбинированный wait_for в wait_apply_button уже дождался
-    отрисовки DOM, повторный полный таймаут на каждой обычной вакансии (до
-    2 x _VISIBILITY_CHECK_TIMEOUT_MS) был чистым оверхедом на happy path.
+    #241 cycle-review round 1 (codex): пробовали пропускать блокирующее ожидание,
+    когда кнопка отклика уже найдена (timeout=0 при apply_button_found=True) —
+    round 2 отклонил это ДВАЖДЫ: (1) codex — комбинированный wait_apply_button
+    доказывает лишь то, что маркер не виден В МОМЕНТ проверки, а не то, что он не
+    отрендерится следом (та же transitional SPA-гонка из #241, теперь непойманная);
+    (2) /review — Playwright timeout=0 означает "отключить таймаут" (ждать
+    бесконечно), а НЕ "мгновенная проверка" — happy-path завис бы навсегда.
+    Блокирующее ожидание с полным таймаутом сохранено безусловно; экономия
+    времени на happy path не стоит риска дублирующего отклика или зависания.
     """
     from ..selector_groups import vacancy_page
 
-    timeout = _VISIBILITY_CHECK_TIMEOUT_MS if blocking else 0
     for selector in (
         vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN,
         vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT,
     ):
         try:
-            page.locator(selector).first.wait_for(state="visible", timeout=timeout)
+            page.locator(selector).first.wait_for(
+                state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
+            )
         except PlaywrightError:
             continue
         reason = f"уже откликались по вакансии {vacancy.vacancy_id}, пропуск"

--- a/src/hhru_bot/apply/dedup.py
+++ b/src/hhru_bot/apply/dedup.py
@@ -27,7 +27,9 @@ logger = logging.getLogger("hhru_bot.apply.dedup")
 _VISIBILITY_CHECK_TIMEOUT_MS = 1_500
 
 
-def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
+def check_already_responded(
+    page: Page, vacancy: VacancyCard, *, blocking: bool = True
+) -> str | None:
     """Возвращает причину отказа, если вакансия уже откликнута.
 
     Дедупликация идёт через history.has_applied() в filter_candidates() (см.
@@ -41,17 +43,24 @@ def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
     навсегда исключает вакансию из будущих прогонов через is_skipped() — скрытая
     или устаревшая SPA-копия маркера, засчитанная как attached, дала бы
     ложноположительный и практически необратимый пропуск валидной вакансии.
+
+    #241 cycle-review round 1 (codex): blocking=True (по умолчанию, ветка
+    "кнопка не найдена" в pipeline._run) ждёт видимость с полным таймаутом —
+    транзитное SPA-состояние ещё может дорендерить маркер. blocking=False
+    (ветка "кнопка уже подтверждена wait_apply_button") проверяет видимость
+    БЕЗ ожидания: комбинированный wait_for в wait_apply_button уже дождался
+    отрисовки DOM, повторный полный таймаут на каждой обычной вакансии (до
+    2 x _VISIBILITY_CHECK_TIMEOUT_MS) был чистым оверхедом на happy path.
     """
     from ..selector_groups import vacancy_page
 
+    timeout = _VISIBILITY_CHECK_TIMEOUT_MS if blocking else 0
     for selector in (
         vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN,
         vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT,
     ):
         try:
-            page.locator(selector).first.wait_for(
-                state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
-            )
+            page.locator(selector).first.wait_for(state="visible", timeout=timeout)
         except PlaywrightError:
             continue
         reason = f"уже откликались по вакансии {vacancy.vacancy_id}, пропуск"

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -219,8 +219,11 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     apply_button_found = apply_steps.wait_apply_button(ctx.page)
     # The combined wait can observe both markers during a transitional SPA
     # render. Re-check independently after it completes so the apply button
-    # cannot win over an already-responded marker.
-    if reason := check_already_responded(ctx.page, ctx.vacancy):
+    # cannot win over an already-responded marker. When the button was already
+    # confirmed present, wait_apply_button's combined wait already settled the
+    # DOM — a non-blocking check is enough (#241 cycle-review round 1: a full
+    # timeout on the happy path was pure overhead, up to 3s per vacancy).
+    if reason := check_already_responded(ctx.page, ctx.vacancy, blocking=not apply_button_found):
         return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
     if not apply_button_found:
         return ctx.fail("кнопка отклика не найдена на странице")

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -219,11 +219,10 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     apply_button_found = apply_steps.wait_apply_button(ctx.page)
     # The combined wait can observe both markers during a transitional SPA
     # render. Re-check independently after it completes so the apply button
-    # cannot win over an already-responded marker. When the button was already
-    # confirmed present, wait_apply_button's combined wait already settled the
-    # DOM — a non-blocking check is enough (#241 cycle-review round 1: a full
-    # timeout on the happy path was pure overhead, up to 3s per vacancy).
-    if reason := check_already_responded(ctx.page, ctx.vacancy, blocking=not apply_button_found):
+    # cannot win over an already-responded marker. #241 cycle-review round 2
+    # rejected a non-blocking fast path here twice (see dedup.py docstring) —
+    # the blocking check stays unconditional.
+    if reason := check_already_responded(ctx.page, ctx.vacancy):
         return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
     if not apply_button_found:
         return ctx.fail("кнопка отклика не найдена на странице")

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -216,9 +216,13 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         return ctx.fail("Сессия недействительна: страница содержит форму входа. Выполните login.")
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)
 
-    if not apply_steps.wait_apply_button(ctx.page):
-        if reason := check_already_responded(ctx.page, ctx.vacancy):
-            return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
+    apply_button_found = apply_steps.wait_apply_button(ctx.page)
+    # The combined wait can observe both markers during a transitional SPA
+    # render. Re-check independently after it completes so the apply button
+    # cannot win over an already-responded marker.
+    if reason := check_already_responded(ctx.page, ctx.vacancy):
+        return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
+    if not apply_button_found:
         return ctx.fail("кнопка отклика не найдена на странице")
 
     # #17: рендер письма через провайдер, если он задан (AI/шаблон). Провайдер

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -377,6 +377,9 @@ def run_apply_for_resume(
             # #226 cycle-review: причина берётся из result.skip_reason, а не
             # жёстко HAS_QUESTIONS — иначе already-responded-skip (#226) терялся
             # бы под чужой причиной (ломало clear-skipped --reason).
+            # Инвариант: все persistent skip-результаты создаются через
+            # ApplyContext.skip(), чей дефолт — HAS_QUESTIONS; новый skip-путь
+            # обязан передать здесь собственный skip_reason явно.
             history.record_skip(resume.resume_id, card.vacancy_id, result.skip_reason)
             print(f"  [skip] {card.title} — {result.reason}")
             continue

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -36,7 +36,7 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -213,6 +213,16 @@ def test_apply_already_responded_is_skip_not_missing_button_failure():
     assert result.acted is False
 
 
+def test_apply_transitional_both_markers_prefers_already_responded():
+    """A transient page showing both markers must fail closed to skip."""
+    page = FakePage(apply_button=True, already_responded=True)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+
+    assert result.skipped is True
+    assert result.skip_reason == "already_applied"
+
+
 def test_apply_already_responded_skip_reason_is_already_applied_not_has_questions():
     """#226 cycle-review round 2 (codex): already-responded skip раньше терялся под
     HAS_QUESTIONS — clear-skipped --reason already_applied не мог его снять, а

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -38,9 +38,10 @@ class _FakeLocator:
         # на объединённом локаторе, а не последовательно кнопка-потом-маркеры
         # (что копило бы полный APPLY_TIMEOUT_MS на each already-responded вакансии).
         self._wait_for_calls = wait_for_calls if wait_for_calls is not None else []
-        # #241 cycle-review round 1 (codex): фиксирует переданный timeout каждого
-        # wait_for-вызова — проверяет, что check_already_responded передаёт 0
-        # (blocking=False), когда apply-кнопка уже подтверждена wait_apply_button.
+        # #241 cycle-review round 2: фиксирует переданный timeout каждого
+        # wait_for-вызова — проверяет, что check_already_responded всегда
+        # получает полный _VISIBILITY_CHECK_TIMEOUT_MS (round 1 пробовал
+        # передавать 0 при подтверждённой кнопке, отклонено дважды).
         self._wait_for_timeouts = wait_for_timeouts if wait_for_timeouts is not None else []
 
     def count(self) -> int:
@@ -112,8 +113,9 @@ class FakePage:
         # already-responded локаторов — считает, что wait_apply_button ждёт
         # объединённым локатором (1 wait_for), а не последовательно.
         self.apply_wait_for_calls: list[int] = []
-        # #241 cycle-review round 1 (codex): фиксирует переданные already-responded
-        # wait_for-таймауты отдельно от общего apply_wait_for_calls счётчика.
+        # #241 cycle-review round 2: фиксирует переданные already-responded
+        # wait_for-таймауты отдельно от общего apply_wait_for_calls счётчика —
+        # проверяет, что они всегда равны полному _VISIBILITY_CHECK_TIMEOUT_MS.
         self.already_responded_wait_for_timeouts: list[float] = []
 
     def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
@@ -234,35 +236,25 @@ def test_apply_transitional_both_markers_prefers_already_responded():
     assert result.skip_reason == "already_applied"
 
 
-def test_apply_button_found_skips_blocking_already_responded_wait():
-    """#241 cycle-review round 1 (codex): когда wait_apply_button уже подтвердил
-    кнопку отклика, DOM уже settled — check_already_responded не должен платить
-    полный _VISIBILITY_CHECK_TIMEOUT_MS на каждом из двух селекторов (до 3с
-    оверхеда на каждую обычную вакансию). Ожидаем timeout=0 на обоих вызовах.
+def test_apply_already_responded_check_always_blocks_regardless_of_button():
+    """#241 cycle-review round 2: попытка пропускать блокирующее ожидание, когда
+    кнопка уже найдена (round 1), была отклонена ДВАЖДЫ — codex указал на гонку
+    состояний (маркер может отрендериться сразу после кнопки), /review указал на
+    Playwright-семантику timeout=0 (означает "без таймаута", т.е. бесконечное
+    ожидание, а не мгновенную проверку). check_already_responded всегда должен
+    получать полный _VISIBILITY_CHECK_TIMEOUT_MS, независимо от apply_button_found.
     """
-    page = FakePage(apply_button=True, already_responded=False)
-
-    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
-
-    assert result.success is True
-    assert page.already_responded_wait_for_timeouts
-    assert all(t == 0 for t in page.already_responded_wait_for_timeouts)
-
-
-def test_apply_button_missing_still_blocks_on_already_responded_wait():
-    """Ветка «кнопка не найдена» — транзитное состояние ещё может дорендерить
-    маркер, полный таймаут ожидания видимости должен сохраниться (#241 п.1).
-    """
-    page = FakePage(apply_button=False, already_responded=False)
-
-    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
-
-    assert result.success is False
-    assert "кнопка отклика не найдена" in result.reason
-    assert page.already_responded_wait_for_timeouts
     from hhru_bot.apply.dedup import _VISIBILITY_CHECK_TIMEOUT_MS
 
-    assert all(t == _VISIBILITY_CHECK_TIMEOUT_MS for t in page.already_responded_wait_for_timeouts)
+    for apply_button in (True, False):
+        page = FakePage(apply_button=apply_button, already_responded=False)
+
+        apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+
+        assert page.already_responded_wait_for_timeouts
+        assert all(
+            t == _VISIBILITY_CHECK_TIMEOUT_MS for t in page.already_responded_wait_for_timeouts
+        )
 
 
 def test_apply_already_responded_skip_reason_is_already_applied_not_has_questions():

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -27,6 +27,7 @@ class _FakeLocator:
         attrs: dict[str, str] | None = None,
         click_error: Exception | None = None,
         wait_for_calls: list[int] | None = None,
+        wait_for_timeouts: list[float] | None = None,
     ):
         self._present = present
         self._attrs = attrs or {}
@@ -37,12 +38,17 @@ class _FakeLocator:
         # на объединённом локаторе, а не последовательно кнопка-потом-маркеры
         # (что копило бы полный APPLY_TIMEOUT_MS на each already-responded вакансии).
         self._wait_for_calls = wait_for_calls if wait_for_calls is not None else []
+        # #241 cycle-review round 1 (codex): фиксирует переданный timeout каждого
+        # wait_for-вызова — проверяет, что check_already_responded передаёт 0
+        # (blocking=False), когда apply-кнопка уже подтверждена wait_apply_button.
+        self._wait_for_timeouts = wait_for_timeouts if wait_for_timeouts is not None else []
 
     def count(self) -> int:
         return 1 if self._present else 0
 
     def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         self._wait_for_calls.append(1)
+        self._wait_for_timeouts.append(timeout)
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -106,6 +112,9 @@ class FakePage:
         # already-responded локаторов — считает, что wait_apply_button ждёт
         # объединённым локатором (1 wait_for), а не последовательно.
         self.apply_wait_for_calls: list[int] = []
+        # #241 cycle-review round 1 (codex): фиксирует переданные already-responded
+        # wait_for-таймауты отдельно от общего apply_wait_for_calls счётчика.
+        self.already_responded_wait_for_timeouts: list[float] = []
 
     def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
@@ -124,7 +133,9 @@ class FakePage:
             vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT,
         ):
             return _FakeLocator(
-                present=self._already_responded, wait_for_calls=self.apply_wait_for_calls
+                present=self._already_responded,
+                wait_for_calls=self.apply_wait_for_calls,
+                wait_for_timeouts=self.already_responded_wait_for_timeouts,
             )
         if selector == success.APPLY_SUCCESS_MARKER:
             return _FakeLocator(present=self._success)
@@ -221,6 +232,37 @@ def test_apply_transitional_both_markers_prefers_already_responded():
 
     assert result.skipped is True
     assert result.skip_reason == "already_applied"
+
+
+def test_apply_button_found_skips_blocking_already_responded_wait():
+    """#241 cycle-review round 1 (codex): когда wait_apply_button уже подтвердил
+    кнопку отклика, DOM уже settled — check_already_responded не должен платить
+    полный _VISIBILITY_CHECK_TIMEOUT_MS на каждом из двух селекторов (до 3с
+    оверхеда на каждую обычную вакансию). Ожидаем timeout=0 на обоих вызовах.
+    """
+    page = FakePage(apply_button=True, already_responded=False)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+
+    assert result.success is True
+    assert page.already_responded_wait_for_timeouts
+    assert all(t == 0 for t in page.already_responded_wait_for_timeouts)
+
+
+def test_apply_button_missing_still_blocks_on_already_responded_wait():
+    """Ветка «кнопка не найдена» — транзитное состояние ещё может дорендерить
+    маркер, полный таймаут ожидания видимости должен сохраниться (#241 п.1).
+    """
+    page = FakePage(apply_button=False, already_responded=False)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+
+    assert result.success is False
+    assert "кнопка отклика не найдена" in result.reason
+    assert page.already_responded_wait_for_timeouts
+    from hhru_bot.apply.dedup import _VISIBILITY_CHECK_TIMEOUT_MS
+
+    assert all(t == _VISIBILITY_CHECK_TIMEOUT_MS for t in page.already_responded_wait_for_timeouts)
 
 
 def test_apply_already_responded_skip_reason_is_already_applied_not_has_questions():

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -50,7 +50,7 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 


### PR DESCRIPTION
Closes #241

Summary:
- Re-check already-responded DOM markers after the combined apply-button wait so transitional pages fail closed to skip.
- Document the ApplyContext.skip() skip_reason invariant.
- Add regression coverage for both markers being visible.

Tests:
- pytest -q tests/test_apply_pipeline.py tests/test_apply_steps.py
- python -m ruff check src/hhru_bot/apply/pipeline.py src/hhru_bot/commands/_common.py tests/test_apply_pipeline.py