### PR TITLE
refactor(apply): centralize verifier verdict model

### DIFF
--- a/src/hhru_bot/apply/verdict.py
+++ b/src/hhru_bot/apply/verdict.py
@@ -57,7 +57,7 @@ def compose(attempts: Iterable[PageRead], vacancy_id: str) -> str:
     """Compose a verdict from reads using one fail-closed decision table."""
     reads = tuple(attempts)
     if any(
-        topic.vacancy_id == vacancy_id and topic.resume_attribution is ResumeAttribution.MATCHED
+        topic.vacancy_id == vacancy_id and topic.resume_attribution == ResumeAttribution.MATCHED
         for read in reads
         for topic in read.topics
     ):
@@ -74,11 +74,11 @@ def compose(attempts: Iterable[PageRead], vacancy_id: str) -> str:
     ):
         return INDETERMINATE
     if any(isinstance(read.completeness, Partial) for read in reads) or any(
-        read.completeness is Completeness.UNRENDERED for read in reads
+        read.completeness == Completeness.UNRENDERED for read in reads
     ):
         return INDETERMINATE
     return (
         NOT_FOUND
-        if any(read.completeness is Completeness.LAST_CONFIRMED for read in reads)
+        if any(read.completeness == Completeness.LAST_CONFIRMED for read in reads)
         else INDETERMINATE
     )

