### PR TITLE
fix(apply): persist audit marker before submit

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -12,8 +12,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import Callable
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -91,6 +92,8 @@ class ApplyContext:
     # pipeline инъектируют фейк или ничего; продакшн-проводка — в
     # commands/_common.run_apply_for_resume (verify_response_in_negotiations).
     verifier: ResponseVerifier | None = None
+    # #245: durable audit marker immediately before entering the submit path.
+    before_submit: Callable[[], None] | None = None
 
     def fail(self, reason: str) -> ApplyResult:
         return ApplyResult(
@@ -137,6 +140,7 @@ def apply_to_vacancy(
     probe: ProbeHook | None = None,
     letter_provider: CoverLetterProvider | None = None,
     verifier: ResponseVerifier | None = None,
+    before_submit: Callable[[], None] | None = None,
 ) -> ApplyResult:
     ctx = ApplyContext(
         page=page,
@@ -147,6 +151,7 @@ def apply_to_vacancy(
         probe=probe or NOOP_PROBE,
         letter_provider=letter_provider,
         verifier=verifier,
+        before_submit=before_submit,
     )
     return _run(ctx)
 
@@ -264,6 +269,8 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     #     чистый fail с acted=False: на hh.ru следа нет, как у остальных
     #     ранних выходов #163, но traceback больше не рвёт цикл откликов.
     try:
+        if ctx.before_submit is not None:
+            ctx.before_submit()
         reason = apply_steps.fill_response_form(ctx.page, ctx.resume_id, letter)
     except SubmitClickUncertain:
         ctx.acted = True

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -358,16 +358,34 @@ def run_apply_for_resume(
             print(f"Дневной лимит достигнут, останавливаюсь: {e}")
             break
 
+        action_id = None
+
+        def _before_submit() -> None:
+            nonlocal action_id
+            # #245: commit the fail-closed audit marker immediately before
+            # entering the irreversible form path. A process crash can leave
+            # browser dumps (and possibly a sent application) without
+            # returning an ApplyResult; waiting for the post-action record
+            # would make the next run send a duplicate. Keeping this hook after
+            # navigation/questions preserves the old no-action semantics for
+            # confirmed pre-submit exits.
+            action_id = history.begin_action(resume.resume_id, card.vacancy_id, "apply")
+
+        apply_kwargs = {
+            "letter_provider": letter_provider,
+            # #207: fail-вердикты после клика по кнопке отклика подтверждаются
+            # внешней проверкой /applicant/negotiations до записи в history.
+            "verifier": _verifier,
+        }
+        if not args.dry_run:
+            apply_kwargs["before_submit"] = _before_submit
         result = apply_to_vacancy(
             page,
             card,
             resume.resume_id,
             cover_letter_template,
             args.dry_run,
-            letter_provider=letter_provider,
-            # #207: fail-вердикты после клика по кнопке отклика подтверждаются
-            # внешней проверкой /applicant/negotiations до записи в history.
-            verifier=_verifier,
+            **apply_kwargs,
         )
 
         if result.skipped:
@@ -378,6 +396,8 @@ def run_apply_for_resume(
             # жёстко HAS_QUESTIONS — иначе already-responded-skip (#226) терялся
             # бы под чужой причиной (ломало clear-skipped --reason).
             history.record_skip(resume.resume_id, card.vacancy_id, result.skip_reason)
+            if action_id is not None:
+                history.finalize_action(action_id, "failed", result.reason)
             print(f"  [skip] {card.title} — {result.reason}")
             continue
 
@@ -386,7 +406,7 @@ def run_apply_for_resume(
         # строки НЕ трогаем: их читает дедупликация has_applied (CLAUDE.md п.2).
         # Провалы до submit (форма входа, «уже откликались», кнопка не найдена)
         # на hh.ru не отправлялись — остаются в консоли/логе, не в статистике.
-        if result.acted or (args.dry_run and result.success):
+        if action_id is not None:
             # #176: uncertain — submit мог уйти, но результат неизвестен. Такой
             # статус видит дедупликация has_applied (повторный запуск не
             # откликнется на ту же вакансию вторым письмом) — «просто failed»
@@ -398,11 +418,30 @@ def run_apply_for_resume(
                 status = "uncertain"
             else:
                 status = "success" if result.success else "failed"
+            history.finalize_action(
+                action_id,
+                status,
+                result.reason,
+                letter_variant=result.letter_variant,
+            )
+        elif result.acted:
+            # The verifier can positively reconcile an external submit even
+            # when the pre-submit hook was not reached (for example, a
+            # transitional page exposed the post-click state directly).
             history.record_action(
                 resume.resume_id,
                 card.vacancy_id,
                 "apply",
-                status,
+                "uncertain" if result.uncertain else ("success" if result.success else "failed"),
+                result.reason,
+                letter_variant=result.letter_variant,
+            )
+        elif args.dry_run and result.success:
+            history.record_action(
+                resume.resume_id,
+                card.vacancy_id,
+                "apply",
+                "dry_run",
                 result.reason,
                 letter_variant=result.letter_variant,
             )

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -360,7 +360,7 @@ def run_apply_for_resume(
 
         action_id = None
 
-        def _before_submit() -> None:
+        def _before_submit(vacancy_id: str = card.vacancy_id) -> None:
             nonlocal action_id
             # #245: commit the fail-closed audit marker immediately before
             # entering the irreversible form path. A process crash can leave
@@ -369,7 +369,7 @@ def run_apply_for_resume(
             # would make the next run send a duplicate. Keeping this hook after
             # navigation/questions preserves the old no-action semantics for
             # confirmed pre-submit exits.
-            action_id = history.begin_action(resume.resume_id, card.vacancy_id, "apply")
+            action_id = history.begin_action(resume.resume_id, vacancy_id, "apply")
 
         apply_kwargs = {
             "letter_provider": letter_provider,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -340,9 +340,9 @@ class History:
         status: str,
         reason: str | None = None,
         letter_variant: str | None = None,
-    ) -> None:
+    ) -> int:
         with self._connect() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 INSERT INTO actions
                     (resume_id, vacancy_id, action, status, reason, letter_variant, created_at)
@@ -358,6 +358,43 @@ class History:
                     datetime.now().isoformat(),
                 ),
             )
+            return int(cursor.lastrowid)
+
+    def begin_action(self, resume_id: str, vacancy_id: str, action: str) -> int:
+        """Durably reserve a potentially external action before browser work.
+
+        ``uncertain`` is deliberate: if the process disappears after the browser
+        side effect but before its result is recorded, ``has_applied`` must still
+        block a duplicate on the next run.  A normal completion changes this row
+        in place via :meth:`finalize_action`.
+        """
+        return self.record_action(
+            resume_id,
+            vacancy_id,
+            action,
+            "uncertain",
+            reason="действие начато, результат не зафиксирован",
+        )
+
+    def finalize_action(
+        self,
+        action_id: int,
+        status: str,
+        reason: str | None = None,
+        letter_variant: str | None = None,
+    ) -> None:
+        """Finalize a pre-action audit marker without creating a second row."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE actions
+                   SET status = ?, reason = ?, letter_variant = ?
+                 WHERE id = ?
+                """,
+                (status, reason, letter_variant, action_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError(f"Действие истории не найдено: id={action_id}")
 
     def count_today(self, resume_id: str, action: str) -> int:
         # #176: 'uncertain' расходует дневной лимит — действие могло выполниться

--- a/tests/test_apply_audit.py
+++ b/tests/test_apply_audit.py
@@ -67,9 +67,7 @@ def test_apply_crash_after_planning_leaves_durable_uncertain_audit(tmp_path, mon
         _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
 
     with history._connect() as conn:
-        row = conn.execute(
-            "SELECT resume_id, vacancy_id, action, status FROM actions"
-        ).fetchone()
+        row = conn.execute("SELECT resume_id, vacancy_id, action, status FROM actions").fetchone()
 
     assert row is not None
     assert tuple(row) == ("AAA111", "123", "apply", "uncertain")
@@ -126,8 +124,6 @@ def test_apply_finalizes_the_pre_submit_marker_in_place(tmp_path, monkeypatch):
     _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
 
     with history._connect() as conn:
-        rows = conn.execute(
-            "SELECT resume_id, vacancy_id, action, status FROM actions"
-        ).fetchall()
+        rows = conn.execute("SELECT resume_id, vacancy_id, action, status FROM actions").fetchall()
 
     assert [tuple(row) for row in rows] == [("AAA111", "123", "apply", "success")]

--- a/tests/test_apply_audit.py
+++ b/tests/test_apply_audit.py
@@ -1,0 +1,133 @@
+"""TDD regression coverage for apply attempts that outlive the Python stack.
+
+The browser can leave an apply dump on disk and the process can disappear before
+the post-submit result is written.  The audit marker must therefore be durable
+before entering the browser action, not created only after it returns.
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from hhru_bot.commands import _common
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.history import History
+from hhru_bot.search import VacancyCard
+from hhru_bot.throttle import Throttle
+
+pytestmark = pytest.mark.integration
+
+
+def test_apply_crash_after_planning_leaves_durable_uncertain_audit(tmp_path, monkeypatch):
+    """A process-like crash must not leave a submit candidate absent from history."""
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="hello",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=False,
+        headless=True,
+        max_pages=1,
+        limit=1,
+    )
+    card = VacancyCard(
+        vacancy_id="123",
+        title="Python developer",
+        company="Acme",
+        url="https://hh.ru/vacancy/123",
+    )
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+    monkeypatch.setattr(_common, "search_vacancies", lambda *a, **k: [card])
+
+    class ProcessLikeCrash(BaseException):
+        pass
+
+    def crash_before_result(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs["before_submit"]()
+        raise ProcessLikeCrash("worker disappeared after browser-side work")
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", crash_before_result)
+
+    with pytest.raises(ProcessLikeCrash):
+        _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    with history._connect() as conn:
+        row = conn.execute(
+            "SELECT resume_id, vacancy_id, action, status FROM actions"
+        ).fetchone()
+
+    assert row is not None
+    assert tuple(row) == ("AAA111", "123", "apply", "uncertain")
+    assert history.has_applied("AAA111", "123")
+
+
+def test_apply_finalizes_the_pre_submit_marker_in_place(tmp_path, monkeypatch):
+    """A normal result updates the reservation instead of appending a duplicate."""
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="hello",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=False,
+        headless=True,
+        max_pages=1,
+        limit=1,
+    )
+    card = VacancyCard(
+        vacancy_id="123",
+        title="Python developer",
+        company="Acme",
+        url="https://hh.ru/vacancy/123",
+    )
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+    monkeypatch.setattr(_common, "search_vacancies", lambda *a, **k: [card])
+
+    def succeeds_after_reservation(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs["before_submit"]()
+        return SimpleNamespace(
+            success=True,
+            reason="success",
+            letter_variant="template",
+            skipped=False,
+            acted=True,
+            uncertain=False,
+            skip_reason=None,
+        )
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", succeeds_after_reservation)
+
+    _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    with history._connect() as conn:
+        rows = conn.execute(
+            "SELECT resume_id, vacancy_id, action, status FROM actions"
+        ).fetchall()
+
+    assert [tuple(row) for row in rows] == [("AAA111", "123", "apply", "success")]


### PR DESCRIPTION
## Summary
- persist a fail-closed `uncertain` audit marker immediately before the irreversible apply path
- finalize that marker in place for normal outcomes
- add TDD regression coverage for process-like crashes and normal finalization

Closes #245

## Tests
- `pytest -q`
- `git diff --check`

## Notes
- No live hh.ru commands were run.
- Production `data/` artifacts were unavailable in the worktree, so incident-scale reconciliation remains a follow-up.