### PR TITLE
perf(tests): reduce pytest suite below 20s

### DIFF
--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -34,6 +34,18 @@ pytestmark = pytest.mark.integration
 _V1, _V2 = "111111", "222222"
 
 
+@pytest.fixture(autouse=True)
+def _mock_navigation_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep retry semantics while skipping production backoff sleeps.
+
+    The fake pages deliberately exhaust ``goto_hh`` retries in several
+    fail-closed cases.  Sleeping for the real 2s + 4s backoff per attempt adds
+    no coverage here: the navigation/retry assertions still execute with a
+    no-op clock.
+    """
+    monkeypatch.setattr("hhru_bot.browser.time.sleep", lambda _seconds: None)
+
+
 @pytest.mark.parametrize(
     ("reads", "expected"),
     [

--- a/tests/test_live_browser_guard.py
+++ b/tests/test_live_browser_guard.py
@@ -34,6 +34,7 @@ F. `async_playwright` — отдельный контекст-менеджер �
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -214,6 +215,10 @@ def test_engine_is_blocked_during_collection(tmp_path: Path) -> None:
 
     marker = tmp_path / "outcome.txt"
     sample = Path(__file__).parent / "test_zz_collection_sample_tmp.py"
+    env = os.environ.copy()
+    # The child only needs pytest core + this repository's conftest.  Avoid
+    # loading unrelated third-party plugins for every collection-guard check.
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     sample.write_text(
         textwrap.dedent(
             f"""
@@ -245,6 +250,7 @@ def test_engine_is_blocked_during_collection(tmp_path: Path) -> None:
             cwd=Path(__file__).parent.parent,
             capture_output=True,
             timeout=180,
+            env=env,
             check=False,
         )
     finally:


### PR DESCRIPTION
Closes #323

## Summary
- Mock `goto_hh` retry backoff sleeps in `test_apply_verify.py`; retry attempts and fail-closed assertions remain intact.
- Disable unrelated auto-loaded third-party pytest plugins in the collection-guard child process; the guard still exercises a real child pytest collection.

## Performance
Measured locally with `pytest -q --durations=0`:

| Test | Before | After |
|---|---:|---:|
| `test_indeterminate_when_goto_fails` | 12.14s | <0.005s |
| `test_indeterminate_when_page1_goto_fails` | 12.02s | <0.005s |
| `test_confirmed_incomplete_attempt_not_masked_by_clean_retry` | 6.01s | <0.005s |
| `test_engine_is_blocked_during_collection` | 1.57s | 0.30s |
| `test_without_dry_run_still_invokes_dangerous_marker` | 0.78s | 0.77s |

- Full suite: **46.66s / 1231 tests** → **10.83s / 1231 tests**.
- No test cases removed or weakened; only test clocks/subprocess plugin loading are optimized.

## Verification
- `pytest -q --durations=0` — 1231 tests, 10.83s, all passed
- `ruff check tests/test_apply_verify.py tests/test_live_browser_guard.py`
- `ruff format --check tests/test_apply_verify.py tests/test_live_browser_guard.py`
