### PR TITLE
feat(apply): stop runs on anti-bot challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,10 @@ Account-wide ответы в чатах: план из локальной ист
   Python + Playwright. Ценно: паттерн персистентной сессии (`state.json`)
   — ручной вход в видимом браузере один раз, затем headless (обход
   блокировки после закрытия API).
+- [semernyakov/hh-auto-apply](https://github.com/semernyakov/hh-auto-apply) —
+  Python + синхронный Playwright, MIT. Ценно: парсер cooldown поднятия
+  резюме из текстов hh.ru («через N ч M мин», «сегодня/завтра в HH:MM»),
+  который можно адаптировать для точного вывода времени в `bump`.
 - [beatwad/XX_Auto_Jobs_Applier](https://github.com/beatwad/XX_Auto_Jobs_Applier)
   — Python + Playwright, MIT. Ценно: config-driven архитектура (YAML) и
   приём решения капчи через Telegram.

--- a/src/hhru_bot/apply/antibot.py
+++ b/src/hhru_bot/apply/antibot.py
@@ -18,13 +18,24 @@ from playwright.sync_api import Page
 _CHALLENGE_PATH_SEGMENTS = frozenset({"captcha", "checkpoint", "nocaptcha"})
 
 # Exact, visible challenge controls from the audited references.  Generic
-# ``[data-qa*='captcha']`` / ``[class*='captcha']`` selectors are intentionally
-# excluded: dormant templates and unrelated vacancy markup could otherwise halt
-# a healthy run (the failure mode is still only a hypothesis, #344).
+# ``[data-qa*='captcha']`` / ``[class*='captcha']`` substring selectors are
+# intentionally excluded: dormant templates and unrelated vacancy markup could
+# otherwise halt a healthy run (the failure mode is still only a hypothesis,
+# #344). Vendor mount points below are a different case: ``.g-recaptcha`` /
+# ``.h-captcha`` and the recaptcha/hcaptcha iframe ``src`` are exact,
+# vendor-specific markers (not a bare "captcha" substring on arbitrary
+# elements), named explicitly in the issue #344 reference implementation
+# (docs/research/reference-selector-diff-audit.md). They carry the same
+# ``filter(visible=True)`` guard as the HH-specific markers, so a dormant
+# template does not trip them either.
 ANTIBOT_MARKER_SELECTORS: tuple[tuple[str, str], ...] = (
     ("captcha_data_qa", "[data-qa='captcha']"),
     ("account_captcha_input", "[data-qa='account-captcha-input']"),
     ("account_captcha_picture", "[data-qa='account-captcha-picture']"),
+    ("recaptcha_iframe", 'iframe[src*="recaptcha" i]'),
+    ("hcaptcha_iframe", 'iframe[src*="hcaptcha" i]'),
+    ("recaptcha_widget", ".g-recaptcha"),
+    ("hcaptcha_widget", ".h-captcha"),
 )
 
 

--- a/src/hhru_bot/apply/antibot.py
+++ b/src/hhru_bot/apply/antibot.py
@@ -22,15 +22,9 @@ _CHALLENGE_PATH_SEGMENTS = frozenset({"captcha", "checkpoint", "nocaptcha"})
 # excluded: dormant templates and unrelated vacancy markup could otherwise halt
 # a healthy run (the failure mode is still only a hypothesis, #344).
 ANTIBOT_MARKER_SELECTORS: tuple[tuple[str, str], ...] = (
-    ("recaptcha_iframe", 'iframe[src*="recaptcha" i]'),
-    ("hcaptcha_iframe", 'iframe[src*="hcaptcha" i]'),
-    ("captcha_iframe", 'iframe[src*="captcha" i]'),
-    ("captcha_iframe_title", 'iframe[title*="captcha" i]'),
     ("captcha_data_qa", "[data-qa='captcha']"),
     ("account_captcha_input", "[data-qa='account-captcha-input']"),
     ("account_captcha_picture", "[data-qa='account-captcha-picture']"),
-    ("google_recaptcha", ".g-recaptcha"),
-    ("hcaptcha", ".h-captcha"),
 )
 
 

--- a/src/hhru_bot/apply/antibot.py
+++ b/src/hhru_bot/apply/antibot.py
@@ -95,3 +95,10 @@ def detect_antibot_on_page(page: Page) -> AntiBotDetection | None:
         except (AttributeError, PlaywrightError):
             continue
     return detect_antibot_challenge(url=url, visible_markers=visible)
+
+
+def raise_for_antibot(page: Page) -> None:
+    """Raise the terminal command signal when the narrow detector confirms it."""
+
+    if detection := detect_antibot_on_page(page):
+        raise AntiBotChallengeDetected(detection)

--- a/src/hhru_bot/apply/antibot.py
+++ b/src/hhru_bot/apply/antibot.py
@@ -1,0 +1,97 @@
+"""Narrow anti-bot challenge detection for apply runs (#344).
+
+This module only detects and reports a challenge.  It never attempts to solve,
+submit, or bypass one.  Detection deliberately uses exact URL path segments and
+visible, challenge-specific DOM markers: a bare ``captcha`` substring elsewhere
+in the page markup or vacancy title is not evidence and must not stop a run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+
+_CHALLENGE_PATH_SEGMENTS = frozenset({"captcha", "checkpoint", "nocaptcha"})
+
+# Exact, visible challenge controls from the audited references.  Generic
+# ``[data-qa*='captcha']`` / ``[class*='captcha']`` selectors are intentionally
+# excluded: dormant templates and unrelated vacancy markup could otherwise halt
+# a healthy run (the failure mode is still only a hypothesis, #344).
+ANTIBOT_MARKER_SELECTORS: tuple[tuple[str, str], ...] = (
+    ("recaptcha_iframe", 'iframe[src*="recaptcha" i]'),
+    ("hcaptcha_iframe", 'iframe[src*="hcaptcha" i]'),
+    ("captcha_iframe", 'iframe[src*="captcha" i]'),
+    ("captcha_iframe_title", 'iframe[title*="captcha" i]'),
+    ("captcha_data_qa", "[data-qa='captcha']"),
+    ("account_captcha_input", "[data-qa='account-captcha-input']"),
+    ("account_captcha_picture", "[data-qa='account-captcha-picture']"),
+    ("google_recaptcha", ".g-recaptcha"),
+    ("hcaptcha", ".h-captcha"),
+)
+
+
+@dataclass(frozen=True)
+class AntiBotDetection:
+    """Confirmed narrow signal that should terminate the current command."""
+
+    signal: str
+    detail: str
+
+
+class AntiBotChallengeDetected(RuntimeError):
+    """Terminal apply-run exception: a human must resolve the challenge."""
+
+    def __init__(self, detection: AntiBotDetection):
+        self.detection = detection
+        super().__init__(
+            "обнаружена анти-бот проверка "
+            f"({detection.detail}); решите её вручную и повторите запуск"
+        )
+
+
+def detect_antibot_challenge(
+    *, url: str, visible_markers: Iterable[str]
+) -> AntiBotDetection | None:
+    """Pure decision function over an URL and already-observed visible markers."""
+
+    try:
+        path_segments = {segment.casefold() for segment in urlparse(url).path.split("/") if segment}
+    except (TypeError, ValueError):
+        path_segments = set()
+    if challenge_segment := next(
+        (segment for segment in _CHALLENGE_PATH_SEGMENTS if segment in path_segments), None
+    ):
+        return AntiBotDetection("url_path", f"URL содержит /{challenge_segment}")
+
+    observed = set(visible_markers)
+    if marker := next(
+        (name for name, _selector in ANTIBOT_MARKER_SELECTORS if name in observed), None
+    ):
+        return AntiBotDetection(marker, f"виден маркер {marker}")
+    return None
+
+
+def detect_antibot_on_page(page: Page) -> AntiBotDetection | None:
+    """Read narrow visible signals from a Page, then delegate to the pure detector.
+
+    A selector read error is not itself evidence of a challenge.  The surrounding
+    pipeline retains its normal fail-closed handling for broken/closed pages.
+    """
+
+    try:
+        url = page.url
+    except (AttributeError, PlaywrightError):
+        url = ""
+
+    visible: list[str] = []
+    for name, selector in ANTIBOT_MARKER_SELECTORS:
+        try:
+            if page.locator(selector).filter(visible=True).count() > 0:
+                visible.append(name)
+        except (AttributeError, PlaywrightError):
+            continue
+    return detect_antibot_challenge(url=url, visible_markers=visible)

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -178,6 +178,10 @@ def _finalize_post_click_failure(ctx: ApplyContext, reason: str) -> ApplyResult:
         return ctx.fail(reason)
     try:
         verdict = ctx.verifier(ctx.page, ctx.vacancy.vacancy_id, ctx.resume_id)
+    except AntiBotChallengeDetected:
+        # A confirmed challenge is terminal, unlike an arbitrary verifier
+        # crash. The pre-submit audit reservation remains fail-closed uncertain.
+        raise
     except Exception as exc:  # noqa: BLE001
         # #207: сбой самой внешней проверки не должен обрывать apply до записи
         # в history и паузы троттлинга — иначе следующий запуск не увидит запись
@@ -337,7 +341,7 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     try:
         ctx.probe("submitted", vacancy_title=ctx.vacancy.title)
 
-        if not wait_success_confirmation(ctx.page):
+        if not wait_success_confirmation(ctx.page, terminal_check=lambda: _halt_if_antibot(ctx)):
             # Честный union-poll до таймаута БЕЗ сигнала — локально успеха не
             # нашли (#163). Но это всё ещё «после действия»: вердикт финализируется
             # внешней проверкой (#207) — found → success, неопределённость чтения

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -174,6 +174,9 @@ def _finalize_post_click_failure(ctx: ApplyContext, reason: str) -> ApplyResult:
     * indeterminate — список не прочитан: fail-closed uncertain+acted —
       has_applied видит запись, троттл ждёт (как у #176).
     """
+    # Inspect the page that failed before the verifier navigates away. A submit
+    # navigation may render a challenge and still raise SubmitClickUncertain.
+    _halt_if_antibot(ctx)
     if ctx.verifier is None:
         return ctx.fail(reason)
     try:

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -22,6 +22,7 @@ from ..browser import goto_hh, has_login_form
 from ..history import SKIP_REASONS
 from ..search import VacancyCard
 from . import steps as apply_steps
+from .antibot import AntiBotChallengeDetected, detect_antibot_on_page
 from .dedup import check_already_responded
 from .letter import VARIANT_TEMPLATE, CoverLetterProvider, render_cover_letter
 from .probe import NOOP_PROBE, ProbeHook
@@ -217,11 +218,15 @@ def _finalize_post_click_failure(ctx: ApplyContext, reason: str) -> ApplyResult:
 def _run(ctx: ApplyContext) -> ApplyResult:
     logger.info("Открываю вакансию: %s (%s)", ctx.vacancy.title, ctx.vacancy.url)
     goto_hh(ctx.page, ctx.vacancy.url)
+    _halt_if_antibot(ctx)
     if has_login_form(ctx.page):
         return ctx.fail("Сессия недействительна: страница содержит форму входа. Выполните login.")
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)
 
     apply_button_found = apply_steps.wait_apply_button(ctx.page)
+    # A challenge can render asynchronously while wait_apply_button is waiting.
+    # Recheck before turning the missing button into an ordinary per-vacancy fail.
+    _halt_if_antibot(ctx)
     # The combined wait can observe both markers during a transitional SPA
     # render. Re-check independently after it completes so the apply button
     # cannot win over an already-responded marker. #241 cycle-review round 2
@@ -262,6 +267,7 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     # fail-исходы финализируются через _finalize_post_click_failure (внешняя
     # проверка /applicant/negotiations), а не сразу ctx.fail.
     navigation_result = apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
+    _halt_if_antibot(ctx)
     if isinstance(navigation_result, str):
         # #350: развёрнутое предупреждение о видимости резюме — недвусмысленный,
         # неисполнимый пропуск; не форма не отрисовалась, а hh.ru дал определённый
@@ -295,6 +301,9 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     #     чистый fail с acted=False: на hh.ru следа нет, как у остальных
     #     ранних выходов #163, но traceback больше не рвёт цикл откликов.
     try:
+        # Last pre-submit barrier: a challenge rendered after the form checks
+        # terminates the whole command before the irreversible click/audit marker.
+        _halt_if_antibot(ctx)
         if ctx.before_submit is not None:
             ctx.before_submit()
         reason = apply_steps.fill_response_form(ctx.page, ctx.resume_id, letter)
@@ -354,3 +363,13 @@ def _run(ctx: ApplyContext) -> ApplyResult:
 
     logger.info("Отклик отправлен: %s", ctx.vacancy.title)
     return ctx.ok("success")
+
+
+def _halt_if_antibot(ctx: ApplyContext) -> None:
+    """Raise the terminal signal without creating a per-vacancy action record."""
+
+    detection = detect_antibot_on_page(ctx.page)
+    if detection is None:
+        return
+    logger.error("[FAIL] %s — %s", ctx.vacancy.title, detection.detail)
+    raise AntiBotChallengeDetected(detection)

--- a/src/hhru_bot/apply/success.py
+++ b/src/hhru_bot/apply/success.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections.abc import Callable
 
 from playwright.sync_api import Page
 
@@ -101,7 +102,9 @@ SUCCESS_CONFIRMATION_TIMEOUT_MS = 30_000
 
 
 def wait_success_confirmation(
-    page: Page, timeout_ms: int = SUCCESS_CONFIRMATION_TIMEOUT_MS
+    page: Page,
+    timeout_ms: int = SUCCESS_CONFIRMATION_TIMEOUT_MS,
+    terminal_check: Callable[[], None] | None = None,
 ) -> bool:
     """Подтверждает успех отклика по позитивным сигналам.
 
@@ -121,6 +124,10 @@ def wait_success_confirmation(
     """
     deadline = time.monotonic() + timeout_ms / 1000
     while True:
+        # #344: a challenge may be the submit response itself. Check on every
+        # poll so we stop immediately instead of waiting 30s and navigating on.
+        if terminal_check is not None:
+            terminal_check()
         if which := _any_positive_signal(page):
             logger.debug("Success подтверждён: %s", which)
             return True

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -161,6 +161,8 @@ def verify_response_in_negotiations(
         try:
             goto_hh(page, NEGOTIATIONS_URL)
         except PlaywrightError as exc:
+            # A navigation timeout may still leave a rendered challenge behind.
+            raise_for_antibot(page)
             problem = f"goto списка откликов не прошёл ({exc})"
             logger.warning("[VERIFY] %s", problem)
         else:
@@ -259,12 +261,17 @@ def _scan_negotiations(
             try:
                 goto_hh(page, f"{NEGOTIATIONS_URL}?page={page_num}")
             except PlaywrightError as exc:
+                # Inspect a page rendered before the navigation timeout before
+                # treating it as an ordinary incomplete scan.
+                raise_for_antibot(page)
                 # Пагинация была подтверждена на странице 0 (мы сюда дошли) —
                 # страница 1 не дочитана: целевая вакансия могла быть на ней.
                 problem = f"goto страницы {page_num} списка не прошёл ({exc})"
                 confirmed_incomplete = True
                 reads.append(PageRead(PageSource.SSR, (), Partial(problem)))
                 break
+            else:
+                raise_for_antibot(page)
         found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
             page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
         )

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -57,6 +57,7 @@ from ..responses import (
     parse_response_card,
 )
 from ..selector_groups import negotiations as ns
+from .antibot import raise_for_antibot
 from .steps import _dump_navigation_diagnostics
 from .verdict import (
     Completeness,
@@ -163,6 +164,9 @@ def verify_response_in_negotiations(
             problem = f"goto списка откликов не прошёл ({exc})"
             logger.warning("[VERIFY] %s", problem)
         else:
+            # #344: do not retry navigation against an account challenge or
+            # downgrade the terminal signal to an indeterminate verdict.
+            raise_for_antibot(page)
             # Истёкшая сессия не лечится ретраями: hhtoken мог остаться в jar,
             # но сервер отвечает формой входа (тот же маркер, что в fetch_responses).
             if not has_auth_cookie(page) or has_login_form(page):

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
+from .apply.antibot import AntiBotChallengeDetected
 from .browser import BrowserLaunchError
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
@@ -171,6 +172,11 @@ def _execute(args: argparse.Namespace) -> None:
             sys.exit(1)
     except BrowserLaunchError as exc:
         print(f"[ENVIRONMENT] {exc}", file=sys.stderr)
+        sys.exit(1)
+    except AntiBotChallengeDetected as exc:
+        # #344: terminal apply/run state.  Do not render a traceback or continue
+        # with another vacancy/resume (or bump in the combined ``run`` command).
+        print(f"[FAIL] {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         print("\nПрервано пользователем.")

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..apply import apply_to_vacancy
-from ..apply.antibot import raise_for_antibot
+from ..apply.antibot import AntiBotChallengeDetected, raise_for_antibot
 from ..apply.letter import CoverLetterProvider
 from ..apply.verify import verify_response_in_negotiations
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
@@ -429,14 +429,22 @@ def run_apply_for_resume(
         }
         if not args.dry_run:
             apply_kwargs["before_submit"] = _before_submit
-        result = apply_to_vacancy(
-            page,
-            card,
-            resume.resume_id,
-            cover_letter_template,
-            args.dry_run,
-            **apply_kwargs,
-        )
+        try:
+            result = apply_to_vacancy(
+                page,
+                card,
+                resume.resume_id,
+                cover_letter_template,
+                args.dry_run,
+                **apply_kwargs,
+            )
+        except AntiBotChallengeDetected as exc:
+            # A post-submit challenge can arrive after before_submit reserved
+            # the row. Keep its dedup/limit-safe uncertain status, but replace
+            # the generic crash reason before terminating the whole command.
+            if action_id is not None:
+                history.finalize_action(action_id, "uncertain", str(exc))
+            raise
 
         if result.skipped:
             # #95: форма требует анкеты — НЕ считаем откликом, НЕ пишем actions,

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..apply import apply_to_vacancy
+from ..apply.antibot import raise_for_antibot
 from ..apply.letter import CoverLetterProvider
 from ..apply.verify import verify_response_in_negotiations
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
@@ -320,6 +321,9 @@ def run_apply_for_resume(
     verify_resume_id = resume.resume_id
     if not args.dry_run:
         ids_by_hash = resolve_numeric_resume_ids(page)
+        # #344: a challenge during the resume preflight is terminal for the
+        # whole apply/run command, not an unknown mapping to continue past.
+        raise_for_antibot(page)
         if ids_by_hash is not None:
             numeric_id = ids_by_hash.get(resume.resume_id)
             if numeric_id is not None:
@@ -356,10 +360,16 @@ def run_apply_for_resume(
     try:
         cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
     except VacancySearchIndeterminate as e:
+        # Search timeouts are normally per-resume failures, but a confirmed
+        # challenge must escape as the terminal AntiBotChallengeDetected state.
+        raise_for_antibot(page)
         # Один сбой рендера не должен скрыться как пустой apply-план или
         # остановить обработку остальных резюме в команде apply/run.
         print(f"[FAIL] {e}")
         return True
+    # Also catch challenge pages that happened to look like an empty/partial
+    # search result to the parser and therefore returned without raising.
+    raise_for_antibot(page)
     scoring_provider = _build_scoring_provider(config, resume)
     plan = build_apply_plan(
         cards,

--- a/tests/test_apply_antibot.py
+++ b/tests/test_apply_antibot.py
@@ -87,20 +87,35 @@ def test_generic_captcha_markup_is_not_queried_or_matched():
 
 
 @pytest.mark.parametrize(
-    "passive_widget",
+    "vendor_selector",
     [
         'iframe[src*="recaptcha" i]',
         'iframe[src*="hcaptcha" i]',
-        'iframe[title*="captcha" i]',
         ".g-recaptcha",
         ".h-captcha",
     ],
 )
-def test_passive_captcha_widget_is_not_a_terminal_marker(passive_widget):
-    page = _Page("https://hh.ru/vacancy/1", {passive_widget: (True, True)})
+def test_visible_vendor_captcha_widget_is_terminal(vendor_selector):
+    page = _Page("https://hh.ru/vacancy/1", {vendor_selector: (True, True)})
+
+    result = detect_antibot_on_page(page)
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "vendor_selector",
+    [
+        'iframe[src*="recaptcha" i]',
+        'iframe[src*="hcaptcha" i]',
+        ".g-recaptcha",
+        ".h-captcha",
+    ],
+)
+def test_hidden_vendor_captcha_widget_does_not_halt_run(vendor_selector):
+    page = _Page("https://hh.ru/vacancy/1", {vendor_selector: (True, False)})
 
     assert detect_antibot_on_page(page) is None
-    assert passive_widget not in page.queried
 
 
 def test_unknown_observed_marker_is_ignored():

--- a/tests/test_apply_antibot.py
+++ b/tests/test_apply_antibot.py
@@ -1,0 +1,95 @@
+"""#344: narrow anti-bot detection without launching a browser."""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.apply.antibot import (
+    ANTIBOT_MARKER_SELECTORS,
+    detect_antibot_challenge,
+    detect_antibot_on_page,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Locator:
+    def __init__(self, *, present: bool, visible: bool):
+        self.present = present
+        self.visible = visible
+
+    def filter(self, *, visible: bool | None = None):
+        if visible is True and not self.visible:
+            return _Locator(present=False, visible=False)
+        return self
+
+    def count(self) -> int:
+        return int(self.present)
+
+
+class _Page:
+    def __init__(self, url: str, markers: dict[str, tuple[bool, bool]] | None = None):
+        self.url = url
+        self.markers = markers or {}
+        self.queried: list[str] = []
+
+    def locator(self, selector: str) -> _Locator:
+        self.queried.append(selector)
+        present, visible = self.markers.get(selector, (False, False))
+        return _Locator(present=present, visible=visible)
+
+
+@pytest.mark.parametrize("segment", ["captcha", "checkpoint", "nocaptcha"])
+def test_detects_exact_challenge_path_segment(segment):
+    result = detect_antibot_challenge(
+        url=f"https://hh.ru/{segment}?backurl=%2Fvacancy%2F1", visible_markers=()
+    )
+
+    assert result is not None
+    assert result.signal == "url_path"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://hh.ru/vacancy/1?next=/captcha",
+        "https://hh.ru/vacancy/captcha-engineer",
+        "https://hh.ru/employer/nocaptcha-labs",
+    ],
+)
+def test_does_not_match_captcha_word_outside_exact_path_segment(url):
+    assert detect_antibot_challenge(url=url, visible_markers=()) is None
+
+
+def test_detects_only_visible_allowlisted_marker():
+    marker_name, selector = ANTIBOT_MARKER_SELECTORS[0]
+    page = _Page("https://hh.ru/vacancy/1", {selector: (True, True)})
+
+    result = detect_antibot_on_page(page)
+
+    assert result is not None
+    assert result.signal == marker_name
+
+
+def test_hidden_challenge_marker_does_not_halt_run():
+    _marker_name, selector = ANTIBOT_MARKER_SELECTORS[0]
+    page = _Page("https://hh.ru/vacancy/1", {selector: (True, False)})
+
+    assert detect_antibot_on_page(page) is None
+
+
+def test_generic_captcha_markup_is_not_queried_or_matched():
+    generic = "[data-qa='vacancy-captcha-hint']"
+    page = _Page("https://hh.ru/vacancy/1", {generic: (True, True)})
+
+    assert detect_antibot_on_page(page) is None
+    assert generic not in page.queried
+
+
+def test_unknown_observed_marker_is_ignored():
+    assert (
+        detect_antibot_challenge(
+            url="https://hh.ru/vacancy/1", visible_markers={"captcha_word_in_markup"}
+        )
+        is None
+    )

--- a/tests/test_apply_antibot.py
+++ b/tests/test_apply_antibot.py
@@ -86,6 +86,23 @@ def test_generic_captcha_markup_is_not_queried_or_matched():
     assert generic not in page.queried
 
 
+@pytest.mark.parametrize(
+    "passive_widget",
+    [
+        'iframe[src*="recaptcha" i]',
+        'iframe[src*="hcaptcha" i]',
+        'iframe[title*="captcha" i]',
+        ".g-recaptcha",
+        ".h-captcha",
+    ],
+)
+def test_passive_captcha_widget_is_not_a_terminal_marker(passive_widget):
+    page = _Page("https://hh.ru/vacancy/1", {passive_widget: (True, True)})
+
+    assert detect_antibot_on_page(page) is None
+    assert passive_widget not in page.queried
+
+
 def test_unknown_observed_marker_is_ignored():
     assert (
         detect_antibot_challenge(

--- a/tests/test_apply_audit.py
+++ b/tests/test_apply_audit.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
 from hhru_bot.commands import _common
 from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
 from hhru_bot.history import History
@@ -127,3 +128,41 @@ def test_apply_finalizes_the_pre_submit_marker_in_place(tmp_path, monkeypatch):
         rows = conn.execute("SELECT resume_id, vacancy_id, action, status FROM actions").fetchall()
 
     assert [tuple(row) for row in rows] == [("AAA111", "123", "apply", "success")]
+
+
+def test_post_submit_challenge_finalizes_uncertain_marker_before_stopping(tmp_path, monkeypatch):
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="python"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="hello",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    args = argparse.Namespace(dry_run=False, headless=True, max_pages=1, limit=1)
+    card = VacancyCard("123", "Python developer", "Acme", "https://hh.ru/vacancy/123")
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+    monkeypatch.setattr(_common, "search_vacancies", lambda *a, **k: [card])
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+
+    def challenge_after_reservation(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs["before_submit"]()
+        raise AntiBotChallengeDetected(detection)
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", challenge_after_reservation)
+
+    with pytest.raises(AntiBotChallengeDetected):
+        _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    with history._connect() as conn:
+        row = conn.execute("SELECT status, reason FROM actions").fetchone()
+
+    assert row is not None
+    assert row["status"] == "uncertain"
+    assert "обнаружена анти-бот проверка" in row["reason"]

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -598,7 +598,7 @@ def test_apply_submit_unconfirmed_is_acted(monkeypatch):
     """#163: submit-клик был, но успех не подтвердился (wait_success_confirmation
     False) — это провал ПОСЛЕ действия: acted=True, цикл откликов обязан
     ждать паузу и писать failed. Регрессия против «фикс отключил троттлинг»."""
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
     page = FakePage(apply_button=True, success=True, submit_in_form=True)
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
     assert result.success is False
@@ -681,7 +681,7 @@ def test_apply_confirmation_error_after_submit_keeps_acted(monkeypatch):
     вакансию, а не оставить её доступной для повторного отклика."""
     from playwright.sync_api import Error as PlaywrightError
 
-    def _raise(_page):
+    def _raise(_page, **_kwargs):
         raise PlaywrightError("Page closed while polling success markers")
 
     monkeypatch.setattr(pipeline_module, "wait_success_confirmation", _raise)
@@ -733,7 +733,7 @@ def test_apply_submit_unconfirmed_external_found_is_success(monkeypatch):
     внешний источник нашёл отклик в /applicant/negotiations — это success
     (acted=True, uncertain сброшен), а не failed: иначе has_applied не видит
     запись и следующий запуск шлёт второе письмо."""
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
     verifier = _verifier("found", "topic=42, resumeId=RID")
     page = FakePage(apply_button=True, success=True, submit_in_form=True)
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False, verifier=verifier)
@@ -747,7 +747,7 @@ def test_apply_submit_unconfirmed_external_found_is_success(monkeypatch):
 def test_apply_submit_unconfirmed_external_not_found_stays_failed(monkeypatch):
     """Подтверждённое внешней проверкой ОТСУТСТВИЕ отклика — вердикт не меняется:
     failed c acted=True (осознанный fail-closed #163, теперь ещё и проверенный)."""
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
     verifier = _verifier("not_found")
     page = FakePage(apply_button=True, success=True, submit_in_form=True)
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False, verifier=verifier)
@@ -760,7 +760,7 @@ def test_apply_submit_unconfirmed_external_not_found_stays_failed(monkeypatch):
 def test_apply_submit_unconfirmed_external_indeterminate_is_uncertain(monkeypatch):
     """Список откликов не прочитан (goto/рендер/сессия) — прежний «честный failed»
     невозможен: исход неизвестен, fail-closed uncertain+acted как у #176."""
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
     verifier = _verifier("indeterminate", "goto не прошёл")
     page = FakePage(apply_button=True, success=True, submit_in_form=True)
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False, verifier=verifier)
@@ -818,7 +818,7 @@ def test_apply_confirmation_error_external_found_upgrades_to_success(monkeypatch
     тоже апгрейд до success."""
     from playwright.sync_api import Error as PlaywrightError
 
-    def _raise(_page):
+    def _raise(_page, **_kwargs):
         raise PlaywrightError("Page closed while polling success markers")
 
     monkeypatch.setattr(pipeline_module, "wait_success_confirmation", _raise)
@@ -837,7 +837,7 @@ def test_apply_verifier_crash_is_uncertain_acted(monkeypatch):
     uncertain + acted, как у #176."""
     from playwright.sync_api import Error as PlaywrightError
 
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
 
     def _crash(page, vacancy_id, resume_id=None):  # noqa: ANN001
         raise PlaywrightError("Page closed while polling negotiations")
@@ -855,7 +855,7 @@ def test_apply_verifier_non_playwright_crash_is_uncertain_acted(monkeypatch):
     SSR/DOM) — тот же класс неопределённости, что и упавшая страница: apply не
     должен оборваться до записи uncertain+acted (иначе дубликат на следующем
     запуске). Граница fail-closed ловит Exception, а не только PlaywrightError."""
-    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page: False)
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
 
     def _crash(page, vacancy_id, resume_id=None):  # noqa: ANN001
         raise ValueError("malformed href in topicList")
@@ -866,3 +866,15 @@ def test_apply_verifier_non_playwright_crash_is_uncertain_acted(monkeypatch):
     assert result.acted is True
     assert result.uncertain is True
     assert "упала" in result.reason
+
+
+def test_apply_verifier_antibot_signal_remains_terminal(monkeypatch):
+    monkeypatch.setattr(pipeline_module, "wait_success_confirmation", lambda page, **_kwargs: False)
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+
+    def _challenge(*_args, **_kwargs):
+        raise AntiBotChallengeDetected(detection)
+
+    page = FakePage(apply_button=True, success=True, submit_in_form=True)
+    with pytest.raises(AntiBotChallengeDetected):
+        apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False, verifier=_challenge)

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -13,6 +13,7 @@ import pytest
 
 import hhru_bot.apply.pipeline as pipeline_module
 from hhru_bot.apply import ProbeHook, apply_to_vacancy
+from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
 from hhru_bot.history import SKIP_REASONS
 from hhru_bot.search import VacancyCard
 
@@ -209,6 +210,42 @@ def test_apply_login_form_is_checked_after_navigation(monkeypatch):
     assert "Сессия недействительна" in result.reason
     assert events == ["goto", "auth"]
     assert result.acted is False  # #163: провал до submit — без паузы и записи
+
+
+def test_antibot_detection_terminates_pipeline_before_per_vacancy_work(monkeypatch):
+    page = FakePage()
+    detection = AntiBotDetection("captcha_data_qa", "виден маркер captcha_data_qa")
+    monkeypatch.setattr(pipeline_module, "detect_antibot_on_page", lambda _page: detection)
+
+    with pytest.raises(AntiBotChallengeDetected, match="решите её вручную"):
+        apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+
+    # The terminal signal is raised immediately after navigation: no apply
+    # button wait, submit attempt, or per-vacancy result/history path follows.
+    assert page.goto_calls == ["https://hh.ru/vacancy/1"]
+    assert page.apply_wait_for_calls == []
+
+
+def test_late_antibot_detection_stops_before_submit_audit_marker(monkeypatch):
+    page = FakePage(submit_in_form=True)
+    detection = AntiBotDetection("hcaptcha", "виден маркер hcaptcha")
+    observations = iter((None, None, None, detection))
+    monkeypatch.setattr(pipeline_module, "detect_antibot_on_page", lambda _page: next(observations))
+    before_submit_calls: list[bool] = []
+
+    with pytest.raises(AntiBotChallengeDetected):
+        apply_to_vacancy(
+            page,
+            _vacancy(),
+            "RID",
+            "x",
+            dry_run=False,
+            before_submit=lambda: before_submit_calls.append(True),
+        )
+
+    # The challenge appeared on the last pre-submit barrier.  No durable action
+    # reservation is created because no irreversible submit was attempted.
+    assert before_submit_calls == []
 
 
 def test_apply_already_responded_not_deduped_by_dom():

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -669,6 +669,34 @@ def test_apply_submit_click_error_is_uncertain_acted():
     assert "неопределён" in result.reason
 
 
+def test_submit_click_challenge_is_checked_before_verifier_navigation(monkeypatch):
+    """A timed-out submit may already have rendered the challenge page."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    from hhru_bot.apply.steps import SubmitClickUncertain
+
+    state = {"challenged": False}
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+
+    def _submit(*_args, **_kwargs):
+        state["challenged"] = True
+        raise SubmitClickUncertain(PlaywrightError("navigation timed out"))
+
+    def _halt(_ctx):
+        if state["challenged"]:
+            raise AntiBotChallengeDetected(detection)
+
+    verifier = _verifier("not_found")
+    monkeypatch.setattr(pipeline_module.apply_steps, "fill_response_form", _submit)
+    monkeypatch.setattr(pipeline_module, "_halt_if_antibot", _halt)
+
+    page = FakePage(apply_button=True, success=True, submit_in_form=True)
+    with pytest.raises(AntiBotChallengeDetected):
+        apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False, verifier=verifier)
+
+    assert verifier.calls == []
+
+
 def test_apply_confirmation_error_after_submit_keeps_acted(monkeypatch):
     """#177 round 3 (Codex): submit-клик прошёл, но wait_success_confirmation
     упал с PlaywrightError (не вернул False, а бросил). Это НЕ то же самое,

--- a/tests/test_apply_placeholder.py
+++ b/tests/test_apply_placeholder.py
@@ -18,6 +18,7 @@ import sqlite3
 
 import pytest
 
+from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
 from hhru_bot.commands import _common
 from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
 from hhru_bot.history import History
@@ -135,3 +136,37 @@ def test_real_url_still_reaches_apply(tmp_path, monkeypatch):
 
     assert failed is False
     assert applied_resume_ids == ["AAA111"]
+
+
+def test_search_challenge_escapes_per_resume_indeterminate_handling(tmp_path, monkeypatch):
+    """#344: a challenged search stops all resumes instead of returning True."""
+
+    from hhru_bot.search import VacancySearchIndeterminate
+
+    def _indeterminate(*_args, **_kwargs):
+        raise VacancySearchIndeterminate("search did not render")
+
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+
+    def _raise_antibot(_page):
+        raise AntiBotChallengeDetected(detection)
+
+    monkeypatch.setattr(_common, "search_vacancies", _indeterminate)
+    monkeypatch.setattr(_common, "raise_for_antibot", _raise_antibot)
+    monkeypatch.setattr(
+        _common,
+        "apply_to_vacancy",
+        lambda *_args, **_kwargs: pytest.fail("challenge must stop before apply"),
+    )
+
+    history_db = tmp_path / "history.db"
+    history = History(history_db)
+    config = _config(tmp_path, _resume("https://hh.ru/resume/AAA111"))
+    throttle = Throttle(config.throttle, history)
+
+    with pytest.raises(AntiBotChallengeDetected):
+        _common.run_apply_for_resume(
+            object(), config, config.resumes[0], history, throttle, _apply_args()
+        )
+
+    assert _row_count(history_db, "actions") == 0

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -218,6 +218,16 @@ def test_success_all_signals_absent_returns_false():
     assert success.wait_success_confirmation(page, timeout_ms=0) is False
 
 
+def test_terminal_check_interrupts_post_submit_poll():
+    page = _FakePage()
+
+    def _terminal() -> None:
+        raise RuntimeError("confirmed challenge")
+
+    with pytest.raises(RuntimeError, match="confirmed challenge"):
+        success.wait_success_confirmation(page, terminal_check=_terminal)
+
+
 def test_success_timeout_logs_page_url(caplog):
     """Ишью #7 критерий готовности: ветки ошибок логируют URL.
 

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -185,6 +185,21 @@ def test_verifier_challenge_stops_before_retry(monkeypatch):
     assert page.wait_for_timeout_calls == []
 
 
+def test_verifier_checks_challenge_after_failed_navigation(monkeypatch):
+    page = FakeNegotiationsPage(goto_error=PlaywrightError("navigation timed out"))
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+    monkeypatch.setattr(
+        verify_module,
+        "raise_for_antibot",
+        lambda _page: (_ for _ in ()).throw(AntiBotChallengeDetected(detection)),
+    )
+
+    with pytest.raises(AntiBotChallengeDetected):
+        verify_response_in_negotiations(page, _V1)
+
+    assert page.wait_for_timeout_calls == []
+
+
 # DOM-разметка без SSR-состояния: карточка с span-вакансией внутри <a> (#44).
 _DOM_HTML = """
 <div data-qa="negotiations-item">
@@ -481,6 +496,47 @@ def test_indeterminate_when_page1_goto_fails():
     result = verify_response_in_negotiations(page, _V2)
     assert result.indeterminate
     assert "goto" in result.detail
+
+
+def test_challenge_after_failed_pagination_navigation_is_terminal(monkeypatch):
+    page0 = _ssr_html([_topic(7, "999999")], extra="<a data-qa='pager-next'>далее</a>")
+    page = _Page1FailsPage({NEGOTIATIONS_URL: page0})
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+    checks = 0
+
+    def _check(_page):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise AntiBotChallengeDetected(detection)
+
+    monkeypatch.setattr(verify_module, "raise_for_antibot", _check)
+
+    with pytest.raises(AntiBotChallengeDetected):
+        verify_response_in_negotiations(page, _V2)
+
+    assert checks == 2
+
+
+def test_challenge_after_successful_pagination_navigation_is_terminal(monkeypatch):
+    page0 = _ssr_html([_topic(7, "999999")], extra="<a data-qa='pager-next'>далее</a>")
+    page1 = _ssr_html([_topic(8, "888888")])
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: page0, f"{NEGOTIATIONS_URL}?page=1": page1})
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+    checks = 0
+
+    def _check(_page):
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise AntiBotChallengeDetected(detection)
+
+    monkeypatch.setattr(verify_module, "raise_for_antibot", _check)
+
+    with pytest.raises(AntiBotChallengeDetected):
+        verify_response_in_negotiations(page, _V2)
+
+    assert checks == 2
 
 
 def test_indeterminate_when_pagination_cap_reached_with_next_page():

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -15,7 +15,9 @@ from types import SimpleNamespace
 import pytest
 from playwright.sync_api import Error as PlaywrightError
 
+import hhru_bot.apply.verify as verify_module
 from _fakes import FakeLocator, _CardLocator, _parse_root, _parse_selector
+from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
 from hhru_bot.apply.verdict import (
     Completeness,
     PageRead,
@@ -165,6 +167,22 @@ def _ssr_html(topics: list[dict], extra: str = "") -> str:
         f"{extra}"
         "</body></html>"
     )
+
+
+def test_verifier_challenge_stops_before_retry(monkeypatch):
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: "<html></html>"})
+    detection = AntiBotDetection("url_path", "URL содержит /captcha")
+
+    def _challenge(_page):
+        raise AntiBotChallengeDetected(detection)
+
+    monkeypatch.setattr(verify_module, "raise_for_antibot", _challenge)
+
+    with pytest.raises(AntiBotChallengeDetected):
+        verify_response_in_negotiations(page, _V1)
+
+    assert page.goto_calls == [NEGOTIATIONS_URL]
+    assert page.wait_for_timeout_calls == []
 
 
 # DOM-разметка без SSR-состояния: карточка с span-вакансией внутри <a> (#44).

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
 from hhru_bot.cli import (
     DEFAULT_CONFIG_PATH,
     DEFAULT_HISTORY_PATH,
@@ -406,3 +407,25 @@ def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch, capsys)
         # (root.handlers.clear() внутри setup_logging), но если assert выше упадёт,
         # handler останется висеть на последующие тесты — чистим в любом случае.
         logging.getLogger("hhru_bot").handlers.clear()
+
+
+def test_antibot_terminal_state_prints_fail_without_traceback(monkeypatch, capsys):
+    """#344: terminal challenge stops the command with a human-readable failure."""
+
+    def _challenge(_args: argparse.Namespace) -> bool:
+        raise AntiBotChallengeDetected(
+            AntiBotDetection("captcha_data_qa", "виден маркер captcha_data_qa")
+        )
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _challenge)
+    with pytest.raises(SystemExit) as exc_info:
+        main(["whoami"])
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "[FAIL] обнаружена анти-бот проверка" in stderr
+    assert "решите её вручную" in stderr
+    assert "Traceback" not in stderr
+    logging.getLogger("hhru_bot").handlers.clear()


### PR DESCRIPTION
## Summary
- add a narrow, allowlisted anti-bot detector for exact challenge URL paths and visible captcha controls
- halt the entire `apply`/`run` command before submit with a human-readable `[FAIL]`, without writing a failed action
- add `semernyakov/hh-auto-apply` to the project reference list

## False-positive policy
- do not inspect vacancy titles or generic `captcha` substrings in markup
- ignore hidden markers and generic `[data-qa*=captcha]` / `[class*=captcha]` matches
- this is detection and stop only; it never attempts to solve or bypass a challenge

## Tests
- `pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`

Closes #344