### PR TITLE
feat(account): add account list command

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -48,9 +48,12 @@ WRITE_COMMANDS = frozenset(
         "resume-position",
         "resume-sections",
         "edit-skills",
-        "account",
     }
 )
+
+# Nested commands need their own classification: account create mutates local
+# files, while account list is a read-only directory scan.
+WRITE_SUBCOMMANDS = frozenset({("account", "create")})
 
 
 def register_commands(subparsers: argparse._SubParsersAction) -> list[str]:
@@ -97,7 +100,7 @@ def main(argv: list[str] | None = None) -> None:
     except AccountError as exc:
         print(f"[FAIL] {exc}")
         sys.exit(1)
-    if args.command not in WRITE_COMMANDS:
+    if not _is_write_command(args):
         return _execute(args)
 
     lock_path = Path(args.history).expanduser().resolve().parent / ".hhru.lock"
@@ -107,6 +110,18 @@ def main(argv: list[str] | None = None) -> None:
     except WriteLockBusy:
         print("[FAIL] другой процесс уже выполняет WRITE-действие")
         sys.exit(1)
+
+
+def _is_write_command(args: argparse.Namespace) -> bool:
+    """Whether this parsed command needs the write lock."""
+    return (
+        args.command in WRITE_COMMANDS
+        or (
+            args.command,
+            getattr(args, "account_command", None),
+        )
+        in WRITE_SUBCOMMANDS
+    )
 
 
 def _resolve_paths(args: argparse.Namespace) -> None:
@@ -138,7 +153,9 @@ def _execute(args: argparse.Namespace) -> None:
     # log сам ничего не логирует — ему не нужны handlers (цикл ревью #61, #58).
     # #179: то же условие решает, есть ли у логгера hhru_bot FileHandler — нужно
     # ниже ещё раз (except Exception), считаем один раз, не дублируем условие.
-    logging_enabled = args.command != "log"
+    logging_enabled = args.command != "log" and not (
+        args.command == "account" and getattr(args, "account_command", None) == "list"
+    )
     if logging_enabled:
         setup_logging(verbose=args.verbose)
 

--- a/src/hhru_bot/commands/account.py
+++ b/src/hhru_bot/commands/account.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 
 import argparse
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..accounts import AccountError
+from ..report import _ascii_table
 
 DEFAULT_DATA_DIR = Path("data")
 DEFAULT_TEMPLATE_PATH = Path("config") / "config.example.yaml"
+
+
+@dataclass(frozen=True)
+class AccountInfo:
+    """A configured local account and whether its history exists."""
+
+    name: str
+    config_path: Path
+    history_exists: bool
 
 
 def register(subparsers) -> None:
@@ -27,6 +38,48 @@ def register(subparsers) -> None:
     )
     create.add_argument("name", help="Имя нового аккаунта")
     create.set_defaults(func=run_create)
