### PR TITLE
fix(apply): revalidate response state before submit

### DIFF
--- a/src/hhru_bot/apply/dedup.py
+++ b/src/hhru_bot/apply/dedup.py
@@ -54,18 +54,18 @@ def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
     """
     from ..selector_groups import vacancy_page
 
-    for selector in (
-        vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN,
-        vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT,
-    ):
-        try:
-            page.locator(selector).first.wait_for(
-                state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
-            )
-        except PlaywrightError:
-            continue
-        reason = f"уже откликались по вакансии {vacancy.vacancy_id}, пропуск"
-        logger.info("%s — %s", vacancy.title, reason)
-        return reason
-    logger.debug("Вакансия '%s': маркеры уже отклика не найдены", vacancy.title)
-    return None
+    # Both markers represent the same state. Waiting on their union keeps the
+    # bounded wait to one timeout instead of paying it once per selector.
+    already_responded = page.locator(vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN).or_(
+        page.locator(vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT)
+    )
+    try:
+        already_responded.first.wait_for(
+            state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
+        )
+    except PlaywrightError:
+        logger.debug("Вакансия '%s': маркеры уже отклика не найдены", vacancy.title)
+        return None
+    reason = f"уже откликались по вакансии {vacancy.vacancy_id}, пропуск"
+    logger.info("%s — %s", vacancy.title, reason)
+    return reason

--- a/src/hhru_bot/apply/dedup.py
+++ b/src/hhru_bot/apply/dedup.py
@@ -60,9 +60,7 @@ def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
         page.locator(vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT)
     )
     try:
-        already_responded.first.wait_for(
-            state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
-        )
+        already_responded.first.wait_for(state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS)
     except PlaywrightError:
         logger.debug("Вакансия '%s': маркеры уже отклика не найдены", vacancy.title)
         return None

--- a/src/hhru_bot/apply/dedup.py
+++ b/src/hhru_bot/apply/dedup.py
@@ -56,11 +56,22 @@ def check_already_responded(page: Page, vacancy: VacancyCard) -> str | None:
 
     # Both markers represent the same state. Waiting on their union keeps the
     # bounded wait to one timeout instead of paying it once per selector.
+    #
+    # #248 cycle-review round 2 (codex): .or_().first selects by DOM order, not
+    # by visibility — if a hidden/stale marker precedes a visible one in the
+    # DOM, .first.wait_for(state="visible") waits on the hidden element and
+    # times out even though the visible marker proves an existing response
+    # (the same transitional-both-markers scenario #241 already documented).
+    # filter(visible=True) restricts the union to visible matches before
+    # .first resolves, so DOM order among hidden elements can't hide a
+    # visible one.
     already_responded = page.locator(vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN).or_(
         page.locator(vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT)
     )
     try:
-        already_responded.first.wait_for(state="visible", timeout=_VISIBILITY_CHECK_TIMEOUT_MS)
+        already_responded.filter(visible=True).first.wait_for(
+            state="attached", timeout=_VISIBILITY_CHECK_TIMEOUT_MS
+        )
     except PlaywrightError:
         logger.debug("Вакансия '%s': маркеры уже отклика не найдены", vacancy.title)
         return None

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -248,6 +248,12 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
     ctx.probe("form_loaded")
 
+    # The vacancy state can change while the letter is rendered and the form
+    # is opened. Re-check immediately before any form processing so a marker
+    # rendered during that window blocks the irreversible submit.
+    if reason := check_already_responded(ctx.page, ctx.vacancy):
+        return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
+
     # #95: detect-only проверка на вопросы/анкету. Делается ДО fill_response_form:
     # форма с вопросами НЕ заполняется и НЕ отправляется (fail-closed по submit).
     questions = detect_questions(ctx.page)

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -242,17 +242,22 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         logger.info("[DRY-RUN] Откликнулся бы на '%s' с письмом:\n%s", ctx.vacancy.title, letter)
         return ctx.ok("dry-run")
 
+    # #247: ревалидация маркера «уже откликались» ДО клика по кнопке отклика.
+    # Маркеры — vacancy-page селекторы (dedup.py), их нет в DOM формы
+    # /applicant/vacancy_response, поэтому проверка после navigate_to_response_form
+    # была бы неэффективной. Здесь, на странице вакансии, она ловит маркер,
+    # отрендерившийся за время рендера письма (letter render — самое долгое
+    # окно TOCTOU, особенно с AI-провайдером). Окно самой навигации (после
+    # клика) vacancy-маркерами не покрыть — его компенсирует post-click
+    # верификация #207 (_finalize_post_click_failure).
+    if reason := check_already_responded(ctx.page, ctx.vacancy):
+        return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
+
     # #207: с клика по кнопке отклика начинается «серая зона» — дальнейшие
     # fail-исходы финализируются через _finalize_post_click_failure (внешняя
     # проверка /applicant/negotiations), а не сразу ctx.fail.
     apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
     ctx.probe("form_loaded")
-
-    # The vacancy state can change while the letter is rendered and the form
-    # is opened. Re-check immediately before any form processing so a marker
-    # rendered during that window blocks the irreversible submit.
-    if reason := check_already_responded(ctx.page, ctx.vacancy):
-        return ctx.skip(reason, skip_reason=SKIP_REASONS.ALREADY_APPLIED)
 
     # #95: detect-only проверка на вопросы/анкету. Делается ДО fill_response_form:
     # форма с вопросами НЕ заполняется и НЕ отправляется (fail-closed по submit).

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -170,6 +170,13 @@ class FakeLocator:
         # already-responded-маркеры одним локатором — объединяем совпадения обоих.
         return FakeLocator(self._root, self._qa_match, matches=self._resolved() + other._resolved())
 
+    def filter(self, *, visible: bool | None = None) -> FakeLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: dedup.check_already_responded() narrows the
+        # union to visible matches before .first. This fake has no hidden/visible
+        # distinction in its parsed HTML model — a matched node is always
+        # considered visible — so filtering is a no-op here.
+        return self
+
 
 class _CardLocator(FakeLocator):
     """Локатор карточки: ``.locator(selector)`` ищет ВНУТРИ этой карточки.

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -59,6 +59,12 @@ class _FakeLocator:
         # already-responded-маркеры одним локатором.
         return _FakeLocator(present=self._present or other._present)
 
