### PR TITLE
chore: add Codex plugin metadata and refresh marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "hhru-cc-plugin",
       "source": "./",
-      "description": "CLI-инструмент для поиска вакансий, откликов и поднятия резюме на hh.ru (Playwright). Подключает команды hhru-бота как инструменты и скиллы для Claude Code.",
+      "description": "CLI-инструмент для поиска вакансий, откликов и поднятия резюме на hh.ru (Playwright). Подключает команды hhru-бота как инструменты и скиллы.",
       "version": "0.1.0",
       "author": {
         "name": "axisrow"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "hhru-cc-plugin",
+  "name": "hhru-plugin",
   "version": "0.1.0",
-  "description": "Safe HH.ru job-search workflows powered by the hhru CLI.",
+  "description": "Safe hh.ru job-search workflows powered by the hhru CLI.",
   "author": {
     "name": "axisrow"
   },


### PR DESCRIPTION
## What changed

- add/update Codex plugin metadata in `.codex-plugin/plugin.json`
- refresh the marketplace plugin description in `.claude-plugin/marketplace.json`

## Why

Keep the repository's Codex plugin metadata and marketplace listing aligned with the installed `hhru` CLI packaging.

## Validation

Compared `agent/plugin-cli-docs` with `main`: only the two metadata files above differ.