--- a/src/hhru_bot/apply/verdict.py
+++ b/src/hhru_bot/apply/verdict.py
@@ -1,0 +1,84 @@
+"""Typed, fail-closed model for reading negotiations (#213).
+
+The browser reader is intentionally kept outside this module.  This module
+contains only the contract and the decision table, so changes to SSR/DOM
+parsing cannot silently change the uncertainty policy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class PageSource(StrEnum):
+    SSR = "SSR"
+    DOM = "DOM"
+
+
+class ResumeAttribution(StrEnum):
+    MATCHED = "matched"
+    FOREIGN = "foreign"
+    INCOMPARABLE = "incomparable"
+    OTHER_OWN = "other_own"
+
+
+class Completeness(StrEnum):
+    LAST_CONFIRMED = "last_confirmed"
+    UNRENDERED = "unrendered"
+
+
+@dataclass(frozen=True)
+class Partial:
+    reason: str
+
+
+@dataclass(frozen=True)
+class TopicRead:
+    vacancy_id: str
+    resume_attribution: ResumeAttribution = ResumeAttribution.MATCHED
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class PageRead:
+    source: PageSource
+    topics: tuple[TopicRead, ...]
+    completeness: Completeness | Partial
+
+
+FOUND = "found"
+NOT_FOUND = "not_found"
+INDETERMINATE = "indeterminate"
+
+
+def compose(attempts: Iterable[PageRead], vacancy_id: str) -> str:
+    """Compose a verdict from reads using one fail-closed decision table."""
+    reads = tuple(attempts)
+    if any(
+        topic.vacancy_id == vacancy_id and topic.resume_attribution is ResumeAttribution.MATCHED
+        for read in reads
+        for topic in read.topics
+    ):
+        return FOUND
+    if any(
+        topic.vacancy_id == vacancy_id
+        and topic.resume_attribution
+        in {
+            ResumeAttribution.INCOMPARABLE,
+            ResumeAttribution.OTHER_OWN,
+        }
+        for read in reads
+        for topic in read.topics
+    ):
+        return INDETERMINATE
+    if any(isinstance(read.completeness, Partial) for read in reads) or any(
+        read.completeness is Completeness.UNRENDERED for read in reads
+    ):
+        return INDETERMINATE
+    return (
+        NOT_FOUND
+        if any(read.completeness is Completeness.LAST_CONFIRMED for read in reads)
+        else INDETERMINATE
+    )

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -58,6 +58,15 @@ from ..responses import (
 )
 from ..selector_groups import negotiations as ns
 from .steps import _dump_navigation_diagnostics
+from .verdict import (
+    Completeness,
+    PageRead,
+    PageSource,
+    Partial,
+    ResumeAttribution,
+    TopicRead,
+    compose,
+)
 
 logger = logging.getLogger("hhru_bot.apply.verify")
 
@@ -94,10 +103,10 @@ INDETERMINATE = "indeterminate"
 #: (fail-closed indeterminate у вызывающего кода); other_own — ДРУГОЕ собственное
 #: резюме аккаунта, но не текущее (fail-closed indeterminate: тема могла быть
 #: создана предыдущим откликом, а не этим кликом — Codex-ревью цикла 2).
-_RESUME_MATCHED = "matched"
-_RESUME_FOREIGN = "foreign"
-_RESUME_INCOMPARABLE = "incomparable"
-_RESUME_OTHER_OWN = "other_own"
+_RESUME_MATCHED = ResumeAttribution.MATCHED
+_RESUME_FOREIGN = ResumeAttribution.FOREIGN
+_RESUME_INCOMPARABLE = ResumeAttribution.INCOMPARABLE
+_RESUME_OTHER_OWN = ResumeAttribution.OTHER_OWN
 
 
 @dataclass(frozen=True)
@@ -240,6 +249,7 @@ def _scan_negotiations(
     problem: str | None = None
     confirmed_incomplete = False
     attribution_incomparable = False
+    reads: list[PageRead] = []
     for page_num in range(NEGOTIATIONS_VERIFY_MAX_PAGES):
         if page_num > 0:
             try:
@@ -249,11 +259,28 @@ def _scan_negotiations(
                 # страница 1 не дочитана: целевая вакансия могла быть на ней.
                 problem = f"goto страницы {page_num} списка не прошёл ({exc})"
                 confirmed_incomplete = True
+                reads.append(PageRead(PageSource.SSR, (), Partial(problem)))
                 break
         found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
             page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
         )
         attribution_incomparable = attribution_incomparable or page_attribution_incomparable
+        if page_attribution_incomparable:
+            reads.append(
+                PageRead(
+                    PageSource.SSR,
+                    (TopicRead(wanted, ResumeAttribution.INCOMPARABLE),),
+                    Completeness.LAST_CONFIRMED,
+                )
+            )
+        elif page_clean:
+            reads.append(PageRead(PageSource.SSR, (), Completeness.LAST_CONFIRMED))
+        else:
+            reads.append(
+                PageRead(
+                    PageSource.SSR, (), Partial(page_problem or "страница прочитана не полностью")
+                )
+            )
         if page_problem:
             problem = page_problem
         if found_detail is not None:
@@ -267,7 +294,15 @@ def _scan_negotiations(
             # Fail-closed: indeterminate, а не ложный not_found (#207).
             problem = "достигнут потолок скана при подтверждённой пагинации"
             confirmed_incomplete = True
+            reads.append(PageRead(PageSource.SSR, (), Partial(problem)))
             break
+    # Keep the legacy tuple for the browser reader, but let the typed decision
+    # table own the final absence/uncertainty policy (#213).
+    composed = compose(reads, wanted)
+    if composed == "not_found":
+        clean = True
+    elif composed == "indeterminate":
+        clean = False
     return None, clean and not problem, problem, confirmed_incomplete, attribution_incomparable
 
 

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -16,6 +16,15 @@ import pytest
 from playwright.sync_api import Error as PlaywrightError
 
 from _fakes import FakeLocator, _CardLocator, _parse_root, _parse_selector
+from hhru_bot.apply.verdict import (
+    Completeness,
+    PageRead,
+    PageSource,
+    Partial,
+    ResumeAttribution,
+    TopicRead,
+    compose,
+)
 from hhru_bot.apply.verify import verify_response_in_negotiations
 from hhru_bot.responses import NEGOTIATIONS_URL
 from hhru_bot.selector_groups import negotiations as ns
@@ -23,6 +32,35 @@ from hhru_bot.selector_groups import negotiations as ns
 pytestmark = pytest.mark.integration
 
 _V1, _V2 = "111111", "222222"
+
+
+@pytest.mark.parametrize(
+    ("reads", "expected"),
+    [
+        ([PageRead(PageSource.SSR, (TopicRead(_V1),), Completeness.LAST_CONFIRMED)], "found"),
+        ([PageRead(PageSource.DOM, (), Completeness.LAST_CONFIRMED)], "not_found"),
+        ([PageRead(PageSource.SSR, (), Partial("pagination"))], "indeterminate"),
+        (
+            [
+                PageRead(
+                    PageSource.SSR,
+                    (TopicRead(_V1, ResumeAttribution.INCOMPARABLE),),
+                    Completeness.LAST_CONFIRMED,
+                )
+            ],
+            "indeterminate",
+        ),
+        (
+            [
+                PageRead(PageSource.SSR, (), Completeness.LAST_CONFIRMED),
+                PageRead(PageSource.DOM, (), Partial("render")),
+            ],
+            "indeterminate",
+        ),
+    ],
+)
+def test_verdict_compose_matrix(reads, expected):
+    assert compose(reads, _V1) == expected
 
 
 class _PageLocator:


### PR DESCRIPTION
## Summary
- add typed SSR/DOM page-read and resume-attribution model
- centralize fail-closed found/not_found/indeterminate composition
- route verifier scan aggregation through the decision table and add matrix coverage

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q tests/test_apply_verify.py tests/test_apply_pipeline.py`

Closes #213