+    def filter(self, *, visible: bool | None = None) -> _FakeLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: dedup.check_already_responded() narrows the
+        # union to visible matches before .first — the fake has no hidden-vs-
+        # visible distinction, so filtering is a no-op here.
+        return self
+
 
 class _ApplyFakePage:
     """Page для apply-pipeline в dry-run: есть кнопка отклика, до формы не доходим."""

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -90,6 +90,14 @@ class _FakeLocator:
             wait_for_timeouts=self._wait_for_timeouts,
         )
 
+    def filter(self, *, visible: bool | None = None) -> _FakeLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: filter(visible=True) narrows the union to
+        # visible matches before .first resolves. The fake only models a single
+        # present/absent boolean per selector (no hidden-vs-visible distinction
+        # within one _present state), so filtering is a no-op here — presence
+        # already implies visibility in this fake's model.
+        return self
+
 
 class FakePage:
     """Имитирует Playwright Page для путей pipeline. Настраивает «состояние» страницы."""
@@ -357,6 +365,21 @@ def test_check_already_responded_ignores_hidden_attached_marker():
         def or_(self, _other):
             return self
 
+        def filter(self, *, visible: bool | None = None):  # noqa: ARG002
+            # A visible-only filter on a purely hidden marker yields no match —
+            # model that as a locator whose wait_for always times out, so the
+            # subsequent wait_for(state="attached") behaves like the real
+            # filter(visible=True) narrowing to zero elements.
+            return _HiddenMarkerLocator._EmptyLocator()
+
+        class _EmptyLocator:
+            @property
+            def first(self):
+                return self
+
+            def wait_for(self, *, state: str = "attached", timeout: float = 0) -> None:  # noqa: ARG002
+                raise PlaywrightTimeoutError("no visible marker")
+
         def wait_for(self, *, state: str = "attached", timeout: float = 0) -> None:  # noqa: ARG002
             if state == "visible":
                 raise PlaywrightTimeoutError("hidden marker")
@@ -368,6 +391,73 @@ def test_check_already_responded_ignores_hidden_attached_marker():
     reason = check_already_responded(_HiddenMarkerPage(), _vacancy())
 
     assert reason is None
