### PR TITLE
feat: switch plugin to editable install (pip install -e .)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ python3 -m playwright install chromium
 # Настройка (вся папка data/ в .gitignore — коммитить не нужно)
 mkdir -p data && cp config/config.example.yaml data/config.yaml
 
-# Все команды запускаются через обёртку run.sh (ставит PYTHONPATH=src и вызывает hhru_bot.cli)
+# Все команды запускаются через обёртку run.sh (вызывает установленный entry point `hhru`)
 ./scripts/run.sh login                                    # ручной вход, сохраняет сессию
 ./scripts/run.sh search --resume <id> --dry-run           # поиск без откликов
 ./scripts/run.sh apply  --resume <id> --dry-run --limit 5 # план откликов
@@ -40,7 +40,7 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
 ```
 
 Тестов, линтера и системы сборки в проекте **нет** — это простой скрипт с `requirements.txt`
-и запуском через `PYTHONPATH=src python3 -m hhru_bot.cli`.
+и запуском через установленный entry point `hhru` (editable install `pip install -e .`).
 
 ## Архитектура
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir -r requirements.txt \
 
 COPY . .
 
-ENV PYTHONPATH=/app/src
+RUN pip install --no-cache-dir -e .
 
-ENTRYPOINT ["python3", "-m", "hhru_bot.cli"]
+ENTRYPOINT ["hhru"]
 CMD ["--headless", "run"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ hh.ru могла отличаться от того, что заложено в 
 ```bash
 pip3 install -r requirements.txt
 python3 -m playwright install chromium
+pip3 install -e .
 ```
 
 ## Настройка

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,6 @@ services:
       - -c
       - >-
         while true; do
-          python3 -m hhru_bot.cli --headless run;
+          hhru --headless run;
           sleep 14400;
         done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [project.scripts]
 hhru-bot = "hhru_bot.cli:main"
+hhru = "hhru_bot.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-export PYTHONPATH="${PROJECT_ROOT}/src"
-
-exec python3 -m hhru_bot.cli "$@"
+exec hhru "$@"

--- a/scripts/scheduled_run.sh
+++ b/scripts/scheduled_run.sh
@@ -3,7 +3,8 @@
 # Этап 6 «автопилот» (#18). Сама обёртка НЕ демон — её вызывает планировщик в
 # нужное время. CLAUDE.md запрещает фоновые демоны внутри проекта.
 #
-# По образцу scripts/run.sh: ставит PYTHONPATH=src и вызывает hhru_bot.cli.
+# CLI резолвится через editable install (pip install -e .) site-packages,
+# без подстановки PYTHONPATH на локальную копию src рядом со скриптом.
 # Дополнительно: пишет свой вывод в data/logs/scheduled.log и вызывает bump + apply.
 # Предохранители (дневные лимиты, кулдаун бампа 4ч) живут в коде — throttle.py.
 #
@@ -16,7 +17,6 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-export PYTHONPATH="${PROJECT_ROOT}/src"
 
 # CLI резолвит data/config.yaml, data/history.db и data/logs/ ОТНОСИТЕЛЬНО cwd
 # (см. cli.py: DEFAULT_CONFIG_PATH = Path("data")/"config.yaml"). launchd и
@@ -37,7 +37,7 @@ LOG_FILE="${LOG_DIR}/scheduled.log"
 } >> "${LOG_FILE}"
 
 # Запускаем CLI, вывод дублируется в scheduled.log. tee без буферизации (-a —
-# дозапись, чтобы история запусков копилась). exit-код пробрасываем дальше,
+# дозапись, чтобы история запусков копировалась). exit-код пробрасываем дальше,
 # чтобы планировщик видел упавший прогон.
 #
 # Интерпретатор: launchd/cron имеют УРЕЗАННЫЙ PATH и НЕ активируют виртуальное
@@ -47,6 +47,7 @@ LOG_FILE="${LOG_DIR}/scheduled.log"
 # launchd-агент через EnvironmentVariables (см. deploy/*.plist) или cron через
 # префикс `HHRU_PYTHON=/path/to/venv/bin/python`. Без него падаем на тот же
 # python3, что и интерактивный run.sh (совместимость с ручным запуском).
+# Без PYTHONPATH=src: код резолвится из site-packages editable install.
 PYTHON_BIN="${HHRU_PYTHON:-python3}"
 run_cli() {
   "${PYTHON_BIN}" -m hhru_bot.cli "$@" 2>&1 | tee -a "${LOG_FILE}"


### PR DESCRIPTION
## Что меняет

Переводит плагин Claude Code с запуска из кэшированной копии исходников на **editable install** (`pip install -e .`) из рабочего репозитория.

## Почему

Сейчас у бота три независимые копии кода, которые расходятся после каждого коммита:
1. Рабочий репозиторий
2. marketplace-репозиторий плагина
3. кэш установленного плагина (не git, копия файлов)

После мерджа PR #277 кэш не докопировал новые файлы (`fill_form.py`, `edit_education.py` и др.) — команды просто не появились в плагине, хотя в рабочем репо они уже были.

## Изменения

- **pyproject.toml**: добавлен entry point `hhru` (оставлен совместимый `hhru-bot`).
- **scripts/run.sh**: теперь вызывает `hhru` напрямую, без `PYTHONPATH=src` и без привязки к локальной копии файлов рядом со скриптом.
- **scripts/scheduled_run.sh**: убран `export PYTHONPATH=.../src`; CLI резолвится из site-packages editable install.
- **Dockerfile**: добавлен `pip install -e .`, entry point переведён на `hhru`.
- **docker-compose.yml**: команда в контейнере переведена на `hhru`.
- **README.md / CLAUDE.md**: обновлены описания установки и запуска под новый механизм.

## Как работает теперь

1. В рабочем репо выполняется `pip install -e .`.
2. Плагин вызывает `scripts/run.sh`, который зовёт установленный entry point `hhru`.
3. `git pull` в рабочем репозитории сразу отражается в поведении плагина — без дополнительного `/plugin update`.

## Проверка

- `ruff check` — OK
- `ruff format --check` — OK
- `pytest` — 1169 passed
- `hhru --help` — entry point резолвируется корректно

Closes #278
