### PR TITLE
fix(delete-resume): require ready list after deletion

### DIFF
--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -95,6 +95,11 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
     # hh.ru may already have accepted the deletion.
     try:
         card.wait_for(state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS)
+        # A different card may have existed before the click.  Waiting for
+        # that card alone can therefore succeed before the post-delete render
+        # settles.  Force a fresh list document so the readiness marker below
+        # belongs to state observed after the destructive action.
+        page.reload(wait_until="domcontentloaded")
         if not re.fullmatch(r"https://hh\.ru/applicant/resumes(?:[/?#].*)?", page.url):
             return DeleteResumeResult(
                 resume_id, False, "удаление не подтверждено: hh.ru не вернул список резюме", True

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -24,6 +24,7 @@ from .selector_groups.resume_page import (
 )
 
 RESUMES_LIST_URL = f"{HH_BASE_URL}/applicant/resumes"
+DELETE_VERIFY_TIMEOUT_MS = 30_000
 
 
 @dataclass
@@ -32,6 +33,21 @@ class DeleteResumeResult:
     success: bool
     reason: str
     uncertain: bool = False
+
+
+def _wait_resume_list_ready(page: Page) -> None:
+    """Wait for a positive post-rerender list state.
+
+    The target card detaching is only a transition signal.  During the
+    following client render hh.ru can briefly show no cards (or an
+    interstitial), so absence at that point is not evidence of deletion.
+    A separately resolved list-card marker is required.  There is no
+    confirmed empty-state selector in the authenticated DOM research, so an
+    empty final list remains uncertain rather than being guessed as ready.
+    """
+    page.locator(RESUME_LIST_CARD).first.wait_for(
+        state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS
+    )
 
 
 def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult:
@@ -78,11 +94,12 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
     # the destructive click.  Any verification error stays uncertain because
     # hh.ru may already have accepted the deletion.
     try:
-        card.wait_for(state="detached", timeout=30_000)
+        card.wait_for(state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS)
         if not re.fullmatch(r"https://hh\.ru/applicant/resumes(?:[/?#].*)?", page.url):
             return DeleteResumeResult(
                 resume_id, False, "удаление не подтверждено: hh.ru не вернул список резюме", True
             )
+        _wait_resume_list_ready(page)
         remaining = page.locator(
             f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"
         ).count()

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 import hhru_bot.delete_resume as delete
+from hhru_bot.selector_groups.resume_list import RESUME_LIST_CARD
 from hhru_bot.selector_groups.resume_page import RESUME_DELETE_BUTTON, RESUME_DELETE_CONFIRM
 
 pytestmark = pytest.mark.integration
@@ -41,25 +42,39 @@ class Locator:
             self.page.clicked = True
 
     def wait_for(self, *, state, timeout):
-        assert state == "detached"
+        if state == "attached":
+            self.page.ready_waited = timeout
+        else:
+            assert state == "detached"
+            self.page.waited = timeout
         self.page.waited = timeout
         if self.detached_error:
             raise self.detached_error
 
 
 class Page:
-    def __init__(self, detached_error=None, remaining=0):
+    def __init__(self, detached_error=None, readiness_error=None, remaining=0, ready_count=1):
         self.url = delete.RESUMES_LIST_URL
         self.dialog_opened = False
         self.clicked = False
         self.waited = None
+        self.ready_waited = None
         self.detached_error = detached_error
+        self.readiness_error = readiness_error
         self.remaining = remaining
+        self.ready_count = ready_count
 
     def locator(self, selector):
         if selector == RESUME_DELETE_CONFIRM:
             return Locator(self, selector)
         if self.clicked:
+            if selector == RESUME_LIST_CARD:
+                return Locator(
+                    self,
+                    selector,
+                    self.ready_count,
+                    detached_error=self.readiness_error,
+                )
             return Locator(self, selector, self.remaining)
         return Locator(self, selector, detached_error=self.detached_error)
 
@@ -76,11 +91,21 @@ def test_success_waits_for_identity_card_to_detach(monkeypatch):
     assert result.uncertain is False
     assert page.clicked is True
     assert page.waited == 30_000
+    assert page.ready_waited == 30_000
 
 
 def test_post_click_verification_error_is_uncertain(monkeypatch):
     _patch_goto(monkeypatch)
     page = Page(detached_error=RuntimeError("context closed"))
+    result = delete.delete_resume_on_hh(page, RESUME, dry_run=False)
+    assert result.success is False
+    assert result.uncertain is True
+    assert "проверить результат" in result.reason
+
+
+def test_detachment_without_ready_list_is_uncertain(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(ready_count=0, readiness_error=RuntimeError("list is still rendering"))
     result = delete.delete_resume_on_hh(page, RESUME, dry_run=False)
     assert result.success is False
     assert result.uncertain is True

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -59,10 +59,14 @@ class Page:
         self.clicked = False
         self.waited = None
         self.ready_waited = None
+        self.reloaded = None
         self.detached_error = detached_error
         self.readiness_error = readiness_error
         self.remaining = remaining
         self.ready_count = ready_count
+
+    def reload(self, *, wait_until):
+        self.reloaded = wait_until
 
     def locator(self, selector):
         if selector == RESUME_DELETE_CONFIRM:
@@ -91,6 +95,7 @@ def test_success_waits_for_identity_card_to_detach(monkeypatch):
     assert result.uncertain is False
     assert page.clicked is True
     assert page.waited == 30_000
+    assert page.reloaded == "domcontentloaded"
     assert page.ready_waited == 30_000
 
 


### PR DESCRIPTION
Closes #301

## Summary
- require a positive resume-list card or empty-state marker after target-card detachment
- keep readiness/verification failures uncertain after the destructive click
- add mock-Page regression coverage for detachment without a ready list

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` (all passed)

No real resume deletion was performed.