### PR TITLE
fix(copy-resume): reconcile hydrated clone flow

### DIFF
--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -135,7 +135,11 @@ def run(args: argparse.Namespace) -> None:
             result.success = False
             result.reason = "новый resume_id не подтверждён (совпал с исходным или пуст)"
 
-    status = "dry_run" if args.dry_run else ("success" if result.success else "failed")
+    status = (
+        "dry_run"
+        if args.dry_run
+        else ("uncertain" if result.uncertain else ("success" if result.success else "failed"))
+    )
     reason = f"new_resume_id={result.new_resume_id}" if status == "success" else result.reason
     # Для action='copy_resume' нет vacancy_id (операция над резюме, не отклик) —
     # как у bump, заполняем sentinel'ом resume_id; UNIQUE-индекс actions существует
@@ -151,5 +155,6 @@ def run(args: argparse.Namespace) -> None:
         print(f"[OK] Резюме {resume.id} скопировано. Новый resume_id: {result.new_resume_id}")
         print(format_config_snippet(result.new_resume_id))
     else:
-        print(f"[FAIL] {resume.id} — {result.reason}")
+        prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
+        print(f"{prefix} {resume.id} — {result.reason}")
         sys.exit(1)

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -680,3 +680,6 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
     logger.info("Резюме '%s' скопировано, новый resume_id: %s", resume.id, new_id)
     return CopyResumeResult(resume.id, True, new_resume_id=new_id)
+
+
+# CI re-trigger after main plugin-name fix

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -536,7 +536,18 @@ def _reconcile_created_resume(
         )
 
     created_id = created.pop()
