### PR TITLE
feat(auth): persist account profile after login

### DIFF
--- a/src/hhru_bot/account_profile.py
+++ b/src/hhru_bot/account_profile.py
@@ -56,10 +56,16 @@ def read_account_profile(page: Page, history_path: str | Path) -> int:
             locator = page.locator(selector)
             count = locator.count()
             if count != 1:
+                if count == 0:
+                    # A successfully loaded profile can legitimately omit a
+                    # private/unfilled field. Remove a previous hh_ru value so
+                    # it cannot leak into a later account's form fill.
+                    history.delete_profile_field(question_key, source="hh_ru")
                 _warn(f"поле «{question_key}» не подтверждено (найдено: {count})")
                 continue
             value = locator.inner_text().strip()
             if not value:
+                history.delete_profile_field(question_key, source="hh_ru")
                 _warn(f"поле «{question_key}» пустое")
                 continue
             history.upsert_profile_field(question_key, value, source="hh_ru")

--- a/src/hhru_bot/account_profile.py
+++ b/src/hhru_bot/account_profile.py
@@ -1,0 +1,71 @@
+"""Read the authenticated account profile from hh.ru.
+
+This is optional enrichment performed after a successful login.  A missing or
+ambiguous DOM field is deliberately not treated as an empty value: only a
+single locator with non-empty text may reach ``History``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+
+from .browser import HH_BASE_URL, goto_hh
+from .history import History
+from .selector_groups import account_profile
+
+PROFILE_FIELDS = (
+    ("Имя", account_profile.ACCOUNT_PROFILE_FIRST_NAME),
+    ("Фамилия", account_profile.ACCOUNT_PROFILE_LAST_NAME),
+    ("Город", account_profile.ACCOUNT_PROFILE_CITY),
+    ("Телефон", account_profile.ACCOUNT_PROFILE_PHONE),
+    ("Email", account_profile.ACCOUNT_PROFILE_EMAIL),
+)
+
+
+def _warn(message: str) -> None:
+    print(f"[WARN] Профиль: {message}")
+
+
+def read_account_profile(page: Page, history_path: str | Path) -> int:
+    """Read profile fields, returning the number safely persisted.
+
+    Navigation and DOM failures are fail-open for the surrounding login flow.
+    Values are fail-closed: count must be exactly one and ``inner_text`` must
+    be non-empty before writing an ``hh_ru`` field.
+    """
+    try:
+        goto_hh(page, f"{HH_BASE_URL}{account_profile.ACCOUNT_PROFILE_PATH}")
+    except PlaywrightError as exc:
+        _warn(f"страница недоступна: {exc}")
+        print("[INFO] Профиль обновлён: 0 полей")
+        return 0
+
+    try:
+        history = History(history_path)
+    except (OSError, sqlite3.Error) as exc:
+        _warn(f"не удалось открыть историю: {exc}")
+        print("[INFO] Профиль обновлён: 0 полей")
+        return 0
+    updated = 0
+    for question_key, selector in PROFILE_FIELDS:
+        try:
+            locator = page.locator(selector)
+            count = locator.count()
+            if count != 1:
+                _warn(f"поле «{question_key}» не подтверждено (найдено: {count})")
+                continue
+            value = locator.inner_text().strip()
+            if not value:
+                _warn(f"поле «{question_key}» пустое")
+                continue
+            history.upsert_profile_field(question_key, value, source="hh_ru")
+            updated += 1
+        except (PlaywrightError, OSError, ValueError, sqlite3.Error) as exc:
+            _warn(f"поле «{question_key}» не прочитано: {exc}")
+
+    print(f"[INFO] Профиль обновлён: {updated} полей")
+    return updated

--- a/src/hhru_bot/account_profile.py
+++ b/src/hhru_bot/account_profile.py
@@ -44,6 +44,21 @@ def read_account_profile(page: Page, history_path: str | Path) -> int:
         print("[INFO] Профиль обновлён: 0 полей")
         return 0
 
+    # A successful navigation alone is not enough: hh.ru can return an error,
+    # auth, or not-yet-rendered page with a zero count for every field. The
+    # confirmed name card is the profile-specific positive marker that permits
+    # absence-based cleanup below.
+    try:
+        page_marker = page.locator(account_profile.ACCOUNT_PROFILE_FIRST_NAME)
+        if page_marker.count() != 1:
+            _warn("страница профиля не подтверждена — старые данные сохранены")
+            print("[INFO] Профиль обновлён: 0 полей")
+            return 0
+    except PlaywrightError as exc:
+        _warn(f"страница профиля не подтверждена: {exc}")
+        print("[INFO] Профиль обновлён: 0 полей")
+        return 0
+
     try:
         history = History(history_path)
     except (OSError, sqlite3.Error) as exc:

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
+from .account_profile import read_account_profile
 from .browser import GOTO_TIMEOUT_MS, HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
 from .config import AppConfig
 
 logger = logging.getLogger("hhru_bot.auth")
 
 
-def login(config: AppConfig) -> None:
+def login(config: AppConfig, history_path: str | Path = Path("data/history.db")) -> None:
     """
     Открывает hh.ru в headed-браузере и ждёт, пока пользователь вручную войдёт
     в аккаунт (логин/пароль, СМС-код, капча — всё, что попросит hh.ru).
