### PR TITLE
feat: add account create command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,15 +25,15 @@ pip3 install -r requirements.txt
 python3 -m playwright install chromium
 
 # Настройка (вся папка data/ в .gitignore — коммитить не нужно)
-mkdir -p data && cp config/config.example.yaml data/config.yaml
+./scripts/run.sh account create default
 
 # Все команды запускаются через обёртку run.sh (вызывает установленный entry point `hhru`)
-./scripts/run.sh login                                    # ручной вход, сохраняет сессию
-./scripts/run.sh search --resume <id> --dry-run           # поиск без откликов
-./scripts/run.sh apply  --resume <id> --dry-run --limit 5 # план откликов
-./scripts/run.sh apply  --resume <id> --limit 5           # боевой отклик
-./scripts/run.sh bump   --resume <id>                     # поднять резюме (не чаще 1 раза в 4 часа)
-./scripts/run.sh run                                       # apply + bump для всех резюме
+./scripts/run.sh --account default login                                    # ручной вход, сохраняет сессию
+./scripts/run.sh --account default search --resume <id> --dry-run           # поиск без откликов
+./scripts/run.sh --account default apply  --resume <id> --dry-run --limit 5 # план откликов
+./scripts/run.sh --account default apply  --resume <id> --limit 5           # боевой отклик
+./scripts/run.sh --account default bump   --resume <id>                     # поднять резюме (не чаще 1 раза в 4 часа)
+./scripts/run.sh --account default run                                       # apply + bump для всех резюме
 
 # Общие флаги: --headless, --verbose, --config <path>, --history <path>, --max-pages <n>
 # --resume опционален — без него команда идёт по всем резюме из конфига
@@ -227,6 +227,9 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
 
 ```
 data/                      # всё изменяемое, целиком в .gitignore
+  accounts/<name>/
+    config.yaml             # настройки аккаунта (создаётся account create)
+    history.db              # история аккаунта
   config.yaml              # личные настройки (шаблон — config/config.example.yaml)
   history.db               # SQLite: история откликов, вакансии, ответы
   storage_state/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,18 @@ pip3 install -e .
 ## Настройка
 
 ```bash
-mkdir -p data && cp config/config.example.yaml data/config.yaml
+hhru account create default
 ```
 
-Отредактируй `data/config.yaml`:
+Команда создаёт `data/accounts/default/config.yaml` из шаблона и не перезаписывает
+существующий аккаунт. Для следующих команд передай имя созданного аккаунта
+глобальным флагом (глобальные флаги указываются до имени команды):
+
+```bash
+./scripts/run.sh --account default login
+```
+
+Отредактируй созданный конфиг:
 - `resumes` — список твоих резюме на hh.ru, у каждого свои фильтры поиска
   (`text`, `area`, `salary_from`, `experience`, `schedule`,
   `exclude_employers`, `exclude_keywords`) и опционально своё сопроводительное
@@ -58,6 +66,10 @@ mkdir -p data && cp config/config.example.yaml data/config.yaml
 
 ```
 data/                      # всё изменяемое, целиком в .gitignore
+  accounts/
+    default/
+      config.yaml           # конфиг аккаунта (создаётся account create)
+      history.db            # история аккаунта
   config.yaml              # твои настройки (шаблон — config/config.example.yaml)
   history.db               # SQLite: история откликов, вакансии, ответы
   storage_state/
@@ -155,12 +167,12 @@ launchctl load ~/Library/LaunchAgents/com.hhru.bot.apply.plist
 
 ```bash
 mkdir -p data
-cp config/config.example.yaml data/config.yaml
-docker compose run --rm hhru --headless run
+  ./scripts/run.sh account create default
+docker compose run --rm --entrypoint hhru hhru --headless --account default run
 ```
 
 Для непрерывного варианта `docker-compose.yml` содержит минимальный sleep-loop:
-он запускает `run --headless`, ждёт 4 часа и повторяет. Запусти его так:
+он запускает `--account default run --headless`, ждёт 4 часа и повторяет. Запусти его так:
 
 ```bash
 docker compose up -d
@@ -180,7 +192,7 @@ ssh user@example.com 'cd /opt/hhru && docker compose up -d --build'
 ssh user@example.com 'cd /opt/hhru && docker compose logs -f hhru'
 ```
 
-Сессию hh.ru сначала создай локально через `./scripts/run.sh login` или выполни
+Сессию hh.ru сначала создай локально через `./scripts/run.sh --account default login` или выполни
 login в контейнере с временно отключённым `--headless`; не передавай пароли в
 compose-файле. Обновление: `git pull && docker compose up -d --build`.
 
@@ -264,6 +276,12 @@ Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-r
 - `--resume` — ID резюме из конфига
 - `--dry-run` — Показать предложение без сохранения
 - `--force` — Подтвердить сохранение без prompt
+
+### `account`
+
+Создание и управление локальными профилями аккаунтов hh.ru.
+
+- (без аргументов)
 
 ### `apply`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     build: .
     init: true
     restart: unless-stopped
+    # The image entrypoint is hhru; this service command is a shell loop.
+    entrypoint: []
+    environment:
+      HHRU_ACCOUNT: default
     volumes:
       - ./data:/app/data
     command:
@@ -10,6 +14,6 @@ services:
       - -c
       - >-
         while true; do
-          hhru --headless run;
+          hhru --account "$${HHRU_ACCOUNT:-default}" --headless run;
           sleep 14400;
         done

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -47,6 +47,7 @@ WRITE_COMMANDS = frozenset(
         "resume-position",
         "resume-sections",
         "edit-skills",
+        "account",
     }
 )
 