+
+
+def test_check_already_responded_visible_marker_survives_hidden_dom_order():
+    """#248 cycle-review round 2 (codex, high): Locator.or_().first selects by
+    DOM order, not by visibility. If a hidden/stale AGAIN marker precedes a
+    visible CHAT marker in the union's DOM order, .first.wait_for(state=
+    "visible") would wait on the hidden element and time out — even though a
+    visible marker exists and proves an existing response. filter(visible=True)
+    must be applied to the union before .first so a hidden element earlier in
+    DOM order cannot hide a visible one later in DOM order.
+    """
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    from hhru_bot.apply.dedup import check_already_responded
+    from hhru_bot.selector_groups import vacancy_page
+
+    class _AgainMarkerLocator:
+        """Hidden, and comes first in the union's DOM order."""
+
+        @property
+        def first(self):
+            return self
+
+        def or_(self, other):
+            return _UnionLocator(other)
+
+        def wait_for(self, *, state: str = "attached", timeout: float = 0) -> None:  # noqa: ARG002
+            raise PlaywrightTimeoutError("hidden — never resolves as visible")
+
+    class _ChatMarkerLocator:
+        """Visible, but second in the union's DOM order."""
+
+        @property
+        def first(self):
+            return self
+
+        def wait_for(self, *, state: str = "attached", timeout: float = 0) -> None:  # noqa: ARG002
+            return None
+
+    class _UnionLocator:
+        """Models Locator.or_(): .first picks by DOM order (AGAIN, i.e. first
+        operand) unless narrowed by filter(visible=True) to only visible matches
+        (here, only the CHAT operand)."""
+
+        def __init__(self, chat_locator):
+            self._chat = chat_locator
+
+        @property
+        def first(self):
+            # Unfiltered union resolves .first to the hidden AGAIN marker
+            # (earlier in DOM order) — this is the bug filter(visible=True) fixes.
+            return _AgainMarkerLocator()
+
+        def filter(self, *, visible: bool | None = None):  # noqa: ARG002
+            # Narrowed to visible matches only: the hidden AGAIN marker drops
+            # out, leaving the visible CHAT marker.
+            return self._chat
+
+    class _MarkerOrderPage:
+        def locator(self, selector: str):
+            if selector == vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT:
+                return _ChatMarkerLocator()
+            return _AgainMarkerLocator()
+
+    reason = check_already_responded(_MarkerOrderPage(), _vacancy())
+
+    assert reason == "уже откликались по вакансии 1, пропуск"
 
 
 def test_wait_apply_button_already_responded_avoids_full_timeout():

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -258,6 +258,8 @@ def test_apply_already_responded_check_always_blocks_regardless_of_button():
         assert all(
             t == _VISIBILITY_CHECK_TIMEOUT_MS for t in page.already_responded_wait_for_timeouts
         )
+
+
 def test_apply_rechecks_responded_marker_before_form_submit():
     """A marker rendered while opening the form must block the submit."""
 

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 
 import hhru_bot.apply.pipeline as pipeline_module
 from hhru_bot.apply import ProbeHook, apply_to_vacancy
+from hhru_bot.history import SKIP_REASONS
 from hhru_bot.search import VacancyCard
 
 pytestmark = pytest.mark.integration
@@ -82,7 +83,9 @@ class _FakeLocator:
         # из объединяемых локаторов присутствует; wait_for-вызовы объединённого
         # локатора продолжают писаться в тот же общий счётчик.
         return _FakeLocator(
-            present=self._present or other._present, wait_for_calls=self._wait_for_calls
+            present=self._present or other._present,
+            wait_for_calls=self._wait_for_calls,
+            wait_for_timeouts=self._wait_for_timeouts,
         )
 
 
@@ -255,6 +258,21 @@ def test_apply_already_responded_check_always_blocks_regardless_of_button():
         assert all(
             t == _VISIBILITY_CHECK_TIMEOUT_MS for t in page.already_responded_wait_for_timeouts
         )
+def test_apply_rechecks_responded_marker_before_form_submit():
+    """A marker rendered while opening the form must block the submit."""
+
+    class _MarkerAppearsAfterNavigation(FakePage):
+        def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+            super().goto(url, wait_until)
+            self._already_responded = True
+
+    page = _MarkerAppearsAfterNavigation(apply_button=True, submit_in_form=True)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+
+    assert result.skipped is True
+    assert result.skip_reason == SKIP_REASONS.ALREADY_APPLIED
+    assert result.acted is False
 
 
 def test_apply_already_responded_skip_reason_is_already_applied_not_has_questions():
@@ -310,6 +328,9 @@ def test_check_already_responded_ignores_hidden_attached_marker():
 
         def count(self) -> int:
             return 1
