### PR TITLE
fix(resume): retry edit controls after hydration

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -13,6 +13,7 @@ import json
 import re
 from dataclasses import asdict, dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -237,16 +238,17 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
         # The server-rendered trigger is visible before React attaches its
         # click handler.  A click in that window is a no-op on live hh.ru, so
         # retry once only when the positive form marker did not appear (#337).
+        profile_path = f"/resume/{resume.resume_id}"
         for attempt in range(2):
             trigger = page.locator(EDIT)
             if trigger.count() != 1:
                 raise RuntimeError("кнопка редактирования позиции не подтверждена")
             trigger.click()
             try:
-                page.locator(FORM).wait_for(state="visible", timeout=10_000)
+                page.locator(FORM).wait_for(state="visible", timeout=30_000)
                 break
             except PlaywrightError as exc:
-                if attempt:
+                if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                     raise RuntimeError("форма редактирования позиции не открылась") from exc
     form_values = read_position(page)
     return PositionValues(

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -14,6 +14,7 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from .browser import HH_BASE_URL, goto_hh, has_login_form
@@ -233,14 +234,20 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
         raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
     current = read_display_position(page)
     if page.locator(FORM).count() == 0:
-        if page.locator(EDIT).count() != 1:
-            raise RuntimeError("кнопка редактирования позиции не подтверждена")
-        page.locator(EDIT).click()
-        # This is a client-side route change, not an inline editor.  Waiting
-        # for the route before the form prevents inspecting the old DOM during
-        # the transition (#328).
-        page.wait_for_url(f"**/resume/edit/{resume.resume_id}/position", wait_until="commit")
-        page.locator(FORM).wait_for(state="visible", timeout=10_000)
+        # The server-rendered trigger is visible before React attaches its
+        # click handler.  A click in that window is a no-op on live hh.ru, so
+        # retry once only when the positive form marker did not appear (#337).
+        for attempt in range(2):
+            trigger = page.locator(EDIT)
+            if trigger.count() != 1:
+                raise RuntimeError("кнопка редактирования позиции не подтверждена")
+            trigger.click()
+            try:
+                page.locator(FORM).wait_for(state="visible", timeout=10_000)
+                break
+            except PlaywrightError as exc:
+                if attempt:
+                    raise RuntimeError("форма редактирования позиции не открылась") from exc
     form_values = read_position(page)
     return PositionValues(
         title=form_values.title or current.title,

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -239,6 +239,7 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
         # click handler.  A click in that window is a no-op on live hh.ru, so
         # retry once only when the positive form marker did not appear (#337).
         profile_path = f"/resume/{resume.resume_id}"
+        edit_path = f"/resume/edit/{resume.resume_id}/position"
         for attempt in range(2):
             trigger = page.locator(EDIT)
             if trigger.count() != 1:
@@ -250,6 +251,12 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
             except PlaywrightError as exc:
                 if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                     raise RuntimeError("форма редактирования позиции не открылась") from exc
+        # A visible FORM alone does not prove it belongs to `resume.resume_id` —
+        # hh.ru routes the editor to its own dedicated edit route, so require
+        # that route as a post-condition (#337 follow-up: the pre-#337
+        # wait_for_url enforced this binding and must not be dropped with it).
+        if urlsplit(page.url).path.rstrip("/") != edit_path:
+            raise RuntimeError("форма редактирования позиции открыта не для того резюме")
     form_values = read_position(page)
     return PositionValues(
         title=form_values.title or current.title,

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -234,12 +234,12 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
     if has_login_form(page):
         raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
     current = read_display_position(page)
+    edit_path = f"/resume/edit/{resume.resume_id}/position"
     if page.locator(FORM).count() == 0:
         # The server-rendered trigger is visible before React attaches its
         # click handler.  A click in that window is a no-op on live hh.ru, so
         # retry once only when the positive form marker did not appear (#337).
         profile_path = f"/resume/{resume.resume_id}"
-        edit_path = f"/resume/edit/{resume.resume_id}/position"
         for attempt in range(2):
             trigger = page.locator(EDIT)
             if trigger.count() != 1:
@@ -251,12 +251,14 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
             except PlaywrightError as exc:
                 if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                     raise RuntimeError("форма редактирования позиции не открылась") from exc
-        # A visible FORM alone does not prove it belongs to `resume.resume_id` —
-        # hh.ru routes the editor to its own dedicated edit route, so require
-        # that route as a post-condition (#337 follow-up: the pre-#337
-        # wait_for_url enforced this binding and must not be dropped with it).
-        if urlsplit(page.url).path.rstrip("/") != edit_path:
-            raise RuntimeError("форма редактирования позиции открыта не для того резюме")
+    # A visible FORM alone does not prove it belongs to `resume.resume_id` —
+    # hh.ru always routes this editor to its own dedicated edit route (never
+    # mounts inline, confirmed by the #328 live audit), so require that route
+    # as a post-condition unconditionally, including when the form was
+    # already mounted before this call (#337 follow-up: the pre-#337
+    # wait_for_url enforced this binding and must not be dropped with it).
+    if urlsplit(page.url).path.rstrip("/") != edit_path:
+        raise RuntimeError("форма редактирования позиции открыта не для того резюме")
     form_values = read_position(page)
     return PositionValues(
         title=form_values.title or current.title,

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -134,17 +134,20 @@ def edit_skills_on_hh(
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     if not has_auth_cookie(page) or has_login_form(page):
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
-    trigger = page.locator(resume_page.RESUME_SKILLS_EDIT_BUTTON)
-    if trigger.count() != 1:
-        return SkillsResult(False, reason="кнопка редактирования навыков не найдена однозначно")
-    trigger.click()
-    # #328: wait for the dedicated keySkills route before querying the editor.
     editor = page.locator(resume_page.RESUME_SKILLS_INPUT)
-    try:
-        page.wait_for_url(f"**/resume/edit/{resume.resume_id}/keySkills", wait_until="commit")
-        editor.wait_for(state="visible")
-    except PlaywrightError:
-        return SkillsResult(False, reason="форма навыков не открылась после перехода")
+    # As with position (#337), the visible SSR trigger can precede React event
+    # hydration.  Only the editor becoming visible confirms that a click worked.
+    for attempt in range(2):
+        trigger = page.locator(resume_page.RESUME_SKILLS_EDIT_BUTTON)
+        if trigger.count() != 1:
+            return SkillsResult(False, reason="кнопка редактирования навыков не найдена однозначно")
+        trigger.click()
+        try:
+            editor.wait_for(state="visible", timeout=10_000)
+            break
+        except PlaywrightError:
+            if attempt:
+                return SkillsResult(False, reason="форма навыков не открылась")
     existing = read_skills(page)
     existing_keys = {skill.casefold() for skill in existing}
     additions = tuple(skill for skill in skills if skill.name.casefold() not in existing_keys)

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -138,6 +138,7 @@ def edit_skills_on_hh(
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
     editor = page.locator(resume_page.RESUME_SKILLS_INPUT)
     profile_path = f"/resume/{resume.resume_id}"
+    edit_path = f"/resume/edit/{resume.resume_id}/keySkills"
     # As with position (#337), the visible SSR trigger can precede React event
     # hydration.  Only the editor becoming visible confirms that a click worked.
     for attempt in range(2):
@@ -151,6 +152,12 @@ def edit_skills_on_hh(
         except PlaywrightError:
             if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                 return SkillsResult(False, reason="форма навыков не открылась")
+    # A visible editor alone does not prove it belongs to `resume.resume_id` —
+    # hh.ru routes the editor to its own dedicated edit route, so require that
+    # route as a post-condition (#337 follow-up: the pre-#337 wait_for_url
+    # enforced this binding and must not be dropped with it).
+    if urlsplit(page.url).path.rstrip("/") != edit_path:
+        return SkillsResult(False, reason="форма навыков открыта не для того резюме")
     existing = read_skills(page)
     existing_keys = {skill.casefold() for skill in existing}
     additions = tuple(skill for skill in skills if skill.name.casefold() not in existing_keys)

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -6,6 +6,7 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -17,6 +18,7 @@ from .selector_groups import resume_page
 logger = logging.getLogger("hhru_bot.skills")
 
 LEVELS = frozenset(("basic", "intermediate", "advanced"))
+EDITOR_MOUNT_TIMEOUT_MS = 30_000
 
 
 @dataclass(frozen=True)
@@ -135,6 +137,7 @@ def edit_skills_on_hh(
     if not has_auth_cookie(page) or has_login_form(page):
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
     editor = page.locator(resume_page.RESUME_SKILLS_INPUT)
+    profile_path = f"/resume/{resume.resume_id}"
     # As with position (#337), the visible SSR trigger can precede React event
     # hydration.  Only the editor becoming visible confirms that a click worked.
     for attempt in range(2):
@@ -143,10 +146,10 @@ def edit_skills_on_hh(
             return SkillsResult(False, reason="кнопка редактирования навыков не найдена однозначно")
         trigger.click()
         try:
-            editor.wait_for(state="visible", timeout=10_000)
+            editor.wait_for(state="visible", timeout=EDITOR_MOUNT_TIMEOUT_MS)
             break
         except PlaywrightError:
-            if attempt:
+            if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                 return SkillsResult(False, reason="форма навыков не открылась")
     existing = read_skills(page)
     existing_keys = {skill.casefold() for skill in existing}

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -70,14 +70,17 @@ def test_fill_mode_preserves_existing_values():
     assert merged.salary == 100000
 
 
-def test_open_position_form_waits_for_dedicated_editor_route(monkeypatch):
-    """#328: the edit click leaves /resume/<id> before the form is mounted."""
+def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
+    """#337: an SSR anchor has no handler until hydration, and URL stays put."""
     resume = bare_resume("resume-id")
     page = MagicMock()
     edit = MagicMock()
     edit.count.return_value = 1
     form = MagicMock()
     form.count.return_value = 0
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    form.wait_for.side_effect = [PlaywrightTimeoutError("not hydrated"), None]
     page.locator.side_effect = lambda selector: {
         resume_position.EDIT: edit,
         resume_position.FORM: form,
@@ -89,8 +92,6 @@ def test_open_position_form_waits_for_dedicated_editor_route(monkeypatch):
 
     resume_position.open_position_form(page, resume)
 
-    edit.click.assert_called_once_with()
-    page.wait_for_url.assert_called_once_with(
-        "**/resume/edit/resume-id/position", wait_until="commit"
-    )
-    form.wait_for.assert_called_once_with(state="visible", timeout=10_000)
+    assert edit.click.call_count == 2
+    assert form.wait_for.call_count == 2
+    page.wait_for_url.assert_not_called()

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -135,12 +135,14 @@ def test_open_position_form_rejects_form_on_wrong_resume_route(monkeypatch):
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
     monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
-    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+    read_position = MagicMock(return_value=PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", read_position)
 
     with pytest.raises(
         RuntimeError, match="форма редактирования позиции открыта не для того резюме"
     ):
         resume_position.open_position_form(page, resume)
+    read_position.assert_not_called()
 
 
 def test_open_position_form_accepts_correct_edit_route_on_first_attempt(monkeypatch):
@@ -194,9 +196,11 @@ def test_open_position_form_rejects_already_mounted_form_on_wrong_route(monkeypa
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
     monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
-    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+    read_position = MagicMock(return_value=PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", read_position)
 
     with pytest.raises(
         RuntimeError, match="форма редактирования позиции открыта не для того резюме"
     ):
         resume_position.open_position_form(page, resume)
+    read_position.assert_not_called()

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -74,6 +74,7 @@ def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     """#337: an SSR anchor has no handler until hydration, and URL stays put."""
     resume = bare_resume("resume-id")
     page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
     edit = MagicMock()
     edit.count.return_value = 1
     form = MagicMock()
@@ -94,4 +95,5 @@ def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
 
     assert edit.click.call_count == 2
     assert form.wait_for.call_count == 2
+    form.wait_for.assert_called_with(state="visible", timeout=30_000)
     page.wait_for_url.assert_not_called()

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -81,7 +81,18 @@ def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     form.count.return_value = 0
     from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-    form.wait_for.side_effect = [PlaywrightTimeoutError("not hydrated"), None]
+    form.wait_for.side_effect = [
+        PlaywrightTimeoutError("not hydrated"),
+        None,
+    ]
+
+    def click_side_effect():
+        # The second attempt's click is the one that actually hydrates and
+        # commits the dedicated edit route.
+        if edit.click.call_count == 2:
+            page.url = "https://hh.ru/resume/edit/resume-id/position"
+
+    edit.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
         resume_position.EDIT: edit,
         resume_position.FORM: form,
@@ -97,3 +108,36 @@ def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     assert form.wait_for.call_count == 2
     form.wait_for.assert_called_with(state="visible", timeout=30_000)
     page.wait_for_url.assert_not_called()
+
+
+def test_open_position_form_rejects_form_on_wrong_resume_route(monkeypatch):
+    """#337 follow-up: a visible form must belong to the requested resume_id.
+
+    The pre-#337 code enforced this via ``wait_for_url`` before querying the
+    form. Dropping that wait must not drop the invariant it protected: a
+    visible ``FORM`` on an unexpected edit route (e.g. hh.ru routed the click
+    to a different resume) must still fail closed instead of being read as
+    the requested resume's position.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    # The form is visible, but the committed route belongs to a different resume.
+    page.url = "https://hh.ru/resume/edit/other-resume-id/position"
+    edit = MagicMock()
+    edit.count.return_value = 1
+    form = MagicMock()
+    form.count.return_value = 0
+    form.wait_for.return_value = None
+    page.locator.side_effect = lambda selector: {
+        resume_position.EDIT: edit,
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+
+    with pytest.raises(
+        RuntimeError, match="форма редактирования позиции открыта не для того резюме"
+    ):
+        resume_position.open_position_form(page, resume)

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -141,3 +141,62 @@ def test_open_position_form_rejects_form_on_wrong_resume_route(monkeypatch):
         RuntimeError, match="форма редактирования позиции открыта не для того резюме"
     ):
         resume_position.open_position_form(page, resume)
+
+
+def test_open_position_form_accepts_correct_edit_route_on_first_attempt(monkeypatch):
+    """Positive counterpart: the post-condition must accept the real edit route.
+
+    Pins the check against `edit_path` specifically — a check comparing
+    against `profile_path` (or any other constant) instead would either
+    reject this legitimate first-attempt success or accept the wrong-route
+    cases the tests above cover, so this test and those must both pass only
+    together with the correct comparison.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/position"
+    edit = MagicMock()
+    edit.count.return_value = 1
+    form = MagicMock()
+    form.count.return_value = 0
+    form.wait_for.return_value = None
+    page.locator.side_effect = lambda selector: {
+        resume_position.EDIT: edit,
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+
+    resume_position.open_position_form(page, resume)
+
+    assert edit.click.call_count == 1
+    assert form.wait_for.call_count == 1
+
+
+def test_open_position_form_rejects_already_mounted_form_on_wrong_route(monkeypatch):
+    """The route post-condition must not be bypassable via a pre-mounted form.
+
+    When ``FORM.count() != 0`` the whole click/retry block is skipped
+    entirely. If the page happens to already show a position form for a
+    different resume (stale editor state, unexpected redirect), that form
+    must still be rejected, not read as the requested resume's position.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/other-resume-id/position"
+    form = MagicMock()
+    form.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+
+    with pytest.raises(
+        RuntimeError, match="форма редактирования позиции открыта не для того резюме"
+    ):
+        resume_position.open_position_form(page, resume)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -154,3 +154,39 @@ def test_edit_skills_rejects_editor_on_wrong_resume_route(monkeypatch) -> None:
 
     assert result.success is False
     assert result.reason == "форма навыков открыта не для того резюме"
+
+
+def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) -> None:
+    """Positive counterpart: the post-condition must accept the real edit route.
+
+    Pins the check against the resume's ``keySkills`` edit path specifically
+    — a check comparing against the profile path (or any other constant)
+    instead would either reject this legitimate first-attempt success or
+    accept the wrong-route case above, so this test and that one must both
+    pass only together with the correct comparison.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/keySkills"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    cancel = MagicMock()
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "read_skills", lambda _page: ())
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is True
+    assert trigger.click.call_count == 1
+    assert editor.wait_for.call_count == 1

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -146,7 +146,8 @@ def test_edit_skills_rejects_editor_on_wrong_resume_route(monkeypatch) -> None:
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
-    monkeypatch.setattr(skills_module, "read_skills", lambda _page: ())
+    read_skills = MagicMock(return_value=())
+    monkeypatch.setattr(skills_module, "read_skills", read_skills)
 
     result = edit_skills_on_hh(
         page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
@@ -154,6 +155,8 @@ def test_edit_skills_rejects_editor_on_wrong_resume_route(monkeypatch) -> None:
 
     assert result.success is False
     assert result.reason == "форма навыков открыта не для того резюме"
+    read_skills.assert_not_called()
+    cancel.click.assert_not_called()
 
 
 def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -61,6 +61,14 @@ def test_edit_skills_retries_pre_hydration_noop_click(monkeypatch) -> None:
 
     editor.wait_for.side_effect = [PlaywrightTimeoutError("not hydrated"), None]
     cancel = MagicMock()
+
+    def click_side_effect():
+        # The second attempt's click is the one that actually hydrates and
+        # commits the dedicated edit route.
+        if trigger.click.call_count == 2:
+            page.url = "https://hh.ru/resume/edit/resume-id/keySkills"
+
+    trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
@@ -111,3 +119,38 @@ def test_edit_skills_does_not_retry_after_navigation_to_editor(monkeypatch) -> N
 
     assert result.success is False
     assert trigger.click.call_count == 1
+
+
+def test_edit_skills_rejects_editor_on_wrong_resume_route(monkeypatch) -> None:
+    """#337 follow-up: a visible editor must belong to the requested resume_id.
+
+    The pre-#337 code enforced this via ``wait_for_url`` before querying the
+    editor. Dropping that wait must not drop the invariant it protected: a
+    visible editor on an unexpected edit route must still fail closed instead
+    of reading/writing skills into the wrong resume.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    # The editor is visible, but the committed route belongs to a different resume.
+    page.url = "https://hh.ru/resume/edit/other-resume-id/keySkills"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    cancel = MagicMock()
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "read_skills", lambda _page: ())
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is False
+    assert result.reason == "форма навыков открыта не для того резюме"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -48,14 +48,17 @@ def test_prompt_mentions_existing_skills_and_mode() -> None:
     assert "до-заполнения" in prompt[1]["content"]
 
 
-def test_edit_skills_waits_for_dedicated_editor_route(monkeypatch) -> None:
-    """#328: skills editor is mounted only after the keySkills route commits."""
+def test_edit_skills_retries_pre_hydration_noop_click(monkeypatch) -> None:
+    """#337: a visible SSR trigger can receive a no-op click before hydration."""
     resume = bare_resume("resume-id")
     page = MagicMock()
     trigger = MagicMock()
     trigger.count.return_value = 1
     editor = MagicMock()
     editor.input_value.return_value = ""
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    editor.wait_for.side_effect = [PlaywrightTimeoutError("not hydrated"), None]
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
@@ -72,7 +75,6 @@ def test_edit_skills_waits_for_dedicated_editor_route(monkeypatch) -> None:
     )
 
     assert result.success is True
-    page.wait_for_url.assert_called_once_with(
-        "**/resume/edit/resume-id/keySkills", wait_until="commit"
-    )
-    editor.wait_for.assert_called_once_with(state="visible")
+    assert trigger.click.call_count == 2
+    assert editor.wait_for.call_count == 2
+    page.wait_for_url.assert_not_called()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -52,6 +52,7 @@ def test_edit_skills_retries_pre_hydration_noop_click(monkeypatch) -> None:
     """#337: a visible SSR trigger can receive a no-op click before hydration."""
     resume = bare_resume("resume-id")
     page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
     trigger = MagicMock()
     trigger.count.return_value = 1
     editor = MagicMock()
@@ -77,4 +78,36 @@ def test_edit_skills_retries_pre_hydration_noop_click(monkeypatch) -> None:
     assert result.success is True
     assert trigger.click.call_count == 2
     assert editor.wait_for.call_count == 2
+    editor.wait_for.assert_called_with(state="visible", timeout=30_000)
     page.wait_for_url.assert_not_called()
+
+
+def test_edit_skills_does_not_retry_after_navigation_to_editor(monkeypatch) -> None:
+    """A slow editor mount after navigation is not a hydration no-op (#337)."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    def navigate_then_timeout(**_kwargs):
+        page.url = "https://hh.ru/resume/edit/resume-id/keySkills"
+        raise PlaywrightTimeoutError("editor is still mounting")
+
+    editor.wait_for.side_effect = navigate_then_timeout
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is False
+    assert trigger.click.call_count == 1


### PR DESCRIPTION
## Summary
- Replace route-only waits after the desired-position and skills edit triggers with the positive editor-form visibility marker.
- Retry exactly once when the initial click lands before React event hydration; retain fail-closed behavior if the form never appears.
- Add regressions for the live SSR-anchor/no-op-click case.

Closes #337

## Verification
- `pytest -q` — passed
- `ruff check src tests` — passed
- `ruff format --check src tests` — passed
- Live dry-runs on training resume `35661…684c54` passed for `resume-position` and `edit-skills`; no mutations were saved.
