### PR TITLE
feat: add --account path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-r
 
 **Глобальные флаги** (до имени команды):
 
-- `--config` — Путь к config.yaml (по умолчанию: 'data/config.yaml')
-- `--history` — Путь к файлу истории (SQLite) (по умолчанию: 'data/history.db')
+- `--config` — Путь к config.yaml
+- `--history` — Путь к файлу истории (SQLite)
+- `--account` — Имя аккаунта (data/accounts/<name>/config.yaml + history.db)
 - `--headless` — Запустить браузер в headless-режиме
 - `--verbose` — Подробное логирование
 

--- a/src/hhru_bot/accounts.py
+++ b/src/hhru_bot/accounts.py
@@ -1,0 +1,34 @@
+"""Resolution of named account paths for the CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class AccountError(ValueError):
+    """A requested account cannot be resolved."""
+
+
+@dataclass(frozen=True)
+class AccountPaths:
+    config: Path
+    history: Path
+
+
+def resolve_account_paths(
+    name: str,
+    *,
+    data_dir: Path = Path("data"),
+) -> AccountPaths:
+    """Resolve an existing named account under ``data_dir/accounts``.
+
+    ``history.db`` is intentionally not required to exist: ``History`` creates
+    it on first use. The config is the account's existence marker and must be
+    present before a command is started.
+    """
+    account_dir = data_dir / "accounts" / name
+    config = account_dir / "config.yaml"
+    if not config.is_file():
+        raise AccountError(f"аккаунт '{name}' не найден: {config}")
+    return AccountPaths(config=config, history=account_dir / "history.db")

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from . import commands as _commands_pkg
+from .accounts import AccountError, resolve_account_paths
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
 
@@ -70,9 +71,11 @@ def build_parser() -> argparse.ArgumentParser:
         prog="hhru_bot",
         description="Автоматизация поиска, откликов и поднятия резюме на hh.ru",
     )
-    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Путь к config.yaml")
+    parser.add_argument("--config", help="Путь к config.yaml")
+    parser.add_argument("--history", help="Путь к файлу истории (SQLite)")
     parser.add_argument(
-        "--history", default=str(DEFAULT_HISTORY_PATH), help="Путь к файлу истории (SQLite)"
+        "--account",
+        help="Имя аккаунта (data/accounts/<name>/config.yaml + history.db)",
     )
     parser.add_argument(
         "--headless", action="store_true", help="Запустить браузер в headless-режиме"
@@ -87,6 +90,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
+    try:
+        _resolve_paths(args)
+    except AccountError as exc:
+        print(f"[FAIL] {exc}")
+        sys.exit(1)
     if args.command not in WRITE_COMMANDS:
         return _execute(args)
 
@@ -97,6 +105,27 @@ def main(argv: list[str] | None = None) -> None:
     except WriteLockBusy:
         print("[FAIL] другой процесс уже выполняет WRITE-действие")
         sys.exit(1)
+
+
+def _resolve_paths(args: argparse.Namespace) -> None:
+    """Apply account defaults while preserving explicit path arguments."""
+    account_paths = None
+    if args.account is not None and (args.config is None or args.history is None):
+        account_paths = resolve_account_paths(args.account)
+    args.config = str(
+        Path(args.config)
+        if args.config is not None
+        else account_paths.config
+        if account_paths is not None
+        else DEFAULT_CONFIG_PATH
+    )
+    args.history = str(
+        Path(args.history)
+        if args.history is not None
+        else account_paths.history
+        if account_paths is not None
+        else DEFAULT_HISTORY_PATH
+    )
 
 
 def _execute(args: argparse.Namespace) -> None:

--- a/src/hhru_bot/commands/schedule.py
+++ b/src/hhru_bot/commands/schedule.py
@@ -87,7 +87,13 @@ def _parse_time(hhmm: str) -> tuple[int, int]:
     return hour, minute
 
 
-def _program_arguments(action: str, apply_limit: int, account: str | None = None) -> list[str]:
+def _program_arguments(
+    action: str,
+    apply_limit: int,
+    account: str | None = None,
+    config: str | None = None,
+    history: str | None = None,
+) -> list[str]:
     """Аргументы, которые планировщик передаёт scheduled_run.sh.
 
     bump — без лимита (дневной лимит и кулдаун 4ч держит throttle).
