### PR TITLE
fix: classify macOS sandbox Chromium launch failures

### DIFF
--- a/skills/hhru/SKILL.md
+++ b/skills/hhru/SKILL.md
@@ -50,6 +50,20 @@ hhru <command> [flags]
    невалидна — `login` (интерактивный вход, требует пользователя).
 3. **Резюме** — `hhru list-resumes`.
 
+## Диагностика sandbox Codex
+
+Если запуск headed Chromium завершается с маркером
+`CODEX_SANDBOX_BROWSER_FAILURE` или в выводе есть сочетание
+`Operation not permitted`, `Crashpad`, `NSApplication` или
+`NSMenuBarPresentationInstance`, это проблема разрешений sandbox среды
+исполнения Codex, а не Chromium, Playwright, hh.ru или сессии аккаунта.
+
+В этом случае не переустанавливай Chromium и не объявляй багом проекта:
+повтори ту же read-only-команду с elevated/system permission. Если elevated
+запуск недоступен, используй `hhru --headless <command>` как безопасный
+обход. Сообщи пользователю, что причина классифицирована как
+`CODEX_SANDBOX_BROWSER_FAILURE`.
+
 ## Справочник команд
 
 | Команда | Природа | Что делает |

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from playwright.sync_api import sync_playwright
 
 from .account_profile import read_account_profile
-from .browser import GOTO_TIMEOUT_MS, HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
+from .browser import (
+    GOTO_TIMEOUT_MS,
+    HH_BASE_URL,
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+    launch_browser,
+)
 from .config import AppConfig
 
 logger = logging.getLogger("hhru_bot.auth")
@@ -29,10 +36,7 @@ def login(config: AppConfig, history_path: str | Path = Path("data/history.db"))
     storage_state_file.parent.mkdir(parents=True, exist_ok=True)
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(
-            headless=False,
-            args=["--disable-blink-features=AutomationControlled"],
-        )
+        browser = launch_browser(p, headless=False)
         context_kwargs: dict = {
             "viewport": {"width": 1366, "height": 900},
             "locale": "ru-RU",

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -48,6 +48,7 @@ def launch_browser(playwright, *, headless: bool) -> Browser:
             ) from exc
         raise
 
+
 HH_BASE_URL = "https://hh.ru"
 # /applicant/resumes redirects to the profile shell; the dedicated list at
 # /applicant/my_resumes is the stable read-only surface used by both

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -19,6 +19,35 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 logger = logging.getLogger("hhru_bot.browser")
 
+
+class BrowserLaunchError(RuntimeError):
+    """Actionable browser-start failure for the CLI/agent boundary."""
+
+
+def launch_browser(playwright, *, headless: bool) -> Browser:
+    """Launch Chromium and classify macOS sandbox failures for the CLI."""
+    try:
+        return playwright.chromium.launch(
+            headless=headless,
+            args=["--disable-blink-features=AutomationControlled"],
+        )
+    except PlaywrightError as exc:
+        details = str(exc)
+        sandbox_markers = (
+            "Operation not permitted",
+            "Crashpad",
+            "NSApplication",
+            "NSMenuBarPresentationInstance",
+        )
+        if not headless and any(marker in details for marker in sandbox_markers):
+            raise BrowserLaunchError(
+                "CODEX_SANDBOX_BROWSER_FAILURE: headed Chromium was blocked by "
+                "the execution sandbox (macOS GUI/Crashpad permission). "
+                "Retry this same command with elevated system permission; "
+                "for read-only work, use 'hhru --headless ...'."
+            ) from exc
+        raise
+
 HH_BASE_URL = "https://hh.ru"
 # /applicant/resumes redirects to the profile shell; the dedicated list at
 # /applicant/my_resumes is the stable read-only surface used by both
@@ -160,10 +189,7 @@ def launch_context(
         # --disable-blink-features=AutomationControlled убирает главный флаг, по
         # которому hh.ru (DDoS-Guard) держит кнопку входа disabled в Playwright.
         # Приём из YAMAKAYAMACO/hh-autoresponder (рабочий против hh.ru).
-        browser: Browser = p.chromium.launch(
-            headless=headless,
-            args=["--disable-blink-features=AutomationControlled"],
-        )
+        browser: Browser = launch_browser(p, headless=headless)
         context_kwargs: dict = {
             "viewport": {"width": 1366, "height": 900},
             "locale": "ru-RU",

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
+from .browser import BrowserLaunchError
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
 
@@ -168,6 +169,9 @@ def _execute(args: argparse.Namespace) -> None:
         # deleted-row count) or None must not be mistaken for a failure.
         if failed is True:
             sys.exit(1)
+    except BrowserLaunchError as exc:
+        print(f"[ENVIRONMENT] {exc}", file=sys.stderr)
+        sys.exit(1)
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")
         sys.exit(130)


### PR DESCRIPTION
## Summary
- `launch_browser()` in `browser.py` wraps `p.chromium.launch()` and detects the sandbox permission failure that blocks headed Chromium under the Codex execution sandbox on macOS (markers: `Operation not permitted`, `Crashpad`, `NSApplication`, `NSMenuBarPresentationInstance`).
- Instead of a raw Playwright crash, it raises `BrowserLaunchError` with an actionable message.
- `cli.py` catches `BrowserLaunchError` and prints a clear `[ENVIRONMENT]` diagnostic instead of a stack trace.
- `auth.py`'s `login()` now goes through the same helper so classification applies there too.
- `skills/hhru/SKILL.md` documents the failure signature and workaround (retry with elevated permission, or fall back to `--headless` for read-only commands) so agents don't misdiagnose this as a Chromium/Playwright/hh.ru/session bug.

## Test plan
- [ ] `ruff check` / `ruff format --check`
- [ ] Manual: trigger sandboxed headed launch and confirm `[ENVIRONMENT] CODEX_SANDBOX_BROWSER_FAILURE...` message instead of raw traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzrNRPbUt1DgvEWLfbewCS