### PR TITLE
refactor: consolidate hh.ru safety checks

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -11,6 +11,7 @@ import logging
 import time
 from contextlib import contextmanager
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Browser, BrowserContext, Page, sync_playwright
 from playwright.sync_api import Error as PlaywrightError
@@ -41,6 +42,49 @@ class PageStateIndeterminate(RuntimeError):
     Пустой результат нельзя выдавать за достоверный, если DOM не подтверждён
     из-за timeout, сетевой ошибки, анти-бота или дрейфа селектора.
     """
+
+
+class NotAuthenticated(PageStateIndeterminate):
+    """The current page does not prove that the hh.ru session is valid."""
+
+
+def require_authenticated_page(
+    page: Page,
+    *,
+    auth_cookie_check=None,
+    login_form_check=None,
+) -> None:
+    """Fail closed when hh.ru did not return an authenticated page.
+
+    This must be called after navigation: the login form is a server-rendered
+    positive signal, while a cookie alone only proves that it remains in the jar.
+    """
+    if not (auth_cookie_check or has_auth_cookie)(page):
+        raise NotAuthenticated(
+            "cookie hhtoken не найден — сессия истекла (запустите `login`, затем повторите)"
+        )
+    if (login_form_check or has_login_form)(page):
+        raise NotAuthenticated(
+            "страница содержит форму входа при наличии hhtoken — сессия отвергнута "
+            "сервером (запустите `login`, затем повторите)"
+        )
+
+
+def open_confirmed_resume(page: Page, resume_id: str) -> None:
+    """Navigate to and strictly confirm the requested resume identity."""
+    if not resume_id:
+        raise ValueError("resume_id is required")
+    goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
+    require_authenticated_page(page)
+    if not resume_identity_matches(page, resume_id):
+        raise ValueError("identity резюме не подтверждён")
+
+
+def resume_identity_matches(page: Page, resume_id: str) -> bool:
+    """Return whether the current URL is exactly the requested resume page."""
+    path = urlsplit(page.url).path.rstrip("/")
+    parts = [part for part in path.split("/") if part]
+    return len(parts) >= 2 and parts[-2] == "resume" and parts[-1] == resume_id
 
 
 # Потолок ожидания навигации по hh.ru. Дефолт Playwright 30с — hh.ru под

--- a/src/hhru_bot/commands/_audit.py
+++ b/src/hhru_bot/commands/_audit.py
@@ -1,0 +1,26 @@
+"""Narrow audit helpers shared by dangerous resume mutations."""
+
+from __future__ import annotations
+
+from ..history import History
+
+
+def action_status(*, dry_run: bool, success: bool, uncertain: bool = False) -> str:
+    """Map a confirmed mutation outcome to the history status vocabulary.
+
+    ``uncertain`` takes precedence over a failed result after a live click: the
+    request may have reached hh.ru and must not be reported as a safe failure.
+    Dry-runs never click, so their explicit status remains first.
+    """
+    if dry_run:
+        return "dry_run"
+    if uncertain:
+        return "uncertain"
+    return "success" if success else "failed"
+
+
+def record_resume_action(
+    history: History, resume_id: str, action: str, status: str, reason: str
+) -> None:
+    """Record an action whose target is exactly one configured resume."""
+    history.record_action(resume_id, resume_id, action, status, reason)

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ._audit import action_status, record_resume_action
 from ._common import add_common_args, resumes_from_args
 
 
@@ -56,19 +57,14 @@ def run(args: argparse.Namespace) -> None:
                 # (count_today), поэтому «просто failed» не годится: он не
                 # остановил бы повторное поднятие раньше 4ч. dry_run по
                 # определению без клика — uncertain там невозможен.
-                if args.dry_run:
-                    status = "dry_run"
-                elif result.uncertain:
-                    status = "uncertain"
-                else:
-                    status = "success" if result.success else "failed"
+                status = action_status(
+                    dry_run=args.dry_run, success=result.success, uncertain=result.uncertain
+                )
                 # Для action='bump' нет естественного vacancy_id (поднятие резюме,
                 # не отклик). actions.vacancy_id NOT NULL — заполняем resume.resume_id
                 # как sentinel; UNIQUE-индекс idx_resume_vacancy_apply существует
                 # только WHERE action='apply', так что коллизий нет.
-                history.record_action(
-                    resume.resume_id, resume.resume_id, "bump", status, result.reason
-                )
+                record_resume_action(history, resume.resume_id, "bump", status, result.reason)
 
             if result.success:
                 print(f"  [OK] {resume.id} поднято")

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -74,6 +74,7 @@ def run(args: argparse.Namespace) -> None:
     from ..copy_resume import copy_resume_on_hh
     from ..history import History
     from ..responses import NotAuthenticated
+    from ._audit import action_status, record_resume_action
 
     config = load_config_or_exit(args.config)
     try:
@@ -105,25 +106,20 @@ def run(args: argparse.Namespace) -> None:
             page = context.new_page()
             result = copy_resume_on_hh(page, resume, args.dry_run)
     except NotAuthenticated as e:
-        history.record_action(
-            resume.resume_id,
-            resume.resume_id,
-            "copy_resume",
-            "failed",
-            str(e),
-        )
+        record_resume_action(history, resume.resume_id, "copy_resume", "failed", str(e))
         print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
         sys.exit(1)
     except Exception as e:
         # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
         # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал
         # ретраи) — копия на hh.ru могла создаться, а локальной записи не будет.
-        # Пишем неуспех в аудит перед прокидыванием исключения дальше, а не молчим.
-        history.record_action(
-            resume.resume_id,
+        # Результат после возможного клика не подтверждён: это ``uncertain`,
+        # а не failed, чтобы не разрешить безопасный на вид повтор.
+        record_resume_action(
+            history,
             resume.resume_id,
             "copy_resume",
-            "failed",
+            "uncertain",
             f"исключение в браузерном шаге: {e}",
         )
         raise
@@ -135,16 +131,12 @@ def run(args: argparse.Namespace) -> None:
             result.success = False
             result.reason = "новый resume_id не подтверждён (совпал с исходным или пуст)"
 
-    status = (
-        "dry_run"
-        if args.dry_run
-        else ("uncertain" if result.uncertain else ("success" if result.success else "failed"))
-    )
+    status = action_status(dry_run=args.dry_run, success=result.success, uncertain=result.uncertain)
     reason = f"new_resume_id={result.new_resume_id}" if status == "success" else result.reason
     # Для action='copy_resume' нет vacancy_id (операция над резюме, не отклик) —
     # как у bump, заполняем sentinel'ом resume_id; UNIQUE-индекс actions существует
     # только WHERE action='apply', коллизий нет.
-    history.record_action(resume.resume_id, resume.resume_id, "copy_resume", status, reason)
+    record_resume_action(history, resume.resume_id, "copy_resume", status, reason)
 
     if args.dry_run:
         if not result.success:

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -93,6 +93,12 @@ def run(args: argparse.Namespace) -> None:
                 "Ничего не отправлено."
             )
             sys.exit(1)
+        if history.has_unresolved_uncertain(resume.resume_id, "copy_resume"):
+            print(
+                f"[FAIL] {resume.id} — предыдущее копирование не подтверждено (uncertain). "
+                "Проверьте статус резюме на hh.ru вручную перед повтором."
+            )
+            sys.exit(1)
         if history.count_today(resume.resume_id, "copy_resume") > 0:
             print(
                 f"[INFO] Уже копировали {resume.id} сегодня — "

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ._audit import action_status
 from .copy_resume import confirm_write, format_config_snippet
 
 
@@ -56,11 +57,7 @@ def run(args: argparse.Namespace) -> None:
     except Exception as exc:
         history.record_action("account", "account", "create_resume", "failed", f"исключение: {exc}")
         raise
-    status = (
-        "dry_run"
-        if dry_run
-        else ("uncertain" if result.uncertain else ("success" if result.success else "failed"))
-    )
+    status = action_status(dry_run=dry_run, success=result.success, uncertain=result.uncertain)
     history.record_action("account", "account", "create_resume", status, result.reason)
     if not result.success:
         prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"

--- a/src/hhru_bot/commands/delete_resume.py
+++ b/src/hhru_bot/commands/delete_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ._audit import action_status, record_resume_action
 from .copy_resume import confirm_write
 
 
@@ -58,25 +59,17 @@ def run(args: argparse.Namespace) -> None:
         ) as context:
             result = delete_resume_on_hh(context.new_page(), resume, dry_run)
     except NotAuthenticated as exc:
-        history.record_action(
-            resume.resume_id, resume.resume_id, "delete_resume", "failed", str(exc)
-        )
+        record_resume_action(history, resume.resume_id, "delete_resume", "failed", str(exc))
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         raise SystemExit(1) from None
     except Exception as exc:
-        history.record_action(
-            resume.resume_id, resume.resume_id, "delete_resume", "failed", f"исключение: {exc}"
+        record_resume_action(
+            history, resume.resume_id, "delete_resume", "failed", f"исключение: {exc}"
         )
         raise
 
-    status = (
-        "dry_run"
-        if dry_run
-        else ("uncertain" if result.uncertain else ("success" if result.success else "failed"))
-    )
-    history.record_action(
-        resume.resume_id, resume.resume_id, "delete_resume", status, result.reason
-    )
+    status = action_status(dry_run=dry_run, success=result.success, uncertain=result.uncertain)
+    record_resume_action(history, resume.resume_id, "delete_resume", status, result.reason)
     if not result.success:
         prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
         print(f"{prefix} {resume.id} — {result.reason}")

--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from ._audit import action_status, record_resume_action
+
 
 def register(subparsers) -> None:
     p = subparsers.add_parser(
@@ -60,10 +62,8 @@ def run(args: argparse.Namespace) -> None:
     # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
     # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
     if not args.dry_run and (result.success or result.uncertain):
-        status = "uncertain" if result.uncertain else "success"
-        history.record_action(
-            resume.resume_id, resume.resume_id, "publish_resume", status, result.reason
-        )
+        status = action_status(dry_run=False, success=result.success, uncertain=result.uncertain)
+        record_resume_action(history, resume.resume_id, "publish_resume", status, result.reason)
 
     if not result.success:
         prefix = "[FAIL]" if not result.uncertain else "[FAIL] (uncertain)"

--- a/src/hhru_bot/config_sections/_validation.py
+++ b/src/hhru_bot/config_sections/_validation.py
@@ -1,0 +1,9 @@
+"""Shared validation primitives for config sections."""
+
+from ..config import ConfigError
+
+
+def require(mapping: dict, key: str, context: str):
+    if key not in mapping or mapping[key] is None:
+        raise ConfigError(f"В конфиге отсутствует обязательное поле '{key}' ({context})")
+    return mapping[key]

--- a/src/hhru_bot/config_sections/account.py
+++ b/src/hhru_bot/config_sections/account.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import ConfigError
+from ._validation import require
 
 
 @dataclass
@@ -19,12 +20,6 @@ class AccountConfig:
     # None = пусть Playwright ставит родной UA (по умолчанию). Задайте строку,
     # только если hh.ru требует конкретный User-Agent.
     user_agent: str | None = None
-
-
-def _require(mapping: dict, key: str, context: str):
-    if key not in mapping or mapping[key] is None:
-        raise ConfigError(f"В конфиге отсутствует обязательное поле '{key}' ({context})")
-    return mapping[key]
 
 
 def parse_account(raw, base_dir: Path) -> AccountConfig:
@@ -43,7 +38,7 @@ def parse_account(raw, base_dir: Path) -> AccountConfig:
     """
     if not raw:
         raise ConfigError("В конфиге отсутствует обязательное поле 'storage_state_file' (account)")
