### PR TITLE
feat: add Codex team plugin marketplace support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "hhru",
+  "interface": {
+    "displayName": "HH.ru"
+  },
+  "plugins": [
+    {
+      "name": "hhru-cc-plugin",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/axisrow/hhru.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "hhru-cc-plugin",
+  "version": "0.1.0",
+  "description": "Safe HH.ru job-search workflows powered by the hhru CLI.",
+  "author": {
+    "name": "axisrow"
+  },
+  "homepage": "https://github.com/axisrow/hhru",
+  "repository": "https://github.com/axisrow/hhru",
+  "license": "MIT",
+  "keywords": [
+    "hh.ru",
+    "job-search",
+    "playwright",
+    "cli",
+    "vacancies",
+    "apply"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "HH.ru",
+    "shortDescription": "Safe hh.ru job-search workflows",
+    "longDescription": "Search vacancies, monitor responses, and run confirmation-gated hh.ru application workflows through the hhru CLI.",
+    "developerName": "axisrow",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/axisrow/hhru",
+    "defaultPrompt": [
+      "Use HH.ru to check my application status.",
+      "Use HH.ru to find relevant vacancies without applying."
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ codex plugin marketplace add axisrow/hhru --ref main
 ```
 
 В Codex CLI открой `/plugins`, выбери marketplace `hhru`, установи
-`hhru-cc-plugin` и начни новый чат. Public submission в OpenAI Plugins Directory
+`hhru-cc-plugin` и начни новый чат. Repo marketplace зарегистрирован в
+`.agents/plugins/marketplace.json`; public submission в OpenAI Plugins Directory
 для командной установки не требуется.
 
 ### Команда `/hhru`

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ ssh user@example.com 'cd /opt/hhru && docker compose logs -f hhru'
 login в контейнере с временно отключённым `--headless`; не передавай пароли в
 compose-файле. Обновление: `git pull && docker compose up -d --build`.
 
-## Claude Code plugin
+## Claude Code и Codex plugin
 
-Этот репозиторий — **маркетплейс** Claude Code-плагина `hhru-cc-plugin`: он
-подключает команды hhru-бота как инструменты и скиллы прямо из CC-сессии
-(оркестратор, воркеры, пользователь). Плагин — только CLI-обёртка + скиллы
-поверх существующих команд, без LLM-транспорта (у Claude Code свой LLM-доступ).
+Этот репозиторий — **маркетплейс** плагина `hhru-cc-plugin` для Claude Code и
+Codex. Он подключает команды hhru-бота как инструменты и скиллы прямо из
+агентской сессии. Плагин — только CLI-обёртка + скиллы поверх существующих
+команд, без LLM-транспорта.
 
 ### Установка
 
@@ -210,6 +210,20 @@ compose-файле. Обновление: `git pull && docker compose up -d --bu
 claude plugin marketplace add axisrow/hhru
 claude plugin install hhru-cc-plugin@hhru --scope user
 ```
+
+### Установка для команды в Codex
+
+Каждый участник устанавливает CLI, затем добавляет marketplace из проверенной
+ветки `main`:
+
+```bash
+pip install "git+https://github.com/axisrow/hhru.git@main"
+codex plugin marketplace add axisrow/hhru --ref main
+```
+
+В Codex CLI открой `/plugins`, выбери marketplace `hhru`, установи
+`hhru-cc-plugin` и начни новый чат. Public submission в OpenAI Plugins Directory
+для командной установки не требуется.
 
 ### Команда `/hhru`
 

--- a/skills/hhru-apply/SKILL.md
+++ b/skills/hhru-apply/SKILL.md
@@ -14,8 +14,8 @@ argument-hint: "[--resume <id>] [--limit N] [--vacancy-id N]"
 ## Шаг 1 — проверь готовность
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" whoami
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" list-resumes
+hhru whoami
+hhru list-resumes
 ```
 
 Если сессия невалидна — `login` (интерактивный, требует пользователя). Если
@@ -27,7 +27,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" list-resumes
 Для конкретной вакансии — диагностический дамп формы без отправки:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" probe --vacancy-id <id>
+hhru probe --vacancy-id <id>
 ```
 
 `probe` ничего не отправляет на hh.ru (submit не кликается). Полезен, чтобы
@@ -36,7 +36,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" probe --vacancy-id <id>
 ## Шаг 3 — сухой прогон (dry-run, обязательно)
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" apply --resume <id> --dry-run --limit 5
+hhru apply --resume <id> --dry-run --limit 5
 ```
 
 `--dry-run` показывает план откликов **без действия** на hh.ru. Покажи
@@ -51,7 +51,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" apply --resume <id> --dry-run --limi
 ## Шаг 4 — боевой отклик (только после подтверждения)
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" apply --resume <id> --limit 5
+hhru apply --resume <id> --limit 5
 ```
 
 Боевой запуск реально отправляет отклики. **Не запускай без явного

--- a/skills/hhru-market/SKILL.md
+++ b/skills/hhru-market/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "[--resume <id>] [--max-pages N]"
 ## Шаг 1 — собрать вакансии (search, READ)
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" search --resume <id> --dry-run --max-pages N
+hhru search --resume <id> --dry-run --max-pages N
 ```
 
 `search` собирает карточки вакансий по фильтрам из конфига и наполняет
@@ -25,7 +25,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" search --resume <id> --dry-run --max
 ## Шаг 2 — агрегаты рынка (market, READ)
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" market
+hhru market
 ```
 
 Сравнение сфер по медианной зарплате (по данным, собранным `search`). Флаг
@@ -35,7 +35,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" market
 ## Шаг 3 — точечные запросы (query, READ)
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" query "SELECT ..."
+hhru query "SELECT ..."
 ```
 
 `query` — read-only SELECT к `history.db`. Полезен для распределения ЗП,

--- a/skills/hhru-monitor/SKILL.md
+++ b/skills/hhru-monitor/SKILL.md
@@ -13,8 +13,8 @@ argument-hint: "[--resume <id>]"
 ## Статус сессии и резюме
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" whoami
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" list-resumes
+hhru whoami
+hhru list-resumes
 ```
 
 `whoami` — действительность сессии + сводка аккаунта (откликов сегодня, новых
@@ -24,7 +24,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" list-resumes
 ## Ответы работодателей
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" responses
+hhru responses
 ```
 
 Мониторинг ответов/приглашений работодателей. `--resume <id>` — по конкретному
@@ -33,7 +33,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" responses
 ## Воронка откликов
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" funnel
+hhru funnel
 ```
 
 Воронка откликов (сколько откликнулся, ответили, пригласили). `--resume <id>` —
@@ -42,7 +42,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" funnel
 ## Статистика
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" stats
+hhru stats
 ```
 
 Сводка и экспорт истории откликов. Флаг `--format csv|md|table` — формат вывода;

--- a/skills/hhru/SKILL.md
+++ b/skills/hhru/SKILL.md
@@ -15,10 +15,10 @@ argument-hint: "[задача: поиск | отклик | поднятие | с
 
 ## Как вызывать CLI
 
-Все команды запускаются через обёртку:
+Все команды запускаются через установленный CLI:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" <command> [flags]
+hhru <command> [flags]
 ```
 
 Общие флаги: `--headless`, `--verbose`, `--config <path>`, `--history <path>`,
@@ -46,9 +46,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" <command> [flags]
 
 1. **Конфиг** — `data/config.yaml` (шаблон `config/config.example.yaml`). Если
    нет — скажи пользователю скопировать шаблон и заполнить `resume_url`.
-2. **Сессия** — `bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" whoami`. Если сессия
+2. **Сессия** — `hhru whoami`. Если сессия
    невалидна — `login` (интерактивный вход, требует пользователя).
-3. **Резюме** — `bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" list-resumes`.
+3. **Резюме** — `hhru list-resumes`.
 
 ## Справочник команд
 
@@ -76,4 +76,4 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" <command> [flags]
 
 Если задача не покрыта скиллами — используй справочник команд выше и правила
 безопасности. Не выдумывай флаги, которых нет в CLI: при сомнении покажи
-`bash "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh" --help`.
+`hhru --help`.

--- a/tests/test_plugin_packaging.py
+++ b/tests/test_plugin_packaging.py
@@ -29,6 +29,25 @@ def test_codex_plugin_manifest_exposes_all_skills():
     ]
 
 
+def test_codex_repo_marketplace_points_to_the_team_plugin():
+    root = _repo_root()
+    marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
+    plugin = marketplace["plugins"][0]
+
+    assert marketplace["name"] == "hhru"
+    assert plugin["name"] == "hhru-cc-plugin"
+    assert plugin["source"] == {
+        "source": "url",
+        "url": "https://github.com/axisrow/hhru.git",
+        "ref": "main",
+    }
+    assert plugin["policy"] == {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    }
+    assert plugin["category"] == "Productivity"
+
+
 def test_shared_skills_use_the_installed_hhru_cli():
     root = _repo_root()
     skill_text = "\n".join(path.read_text() for path in (root / "skills").glob("*/SKILL.md"))

--- a/tests/test_plugin_packaging.py
+++ b/tests/test_plugin_packaging.py
@@ -1,0 +1,37 @@
+"""Smoke checks for dual Claude Code and Codex plugin packaging."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_codex_plugin_manifest_exposes_all_skills():
+    root = _repo_root()
+    manifest = json.loads((root / ".codex-plugin" / "plugin.json").read_text())
+
+    assert manifest["name"] == "hhru-cc-plugin"
+    assert manifest["skills"] == "./skills/"
+    assert manifest["interface"]["capabilities"] == ["Read", "Write"]
+    assert sorted(path.parent.name for path in (root / "skills").glob("*/SKILL.md")) == [
+        "hhru",
+        "hhru-apply",
+        "hhru-market",
+        "hhru-monitor",
+    ]
+
+
+def test_shared_skills_use_the_installed_hhru_cli():
+    root = _repo_root()
+    skill_text = "\n".join(path.read_text() for path in (root / "skills").glob("*/SKILL.md"))
+
+    assert "CLAUDE_PLUGIN_ROOT" not in skill_text
+    assert "hhru " in skill_text


### PR DESCRIPTION
## Summary
- add a native Codex plugin manifest while preserving Claude Code compatibility
- make shared skills invoke the installed canonical `hhru` CLI
- document team installation from the `main` marketplace branch
- add smoke coverage for Codex plugin packaging

## Validation
- `python3 -m ruff check src tests`
- `python3 -m ruff format --check src tests`
- `python3 -m pytest` (1209 passed, 2 deselected)
- verified the minimal plugin archive with `unzip -t`