+
+    list_accounts = commands.add_parser(
+        "list",
+        help="Показать настроенные локальные аккаунты (READ)",
+    )
+    list_accounts.set_defaults(func=run_list)
+
+
+def scan_accounts(data_dir: Path = DEFAULT_DATA_DIR) -> list[AccountInfo]:
+    """Find account configs below ``data_dir/accounts`` without changing files."""
+    accounts_dir = data_dir / "accounts"
+    if not accounts_dir.is_dir():
+        return []
+
+    result: list[AccountInfo] = []
+    for config_path in sorted(accounts_dir.glob("*/config.yaml")):
+        if not config_path.is_file():
+            continue
+        account_dir = config_path.parent
+        result.append(
+            AccountInfo(
+                name=account_dir.name,
+                config_path=config_path,
+                history_exists=(account_dir / "history.db").is_file(),
+            )
+        )
+    return result
+
+
+def run_list(args: argparse.Namespace) -> None:
+    """Print configured accounts and local history presence."""
+    del args
+    accounts = scan_accounts()
+    if not accounts:
+        print("[INFO] Аккаунтов не найдено. Используйте hhru account create <name>.")
+        return
+
+    rows = [
+        [account.name, str(account.config_path), "да" if account.history_exists else "нет"]
+        for account in accounts
+    ]
+    print(_ascii_table(["name", "config_path", "history_exists"], rows))
 
 
 def create_account(

--- a/tests/test_account_command.py
+++ b/tests/test_account_command.py
@@ -68,3 +68,49 @@ def test_create_cleans_up_partial_copy(tmp_path, monkeypatch):
     with pytest.raises(OSError, match="disk full"):
         account_cmd.create_account("marketing")
     assert not (tmp_path / "data" / "accounts" / "marketing").exists()
+
+
+def test_scan_accounts_lists_configs_and_history_state(tmp_path):
+    accounts_dir = tmp_path / "data" / "accounts"
+    for name in ("zeta", "alpha"):
+        (accounts_dir / name).mkdir(parents=True)
+        (accounts_dir / name / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (accounts_dir / "alpha" / "history.db").touch()
+    (accounts_dir / "ignored").mkdir()
+    (accounts_dir / "ignored" / "notes.txt").touch()
+
+    accounts = account_cmd.scan_accounts(tmp_path / "data")
+
+    assert [(account.name, account.history_exists) for account in accounts] == [
+        ("alpha", True),
+        ("zeta", False),
+    ]
+    assert accounts[0].config_path == accounts_dir / "alpha" / "config.yaml"
+
+
+def test_scan_accounts_empty_when_directory_is_missing(tmp_path):
+    assert account_cmd.scan_accounts(tmp_path / "data") == []
+
+
+def test_run_list_prints_info_for_empty_directory(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    account_cmd.run_list(argparse.Namespace())
+
+    assert capsys.readouterr().out == (
+        "[INFO] Аккаунтов не найдено. Используйте hhru account create <name>.\n"
+    )
+
+
+def test_run_list_prints_ascii_table(tmp_path, monkeypatch, capsys):
+    account_dir = tmp_path / "data" / "accounts" / "work"
+    account_dir.mkdir(parents=True)
+    (account_dir / "config.yaml").touch()
+    monkeypatch.chdir(tmp_path)
+
+    account_cmd.run_list(argparse.Namespace())
+
+    output = capsys.readouterr().out
+    assert "| name" in output and "config_path" in output and "history_exists" in output
+    assert "| work" in output and "data/accounts/work/config.yaml" in output
+    assert "нет" in output

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from hhru_bot import cli
 from hhru_bot.cli import WRITE_COMMANDS, main
 from hhru_bot.write_lock import WriteLockBusy, acquire_write_lock
 
@@ -36,7 +37,6 @@ def test_cli_rejects_concurrent_write_command(tmp_path, capsys):
 
 def test_lock_covers_all_hhru_write_commands():
     assert WRITE_COMMANDS == {
-        "account",
         "apply",
         "bump",
         "run",
@@ -52,3 +52,23 @@ def test_lock_covers_all_hhru_write_commands():
         "resume-sections",
         "edit-skills",
     }
+
+
+def test_account_list_is_read_only_and_bypasses_lock_and_logging(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        cli,
+        "setup_logging",
+        lambda **kwargs: pytest.fail("account list must not initialize file logging"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "acquire_write_lock",
+        lambda path: pytest.fail("account list must not acquire the write lock"),
+    )
+
+    main(["account", "list"])
+
+    assert "Аккаунтов не найдено" in capsys.readouterr().out
+    assert not (tmp_path / "data").exists()


### PR DESCRIPTION
## Summary
- add read-only `hhru account list` scanning configured account directories
- show config paths and whether each local history database exists
- cover populated and empty account directories with unit tests

Closes #291

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`

## Risks
- read-only filesystem scan; no hh.ru or database access.