### PR TITLE
fix(publish-resume): omit pre-click failures from action history

### DIFF
--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -52,14 +52,14 @@ def run(args: argparse.Namespace) -> None:
         ) as context:
             result = publish_resume_on_hh(context.new_page(), resume, args.dry_run)
     except NotAuthenticated as exc:
-        if not args.dry_run:
-            history.record_action(
-                resume.resume_id, resume.resume_id, "publish_resume", "failed", str(exc)
-            )
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         sys.exit(1)
 
-    if not args.dry_run:
+    # actions — журнал взаимодействий с hh.ru, а не всех проверок команды.
+    # До клика (identity/state/button guards) внешний эффект невозможен и не
+    # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
+    # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
+    if not args.dry_run and (result.success or result.uncertain):
         status = "uncertain" if result.uncertain else ("success" if result.success else "failed")
         history.record_action(
             resume.resume_id, resume.resume_id, "publish_resume", status, result.reason

--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -60,7 +60,7 @@ def run(args: argparse.Namespace) -> None:
     # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
     # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
     if not args.dry_run and (result.success or result.uncertain):
-        status = "uncertain" if result.uncertain else ("success" if result.success else "failed")
+        status = "uncertain" if result.uncertain else "success"
         history.record_action(
             resume.resume_id, resume.resume_id, "publish_resume", status, result.reason
         )

--- a/tests/test_publish_resume_command.py
+++ b/tests/test_publish_resume_command.py
@@ -176,31 +176,27 @@ def test_run_dry_run_bypasses_uncertain_guard(env, capsys, tmp_path):
     assert "[DRY-RUN]" in out
 
 
-def test_run_plain_failure_does_not_count_toward_limit(env, capsys, tmp_path):
+def test_run_plain_failure_is_not_recorded_or_counted(env, capsys, tmp_path):
     env.result = PublishResumeResult("python", False, "кнопка не найдена")
     with pytest.raises(SystemExit):
         cmd.run(_args(tmp_path, force=True))
     h = History(tmp_path / "h.db")
     assert h.count_today(RESUME_ID, "publish_resume") == 0
+    with h._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0
 
 
-def test_run_not_authenticated_records_failed_and_exits(env, capsys, tmp_path):
+def test_run_not_authenticated_is_not_recorded_and_exits(env, capsys, tmp_path):
     env.exc = NotAuthenticated("сессия истекла")
     with pytest.raises(SystemExit):
         cmd.run(_args(tmp_path, force=True))
     out = capsys.readouterr().out
     assert "[FAIL]" in out
     assert "Сессия недействительна" in out
-    # failed не расходует дневной лимит/кулдаун (никакого клика не было вовсе —
-    # сессия отвергнута до захода на страницу резюме), но факт попытки
-    # остаётся в аудите (actions), не только в exit-коде.
+    # Никакого клика не было вовсе — сессия отвергнута до захода на страницу
+    # резюме, поэтому pre-click отказ не оставляет строку в actions.
     with History(tmp_path / "h.db")._connect() as conn:
-        row = conn.execute(
-            "SELECT status FROM actions WHERE resume_id = ? AND action = 'publish_resume'",
-            (RESUME_ID,),
-        ).fetchone()
-    assert row is not None
-    assert row["status"] == "failed"
+        assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0
 
 
 def test_run_dry_run_writes_nothing_to_history(env, capsys, tmp_path):


### PR DESCRIPTION
Closes #227

## Summary
- keep `actions` limited to successful or click-uncertain publish attempts
- stop recording authentication and other pre-click failures as `publish_resume` actions
- update command tests for the audit contract

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q tests/test_publish_resume.py tests/test_publish_resume_command.py tests/test_history_stats.py`