### PR TITLE
docs: parameterize scheduled jobs by account

### DIFF
--- a/deploy/com.hhru.bot.apply.plist
+++ b/deploy/com.hhru.bot.apply.plist
@@ -2,6 +2,10 @@
 <!--
   launchd LaunchAgent (macOS) — ШАБЛОН. Ежедневный apply откликов (#18).
 
+  Этот шаблон рассчитан на один именованный аккаунт. Для каждого аккаунта
+  создайте отдельную копию, заменив __ACCOUNT_NAME__ во всём файле; это также
+  делает Label уникальным для launchd.
+
   CLAUDE.md ЗАПРЕЩАЕТ фоновые демоны внутри кода проекта. Этот файл — не часть
   кода, а конфиг внешнего планировщика ОС (launchd), который пользователь
   устанавливает САМ под свою машину. Он лишь «нажимает кнопку» — зовёт
@@ -21,14 +25,19 @@
                       в активированном venv). launchd НЕ активирует venv и имеет
                       урезанный PATH — без этого джоб упадёт на ModuleNotFoundError:
                       playwright. scheduled_run.sh читает HHRU_PYTHON.
+    __ACCOUNT_NAME__ — имя аккаунта из data/accounts/<name>/ (например, marketing)
 
   Установка:
-    cp deploy/com.hhru.bot.apply.plist ~/Library/LaunchAgents/com.hhru.bot.apply.plist
-    # (предварительно заменив плейсхолдеры в копии)
-    launchctl load ~/Library/LaunchAgents/com.hhru.bot.apply.plist
+    sed -e 's|__REPO_ROOT__|/Users/me/hhru|g' \
+        -e 's|__LOG_DIR__|/Users/me/hhru/data/logs|g' \
+        -e 's|__PYTHON_BIN__|/Users/me/hhru/.venv/bin/python|g' \
+        -e 's|__ACCOUNT_NAME__|marketing|g' \
+        deploy/com.hhru.bot.apply.plist > \
+        ~/Library/LaunchAgents/com.hhru.bot.apply.marketing.plist
+    launchctl load ~/Library/LaunchAgents/com.hhru.bot.apply.marketing.plist
   Проверка/выгрузка:
     launchctl list | grep hhru
-    launchctl unload ~/Library/LaunchAgents/com.hhru.bot.apply.plist
+    launchctl unload ~/Library/LaunchAgents/com.hhru.bot.apply.marketing.plist
 
   Эквивалентный конфиг генерируется командой:
     hhru-bot schedule (формат plist, действие apply, время 10:00, лимит 5)
@@ -37,10 +46,12 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.hhru.bot.apply</string>
+    <string>com.hhru.bot.apply.__ACCOUNT_NAME__</string>
     <key>ProgramArguments</key>
     <array>
         <string>__REPO_ROOT__/scripts/scheduled_run.sh</string>
+        <string>--account</string>
+        <string>__ACCOUNT_NAME__</string>
         <string>--headless</string>
         <string>apply</string>
         <string>--limit</string>

--- a/deploy/com.hhru.bot.bump.plist
+++ b/deploy/com.hhru.bot.bump.plist
@@ -2,6 +2,10 @@
 <!--
   launchd LaunchAgent (macOS) — ШАБЛОН. Регулярный bump резюме каждые ~4ч (#18).
 
+  Этот шаблон рассчитан на один именованный аккаунт. Для каждого аккаунта
+  создайте отдельную копию, заменив __ACCOUNT_NAME__ во всём файле; это также
+  делает Label уникальным для launchd.
+
   CLAUDE.md ЗАПРЕЩАЕТ фоновые демоны внутри кода проекта. Этот файл — не часть
   кода, а конфиг внешнего планировщика ОС (launchd), который пользователь
   устанавливает САМ под свою машину. Он лишь «нажимает кнопку» — зовёт
@@ -17,14 +21,19 @@
                       в активированном venv). launchd НЕ активирует venv и имеет
                       урезанный PATH — без этого джоб упадёт на ModuleNotFoundError:
                       playwright. scheduled_run.sh читает HHRU_PYTHON.
+    __ACCOUNT_NAME__ — имя аккаунта из data/accounts/<name>/ (например, marketing)
 
   Установка:
-    cp deploy/com.hhru.bot.bump.plist ~/Library/LaunchAgents/com.hhru.bot.bump.plist
-    # (предварительно заменив плейсхолдеры в копии)
-    launchctl load ~/Library/LaunchAgents/com.hhru.bot.bump.plist
+    sed -e 's|__REPO_ROOT__|/Users/me/hhru|g' \
+        -e 's|__LOG_DIR__|/Users/me/hhru/data/logs|g' \
+        -e 's|__PYTHON_BIN__|/Users/me/hhru/.venv/bin/python|g' \
+        -e 's|__ACCOUNT_NAME__|marketing|g' \
+        deploy/com.hhru.bot.bump.plist > \
+        ~/Library/LaunchAgents/com.hhru.bot.bump.marketing.plist
+    launchctl load ~/Library/LaunchAgents/com.hhru.bot.bump.marketing.plist
   Проверка/выгрузка:
     launchctl list | grep hhru
-    launchctl unload ~/Library/LaunchAgents/com.hhru.bot.bump.plist
+    launchctl unload ~/Library/LaunchAgents/com.hhru.bot.bump.marketing.plist
 
   Эквивалентный конфиг генерируется командой:
     hhru-bot schedule (формат plist, действие bump, интервал 4 часа)
@@ -33,10 +42,12 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.hhru.bot.bump</string>
+    <string>com.hhru.bot.bump.__ACCOUNT_NAME__</string>
     <key>ProgramArguments</key>
     <array>
         <string>__REPO_ROOT__/scripts/scheduled_run.sh</string>
+        <string>--account</string>
+        <string>__ACCOUNT_NAME__</string>
         <string>--headless</string>
         <string>bump</string>
     </array>

--- a/docs/market-recipes.md
+++ b/docs/market-recipes.md
@@ -16,10 +16,12 @@ READ-only анализ рынка с целью **максимизация до�
 отдаёт ни под каким `data-qa` (#117).
 
 Сначала **соберите данные** по нескольким сферам — прогоните search с разными
-`text` в `config.yaml` (или несколькими резюме):
+`text` в `config.yaml` (или несколькими резюме). Для именованного аккаунта
+конфиг и история автоматически берутся из `data/accounts/<name>/`:
 
 ```
 ./scripts/run.sh search --resume <id> --max-pages 5
+./scripts/run.sh --account marketing search --resume <id> --max-pages 5
 ```
 
 Дальше — всё через `query` (read-only SELECT к `history.db`):
@@ -36,6 +38,18 @@ READ-only анализ рынка с целью **максимизация до�
 ```
 ./scripts/run.sh --history data/history.db query "<SQL>"
 ```
+
+Для отдельного аккаунта достаточно одного флага (он также должен стоять до
+подкоманды):
+
+```
+./scripts/run.sh --account marketing query "<SQL отсюда>"
+./scripts/run.sh --account marketing query "<SQL>" --csv
+```
+
+Аккаунт `marketing` должен иметь файл `data/accounts/marketing/config.yaml`;
+его история хранится в `data/accounts/marketing/history.db`. Явно переданные
+`--config` и `--history` имеют приоритет над соответствующими путями аккаунта.
 
 Все запросы ниже — `SELECT`/`WITH`, безопасны (read-only).
 

--- a/scripts/scheduled_run.sh
+++ b/scripts/scheduled_run.sh
@@ -11,6 +11,10 @@
 # Аргументы передаются дальше CLI как есть, например:
 #   scripts/scheduled_run.sh bump --headless
 #   scripts/scheduled_run.sh apply --headless --limit 5
+# Для именованного аккаунта передайте глобальный флаг до команды:
+#   scripts/scheduled_run.sh --account marketing --headless apply --limit 5
+# Либо задайте HHRU_ACCOUNT=marketing; явный --account в аргументах имеет
+# приоритет, если заданы оба варианта.
 # Планировщик обычно зовёт одно действие за раз (см. deploy/*.plist шаблоны и
 # вывод `hhru-bot schedule`).
 
@@ -54,4 +58,9 @@ run_cli() {
   return "${PIPESTATUS[0]}"
 }
 
-run_cli "$@"
+ACCOUNT_ARGS=()
+if [[ -n "${HHRU_ACCOUNT:-}" ]]; then
+  ACCOUNT_ARGS=(--account "${HHRU_ACCOUNT}")
+fi
+
+run_cli "${ACCOUNT_ARGS[@]}" "$@"


### PR DESCRIPTION
Closes #292

## Summary
- add HHRU_ACCOUNT support and documented --account usage to scheduled_run.sh
- parameterize apply/bump launchd templates with per-account placeholders and unique labels
- document --account market analysis recipes

## Tests
- pytest -q
- ruff check src tests
- ruff format --check src tests
- plistlib parse of deploy/*.plist
- mock scheduled_run.sh verification for explicit and environment account

## Risks
- launchd templates now require replacing __ACCOUNT_NAME__ before installation.