@@ -89,6 +91,7 @@ def login(config: AppConfig) -> None:
         # проверка cookie здесь была бы недостижимым дублированием.
         context.storage_state(path=str(storage_state_file))
         logger.info("Сессия сохранена: %s", storage_state_file)
+        read_account_profile(page, history_path)
 
         context.close()
         browser.close()

--- a/src/hhru_bot/auth_code.py
+++ b/src/hhru_bot/auth_code.py
@@ -82,6 +82,8 @@ def submit_code(config: AppConfig, code: str) -> None:
     pending = _pending_path(config)
     if not pending.exists():
         raise RuntimeError("Промежуточная сессия не найдена: сначала выполните --request")
+    # TODO(#167, #285): once authenticated code login is implemented, reuse
+    # account_profile.read_account_profile here after positive auth confirmation.
     # hh.ru did not expose the code input in the anonymous live dump.  Failing
     # explicitly is safer than guessing a selector and silently timing out.
     raise RuntimeError(

--- a/src/hhru_bot/commands/login.py
+++ b/src/hhru_bot/commands/login.py
@@ -15,4 +15,4 @@ def run(args: argparse.Namespace) -> None:
     from ..config import load_config_or_exit
 
     config = load_config_or_exit(args.config)
-    login(config)
+    login(config, history_path=args.history)

--- a/tests/test_account_profile_login.py
+++ b/tests/test_account_profile_login.py
@@ -1,0 +1,80 @@
+"""Characterization tests for optional profile enrichment during login."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from playwright.sync_api import Error as PlaywrightError
+
+from hhru_bot import account_profile
+from hhru_bot.history import History
+from hhru_bot.selector_groups import account_profile as profile_selectors
+
+pytestmark = pytest.mark.integration
+
+
+def _page_for(*, counts: dict[str, int], values: dict[str, str] | None = None):
+    values = values or {}
+    page = MagicMock(name="Page")
+
+    def locator(selector: str):
+        loc = MagicMock(name=selector)
+        loc.count.return_value = counts.get(selector, 0)
+        loc.inner_text.return_value = values.get(selector, "")
+        return loc
+
+    page.locator.side_effect = locator
+    return page
+
+
+def test_read_account_profile_persists_only_confirmed_fields(monkeypatch, tmp_path):
+    selectors = profile_selectors
+    page = _page_for(
+        counts={
+            selectors.ACCOUNT_PROFILE_FIRST_NAME: 1,
+            selectors.ACCOUNT_PROFILE_LAST_NAME: 2,
+            selectors.ACCOUNT_PROFILE_PHONE: 1,
+        },
+        values={
+            selectors.ACCOUNT_PROFILE_FIRST_NAME: "Анна",
+            selectors.ACCOUNT_PROFILE_PHONE: " +7 900 ",
+        },
+    )
+    monkeypatch.setattr(account_profile, "goto_hh", MagicMock())
+
+    assert account_profile.read_account_profile(page, tmp_path / "history.db") == 2
+
+    fields = History(tmp_path / "history.db").list_profile_fields()
+    assert {(field["question_key"], field["value"]) for field in fields} == {
+        ("имя", "Анна"),
+        ("телефон", "+7 900"),
+    }
+
+
+def test_read_account_profile_is_fail_open_when_page_unavailable(monkeypatch, tmp_path, capsys):
+    page = MagicMock(name="Page")
+    monkeypatch.setattr(account_profile, "goto_hh", MagicMock(side_effect=PlaywrightError("down")))
+
+    assert account_profile.read_account_profile(page, tmp_path / "history.db") == 0
+    assert "[WARN] Профиль: страница недоступна" in capsys.readouterr().out
+    assert not (tmp_path / "history.db").exists()
+
+
+def test_read_account_profile_does_not_write_empty_or_ambiguous_values(
+    monkeypatch, tmp_path, capsys
+):
+    page = _page_for(
+        counts={
+            profile_selectors.ACCOUNT_PROFILE_FIRST_NAME: 1,
+            profile_selectors.ACCOUNT_PROFILE_LAST_NAME: 2,
+        },
+        values={profile_selectors.ACCOUNT_PROFILE_FIRST_NAME: "  "},
+    )
+    monkeypatch.setattr(account_profile, "goto_hh", MagicMock())
+
+    assert account_profile.read_account_profile(page, tmp_path / "history.db") == 0
+    assert History(tmp_path / "history.db").list_profile_fields() == []
+    output = capsys.readouterr().out
+    assert "поле «Имя» пустое" in output
+    assert "поле «Фамилия» не подтверждено" in output

--- a/tests/test_account_profile_login.py
+++ b/tests/test_account_profile_login.py
@@ -80,9 +80,7 @@ def test_read_account_profile_does_not_write_empty_or_ambiguous_values(
     assert "поле «Фамилия» не подтверждено" in output
 
 
-def test_read_account_profile_removes_stale_hh_values_on_confirmed_absence(
-    monkeypatch, tmp_path
-):
+def test_read_account_profile_removes_stale_hh_values_on_confirmed_absence(monkeypatch, tmp_path):
     history = History(tmp_path / "history.db")
     history.upsert_profile_field("Имя", "Старое имя", source="hh_ru")
     page = _page_for(counts={})

--- a/tests/test_account_profile_login.py
+++ b/tests/test_account_profile_login.py
@@ -78,3 +78,15 @@ def test_read_account_profile_does_not_write_empty_or_ambiguous_values(
     output = capsys.readouterr().out
     assert "поле «Имя» пустое" in output
     assert "поле «Фамилия» не подтверждено" in output
+
+
+def test_read_account_profile_removes_stale_hh_values_on_confirmed_absence(
+    monkeypatch, tmp_path
+):
+    history = History(tmp_path / "history.db")
+    history.upsert_profile_field("Имя", "Старое имя", source="hh_ru")
+    page = _page_for(counts={})
+    monkeypatch.setattr(account_profile, "goto_hh", MagicMock())
+
+    assert account_profile.read_account_profile(page, tmp_path / "history.db") == 0
+    assert history.list_profile_fields() == []

--- a/tests/test_account_profile_login.py
+++ b/tests/test_account_profile_login.py
@@ -82,9 +82,22 @@ def test_read_account_profile_does_not_write_empty_or_ambiguous_values(
 
 def test_read_account_profile_removes_stale_hh_values_on_confirmed_absence(monkeypatch, tmp_path):
     history = History(tmp_path / "history.db")
-    history.upsert_profile_field("Имя", "Старое имя", source="hh_ru")
+    history.upsert_profile_field("Город", "Старый город", source="hh_ru")
+    page = _page_for(
+        counts={profile_selectors.ACCOUNT_PROFILE_FIRST_NAME: 1},
+        values={profile_selectors.ACCOUNT_PROFILE_FIRST_NAME: "Новое имя"},
+    )
+    monkeypatch.setattr(account_profile, "goto_hh", MagicMock())
+
+    assert account_profile.read_account_profile(page, tmp_path / "history.db") == 1
+    assert history.get_profile_answers() == {"имя": "Новое имя"}
+
+
+def test_read_account_profile_preserves_values_when_page_marker_is_missing(monkeypatch, tmp_path):
+    history = History(tmp_path / "history.db")
+    history.upsert_profile_field("Телефон", "+7", source="hh_ru")
     page = _page_for(counts={})
     monkeypatch.setattr(account_profile, "goto_hh", MagicMock())
 
     assert account_profile.read_account_profile(page, tmp_path / "history.db") == 0
-    assert history.list_profile_fields() == []
+    assert history.get_profile_answers() == {"телефон": "+7"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -55,10 +56,13 @@ def test_login_succeeds_when_auth_confirmed_on_third_poll(monkeypatch, tmp_path)
     monkeypatch.setattr(time, "monotonic", itertools.chain([0, 2, 4], itertools.repeat(4)).__next__)
 
     config = MagicMock(storage_state_file=tmp_path / "session.json", user_agent=None)
+    read_profile = MagicMock()
+    monkeypatch.setattr(auth, "read_account_profile", read_profile)
 
     auth.login(config)
 
     context.storage_state.assert_called_once_with(path=str(config.storage_state_file))
+    read_profile.assert_called_once_with(context.new_page.return_value, Path("data/history.db"))
 
 
 def test_login_times_out_when_login_form_never_disappears(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add shared authenticated `/profile/me` reader with fail-open navigation and fail-closed field persistence
- persist only unique, non-empty profile fields to `account_profile` with source `hh_ru`
- run profile enrichment after successful `auth.login()` session storage and pass the CLI history path
- leave `login-code --submit` unchanged; it remains the intentional #167 stub, with a TODO hook for #285

## Tests
- `pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`

Closes #285