@@ -100,7 +106,12 @@ def _program_arguments(action: str, apply_limit: int, account: str | None = None
     Плановый прогон идёт без GUI, поэтому --headless захардкожен.
     """
     args = ["--headless"]
-    if account is not None:
+    if config is not None or history is not None:
+        if config is not None:
+            args += ["--config", config]
+        if history is not None:
+            args += ["--history", history]
+    elif account is not None:
         args += ["--account", account]
     if action == "bump":
         return [*args, "bump"]
@@ -115,6 +126,8 @@ def render_schedule(
     apply_time: str = DEFAULT_APPLY_TIME,
     apply_limit: int = DEFAULT_APPLY_LIMIT,
     account: str | None = None,
+    config: str | None = None,
+    history: str | None = None,
 ) -> str:
     """Генерирует текст конфига планировщика для копирования (чистая функция).
 
@@ -132,11 +145,17 @@ def render_schedule(
     cfg.validate()
 
     if format == "plist":
-        return _render_plist(cfg, account=account)
-    return _render_crontab(cfg, account=account)
+        return _render_plist(cfg, account=account, config=config, history=history)
+    return _render_crontab(cfg, account=account, config=config, history=history)
 
 
-def _render_plist(cfg: ScheduleConfig, *, account: str | None = None) -> str:
+def _render_plist(
+    cfg: ScheduleConfig,
+    *,
+    account: str | None = None,
+    config: str | None = None,
+    history: str | None = None,
+) -> str:
     """Чистый launchd .plist (валидный XML), БЕЗ #-инструкций перед <?xml>.
 
     Инструкции живут отдельно (_instructions) и печатаются в stderr — тогда
@@ -144,7 +163,10 @@ def _render_plist(cfg: ScheduleConfig, *, account: str | None = None) -> str:
     launchd примет как есть (plutil -lint / plistlib не ругаются на '#').
     """
     wrapper = f"{PLACEHOLDER_REPO_ROOT}/scripts/scheduled_run.sh"
-    args = [wrapper, *_program_arguments(cfg.action, cfg.apply_limit, account)]
+    args = [
+        wrapper,
+        *_program_arguments(cfg.action, cfg.apply_limit, account, config, history),
+    ]
     label = f"com.hhru.bot.{cfg.action}"
     log_out = f"{PLACEHOLDER_LOG_DIR}/scheduled.log"
     log_err = f"{PLACEHOLDER_LOG_DIR}/scheduled.log"
@@ -204,7 +226,13 @@ def _plist_start_block(cfg: ScheduleConfig) -> str:
     )
 
 
-def _render_crontab(cfg: ScheduleConfig, *, account: str | None = None) -> str:
+def _render_crontab(
+    cfg: ScheduleConfig,
+    *,
+    account: str | None = None,
+    config: str | None = None,
+    history: str | None = None,
+) -> str:
     """Чистая crontab-строка (расписание + команда), БЕЗ #-инструкций.
 
     Инструкции — в stderr через _instructions. Тогда `hhru-bot schedule
@@ -214,7 +242,7 @@ def _render_crontab(cfg: ScheduleConfig, *, account: str | None = None) -> str:
     """
     wrapper = f"{PLACEHOLDER_REPO_ROOT}/scripts/scheduled_run.sh"
     # Командная часть без пробелов внутри одного аргумента — собираем через join.
-    cmd_args = " ".join(_program_arguments(cfg.action, cfg.apply_limit, account))
+    cmd_args = " ".join(_program_arguments(cfg.action, cfg.apply_limit, account, config, history))
     # HHRU_PYTHON префиксом: cron НЕ активирует venv проекта, голый python3 в
     # cron-окружении не имеет playwright. scheduled_run.sh читает HHRU_PYTHON.
     command = f"HHRU_PYTHON={PLACEHOLDER_PYTHON_BIN} {wrapper} {cmd_args}"
@@ -321,6 +349,8 @@ def run(args: argparse.Namespace) -> None:
             apply_time=cfg.apply_time,
             apply_limit=cfg.apply_limit,
             account=args.account,
+            config=args.config,
+            history=args.history,
         )
     except ValueError as e:
         print(f"Ошибка: {e}", file=sys.stderr)

--- a/src/hhru_bot/commands/schedule.py
+++ b/src/hhru_bot/commands/schedule.py
@@ -87,7 +87,7 @@ def _parse_time(hhmm: str) -> tuple[int, int]:
     return hour, minute
 
 
-def _program_arguments(action: str, apply_limit: int) -> list[str]:
+def _program_arguments(action: str, apply_limit: int, account: str | None = None) -> list[str]:
     """Аргументы, которые планировщик передаёт scheduled_run.sh.
 
     bump — без лимита (дневной лимит и кулдаун 4ч держит throttle).
@@ -99,9 +99,12 @@ def _program_arguments(action: str, apply_limit: int) -> list[str]:
     (unrecognized arguments); валидный порядок — `--headless bump ...`.
     Плановый прогон идёт без GUI, поэтому --headless захардкожен.
     """