-    storage_state_file = _require(raw, "storage_state_file", "account")
+    storage_state_file = require(raw, "storage_state_file", "account")
     # user_agent опционален: None = родной UA Playwright (никакого хардкода).
     user_agent = raw.get("user_agent")
     if user_agent is not None and not isinstance(user_agent, str):

--- a/src/hhru_bot/config_sections/search.py
+++ b/src/hhru_bot/config_sections/search.py
@@ -8,12 +8,7 @@ from __future__ import annotations
 
 from ..config import ConfigError, SearchFilters
 from ._registry import register
-
-
-def _require(mapping: dict, key: str, context: str):
-    if key not in mapping or mapping[key] is None:
-        raise ConfigError(f"В конфиге отсутствует обязательное поле '{key}' ({context})")
-    return mapping[key]
+from ._validation import require
 
 
 @register("search")
@@ -22,7 +17,7 @@ def parse_search(raw, context: str) -> SearchFilters:
     if not raw:
         raise ConfigError(f"В конфиге отсутствует обязательное поле 'search' ({context})")
     return SearchFilters(
-        text=_require(raw, "text", f"{context}.text"),
+        text=require(raw, "text", f"{context}.text"),
         area=raw.get("area"),
         salary_from=raw.get("salary_from"),
         experience=raw.get("experience"),

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -648,23 +648,24 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     assert duplicate is not None
     # Снимок для post-WRITE diff делаем только после полной pre-write готовности.
     before = _card_hashes(page)
-    duplicate.click()
-    logger.info("Клик по «Дублировать» — жду страницу нового резюме")
 
-    new_id = ""
     try:
-        page.wait_for_url(_RESUME_HASH_RE, timeout=COPY_TIMEOUT_MS)
-        m = _RESUME_HASH_RE.search(page.url)
-        if m:
-            new_id = m.group(1)
-    except PlaywrightTimeoutError:
-        logger.warning("Навигация на новое резюме не дождалась — сверяю список резюме")
+        duplicate.click()
+        logger.info("Клик по «Дублировать» — жду страницу нового резюме")
 
-    # URL is only a candidate.  Always reconcile against the list because the
-    # click may have produced a SPA navigation without creating a resume, and
-    # the URL alone does not prove that the clone is visible in the account.
-    url_candidate = "" if new_id == resume.resume_id else new_id
-    try:
+        new_id = ""
+        try:
+            page.wait_for_url(_RESUME_HASH_RE, timeout=COPY_TIMEOUT_MS)
+            m = _RESUME_HASH_RE.search(page.url)
+            if m:
+                new_id = m.group(1)
+        except PlaywrightTimeoutError:
+            logger.warning("Навигация на новое резюме не дождалась — сверяю список резюме")
+
+        # URL is only a candidate.  Always reconcile against the list because the
+        # click may have produced a SPA navigation without creating a resume, and
+        # the URL alone does not prove that the clone is visible in the account.
+        url_candidate = "" if new_id == resume.resume_id else new_id
         new_id, reconciliation_failure = _reconcile_created_resume(page, before, url_candidate)
     except (NotAuthenticated, ResumeListIndeterminate, PlaywrightError) as exc:
         # WRITE-клик уже отправлен; исключение здесь не доказывает, что копия
@@ -675,6 +676,7 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
             uncertain=True,
             reason=f"состояние после WRITE-клика не подтверждено: {exc} (fail-closed)",
         )
