### PR TITLE
feat: serialize hh.ru write commands

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -31,10 +31,17 @@ from .write_lock import WriteLockBusy, acquire_write_lock
 DEFAULT_CONFIG_PATH = Path("data") / "config.yaml"
 DEFAULT_HISTORY_PATH = Path("data") / "history.db"
 
-WRITE_COMMANDS = frozenset({
-    "apply", "bump", "run", "copy-resume", "publish-resume",
-    "reply-employers", "clear-negotiations",
-})
+WRITE_COMMANDS = frozenset(
+    {
+        "apply",
+        "bump",
+        "run",
+        "copy-resume",
+        "publish-resume",
+        "reply-employers",
+        "clear-negotiations",
+    }
+)
 
 
 def register_commands(subparsers: argparse._SubParsersAction) -> list[str]:

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from . import commands as _commands_pkg
 from .logging_setup import setup_logging
+from .write_lock import WriteLockBusy, acquire_write_lock
 
 # Дефолтные пути — ОТНОСИТЕЛЬНЫЕ (relative-to-cwd), а не привязанные к пакету.
 # После `pip install` пакет уезжает в site-packages, и привязка путей к
@@ -29,6 +30,11 @@ from .logging_setup import setup_logging
 # целиком в .gitignore одной строкой.
 DEFAULT_CONFIG_PATH = Path("data") / "config.yaml"
 DEFAULT_HISTORY_PATH = Path("data") / "history.db"
+
+WRITE_COMMANDS = frozenset({
+    "apply", "bump", "run", "copy-resume", "publish-resume",
+    "reply-employers", "clear-negotiations",
+})
 
 
 def register_commands(subparsers: argparse._SubParsersAction) -> list[str]:
@@ -68,7 +74,19 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command not in WRITE_COMMANDS:
+        return _execute(args)
 
+    lock_path = Path(args.history).expanduser().resolve().parent / ".hhru.lock"
+    try:
+        with acquire_write_lock(lock_path):
+            return _execute(args)
+    except WriteLockBusy:
+        print("[FAIL] другой процесс уже выполняет WRITE-действие")
+        sys.exit(1)
+
+
+def _execute(args: argparse.Namespace) -> None:
     # READ-команда `log` намеренно минует setup_logging: FileHandler создал бы
     # data/logs/hhru_bot.log на запись до run(), что нарушает READ-контракт «не меняет
     # локально» (#21), делает ветку «файл не найден» недостижимой (setup_logging

--- a/src/hhru_bot/write_lock.py
+++ b/src/hhru_bot/write_lock.py
@@ -1,0 +1,27 @@
+"""Advisory inter-process lock for commands that can mutate hh.ru."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+from collections.abc import Iterator
+from pathlib import Path
+
+
+class WriteLockBusy(RuntimeError):
+    """Another hhru-bot write command is already running."""
+
+
+@contextlib.contextmanager
+def acquire_write_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive, non-blocking lock until the command finishes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise WriteLockBusy from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.cli import WRITE_COMMANDS, main
+from hhru_bot.write_lock import WriteLockBusy, acquire_write_lock
+
+pytestmark = pytest.mark.unit
+
+
+def test_write_lock_blocks_second_process_descriptor(tmp_path):
+    path = tmp_path / ".hhru.lock"
+    with acquire_write_lock(path):
+        with pytest.raises(WriteLockBusy):
+            with acquire_write_lock(path):
+                pass
+
+
+def test_write_lock_can_be_reused_after_release(tmp_path):
+    path = tmp_path / ".hhru.lock"
+    with acquire_write_lock(path):
+        pass
+    with acquire_write_lock(path):
+        pass
+
+
+def test_cli_rejects_concurrent_write_command(tmp_path, capsys):
+    history = tmp_path / "history.db"
+    lock = tmp_path / ".hhru.lock"
+    with acquire_write_lock(lock):
+        with pytest.raises(SystemExit) as exc:
+            main(["--history", str(history), "bump"])
+    assert exc.value.code == 1
+    assert "другой процесс уже выполняет WRITE-действие" in capsys.readouterr().out
+
+
+def test_lock_covers_all_hhru_write_commands():
+    assert WRITE_COMMANDS == {
+        "apply",
+        "bump",
+        "run",
+        "copy-resume",
+        "publish-resume",
+        "reply-employers",
+        "clear-negotiations",
+    }


### PR DESCRIPTION
Closes #229

## Summary
- add a non-blocking advisory flock lock beside the history database
- serialize all WRITE-hh-ru CLI commands and fail clearly on contention
- add lock lifecycle and CLI contention tests

## Tests
- `ruff check src/hhru_bot/cli.py src/hhru_bot/write_lock.py tests/test_write_lock.py`
- focused command suite: 112 passed
- full suite started locally but exceeded the execution window before printing its final summary

## Risk
- Unix-only `fcntl` advisory locking, matching the project macOS/Linux CLI runtime.