### PR TITLE
fix: wait for dedicated edit route before querying resume position/skills forms

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -1,9 +1,10 @@
 """LLM planning and browser editing for the resume position block (#259).
 
-The browser side deliberately uses only selectors confirmed by the live probe in
-issue #268.  In particular, editing is inline on ``/resume/<id>``; there is no
-``/edit`` route.  The save button is kept behind the command's explicit write
-confirmation and is never clicked by the dry-run path.
+The browser side deliberately uses only selectors confirmed by the live probe.
+Opening the position editor navigates to its dedicated ``/resume/edit/<id>/position``
+route, so its form must not be queried until that navigation has committed (#328).
+The save button is kept behind the command's explicit write confirmation and is
+never clicked by the dry-run path.
 """
 
 from __future__ import annotations
@@ -235,6 +236,10 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
         if page.locator(EDIT).count() != 1:
             raise RuntimeError("кнопка редактирования позиции не подтверждена")
         page.locator(EDIT).click()
+        # This is a client-side route change, not an inline editor.  Waiting
+        # for the route before the form prevents inspecting the old DOM during
+        # the transition (#328).
+        page.wait_for_url(f"**/resume/edit/{resume.resume_id}/position", wait_until="commit")
         page.locator(FORM).wait_for(state="visible", timeout=10_000)
     form_values = read_position(page)
     return PositionValues(

--- a/src/hhru_bot/selector_groups/resume_page.py
+++ b/src/hhru_bot/selector_groups/resume_page.py
@@ -20,13 +20,16 @@ RESUME_PUBLISH_BUTTON_DATA_QA = "[data-qa='resume-publish']"
 RESUME_VISIBILITY_BUTTON = "button:has-text('Изменить видимость')"
 
 # Inline editor selectors confirmed by the authenticated read-only research in
-# issue #268.  The about section is not available at /resume/{id}/edit.
+# issue #268.  NOTE: #268 called this section inline (no /edit route), but #328
+# found the same claim false for the neighbouring position/skills editors on
+# this same profile page — this claim is unaudited against #328's finding and
+# should not be trusted until re-verified on live DOM (see #328 follow-up).
 RESUME_EDIT_ABOUT_BUTTON = "[data-qa='resume-edit-button-about']"
 RESUME_ABOUT_EDITOR = "[data-qa='resume-editor-about']"
 RESUME_ABOUT_NO_EXPERIENCE_REASON = "[data-qa^='resume-editor-about-no-experience-reason-']"
 
-# Skills are edited inline on /resume/{id}; /resume/{id}/edit is not a route
-# (confirmed by the authenticated read-only probe for issue #268).
+# The profile-page control routes to /resume/edit/{id}/keySkills before the
+# editor is mounted (authenticated live audit, #328).
 RESUME_SKILLS_EDIT_BUTTON = "[data-qa='skills-add']"
 RESUME_SKILLS_INPUT = "[data-qa='resume-editor-skills-input']"
 RESUME_SKILLS_CHIP_INPUT = "[data-qa='chips-trigger-input']"

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -130,7 +130,7 @@ def edit_skills_on_hh(
     dry_run: bool,
     mode: str,
 ) -> SkillsResult:
-    """Open the confirmed inline editor; save only when the caller authorized it."""
+    """Open the confirmed skills editor; save only when the caller authorized it."""
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     if not has_auth_cookie(page) or has_login_form(page):
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
@@ -138,11 +138,13 @@ def edit_skills_on_hh(
     if trigger.count() != 1:
         return SkillsResult(False, reason="кнопка редактирования навыков не найдена однозначно")
     trigger.click()
+    # #328: wait for the dedicated keySkills route before querying the editor.
     editor = page.locator(resume_page.RESUME_SKILLS_INPUT)
     try:
+        page.wait_for_url(f"**/resume/edit/{resume.resume_id}/keySkills", wait_until="commit")
         editor.wait_for(state="visible")
     except PlaywrightError:
-        return SkillsResult(False, reason="inline-форма навыков не открылась")
+        return SkillsResult(False, reason="форма навыков не открылась после перехода")
     existing = read_skills(page)
     existing_keys = {skill.casefold() for skill in existing}
     additions = tuple(skill for skill in skills if skill.name.casefold() not in existing_keys)

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -1,5 +1,9 @@
+from unittest.mock import MagicMock
+
 import pytest
 
+import hhru_bot.resume_position as resume_position
+from hhru_bot.config import bare_resume
 from hhru_bot.resume_position import (
     PositionValues,
     build_position_prompt,
@@ -64,3 +68,29 @@ def test_fill_mode_preserves_existing_values():
     assert merged.employment is None
     assert merged.business_trips is None
     assert merged.salary == 100000
+
+
+def test_open_position_form_waits_for_dedicated_editor_route(monkeypatch):
+    """#328: the edit click leaves /resume/<id> before the form is mounted."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    edit = MagicMock()
+    edit.count.return_value = 1
+    form = MagicMock()
+    form.count.return_value = 0
+    page.locator.side_effect = lambda selector: {
+        resume_position.EDIT: edit,
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+
+    resume_position.open_position_form(page, resume)
+
+    edit.click.assert_called_once_with()
+    page.wait_for_url.assert_called_once_with(
+        "**/resume/edit/resume-id/position", wait_until="commit"
+    )
+    form.wait_for.assert_called_once_with(state="visible", timeout=10_000)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from hhru_bot.skills import build_skills_prompt, parse_manual_skills, parse_skill_plan
+import hhru_bot.skills as skills_module
+from hhru_bot.config import bare_resume
+from hhru_bot.skills import (
+    Skill,
+    build_skills_prompt,
+    edit_skills_on_hh,
+    parse_manual_skills,
+    parse_skill_plan,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -36,3 +46,33 @@ def test_prompt_mentions_existing_skills_and_mode() -> None:
     prompt = build_skills_prompt("Python backend", ("Git",), "append")
     assert "Git" in prompt[1]["content"]
     assert "до-заполнения" in prompt[1]["content"]
+
+
+def test_edit_skills_waits_for_dedicated_editor_route(monkeypatch) -> None:
+    """#328: skills editor is mounted only after the keySkills route commits."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    editor.input_value.return_value = ""
+    cancel = MagicMock()
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "read_skills", lambda _page: ())
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is True
+    page.wait_for_url.assert_called_once_with(
+        "**/resume/edit/resume-id/keySkills", wait_until="commit"
+    )
+    editor.wait_for.assert_called_once_with(state="visible")


### PR DESCRIPTION
## Что делает

Фиксит навигационную race condition (#328): клик по кнопке редактирования блока "Желаемая профессия и условия" или "Навыки" на `/resume/{id}` не рендерит форму inline, а уводит на отдельный route (`/resume/edit/{id}/position` и `/resume/edit/{id}/keySkills` соответственно). Прежний код (по неверному допущению из #268) сразу ждал видимость формы без ожидания навигации — в реальном прогоне это приводило к таймауту и `[FAIL]` даже при полностью рабочем UI.

`open_position_form()` и `edit_skills_on_hh()` теперь дожидаются `page.wait_for_url(..., wait_until="commit")` перед строгой проверкой видимости формы — паттерн, уже используемый в проекте для аналогичных навигационных кликов (`apply/steps.py` и др., см. CLAUDE.md).

Подтверждено вручную на живом DOM (аутентифицированная сессия, реальный черновик резюме).

## Что НЕ делает

Это покрывает 2 из 8 файлов, перечисленных в #328 как кандидаты на такой же аудит (`resume_position.py`, `skills.py`). Остальные 6 (`about.py`, `bump.py`, `create_resume.py`, `delete_resume.py`, `apply/steps.py`, `commands/clear_negotiations.py`) не тронуты — PR не закрывает #328.

Отдельно: комментарий над `RESUME_EDIT_ABOUT_BUTTON` в `selector_groups/resume_page.py`, до сих пор ссылающийся на утверждение #268 "inline editor, no /edit route", помечен как неаудированный — точно такое же утверждение для соседних `position`/`skills`-редакторов той же страницы только что оказалось неверным. Поведение `about.py` не менял без отдельной живой проверки.

## Тесты

- Добавлены unit-тесты на новый `wait_for_url` вызов в обеих функциях (мок Playwright `Page`).
- `pytest -q` — всё зелёное (обычный прогон, live-категории не задействованы).
- `ruff check` / `ruff format --check` — чисто.

Refs #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)