-    if url_candidate and url_candidate != created_id:
+    # Identity-bound success (#311): a bare account-wide list diff is not proof
+    # the clone was this click's product.  Without a URL candidate matching the
+    # list, the new card could be a concurrent creation (or a pre-existing
+    # unrelated resume) — recording it as the clone would write a wrong id into
+    # config.  Fail closed and let the user reconcile manually.
+    if not url_candidate:
+        return "", (
+            f"URL после дублирования не подтвердил новый resume_id, а список "
+            f"показал {created_id} — связать копию с этим кликом однозначно "
+            "нельзя (fail-closed; сверьте список резюме вручную)"
+        )
+    if url_candidate != created_id:
         return "", (
             f"URL после дублирования указывает на {url_candidate}, а список "
             f"подтвердил {created_id} — состояние копии не подтверждено "

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -75,6 +75,10 @@ class CopyResumeResult:
     success: bool
     new_resume_id: str = ""
     reason: str = ""
+    # True: копия могла быть создана, но это не подтверждено (post-WRITE, #176/#207).
+    # Записывается в actions как `uncertain`, а не `failed`, чтобы повторный запуск
+    # не выглядел безопасным (зеркалит DeleteResumeResult.uncertain, #293).
+    uncertain: bool = False
 
 
 @dataclass
@@ -649,16 +653,19 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     # click may have produced a SPA navigation without creating a resume, and
     # the URL alone does not prove that the clone is visible in the account.
     url_candidate = "" if new_id == resume.resume_id else new_id
-    new_id, reconciliation_failure = _reconcile_created_resume(page, before, url_candidate)
-    if reconciliation_failure:
-        return CopyResumeResult(resume.id, False, reason=reconciliation_failure)
-
-    if new_id == resume.resume_id:
+    try:
+        new_id, reconciliation_failure = _reconcile_created_resume(page, before, url_candidate)
+    except (NotAuthenticated, ResumeListIndeterminate, PlaywrightError) as exc:
+        # WRITE-клик уже отправлен; исключение здесь не доказывает, что копия
+        # не создана (таймаут, отзыв сессии, stale DOM) — fail-closed, uncertain.
         return CopyResumeResult(
             resume.id,
             False,
-            reason="новый resume_id совпал с исходным — копия не создана (fail-closed)",
+            uncertain=True,
+            reason=f"состояние после WRITE-клика не подтверждено: {exc} (fail-closed)",
         )
+    if reconciliation_failure:
+        return CopyResumeResult(resume.id, False, uncertain=True, reason=reconciliation_failure)
 
     logger.info("Резюме '%s' скопировано, новый resume_id: %s", resume.id, new_id)
     return CopyResumeResult(resume.id, True, new_resume_id=new_id)

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -23,7 +23,14 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, PageStateIndeterminate, goto_hh, has_auth_cookie, has_login_form
+from .browser import (
+    HH_BASE_URL,
+    RESUMES_FULL_LIST_URL,
+    PageStateIndeterminate,
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+)
 from .config import ResumeConfig
 from .negotiations_probe import parse_initial_state
 
@@ -43,7 +50,10 @@ from .selector_groups.resume_list import (
 
 logger = logging.getLogger("hhru_bot.copy_resume")
 
-RESUMES_LIST_URL = f"{HH_BASE_URL}/applicant/resumes"
+# /applicant/resumes now redirects to the profile shell.  Keep the historical
+# name as the module-level seam used by callers/tests, but point every list
+# operation at the dedicated, stable list surface (#311).
+RESUMES_LIST_URL = RESUMES_FULL_LIST_URL
 COPY_TIMEOUT_MS = 30_000
 PROFILE_STALL_SECONDS = 15.0
 PROFILE_ABSOLUTE_TIMEOUT_SECONDS = 300.0
@@ -215,7 +225,12 @@ def _wait_duplicate_action(
     обязано дать ровно одно совпадение.
     """
     more = card.locator(RESUME_LIST_ACTION_MORE)
-    duplicate = page.locator(RESUME_DUPLICATE_MENU_ITEM).or_(card.locator(RESUME_DUPLICATE_INLINE))
+    # Both menu implementations are rendered outside the target card: the
+    # opened action sheet is a portal, including the live ``resume-dublicate``
+    # variant on /applicant/my_resumes.  The target card remains identity-bound
+    # through ``more``; after that safe menu open, require exactly one global
+    # duplicate action instead of incorrectly scoping the portal to the card.
+    duplicate = page.locator(f"{RESUME_DUPLICATE_MENU_ITEM}, {RESUME_DUPLICATE_INLINE}")
     profile_ready = page.locator(RESUME_PROFILE_READY)
     menu_opened = False
     ready_seen = False
@@ -481,8 +496,49 @@ def _wait_resume_list_ready(page: Page) -> None:
     except PlaywrightTimeoutError:
         raise ResumeListIndeterminate(
             "карточки резюме не появились за отведённое время — состояние "
-            "/applicant/resumes не подтверждено"
+            f"{RESUMES_LIST_URL} не подтверждено"
         ) from None
+
+
+def _reconcile_created_resume(
+    page: Page,
+    before: set[str],
+    url_candidate: str,
+) -> tuple[str, str]:
+    """Confirm the clone in the stable list after the WRITE click (#311).
+
+    A profile URL is only a candidate: the clone request may have failed, or
+    navigation may have landed on an existing profile.  The list diff is the
+    authoritative post-action proof and must contain exactly one new id.
+    """
+    _goto_resumes_list(page, post_write=True)
+    _wait_resume_list_ready(page)
+
+    deadline = _monotonic() + COPY_TIMEOUT_MS / 1000
+    created: set[str] = set()
+    while True:
+        created = _card_hashes(page) - before
+        if len(created) == 1:
+            break
+        if _monotonic() >= deadline:
+            break
+        page.wait_for_timeout(PROFILE_POLL_MS)
+
+    if len(created) != 1:
+        return "", (
+            f"hh.ru не подтвердил создание копии (новых резюме в списке: "
+            f"{len(created)}) — состояние после WRITE-клика не подтверждено "
+            "(fail-closed)"
+        )
+
+    created_id = created.pop()
+    if url_candidate and url_candidate != created_id:
+        return "", (
+            f"URL после дублирования указывает на {url_candidate}, а список "
+            f"подтвердил {created_id} — состояние копии не подтверждено "
+            "(fail-closed)"
+        )
+    return created_id, ""
 
 
 def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
@@ -589,22 +645,13 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     except PlaywrightTimeoutError:
         logger.warning("Навигация на новое резюме не дождалась — сверяю список резюме")
 
-    if not new_id or new_id == resume.resume_id:
-        # Fallback: hh.ru мог увести не на страницу копии — сверяем список до/после.
-        # post_write=True: клик по «Дублировать» уже отправлен выше, поэтому
-        # отзыв сессии здесь — это неподтверждённое состояние копии, а не
-        # обычный pre-write отказ (Codex adversarial review, PR #158).
-        _goto_resumes_list(page, post_write=True)
-        _wait_resume_list_ready(page)
-        created = _card_hashes(page) - before
-        if len(created) != 1:
-            return CopyResumeResult(
-                resume.id,
-                False,
-                reason=f"hh.ru не подтвердил создание копии (новых резюме в списке: "
-                f"{len(created)}) — останавливаюсь (fail-closed)",
-            )
-        new_id = created.pop()
+    # URL is only a candidate.  Always reconcile against the list because the
+    # click may have produced a SPA navigation without creating a resume, and
+    # the URL alone does not prove that the clone is visible in the account.
+    url_candidate = "" if new_id == resume.resume_id else new_id
+    new_id, reconciliation_failure = _reconcile_created_resume(page, before, url_candidate)
+    if reconciliation_failure:
+        return CopyResumeResult(resume.id, False, reason=reconciliation_failure)
 
     if new_id == resume.resume_id:
         return CopyResumeResult(

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -101,7 +101,20 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
                     resume_id, False, f"не удалось открыть подтверждение: {exc}"
                 )
             page.reload(wait_until="domcontentloaded")
+            # Same commit-vs-hydration guard as above: after domcontentloaded the
+            # React card may not be attached yet, so a bare count()==0 right after
+            # the reload must not be treated as a permanent failure.
             card = page.locator(card_selector)
+            if card.count() == 0:
+                try:
+                    card.first.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
+                except PlaywrightError:
+                    return DeleteResumeResult(
+                        resume_id,
+                        False,
+                        f"карточка resume_id={resume_id} не появилась после recovery reload",
+                        False,
+                    )
             if card.count() != 1:
                 return DeleteResumeResult(
                     resume_id,

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -57,9 +57,20 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
     """
     resume_id = resume.resume_id
     goto_hh(page, RESUMES_FULL_LIST_URL)
-    card = page.locator(
+    card_selector = (
         f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"
     )
+    card = page.locator(card_selector)
+    if card.count() == 0:
+        try:
+            card.first.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
+        except PlaywrightError:
+            return DeleteResumeResult(
+                resume_id,
+                False,
+                f"карточка resume_id={resume_id} не появилась после загрузки списка",
+                False,
+            )
     if card.count() != 1:
         return DeleteResumeResult(
             resume_id, False, f"карточка resume_id={resume_id} не подтверждена однозначно", False
@@ -72,14 +83,40 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
     if dry_run:
         return DeleteResumeResult(resume_id, True, "dry-run; кнопка удаления не нажата")
 
-    try:
-        button.first.click()
-        # The confirm dialog renders asynchronously after the click (React);
-        # an immediate count() can observe the DOM before it mounts (same
-        # commit-vs-hydration race documented in create_resume.py for #304).
-        page.locator(RESUME_DELETE_CONFIRM).first.wait_for(state="visible", timeout=15000)
-    except PlaywrightError as exc:
-        return DeleteResumeResult(resume_id, False, f"не удалось открыть подтверждение: {exc}")
+    for attempt in range(2):
+        try:
+            # The action can be present in SSR while its React handler is not
+            # attached yet.  A bounded pre-click wait plus one safe reload
+            # avoids treating that hydration race as a permanent failure.
+            button.first.wait_for(state="visible", timeout=15000)
+            button.first.click()
+            # The confirm dialog renders asynchronously after the click (React);
+            # an immediate count() can observe the DOM before it mounts (same
+            # commit-vs-hydration race documented in create_resume.py for #304).
+            page.locator(RESUME_DELETE_CONFIRM).first.wait_for(state="visible", timeout=15000)
+            break
+        except PlaywrightError as exc:
+            if attempt == 1:
+                return DeleteResumeResult(
+                    resume_id, False, f"не удалось открыть подтверждение: {exc}"
+                )
+            page.reload(wait_until="domcontentloaded")
+            card = page.locator(card_selector)
+            if card.count() != 1:
+                return DeleteResumeResult(
+                    resume_id,
+                    False,
+                    f"карточка resume_id={resume_id} не подтверждена после recovery reload",
+                    False,
+                )
+            button = card.locator(RESUME_DELETE_BUTTON)
+            if button.count() != 1:
+                return DeleteResumeResult(
+                    resume_id,
+                    False,
+                    "кнопка удаления не подтверждена после recovery reload",
+                    False,
+                )
 
     confirm = page.locator(RESUME_DELETE_CONFIRM)
     if page.locator(RESUME_DELETE_HIDE_CONFIRM).count() > 1 or confirm.count() != 1:
@@ -104,9 +141,17 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
         # belongs to state observed after the destructive action.
         page.reload(wait_until="domcontentloaded")
         if not re.fullmatch(r"https://hh\.ru/applicant/my_resumes(?:[/?#].*)?", page.url):
-            return DeleteResumeResult(
-                resume_id, False, "удаление не подтверждено: hh.ru не вернул список резюме", True
-            )
+            # hh.ru may redirect a reload to the profile shell.  That route is
+            # not a valid post-delete proof; explicitly return to the stable
+            # list before deciding whether the destructive action succeeded.
+            goto_hh(page, RESUMES_FULL_LIST_URL)
+            if not re.fullmatch(r"https://hh\.ru/applicant/my_resumes(?:[/?#].*)?", page.url):
+                return DeleteResumeResult(
+                    resume_id,
+                    False,
+                    "удаление не подтверждено: hh.ru не вернул список резюме",
+                    True,
+                )
         _wait_resume_list_ready(page)
         remaining = page.locator(
             f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -304,15 +304,17 @@ def test_post_click_login_form_reports_unconfirmed_state(monkeypatch):
     # second (fallback, post-click) navigation.
     monkeypatch.setattr(cr, "has_login_form", lambda p: len(goto_calls) >= 2)
 
-    with pytest.raises(cr.NotAuthenticated) as exc_info:
-        cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
 
     assert len(goto_calls) == 2  # pre-click goto + fallback goto after the click
     assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE), ("", DUP_SEL)]
     assert page.reloads == []  # после WRITE-клика recovery категорически запрещён
-    message = str(exc_info.value)
-    assert "НЕ подтверждено" in message
-    assert "уже создана" in message
+    # Неопределённое состояние после WRITE-клика → uncertain (а не обычный
+    # failed): копия могла создаться, повтор не должен выглядеть безопасным.
+    assert result.success is False
+    assert result.uncertain is True
+    assert "НЕ подтверждено" in result.reason
+    assert "уже создана" in result.reason
 
 
 def test_pre_click_login_form_reports_ordinary_failure(monkeypatch):
@@ -639,6 +641,7 @@ def test_new_url_without_list_reconciliation_fails_closed(monkeypatch):
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
 
     assert not result.success
+    assert result.uncertain is True
     assert "не подтвердил создание копии" in result.reason
 
 
@@ -653,6 +656,7 @@ def test_url_and_list_reconciliation_mismatch_fails_closed(monkeypatch):
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
 
     assert not result.success
+    assert result.uncertain is True
     assert NEW_ID in result.reason
     assert other_id in result.reason
 
@@ -663,6 +667,7 @@ def test_no_navigation_and_no_new_card_fails(monkeypatch):
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert not result.success
+    assert result.uncertain is True
     assert result.new_resume_id == ""
 
 
@@ -672,3 +677,26 @@ def test_multiple_new_cards_ambiguous_fails(monkeypatch):
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert not result.success
+    assert result.uncertain is True
+
+
+def test_reconcile_exception_after_write_is_uncertain(monkeypatch):
+    # WRITE-клик уже отправлен, но reconcile падает (не прочитан список) — это
+    # не доказывает, что копия не создана, поэтому исход uncertain (fail-closed,
+    # зеркалит #176/#207).
+    page = StubPage(
+        card_hashes=[{OLD_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
+    _patch_env(monkeypatch, page)
+
+    def boom():
+        raise cr.ResumeListIndeterminate("список не прочитан")
+
+    monkeypatch.setattr(cr, "_wait_resume_list_ready", lambda p: boom())
+
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert not result.success
+    assert result.uncertain is True
+    assert "не подтверждено" in result.reason

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -259,7 +259,7 @@ def test_dry_run_does_not_click(monkeypatch):
 def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
     """#153: auth probe is fast, then fallback waits for rendered cards (#142)."""
     page = StubPage(
-        url_after_click=f"https://hh.ru/resume/{OLD_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}", card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}]
     )
     _patch_env(monkeypatch, page)
     page.events = []
@@ -617,18 +617,36 @@ def test_duplicate_portal_is_authorized_by_identity_bound_menu(monkeypatch):
     assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE), ("", DUP_SEL)]
 
 
-def test_url_shows_old_id_falls_back_to_list_diff(monkeypatch):
-    # Навигация привела на URL исходного резюме — новый id берём из diff списка.
+def test_url_shows_old_id_without_candidate_fails_closed(monkeypatch):
+    # Навигация привела на URL исходного резюме — url_candidate пуст. Без
+    # identity-bound привязки список мог показать чужое/конкурентное резюме как
+    # «копию»; поэтому diff без кандидата не даёт успех — fail-closed.
     page = StubPage(
         url_after_click=f"https://hh.ru/resume/{OLD_ID}",
         card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
     )
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
-    assert result.success
-    assert result.new_resume_id == NEW_ID
+    assert not result.success
+    assert result.uncertain is True
+    assert "не подтвердил новый resume_id" in result.reason
     # Список перезагружали для diff.
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
+
+
+def test_concurrent_no_navigation_diff_never_succeeds(monkeypatch):
+    # url_candidate пуст, но в diff ровно одна новая карточка. Это может быть
+    # чужое/конкурентное создание, а не продукт этого клика — success с этим id
+    # записал бы в config неверный resume_id. Должен быть uncertain.
+    page = StubPage(
+        url_after_click=f"https://hh.ru/resume/{OLD_ID}",
+        card_hashes=[{OLD_ID}, {OLD_ID, "d" * 38}],
+    )
+    _patch_env(monkeypatch, page)
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+    assert not result.success
+    assert result.uncertain is True
+    assert "однозначно нельзя" in result.reason
 
 
 def test_new_url_without_list_reconciliation_fails_closed(monkeypatch):

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -369,6 +369,7 @@ def test_duplicate_button_can_appear_after_menu_poll(monkeypatch):
     duplicate = StubLocator(None, DUP_SEL, count=0, scope=CARD_SEL)
     page = StubPage(
         dup_locators={CARD_SEL: duplicate},
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
         url_after_click=f"https://hh.ru/resume/{NEW_ID}",
     )
     page.tick_actions = [lambda: setattr(duplicate, "_count", 1)]
@@ -383,7 +384,10 @@ def test_duplicate_button_can_appear_after_menu_poll(monkeypatch):
 
 def test_profile_ready_marker_can_appear_after_ssr_card(monkeypatch):
     duplicate = StubLocator(None, DUP_SEL, count=0, scope=CARD_SEL)
-    page = StubPage(url_after_click=f"https://hh.ru/resume/{NEW_ID}")
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
     page._dup_locators[CARD_SEL] = duplicate
     page.ready_count = 0
     page.tick_actions = [
@@ -409,7 +413,10 @@ def test_profile_ready_marker_can_appear_after_ssr_card(monkeypatch):
 
 def test_hydration_error_reloads_once_then_succeeds(monkeypatch):
     duplicate = StubLocator(None, DUP_SEL, count=0, scope=CARD_SEL)
-    page = StubPage(url_after_click=f"https://hh.ru/resume/{NEW_ID}")
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
     page._dup_locators[CARD_SEL] = duplicate
     page.ready_count = 0
     page.goto_action = lambda: page.emit(
@@ -532,7 +539,10 @@ def test_unrelated_background_request_does_not_extend_stall(monkeypatch):
 
 def test_profile_resource_progress_extends_watchdog_until_ready(monkeypatch):
     duplicate = StubLocator(None, DUP_SEL, count=0, scope=CARD_SEL)
-    page = StubPage(url_after_click=f"https://hh.ru/resume/{NEW_ID}")
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
     page._dup_locators[CARD_SEL] = duplicate
     page.ready_count = 0
     profile = StubRequest("https://resume-profile-front.hh.ru/static/chunk.js")
@@ -580,7 +590,10 @@ def test_duplicate_button_ambiguous_on_page_fails_closed(monkeypatch):
 
 
 def test_success_via_url_navigation(monkeypatch):
-    page = StubPage(url_after_click=f"https://hh.ru/resume/{NEW_ID}?query=1")
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}?query=1",
+    )
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert result.success
@@ -593,6 +606,7 @@ def test_duplicate_portal_is_authorized_by_identity_bound_menu(monkeypatch):
     # обязан содержать ровно одно глобальное действие.
     page = StubPage(
         dup_locators={CARD_SEL: StubLocator(None, DUP_SEL)},
+        card_hashes=[{OLD_ID}, {OLD_ID, NEW_ID}],
         url_after_click=f"https://hh.ru/resume/{NEW_ID}",
     )
     _patch_env(monkeypatch, page)
@@ -613,6 +627,34 @@ def test_url_shows_old_id_falls_back_to_list_diff(monkeypatch):
     assert result.new_resume_id == NEW_ID
     # Список перезагружали для diff.
     assert page.gotos == [cr.RESUMES_LIST_URL, cr.RESUMES_LIST_URL]
+
+
+def test_new_url_without_list_reconciliation_fails_closed(monkeypatch):
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
+    _patch_env(monkeypatch, page)
+
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert not result.success
+    assert "не подтвердил создание копии" in result.reason
+
+
+def test_url_and_list_reconciliation_mismatch_fails_closed(monkeypatch):
+    other_id = "c" * 38
+    page = StubPage(
+        card_hashes=[{OLD_ID}, {OLD_ID, other_id}],
+        url_after_click=f"https://hh.ru/resume/{NEW_ID}",
+    )
+    _patch_env(monkeypatch, page)
+
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert not result.success
+    assert NEW_ID in result.reason
+    assert other_id in result.reason
 
 
 def test_no_navigation_and_no_new_card_fails(monkeypatch):

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page as PlaywrightPage
 
 import hhru_bot.delete_resume as delete
@@ -19,13 +20,17 @@ RESUME = SimpleNamespace(resume_id=RESUME_ID)
 
 
 class Locator:
-    def __init__(self, page, selector, count=1, detached_error=None):
+    def __init__(self, page, selector, count=1, detached_error=None, hydration=False):
         self.page = page
         self.selector = selector
         self._count = count
         self.detached_error = detached_error
+        self.hydration = hydration
 
     def count(self):
+        # Hydration locator: attached only after the recovery attached-wait.
+        if self.hydration and not self.page._recovery_hydrated:
+            return 0
         return self._count
 
     def locator(self, selector):
@@ -45,10 +50,19 @@ class Locator:
 
     def wait_for(self, *, state, timeout):
         if state == "visible":
+            if (
+                self.selector == RESUME_DELETE_CONFIRM
+                and self.page.confirm_error
+                and not self.page._confirm_failed
+            ):
+                self.page._confirm_failed = True
+                raise self.page.confirm_error
             self.page.confirm_waited = timeout
             return
         if state == "attached":
             self.page.ready_waited = timeout
+            if self.hydration:
+                self.page._recovery_hydrated = True
         else:
             assert state == "detached"
             self.page.waited = timeout
@@ -58,7 +72,14 @@ class Locator:
 
 
 class Page:
-    def __init__(self, detached_error=None, readiness_error=None, remaining=0, ready_count=1):
+    def __init__(
+        self,
+        detached_error=None,
+        readiness_error=None,
+        remaining=0,
+        ready_count=1,
+        confirm_error=None,
+    ):
         self.url = delete.RESUMES_FULL_LIST_URL
         self.dialog_opened = False
         self.clicked = False
@@ -70,9 +91,16 @@ class Page:
         self.readiness_error = readiness_error
         self.remaining = remaining
         self.ready_count = ready_count
+        self.confirm_error = confirm_error
+        self._confirm_failed = False
+        self.recovery_hydration = False
+        self._recovery_hydrated = False
 
     def reload(self, *, wait_until):
         self.reloaded = wait_until
+        # After the recovery reload the card must be re-established through the
+        # attached-wait before its count is trusted (commit-vs-hydration race).
+        self.recovery_hydration = True
 
     def locator(self, selector):
         if selector == RESUME_DELETE_CONFIRM:
@@ -86,6 +114,8 @@ class Page:
                     detached_error=self.readiness_error,
                 )
             return Locator(self, selector, self.remaining)
+        if self.recovery_hydration:
+            return Locator(self, selector, hydration=True)
         return Locator(self, selector, detached_error=self.detached_error)
 
 
@@ -121,3 +151,15 @@ def test_detachment_without_ready_list_is_uncertain(monkeypatch):
     assert result.success is False
     assert result.uncertain is True
     assert "проверить результат" in result.reason
+
+
+def test_recovery_reload_waits_for_card_hydration(monkeypatch):
+    # Первый клик подтверждения не дождался (hydration), recovery перезагрузил
+    # страницу; после reload карточка появляется только через attached-wait, а
+    # не как мгновенный count()==0 → ложный отказ «не подтверждена после
+    # recovery reload». Без фикса (голый count()==0) удаление ошибочно падало бы.
+    _patch_goto(monkeypatch)
+    page = Page(confirm_error=PlaywrightError("confirm not mounted yet"))
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+    assert result.success is True
+    assert page.reloaded == "domcontentloaded"


### PR DESCRIPTION
## Summary

Fixes #311.

The CLI could recover from a hydration failure, but then fail to find the live duplicate action or report an unconfirmed result after the write.

## Changes

- Use the stable `/applicant/my_resumes` list surface.
- Find the portal-rendered `resume-dublicate` action globally after opening the identity-bound card menu.
- Always reconcile a clone against the post-write list diff; treat the URL only as a candidate.
- Add bounded hydration recovery for delete-resume target cards and confirmation dialogs.
- Re-enter the stable list route when hh.ru reloads into the profile shell after deletion.

## Validation

- Full `pytest`
- `ruff check src tests`
- `ruff format --check src tests`
- Live CLI create -> reconcile -> delete -> reconcile for issue #311
- Live DOM verification on hh.ru