+
     if reconciliation_failure:
         return CopyResumeResult(resume.id, False, uncertain=True, reason=reconciliation_failure)
 

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -12,13 +12,11 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import Any, cast
-from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import HH_BASE_URL, goto_hh, has_login_form
-from .responses import NotAuthenticated
+from .browser import open_confirmed_resume, resume_identity_matches
 from .selector_groups.resume_experience import (
     EXPERIENCE_ADD_BUTTON,
     EXPERIENCE_CANCEL,
@@ -187,11 +185,6 @@ def _merge_fill_plan(
     return merged
 
 
-def _identity_matches(page: Page, resume_id: str) -> bool:
-    parts = [part for part in urlsplit(page.url).path.split("/") if part]
-    return len(parts) >= 2 and parts[-2] == "resume" and parts[-1] == resume_id
-
-
 def _fill(locator, value: str) -> None:
     if locator.count() != 1:
         raise ValueError(f"поле определяется неоднозначно ({locator.count()})")
@@ -206,11 +199,7 @@ def _read(locator) -> str:
 
 def read_experience_on_hh(page: Page, resume_id: str) -> list[ExperienceEntry]:
     """Read existing rows through their confirmed editor fields, without save."""
-    goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
-    if has_login_form(page):
-        raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
-    if not _identity_matches(page, resume_id):
-        raise ValueError("identity резюме не подтверждён")
+    open_confirmed_resume(page, resume_id)
     count = 0
     while page.locator(EXPERIENCE_EDIT_BUTTON.format(index=count)).count() == 1:
         count += 1
@@ -242,10 +231,9 @@ def edit_experience_on_hh(
     page: Page, resume_id: str, plan: ExperiencePlan, *, dry_run: bool, indexes=None
 ):
     """Apply a plan to one or more rows; return a list of textual results."""
-    goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
-    if has_login_form(page):
-        raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
-    if not _identity_matches(page, resume_id):
+    try:
+        open_confirmed_resume(page, resume_id)
+    except ValueError:
         return ["identity резюме не подтверждён"]
     if plan.used_fallback and not plan.entries:
         return [plan.reason or "LLM не предложил безопасных изменений"]
@@ -293,7 +281,7 @@ def edit_experience_on_hh(
                     )
                 except PlaywrightError as exc:
                     return results + [f"строка {index}: сохранение не подтверждено: {exc}"]
-                if not _identity_matches(page, resume_id):
+                if not resume_identity_matches(page, resume_id):
                     return results + [f"строка {index}: после save identity резюме не подтверждён"]
                 results.append(f"строка {index}: сохранено")
         except (PlaywrightError, ValueError) as exc:

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -82,8 +82,8 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         raise ValueError("max_pages must be >= 1")
 
     # Lazy imports avoid a module cycle while responses.py recovers topics.
-    from .browser import goto_hh, has_auth_cookie, has_login_form
-    from .responses import NEGOTIATIONS_URL, NotAuthenticated, _has_next_page
+    from .browser import goto_hh, require_authenticated_page
+    from .responses import NEGOTIATIONS_URL, _has_next_page
 
     refs: list[TopicRef] = []
     for page_num in range(max_pages):
@@ -96,15 +96,7 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         # диагностируемого NotAuthenticated — тот же класс ошибки, что и
         # пустой inbox, но с другой причиной, которую вызывающий код не
         # должен путать с завершённой пагинацией.
-        if not has_auth_cookie(page):
-            raise NotAuthenticated(
-                "cookie hhtoken не найден — сессия истекла (запустите `login`, затем повторите)"
-            )
-        if has_login_form(page):
-            raise NotAuthenticated(
-                "страница содержит форму входа при наличии hhtoken — сессия отвергнута "
-                "сервером (запустите `login`, затем повторите)"
-            )
+        require_authenticated_page(page)
         refs.extend(topic_refs(page.content()))
         try:
             has_next = _has_next_page(page, page_num)

--- a/src/hhru_bot/publish_resume.py
+++ b/src/hhru_bot/publish_resume.py
@@ -16,7 +16,12 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import open_confirmed_resume, require_authenticated_page, resume_identity_matches
+from .browser import (
+    NotAuthenticated,
+    open_confirmed_resume,
+    require_authenticated_page,
+    resume_identity_matches,
+)
 from .config import ResumeConfig
 from .selector_groups.resume_page import (
     RESUME_PUBLISH_BUTTON,
@@ -249,7 +254,12 @@ def publish_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> Pub
                     uncertain=True,
                 )
             after = parse_resume_state(page.content(), resume.resume_id)
-        except PlaywrightError as exc:
+        except (PlaywrightError, NotAuthenticated) as exc:
+            # После клика сессия могла быть отвергнута при reload (страница
+            # вернула форму входа). Клик уже ушёл, поэтому это серая зона —
+            # uncertain, а не утечка NotAuthenticated наружу (иначе команда
+            # вышла бы [FAIL] без записи uncertain-аудита и позволила бы
+            # бездумный повтор --force поверх уже состоявшейся публикации).
             return PublishResumeResult(
                 resume.id,
                 False,

--- a/src/hhru_bot/publish_resume.py
+++ b/src/hhru_bot/publish_resume.py
@@ -11,15 +11,13 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, goto_hh, has_login_form
+from .browser import open_confirmed_resume, require_authenticated_page, resume_identity_matches
 from .config import ResumeConfig
-from .responses import NotAuthenticated
 from .selector_groups.resume_page import (
     RESUME_PUBLISH_BUTTON,
     RESUME_PUBLISH_BUTTON_DATA_QA,
@@ -28,7 +26,6 @@ from .selector_groups.resume_page import (
 
 logger = logging.getLogger("hhru_bot.publish_resume")
 PUBLISH_TIMEOUT_MS = 30_000
-_RESUME_URL_RE = re.compile(r"/resume/([^/?#]+)")
 
 
 @dataclass
@@ -113,12 +110,6 @@ def _state_from_mapping(record: dict, scheme: dict | None = None) -> ResumePubli
     )
 
 
-def _identity_matches(page: Page, resume_id: str) -> bool:
-    path = urlsplit(page.url).path.rstrip("/")
-    match = _RESUME_URL_RE.fullmatch(path) or _RESUME_URL_RE.search(path)
-    return bool(match and match.group(1) == resume_id)
-
-
 def _visibility_text(page: Page) -> str:
     """Read visibility control text only; never click the visibility control."""
     locator = page.locator(RESUME_VISIBILITY_BUTTON)
@@ -129,11 +120,9 @@ def _visibility_text(page: Page) -> str:
 
 def publish_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> PublishResumeResult:
     """Inspect one config resume and optionally click its publish button."""
-    url = f"{HH_BASE_URL}/resume/{resume.resume_id}"
-    goto_hh(page, url)
-    if has_login_form(page):
-        raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
-    if not _identity_matches(page, resume.resume_id):
+    try:
+        open_confirmed_resume(page, resume.resume_id)
+    except ValueError:
         return PublishResumeResult(resume.id, False, "identity резюме не подтверждён")
 
     state = parse_resume_state(page.content(), resume.resume_id)
@@ -251,7 +240,8 @@ def publish_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> Pub
         # One read-only reload revalidates server state before we report failure.
         try:
             page.reload(wait_until="domcontentloaded")
-            if not _identity_matches(page, resume.resume_id):
+            require_authenticated_page(page)
+            if not resume_identity_matches(page, resume.resume_id):
                 return PublishResumeResult(
                     resume.id,
                     False,

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -27,10 +27,11 @@ from playwright.sync_api import Page
 
 from .browser import (
     HH_BASE_URL,
-    PageStateIndeterminate,
+    NotAuthenticated,  # noqa: F401
     goto_hh,
     has_auth_cookie,
     has_login_form,
+    require_authenticated_page,
 )
 from .selector_groups import negotiations as ns
 
@@ -42,14 +43,6 @@ NEGOTIATIONS_URL = f"{HH_BASE_URL}/applicant/negotiations"
 # рендера hh.ru; если за это время карточек нет — считаем страницу пустой/селектор
 # устаревшим (см. fetch_responses). Не бесконечно, чтобы обход не зависал.
 RENDER_TIMEOUT_MS = 10_000
-
-
-class NotAuthenticated(PageStateIndeterminate):
-    """Сессия hh.ru истекла: страница переговоров не подтверждает auth-cookie.
-
-    fetch_responses поднимает это, чтобы команда responses НЕ трактовала пустой
-    результат выгруженной сессии как «нет новых ответов» и НЕ затирала историю.
-    """
 
 
 class ResponsesIndeterminate(RuntimeError):
@@ -345,20 +338,9 @@ def fetch_responses(page: Page, max_pages: int = 5) -> list[ResponseItem]:
 
         # Проверяем единый auth-маркер до чтения DOM: пустая страница без cookie
         # не должна маскироваться под пустой inbox.
-        if not has_auth_cookie(page):
-            raise NotAuthenticated(
-                "cookie hhtoken не найден — сессия истекла (запустите `login`, затем повторите)"
-            )
-
-        # A stale/revoked hhtoken can remain in the jar.  The login form is a
-        # server-rendered positive indication that hh.ru rejected the session;
-        # URL checks are deliberately excluded because they rejected valid
-        # sessions in #140/#145.
-        if has_login_form(page):
-            raise NotAuthenticated(
-                "страница содержит форму входа при наличии hhtoken — сессия отвергнута "
-                "сервером (запустите `login`, затем повторите)"
-            )
+        require_authenticated_page(
+            page, auth_cookie_check=has_auth_cookie, login_form_check=has_login_form
+        )
 
         # DOMContentLoaded приходит раньше JS-карточек. Перед count() ждём attached
         # ограниченное время: так delayed-render карточки попадают в обход. У

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -15,7 +15,13 @@ import pytest
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot import browser
-from hhru_bot.browser import GOTO_TIMEOUT_MS, goto_hh
+from hhru_bot.browser import (
+    GOTO_TIMEOUT_MS,
+    NotAuthenticated,
+    goto_hh,
+    open_confirmed_resume,
+    require_authenticated_page,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -162,6 +168,34 @@ def test_has_auth_cookie_false_on_empty_cookies():
     page.context.cookies.return_value = []
 
     assert browser.has_auth_cookie(page) is False
+
+
+def test_require_authenticated_page_rejects_missing_cookie():
+    page = MagicMock(name="Page")
+    page.context.cookies.return_value = []
+    with pytest.raises(NotAuthenticated, match="hhtoken"):
+        require_authenticated_page(page)
+
+
+def test_require_authenticated_page_rejects_login_form_with_cookie(monkeypatch):
+    page = MagicMock(name="Page")
+    page.context.cookies.return_value = [{"name": "hhtoken"}]
+    monkeypatch.setattr(browser, "has_login_form", lambda page: True)
+    with pytest.raises(NotAuthenticated, match="форму входа"):
+        require_authenticated_page(page)
+
+
+def test_open_confirmed_resume_checks_auth_and_identity(monkeypatch):
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/123"
+    page.context.cookies.return_value = [{"name": "hhtoken"}]
+    monkeypatch.setattr(browser, "goto_hh", lambda page, url: None)
+    monkeypatch.setattr(browser, "has_login_form", lambda page: False)
+    open_confirmed_resume(page, "123")
+
+    page.url = "https://hh.ru/resume/other"
+    with pytest.raises(ValueError, match="identity"):
+        open_confirmed_resume(page, "123")
 
 
 def test_browser_has_no_legacy_url_auth_checker():

--- a/tests/test_command_audit.py
+++ b/tests/test_command_audit.py
@@ -1,0 +1,37 @@
+"""Shared audit primitives for dangerous CLI mutations (#308)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.commands._audit import action_status, record_resume_action
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("dry_run", "success", "uncertain", "expected"),
+    [
+        (True, True, False, "dry_run"),
+        (True, False, True, "dry_run"),
+        (False, True, False, "success"),
+        (False, False, False, "failed"),
+        (False, False, True, "uncertain"),
+    ],
+)
+def test_action_status_preserves_uncertain_after_a_live_click(
+    dry_run, success, uncertain, expected
+):
+    assert action_status(dry_run=dry_run, success=success, uncertain=uncertain) == expected
+
+
+def test_record_resume_action_uses_resume_as_the_audit_scope(tmp_path):
+    history = History(tmp_path / "history.db")
+    record_resume_action(
+        history, "resume-1", "copy_resume", "uncertain", "click may have reached hh.ru"
+    )
+
+    with history._connect() as conn:
+        row = conn.execute("SELECT resume_id, vacancy_id, action, status FROM actions").fetchone()
+    assert tuple(row) == ("resume-1", "resume-1", "copy_resume", "uncertain")

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -256,6 +256,30 @@ def test_dry_run_does_not_click(monkeypatch):
     assert page.gotos == [cr.RESUMES_LIST_URL]
 
 
+def test_duplicate_click_error_is_uncertain(monkeypatch):
+    class ErrorDuplicate(StubLocator):
+        @property
+        def first(self):
+            return self
+
+        def click(self, timeout=None):
+            raise PlaywrightError("navigation interrupted")
+
+    page = StubPage(
+        dup_locators={
+            "": ErrorDuplicate(None, DUP_SEL),
+            CARD_SEL: ErrorDuplicate(None, DUP_SEL),
+        }
+    )
+    _patch_env(monkeypatch, page)
+
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert result.success is False
+    assert result.uncertain is True
+    assert "не подтверждено" in result.reason
+
+
 def test_goto_hh_ready_selector_and_login_check_order(monkeypatch):
     """#153: auth probe is fast, then fallback waits for rendered cards (#142)."""
     page = StubPage(

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -210,3 +210,22 @@ def test_run_browser_exception_still_records_audit_then_reraises(env, tmp_path, 
         ).fetchone()
     assert row["status"] == "uncertain"
     assert "исключение в браузерном шаге" in row["reason"]
+
+
+def test_run_uncertain_blocks_subsequent_copy(env, tmp_path, monkeypatch, capsys):
+    # Regression test for Codex finding: uncertain copy results must block retries.
+    # Если есть unresolved uncertain запись, следующий run должен fail с explicit error,
+    # а не позволять повторный клик который создаст дубликат резюме на hh.ru.
+    h = History(tmp_path / "h.db")
+    # Сначала записываем uncertain (как будто предыдущий клик мог уйти)
+    h.record_action(
+        OLD_ID, OLD_ID, "copy_resume", "uncertain", "состояние после WRITE-клика не подтверждено"
+    )
+    # Пытаемся запустить снова — должен быть rejected
+    with pytest.raises(SystemExit) as exc:
+        cmd.run(_args(tmp_path, force=True))
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "не подтверждено (uncertain)" in out
+    assert env.calls == []  # до браузера не дошло

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -190,7 +190,7 @@ def test_run_repeat_today_warns(env, capsys, tmp_path):
 def test_run_browser_exception_still_records_audit_then_reraises(env, tmp_path, monkeypatch):
     # Клик по «Дублировать» уже мог уйти на hh.ru раньше, чем упало исключение
     # (например, goto_hh при diff-fallback исчерпал ретраи) — не должны молчать
-    # локально о попытке: пишем failed в actions ДО того, как исключение улетит
+    # локально о попытке: пишем uncertain в actions ДО того, как исключение улетит
     # дальше (#132 review: без этого возможна копия на hh.ru без локальной записи).
     def raising_copy(page, resume, dry_run):
         env.calls.append((resume.id, dry_run))
@@ -202,11 +202,11 @@ def test_run_browser_exception_still_records_audit_then_reraises(env, tmp_path, 
         cmd.run(_args(tmp_path, force=True))
 
     h = History(tmp_path / "h.db")
-    assert h.count_today(OLD_ID, "copy_resume") == 0  # status='failed', не success
+    assert h.count_today(OLD_ID, "copy_resume") == 1  # uncertain расходует лимит fail-closed
     with h._connect() as conn:
         row = conn.execute(
             "SELECT status, reason FROM actions WHERE resume_id = ? AND action = 'copy_resume'",
             (OLD_ID,),
         ).fetchone()
-    assert row["status"] == "failed"
+    assert row["status"] == "uncertain"
     assert "исключение в браузерном шаге" in row["reason"]

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from playwright.sync_api import Error as PlaywrightError
 
@@ -55,6 +57,7 @@ class _Page:
         self.clicked = 0
         self.reloaded = 0
         self.url = f"https://hh.ru/resume/{RESUME_ID}"
+        self.context = SimpleNamespace(cookies=lambda: [{"name": "hhtoken"}])
 
     def content(self):
         return self.markup
@@ -86,8 +89,13 @@ def _markup(**overrides):
 
 def _run(page, monkeypatch, *, preserve_url=False):
     goto = (lambda page, url: None) if preserve_url else lambda page, url: setattr(page, "url", url)
-    monkeypatch.setattr(publish, "goto_hh", goto)
-    monkeypatch.setattr(publish, "has_login_form", lambda page: False)
+
+    def open_confirmed(page, resume_id):
+        goto(page, f"https://hh.ru/resume/{resume_id}")
+        if preserve_url:
+            raise ValueError("identity резюме не подтверждён")
+
+    monkeypatch.setattr(publish, "open_confirmed_resume", open_confirmed)
     return publish.publish_resume_on_hh(page, _resume(), dry_run=False)
 
 
@@ -204,8 +212,11 @@ def test_publish_rejects_missing_or_ambiguous_button(monkeypatch):
 
 def test_publish_dry_run_never_clicks(monkeypatch):
     page = _Page(_markup())
-    monkeypatch.setattr(publish, "goto_hh", lambda page, url: setattr(page, "url", url))
-    monkeypatch.setattr(publish, "has_login_form", lambda page: False)
+    monkeypatch.setattr(
+        publish,
+        "open_confirmed_resume",
+        lambda page, resume_id: setattr(page, "url", f"https://hh.ru/resume/{resume_id}"),
+    )
     result = publish.publish_resume_on_hh(page, _resume(), dry_run=True)
     assert result.success
     assert page.clicked == 0

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -4,6 +4,7 @@ import pytest
 from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.publish_resume as publish
+from hhru_bot.browser import NotAuthenticated
 from hhru_bot.config import ResumeConfig, SearchFilters
 from hhru_bot.publish_resume import parse_resume_state
 
@@ -267,3 +268,26 @@ def test_publish_pre_click_rejection_is_not_uncertain(monkeypatch):
     result = _run(page, monkeypatch)
     assert not result.success
     assert result.uncertain is False
+
+
+def test_publish_reload_session_rejection_after_click_is_uncertain(monkeypatch):
+    # #308: клик по кнопке публикации состоялся, но read-only reload после
+    # клика выявил, что сессия отвергнута (страница отдала форму входа).
+    # require_authenticated_page поднимает NotAuthenticated (RuntimeError),
+    # который раньше утекал мимо `except PlaywrightError` наружу, и команда
+    # выходила без записи uncertain-аудита — повторный --force мог бы
+    # опубликовать поверх уже состоявшейся публикации. Теперь это fail-closed
+    # серая зона: uncertain=True, а не необработанное исключение.
+    class _AuthRejectedPage(_Page):
+        def reload(self, wait_until=None):
+            super().reload(wait_until=wait_until)
+            raise NotAuthenticated("сессия отвергнута сервером")
+
+    page = _AuthRejectedPage(_markup(status="not_finished"))
+    page.after_markup = _markup(status="not_finished", isSearchable=False)
+    monkeypatch.setattr(publish, "PUBLISH_TIMEOUT_MS", 1)
+    result = _run(page, monkeypatch)
+    assert not result.success
+    assert result.uncertain is True
+    assert "не подтверждён" in result.reason
+    assert page.clicked == 1


### PR DESCRIPTION
Closes #308

## Summary
- centralize authenticated-page validation and preserve the responses exception re-export
- centralize strict resume navigation and identity checks for experience and publish-resume
- share narrow mutation-audit status and resume-scoped recording helpers across create, delete, copy, publish, and bump commands
- preserve `uncertain` for post-click copy failures and consolidate config required-field validation

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`