### PR TITLE
feat: show pending external tests in summaries

### DIFF
--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -8,6 +8,7 @@ ASCII-таблицы/текстовые префиксы для table, CSV дл�
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timedelta
 
 PERIODS = ("today", "week", "month", "all")
 FORMATS = ("table", "csv", "md")
@@ -64,12 +65,24 @@ def run(args: argparse.Namespace) -> None:
 
     history = History(args.history)
 
+    # Назначения внешних тестов — read-only факты без автоматического перехода
+    # на сторонний домен. Пока отдельного acknowledgement нет, все записи
+    # считаются ожидающими внимания пользователя.
+    test_since = datetime.min
+    if args.period == "today":
+        test_since = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    elif args.period in {"week", "month"}:
+        test_since = datetime.now() - timedelta(days={"week": 7, "month": 30}[args.period])
+    pending_tests = len(history.test_assignments_since(test_since))
+
     if args.list:
         rows = history.list_actions(resume_id=resume_id, period=args.period, limit=args.limit)
         print(format_actions(rows, args.format))
     else:
         summary = history.summary(resume_id=resume_id, period=args.period)
         print(format_summary(summary, args.format))
+        if args.format != "csv":
+            print(f"Тестов ожидает: {pending_tests}")
         # CSV — экспорт для машин: один документ, одна схема колонок (см. #112
         # ревью). Reply-сводка имеет другую схему (metric,value), поэтому в csv
         # её печатать вторым документом в тот же stdout-поток нельзя — консьюмер,

--- a/src/hhru_bot/commands/whoami.py
+++ b/src/hhru_bot/commands/whoami.py
@@ -136,6 +136,7 @@ def run(args: argparse.Namespace) -> None:
     new_responses = len(history.new_responses_since(now - timedelta(hours=24)))
     all_responses = history.new_responses_since(datetime.min)
     invitations = sum(1 for r in all_responses if r.get("status") == "invitation")
+    pending_tests = len(history.test_assignments_since(datetime.min))
 
     resume_label = ", ".join(r.id for r in resumes) or "(нет резюме в конфиге)"
 
@@ -144,6 +145,7 @@ def run(args: argparse.Namespace) -> None:
         ["Откликов сегодня", f"{applied_today} / {apply_limit}"],
         ["Новых ответов 24ч", str(new_responses)],
         ["Приглашений", str(invitations)],
+        ["Тестов ожидает", str(pending_tests)],
     ]
 
     print(_ascii_table(["Поле", "Значение"], rows))

--- a/tests/test_stats_command.py
+++ b/tests/test_stats_command.py
@@ -74,6 +74,20 @@ def test_stats_run_empty_db_does_not_crash(capsys, tmp_path):
     out = capsys.readouterr().out
     assert "apply" in out
     assert "0" in out  # нули на пустой истории
+    assert "Тестов ожидает: 0" in out
+
+
+def test_stats_run_shows_pending_external_tests(capsys, tmp_path):
+    config = _write_config(tmp_path, _minimal_config())
+    h = History(tmp_path / "h.db")
+    h.record_test_assigned(
+        None, "v1", "topic-1", "Acme", "https://example.test/quiz", "Пройдите тест"
+    )
+
+    stats_cmd.run(_args(config, tmp_path / "h.db"))
+    out = capsys.readouterr().out
+
+    assert "Тестов ожидает: 1" in out
 
 
 def test_stats_run_list_mode_md(capsys, tmp_path):

--- a/tests/test_whoami_command.py
+++ b/tests/test_whoami_command.py
@@ -261,6 +261,23 @@ def test_empty_history_shows_zero_counts(tmp_path, capsys):
     # 0 откликов / лимит
     assert "0 / 40" in out
     assert "Приглашений" in out
+    assert "Тестов ожидает" in out
+    assert "| Тестов ожидает" in out
+    assert "| 0            |" in out
+
+
+def test_summary_counts_pending_external_tests(tmp_path, capsys):
+    session = _valid_session(tmp_path)
+    cfg = _write_config(tmp_path, _config_body(str(session)))
+    h = History(tmp_path / "h.db")
+    h.record_test_assigned(
+        None, "v1", "topic-1", "Acme", "https://example.test/quiz", "Пройдите тест"
+    )
+
+    out = _run(_args(cfg, tmp_path / "h.db"), capsys)
+
+    assert "| Тестов ожидает" in out
+    assert "| 1            |" in out
 
 
 def test_resume_filter_counts_only_selected(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- show pending external test assignments in `whoami`
- show period-scoped pending assignments in human-readable `stats` output
- add regression coverage

Closes #181

## Tests
- `PYTHONPATH=src pytest -q tests/test_whoami_command.py tests/test_stats_command.py tests/test_history_schema.py`
- `ruff check src tests`
- `ruff format --check src tests`