### PR TITLE
feat: add account profile history storage

### DIFF
--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .external_forms.detect import normalize
+
 if TYPE_CHECKING:
     # SalaryInfo (доменный тип #34) возвращается estimate_salary (#93). Ленивый
     # импорт внутри метода разрывает цикл history <-> search (search тянет history
@@ -74,6 +76,18 @@ CREATE TABLE IF NOT EXISTS manual_offers (
     vacancy_id TEXT NOT NULL,
     marked_at TEXT NOT NULL,
     UNIQUE (resume_id, vacancy_id)
+);
+
+-- account_profile — единый профиль аккаунта для автозаполнения внешних форм
+-- (#282). Одинаковый вопрос может иметь два значения: ручное значение имеет
+-- приоритет над автоматически считанным с hh.ru, но строки хранятся отдельно.
+CREATE TABLE IF NOT EXISTS account_profile (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    question_key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    source TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (question_key, source)
 );
 
 -- vacancies_seen — собранные карточки вакансий (#66, Этап 1: рынок).
@@ -1003,6 +1017,57 @@ class History:
                 "SELECT vacancy_id, title, company, salary_from, salary_to, salary_currency, "
                 "search_query, first_seen_at, last_seen_at, employer_tier "
                 "FROM vacancies_seen ORDER BY last_seen_at DESC, id DESC"
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    # --- Профиль аккаунта для внешних форм (#282/#284) -----------------------
+
+    def upsert_profile_field(self, question_key: str, value: str, source: str) -> None:
+        """Сохраняет значение профиля, не смешивая источники.
+
+        Ключ нормализуется тем же правилом, что и подписи полей внешних форм.
+        Поэтому повторный login обновляет только ``hh_ru``-строку, а ручное
+        значение для того же вопроса остаётся отдельной строкой.
+        """
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO account_profile (question_key, value, source, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(question_key, source) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                (normalize(question_key), value, source, now),
+            )
+
+    def get_profile_answers(self) -> dict[str, str]:
+        """Возвращает профиль для ``apply_answers`` с приоритетом manual."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT question_key, value
+                FROM account_profile
+                ORDER BY question_key,
+                         CASE source WHEN 'manual' THEN 0 ELSE 1 END,
+                         id
+                """
+            ).fetchall()
+        answers: dict[str, str] = {}
+        for row in rows:
+            answers.setdefault(row["question_key"], row["value"])
+        return answers
+
+    def list_profile_fields(self) -> list[dict]:
+        """Возвращает все исходные строки профиля для ``profile show``."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT question_key, value, source, updated_at
+                FROM account_profile
+                ORDER BY question_key, source, id
+                """
             ).fetchall()
         return [dict(row) for row in rows]
 

--- a/tests/test_account_profile.py
+++ b/tests/test_account_profile.py
@@ -1,0 +1,58 @@
+"""Тесты account_profile: SQL-контракт и приоритет источников."""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.unit
+
+
+def test_profile_upsert_replaces_only_same_source_and_normalizes_key(tmp_path):
+    history = History(tmp_path / "history.db")
+
+    history.upsert_profile_field("  Телефон\n", "+7 900", source="hh_ru")
+    history.upsert_profile_field("телефон", "+7 901", source="hh_ru")
+    history.upsert_profile_field("телефон", "@user", source="manual")
+
+    assert history.list_profile_fields() == [
+        {
+            "question_key": "телефон",
+            "value": "+7 901",
+            "source": "hh_ru",
+            "updated_at": history.list_profile_fields()[0]["updated_at"],
+        },
+        {
+            "question_key": "телефон",
+            "value": "@user",
+            "source": "manual",
+            "updated_at": history.list_profile_fields()[1]["updated_at"],
+        },
+    ]
+
+
+def test_get_profile_answers_manual_overrides_hh_ru(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.upsert_profile_field("Имя", "Анна", source="hh_ru")
+    history.upsert_profile_field("Телефон", "+7", source="hh_ru")
+    history.upsert_profile_field("Имя", "Alice", source="manual")
+    history.upsert_profile_field("Telegram", "@alice", source="manual")
+
+    assert history.get_profile_answers() == {
+        "имя": "Alice",
+        "телефон": "+7",
+        "telegram": "@alice",
+    }
+
+
+def test_list_profile_fields_returns_raw_rows(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.upsert_profile_field("Имя", "Анна", source="hh_ru")
+    history.upsert_profile_field("Имя", "Alice", source="manual")
+
+    fields = history.list_profile_fields()
+
+    assert len(fields) == 2
+    assert {field["source"] for field in fields} == {"hh_ru", "manual"}
+    assert all(set(field) == {"question_key", "value", "source", "updated_at"} for field in fields)


### PR DESCRIPTION
Closes #284

## Summary
- add the `account_profile` table to the canonical SQLite schema
- add normalized profile upserts with independent `hh_ru` and `manual` rows
- expose merged answers with `manual` priority and raw rows for `profile show`
- add unit tests covering upsert isolation, source priority, normalization, and row shape

## Verification
- `pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`

## Scope
Pure SQLite/history logic only; no browser or live hh.ru access.