--- a/src/hhru_bot/commands/account.py
+++ b/src/hhru_bot/commands/account.py
@@ -1,0 +1,83 @@
+"""Команды управления локальными профилями аккаунтов."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from ..accounts import AccountError
+
+DEFAULT_DATA_DIR = Path("data")
+DEFAULT_TEMPLATE_PATH = Path("config") / "config.example.yaml"
+
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(
+        "account",
+        help="Управление локальными аккаунтами",
+        description="Создание и управление локальными профилями аккаунтов hh.ru.",
+    )
+    commands = p.add_subparsers(dest="account_command", required=True)
+
+    create = commands.add_parser(
+        "create",
+        help="Создать локальный аккаунт из шаблона конфигурации",
+        description="Создать data/accounts/<name>/ и скопировать туда шаблон конфига.",
+    )
+    create.add_argument("name", help="Имя нового аккаунта")
+    create.set_defaults(func=run_create)
+
+
+def create_account(
+    name: str,
+    *,
+    data_dir: Path = DEFAULT_DATA_DIR,
+    template_path: Path = DEFAULT_TEMPLATE_PATH,
+) -> Path:
+    """Create an account directory and copy the shipped config template.
+
+    The directory is created without ``exist_ok`` so a repeated command cannot
+    silently overwrite an existing account.
+    """
+    if not name or name in {".", ".."} or Path(name).name != name:
+        raise AccountError(f"недопустимое имя аккаунта: {name!r}")
+    if not template_path.is_file():
+        raise AccountError(f"шаблон конфигурации не найден: {template_path}")
+
+    account_dir = data_dir / "accounts" / name
+    try:
+        account_dir.mkdir(parents=True)
+    except FileExistsError as exc:
+        raise AccountError(
+            f"аккаунт '{name}' уже существует: {account_dir} (перезапись запрещена)"
+        ) from exc
+
+    destination = account_dir / "config.yaml"
+    try:
+        shutil.copyfile(template_path, destination)
+    except OSError:
+        # Do not leave a misleading empty account behind when copying fails.
+        try:
+            destination.unlink(missing_ok=True)
+            account_dir.rmdir()
+        except OSError:
+            # Preserve the original copy error; cleanup is best effort.
+            pass
+        raise
+    return destination
+
+
+def run_create(args: argparse.Namespace) -> bool:
+    """Create an account and return whether the command failed."""
+    try:
+        config_path = create_account(args.name)
+    except (AccountError, OSError) as exc:
+        print(f"[FAIL] {exc}")
+        return True
+
+    print(
+        f'[OK] Аккаунт "{args.name}" создан: {config_path} — '
+        "отредактируйте resume_url и параметры перед использованием."
+    )
+    return False

--- a/tests/test_account_command.py
+++ b/tests/test_account_command.py
@@ -1,0 +1,70 @@
+"""Тесты команды ``account create`` (только локальная файловая система)."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from hhru_bot.commands import account as account_cmd
+
+pytestmark = pytest.mark.unit
+
+
+def _args(name: str) -> argparse.Namespace:
+    return argparse.Namespace(name=name)
+
+
+def test_create_copies_template(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    template = tmp_path / "config" / "config.example.yaml"
+    template.parent.mkdir()
+    template.write_text(
+        "account:\n  storage_state_file: storage_state/session.json\n", encoding="utf-8"
+    )
+
+    assert account_cmd.run_create(_args("marketing")) is False
+    created = tmp_path / "data" / "accounts" / "marketing" / "config.yaml"
+    assert created.read_text(encoding="utf-8") == template.read_text(encoding="utf-8")
+    assert 'Аккаунт "marketing" создан' in capsys.readouterr().out
+
+
+def test_create_does_not_overwrite_existing_account(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    template = tmp_path / "config" / "config.example.yaml"
+    template.parent.mkdir()
+    template.write_text("new template", encoding="utf-8")
+    account_dir = tmp_path / "data" / "accounts" / "marketing"
+    account_dir.mkdir(parents=True)
+    config = account_dir / "config.yaml"
+    config.write_text("personal config", encoding="utf-8")
+
+    assert account_cmd.run_create(_args("marketing")) is True
+    assert config.read_text(encoding="utf-8") == "personal config"
+    assert "перезапись запрещена" in capsys.readouterr().out
+
+
+def test_create_rejects_path_traversal(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    template = tmp_path / "config" / "config.example.yaml"
+    template.parent.mkdir()
+    template.write_text("template", encoding="utf-8")
+
+    assert account_cmd.run_create(_args("../outside")) is True
+    assert "недопустимое имя" in capsys.readouterr().out
+
+
+def test_create_cleans_up_partial_copy(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    template = tmp_path / "config" / "config.example.yaml"
+    template.parent.mkdir()
+    template.write_text("template", encoding="utf-8")
+
+    def fail_after_partial_write(_source, destination):
+        destination.write_text("partial", encoding="utf-8")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(account_cmd.shutil, "copyfile", fail_after_partial_write)
+    with pytest.raises(OSError, match="disk full"):
+        account_cmd.create_account("marketing")
+    assert not (tmp_path / "data" / "accounts" / "marketing").exists()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -74,6 +74,7 @@ def test_all_commands_registered():
     parser = _build()
     action = _subparser_actions(parser)
     assert set(action.choices) == {
+        "account",
         "login",
         "login-code",
         "search",
@@ -119,6 +120,7 @@ def test_register_commands_returns_names():
     # (проверяется отдельно в test_all_commands_registered через action.choices).
     # Аналогично модуль list_resumes регистрирует команду 'list-resumes'.
     assert set(names) == {
+        "account",
         "login",
         "login_code",
         "search",

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -36,6 +36,7 @@ def test_cli_rejects_concurrent_write_command(tmp_path, capsys):
 
 def test_lock_covers_all_hhru_write_commands():
     assert WRITE_COMMANDS == {
+        "account",
         "apply",
         "bump",
         "run",


### PR DESCRIPTION
## Summary
- add `hhru account create <name>` to initialize a local account from the shipped config template
- refuse existing account directories and unsafe path names
- document the account setup recipe and add unit coverage

## Tests
- `pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`
- `python3 scripts/gen_cli_docs.py --check`

Closes #290