+
+        def or_(self, _other):
+            return self
 
         def wait_for(self, *, state: str = "attached", timeout: float = 0) -> None:  # noqa: ARG002
             if state == "visible":

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 import hhru_bot.apply.pipeline as pipeline_module
@@ -261,16 +263,37 @@ def test_apply_already_responded_check_always_blocks_regardless_of_button():
 
 
 def test_apply_rechecks_responded_marker_before_form_submit():
-    """A marker rendered while opening the form must block the submit."""
+    """A marker rendered during letter generation must block the submit.
 
-    class _MarkerAppearsAfterNavigation(FakePage):
-        def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
-            super().goto(url, wait_until)
-            self._already_responded = True
+    The recheck runs on the vacancy page (before navigating to the response
+    form), so it can see vacancy-page markers. The marker appears only after
+    the initial check, during letter render — the TOCTOU window #247 targets.
+    The fake is URL-aware: vacancy-page markers exist only on the vacancy page,
+    so the test fails if the recheck is ever moved after navigation (where the
+    response-form DOM has no vacancy markers).
+    """
 
-    page = _MarkerAppearsAfterNavigation(apply_button=True, submit_in_form=True)
+    class _MarkerAppearsDuringLetterRender(FakePage):
+        def wait_for_url(self, _url_pattern, **_kwargs):
+            # navigate_to_response_form lands on the response-form page, where
+            # vacancy-page markers are absent.
+            self.url = "/applicant/vacancy_response"
 
-    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+        def locator(self, selector: str):
+            if self.url.startswith("https://hh.ru/vacancy/"):
+                return super().locator(selector)
+            return _FakeLocator(present=False)
+
+    page = _MarkerAppearsDuringLetterRender(apply_button=True, submit_in_form=True)
+
+    class _LetterProvider:
+        def render(self, _vacancy):
+            page._already_responded = True
+            return SimpleNamespace(text="x", variant="template")
+
+    result = apply_to_vacancy(
+        page, _vacancy(), "RID", "x", dry_run=False, letter_provider=_LetterProvider()
+    )
 
     assert result.skipped is True
     assert result.skip_reason == SKIP_REASONS.ALREADY_APPLIED

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -82,6 +82,12 @@ class _FakeLocator:
         # already-responded-маркеры одним локатором.
         return _FakeLocator(present=self._present or other._present)
 
+    def filter(self, *, visible: bool | None = None) -> _FakeLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: dedup.check_already_responded() narrows the
+        # union to visible matches before .first — the fake has no hidden-vs-
+        # visible distinction, so filtering is a no-op here.
+        return self
+
 
 class _ClickTrackingLocator(_FakeLocator):
     """Локатор, сообщающий о каждом click() в общий счётчик владельца-страницы."""

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -632,6 +632,12 @@ class _SimpleLocator:
         # already-responded-маркеры одним локатором.
         return _SimpleLocator(self._present or other._present)
 
+    def filter(self, *, visible: bool | None = None) -> _SimpleLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: dedup.check_already_responded() narrows the
+        # union to visible matches before .first — the fake has no hidden-vs-
+        # visible distinction, so filtering is a no-op here.
+        return self
+
 
 class _ApplyPipelineFakePage:
     """Не-dry-run прогон до questions-indeterminate: кнопка отклика есть,

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -73,6 +73,12 @@ class _FakeLocator:
         # already-responded-маркеры одним локатором.
         return _FakeLocator(present=self._present or other._present)
 
+    def filter(self, *, visible: bool | None = None) -> _FakeLocator:  # noqa: ARG002
+        # #248 cycle-review round 2: dedup.check_already_responded() narrows the
+        # union to visible matches before .first — the fake has no hidden-vs-
+        # visible distinction, so filtering is a no-op here.
+        return self
+
 
 class _ApplyFakePage:
     """Page для apply-pipeline: есть кнопка отклика.


### PR DESCRIPTION
Closes #247

## Summary
- combine already-responded marker waits into one bounded Playwright wait
- revalidate the live response state immediately before form processing/submit
- add regression coverage for a marker appearing during navigation

## Tests
- `pytest -q tests/test_apply_pipeline.py tests/test_apply_probe.py tests/test_apply_letter_integration.py`
- `ruff check src/hhru_bot/apply/dedup.py src/hhru_bot/apply/pipeline.py tests/test_apply_pipeline.py`
- `git diff --check`