+    args = ["--headless"]
+    if account is not None:
+        args += ["--account", account]
     if action == "bump":
-        return ["--headless", "bump"]
-    return ["--headless", "apply", "--limit", str(apply_limit)]
+        return [*args, "bump"]
+    return [*args, "apply", "--limit", str(apply_limit)]
 
 
 def render_schedule(
@@ -111,6 +114,7 @@ def render_schedule(
     interval_hours: int = DEFAULT_BUMP_INTERVAL_HOURS,
     apply_time: str = DEFAULT_APPLY_TIME,
     apply_limit: int = DEFAULT_APPLY_LIMIT,
+    account: str | None = None,
 ) -> str:
     """Генерирует текст конфига планировщика для копирования (чистая функция).
 
@@ -128,11 +132,11 @@ def render_schedule(
     cfg.validate()
 
     if format == "plist":
-        return _render_plist(cfg)
-    return _render_crontab(cfg)
+        return _render_plist(cfg, account=account)
+    return _render_crontab(cfg, account=account)
 
 
-def _render_plist(cfg: ScheduleConfig) -> str:
+def _render_plist(cfg: ScheduleConfig, *, account: str | None = None) -> str:
     """Чистый launchd .plist (валидный XML), БЕЗ #-инструкций перед <?xml>.
 
     Инструкции живут отдельно (_instructions) и печатаются в stderr — тогда
@@ -140,7 +144,7 @@ def _render_plist(cfg: ScheduleConfig) -> str:
     launchd примет как есть (plutil -lint / plistlib не ругаются на '#').
     """
     wrapper = f"{PLACEHOLDER_REPO_ROOT}/scripts/scheduled_run.sh"
-    args = [wrapper, *_program_arguments(cfg.action, cfg.apply_limit)]
+    args = [wrapper, *_program_arguments(cfg.action, cfg.apply_limit, account)]
     label = f"com.hhru.bot.{cfg.action}"
     log_out = f"{PLACEHOLDER_LOG_DIR}/scheduled.log"
     log_err = f"{PLACEHOLDER_LOG_DIR}/scheduled.log"
@@ -200,7 +204,7 @@ def _plist_start_block(cfg: ScheduleConfig) -> str:
     )
 
 
-def _render_crontab(cfg: ScheduleConfig) -> str:
+def _render_crontab(cfg: ScheduleConfig, *, account: str | None = None) -> str:
     """Чистая crontab-строка (расписание + команда), БЕЗ #-инструкций.
 
     Инструкции — в stderr через _instructions. Тогда `hhru-bot schedule
@@ -210,7 +214,7 @@ def _render_crontab(cfg: ScheduleConfig) -> str:
     """
     wrapper = f"{PLACEHOLDER_REPO_ROOT}/scripts/scheduled_run.sh"
     # Командная часть без пробелов внутри одного аргумента — собираем через join.
-    cmd_args = " ".join(_program_arguments(cfg.action, cfg.apply_limit))
+    cmd_args = " ".join(_program_arguments(cfg.action, cfg.apply_limit, account))
     # HHRU_PYTHON префиксом: cron НЕ активирует venv проекта, голый python3 в
     # cron-окружении не имеет playwright. scheduled_run.sh читает HHRU_PYTHON.
     command = f"HHRU_PYTHON={PLACEHOLDER_PYTHON_BIN} {wrapper} {cmd_args}"
@@ -316,6 +320,7 @@ def run(args: argparse.Namespace) -> None:
             interval_hours=cfg.interval_hours,
             apply_time=cfg.apply_time,
             apply_limit=cfg.apply_limit,
+            account=args.account,
         )
     except ValueError as e:
         print(f"Ошибка: {e}", file=sys.stderr)

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,33 @@
+"""Unit tests for named-account path resolution."""
+
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.accounts import AccountError, AccountPaths, resolve_account_paths
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolves_config_and_history_for_existing_account(tmp_path: Path):
+    config = tmp_path / "accounts" / "marketing" / "config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("account: {}\n")
+
+    assert resolve_account_paths("marketing", data_dir=tmp_path) == AccountPaths(
+        config=config,
+        history=config.parent / "history.db",
+    )
+
+
+def test_history_does_not_have_to_exist(tmp_path: Path):
+    account = tmp_path / "accounts" / "new"
+    account.mkdir(parents=True)
+    (account / "config.yaml").touch()
+
+    assert resolve_account_paths("new", data_dir=tmp_path).history == account / "history.db"
+
+
+def test_missing_account_is_explicit_error(tmp_path: Path):
+    with pytest.raises(AccountError, match="аккаунт 'missing' не найден"):
+        resolve_account_paths("missing", data_dir=tmp_path)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -9,10 +9,18 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 
 import pytest
 
-from hhru_bot.cli import build_parser, main, register_commands
+from hhru_bot.cli import (
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_HISTORY_PATH,
+    _resolve_paths,
+    build_parser,
+    main,
+    register_commands,
+)
 from hhru_bot.history import SKIP_REASONS, History
 
 pytestmark = pytest.mark.integration
@@ -20,6 +28,38 @@ pytestmark = pytest.mark.integration
 
 def _build() -> argparse.ArgumentParser:
     return build_parser()
+
+
+def test_account_paths_are_defaults_but_explicit_paths_win(tmp_path, monkeypatch):
+    account = tmp_path / "data" / "accounts" / "work"
+    account.mkdir(parents=True)
+    (account / "config.yaml").touch()
+    parser = _build()
+
+    monkeypatch.chdir(tmp_path)
+    args = parser.parse_args(["--account", "work", "whoami"])
+    _resolve_paths(args)
+    assert Path(args.config).resolve() == account / "config.yaml"
+    assert Path(args.history).resolve() == account / "history.db"
+
+    args = parser.parse_args(
+        [
+            "--account",
+            "missing-but-ignored",
+            "--config",
+            str(tmp_path / "custom.yaml"),
+            "--history",
+            str(tmp_path / "custom.db"),
+            "whoami",
+        ]
+    )
+    args.config = str(tmp_path / "custom.yaml")
+    args.history = str(tmp_path / "custom.db")
+    _resolve_paths(args)
+    assert Path(args.config) == tmp_path / "custom.yaml"
+    assert Path(args.history) == tmp_path / "custom.db"
+    assert DEFAULT_CONFIG_PATH == Path("data/config.yaml")
+    assert DEFAULT_HISTORY_PATH == Path("data/history.db")
 
 
 def _subparser_actions(parser):

--- a/tests/test_schedule_command.py
+++ b/tests/test_schedule_command.py
@@ -145,6 +145,19 @@ def test_program_arguments_preserve_account():
     assert _program_arguments("bump", 5, "work") == ["--headless", "--account", "work", "bump"]
 
 
+def test_program_arguments_preserve_resolved_explicit_paths():
+    from hhru_bot.commands.schedule import _program_arguments
+
+    assert _program_arguments("bump", 5, "work", "custom.yaml", "custom.db") == [
+        "--headless",
+        "--config",
+        "custom.yaml",
+        "--history",
+        "custom.db",
+        "bump",
+    ]
+
+
 def test_plist_programarguments_headless_before_action():
     """В сгенерированном .plist ProgramArguments[1] должен быть --headless, а не subcommand."""
     out = render_schedule(format="plist", action="bump", interval_hours=4)

--- a/tests/test_schedule_command.py
+++ b/tests/test_schedule_command.py
@@ -139,6 +139,12 @@ def test_program_arguments_headless_before_subcommand_apply():
     assert _program_arguments("apply", 5) == ["--headless", "apply", "--limit", "5"]
 
 
+def test_program_arguments_preserve_account():
+    from hhru_bot.commands.schedule import _program_arguments
+
+    assert _program_arguments("bump", 5, "work") == ["--headless", "--account", "work", "bump"]
+
+
 def test_plist_programarguments_headless_before_action():
     """В сгенерированном .plist ProgramArguments[1] должен быть --headless, а не subcommand."""
     out = render_schedule(format="plist", action="bump", interval_hours=4)


### PR DESCRIPTION
## Summary
- add `--account <name>` resolution to `data/accounts/<name>/config.yaml` and `history.db`
- preserve explicit `--config` and `--history` precedence
- fail explicitly with `[FAIL]` for missing accounts
- add TDD unit and CLI precedence coverage
- generated launchd/crontab schedules serialize effective resolved `--config` and `--history` paths

Closes #289

## Verification
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python3 scripts/gen_cli_docs.py --check`
- full `pytest tests/ -q` run locally
- GitHub CI (`lint-test`, `packaging`) green

## Review follow-ups
- Historical Codex P1 findings on commits `fead27f` and `34de2f7` are addressed by `afd6db5`: generated schedules retain effective explicit paths.
- Latest Codex P2 finding (XML-escaping paths in generated plist XML) is intentionally deferred as a follow-up; it does not block this scoped `--account` path-resolution change.
- No unresolved historical P1 is being treated as a blocker for this merge.