### PR TITLE
fix(resume): require identity when parsing publish state

### DIFF
--- a/src/hhru_bot/publish_resume.py
+++ b/src/hhru_bot/publish_resume.py
@@ -70,35 +70,34 @@ def _walk_json(value):
             yield from _walk_json(child)
 
 
-def parse_resume_state(markup: str, resume_id: str | None = None) -> ResumePublishState:
-    """Extract state, optionally from the structured record for ``resume_id``.
+def parse_resume_state(markup: str, resume_id: str) -> ResumePublishState:
+    """Extract state from the structured record for ``resume_id``.
 
     The page can contain state for more than one resume in embedded bootstrap
-    data. When an identity is supplied, never combine fields from separate
-    records; an unscoped regex fallback is retained for small SSR fixtures.
+    data. Never combine fields from separate records.
     """
-    if resume_id:
-        decoder = json.JSONDecoder()
-        for match in re.finditer(r"\{", markup):
-            try:
-                candidate, _ = decoder.raw_decode(markup[match.start() :])
-            except json.JSONDecodeError:
-                continue
-            for record in _walk_json(candidate):
-                if not isinstance(record, dict):
-                    continue
-                identifiers = {str(record.get(key, "")) for key in ("id", "hash", "resumeId")}
-                if resume_id not in identifiers:
-                    continue
-                # hh.ru keeps the wizard's ``scheme`` next to the resume
-                # record, rather than inside it.  It is still page-scoped and
-                # therefore safe to attach only after the target identity was
-                # found in this JSON document.
-                scheme = candidate.get("scheme") if isinstance(candidate, dict) else None
-                return _state_from_mapping(record, scheme)
-        return ResumePublishState()
+    if not resume_id:
+        raise ValueError("resume_id is required to parse resume state safely")
 
-    return _state_from_regex(markup)
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"\{", markup):
+        try:
+            candidate, _ = decoder.raw_decode(markup[match.start() :])
+        except json.JSONDecodeError:
+            continue
+        for record in _walk_json(candidate):
+            if not isinstance(record, dict):
+                continue
+            identifiers = {str(record.get(key, "")) for key in ("id", "hash", "resumeId")}
+            if resume_id not in identifiers:
+                continue
+            # hh.ru keeps the wizard's ``scheme`` next to the resume
+            # record, rather than inside it.  It is still page-scoped and
+            # therefore safe to attach only after the target identity was
+            # found in this JSON document.
+            scheme = candidate.get("scheme") if isinstance(candidate, dict) else None
+            return _state_from_mapping(record, scheme)
+    return ResumePublishState()
 
 
 def _state_from_mapping(record: dict, scheme: dict | None = None) -> ResumePublishState:
@@ -112,31 +111,6 @@ def _state_from_mapping(record: dict, scheme: dict | None = None) -> ResumePubli
         can_publish_or_update=record.get("canPublishOrUpdate"),
         next_incomplete_screen_id=next_incomplete,
     )
-
-
-def _state_from_regex(markup: str) -> ResumePublishState:
-    """Fixture-friendly fallback when no record identity is available."""
-    state = ResumePublishState()
-    for field in (
-        "status",
-        "isSearchable",
-        "canPublishOrUpdate",
-        "nextIncompleteScreenId",
-    ):
-        match = re.search(rf'"{field}"\s*:\s*("(?:[^"\\]|\\.)*"|true|false|null)', markup)
-        if not match:
-            continue
-        raw = match.group(1)
-        value = None if raw == "null" else json.loads(raw)
-        if field == "status":
-            state.status = value
-        elif field == "isSearchable":
-            state.is_searchable = value
-        elif field == "canPublishOrUpdate":
-            state.can_publish_or_update = value
-        else:
-            state.next_incomplete_screen_id = value
-    return state
 
 
 def _identity_matches(page: Page, resume_id: str) -> bool:

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -93,8 +93,9 @@ def _run(page, monkeypatch, *, preserve_url=False):
 
 def test_parse_resume_state_keeps_independent_fields():
     state = parse_resume_state(
-        '{"status":"not_finished","isSearchable":false,"canPublishOrUpdate":true,'
-        '"nextIncompleteScreenId":"professional_role"}'
+        f'{{"id":"{RESUME_ID}","status":"not_finished","isSearchable":false,'
+        '"canPublishOrUpdate":true,"nextIncompleteScreenId":"professional_role"}}',
+        RESUME_ID,
     )
     assert state.status == "not_finished"
     assert state.is_searchable is False
@@ -103,11 +104,16 @@ def test_parse_resume_state_keeps_independent_fields():
 
 
 def test_parse_resume_state_does_not_guess_missing_values():
-    state = parse_resume_state('{"status":"not_finished"}')
+    state = parse_resume_state(f'{{"id":"{RESUME_ID}","status":"not_finished"}}', RESUME_ID)
     assert state.status == "not_finished"
     assert state.is_searchable is None
     assert state.can_publish_or_update is None
     assert state.next_incomplete_screen_id is None
+
+
+def test_parse_resume_state_requires_identity():
+    with pytest.raises(ValueError, match="resume_id is required"):
+        parse_resume_state('{"status":"not_finished"}', "")
 
 
 def test_parse_resume_state_binds_all_fields_to_target_record():


### PR DESCRIPTION
## Summary
- remove the unscoped regex fallback from `parse_resume_state`
- require a resume identity and parse all fields from that record only
- update tests to cover identity enforcement

## Why
On multi-resume SSR pages, independent regex searches could combine state fields from different resumes. Identity-scoped parsing is the only safe path.

Fixes #228

## Tests
- `ruff check src/hhru_bot/publish_resume.py tests/test_publish_resume.py`
- `pytest tests/test_publish_resume.py`
- `pytest` (1121 passed, 2 deselected)
