### PR TITLE
fix(apply): distinguish unrendered response forms

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -261,7 +261,10 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     # #207: с клика по кнопке отклика начинается «серая зона» — дальнейшие
     # fail-исходы финализируются через _finalize_post_click_failure (внешняя
     # проверка /applicant/negotiations), а не сразу ctx.fail.
-    apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
+    if not apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id):
+        reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
+        logger.warning("[FAIL] %s — %s", ctx.vacancy.title, reason)
+        return _finalize_post_click_failure(ctx, reason)
     ctx.probe("form_loaded")
 
     # #95: detect-only проверка на вопросы/анкету. Делается ДО fill_response_form:

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -185,7 +185,17 @@ def probe_vacancy(
             return ProbeResult(vacancy, False, reason, skipped=True)
         return ProbeResult(vacancy, False, "кнопка отклика не найдена на странице")
 
-    apply_steps.navigate_to_response_form(page, vacancy.vacancy_id)
+    if not apply_steps.navigate_to_response_form(page, vacancy.vacancy_id):
+        reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
+        partial_ctx = ProbeContext(
+            vacancy_id=vacancy.vacancy_id,
+            vacancy_url=vacancy.url,
+            stage="form_indeterminate",
+            logs_dir=ctx_dir.logs_dir,
+        )
+        dump_probe_snapshot(page, partial_ctx, best_effort=True)
+        logger.warning("[WARN %s] %s — %s", PAGE_STATE["indeterminate"], vacancy.title, reason)
+        return ProbeResult(vacancy, success=False, reason=reason, skipped=True)
     logger.info("[PROBE] Дошёл до формы отклика, сохраняю исходный DOM")
 
     # Сохраняем форму до любых взаимодействий с её полями. В частности, не

--- a/src/hhru_bot/apply/questions.py
+++ b/src/hhru_bot/apply/questions.py
@@ -86,7 +86,10 @@ class QuestionDetection:
         return cls(True, reason, indeterminate=True)
 
 
-_SCOPE_NOT_FOUND_REASON = "не удалось определить границы формы отклика (нет <form>-предка у submit)"
+_SCOPE_NOT_FOUND_REASON = (
+    "не удалось подтвердить состояние формы отклика (форма не отрисовалась "
+    "или границы формы не определены)"
+)
 _RUNTIME_ERROR_REASON = (
     "ошибка при проверке анкеты формы отклика — отправка отменена (нестабильная страница)"
 )

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -108,8 +108,12 @@ def wait_apply_button(page: Page) -> bool:
     return apply_button.count() > 0
 
 
-def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> None:
+def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> bool:
     """Кликает кнопку отклика и дожидается навигации на форму отклика.
+
+    Возвращает ``True``, если submit-кнопка формы стала видимой, иначе ``False``.
+    Это различие важно: pipeline не должен запускать детекцию вопросов для формы,
+    рендер которой не подтверждён.
 
     ``vacancy_id`` (опционален — probe.py его тоже передаёт, но не обязан) даёт
     диагностическим дампам таймаутов отдельное имя на вакансию, чтобы не терять
@@ -165,12 +169,12 @@ def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> None
         # Клик по apply-кнопке — до submit, ранний отказ (#163): на hh.ru следа
         # нет, не крашим цикл откликов необработанным исключением.
         logger.warning("Клик по кнопке отклика упал с ошибкой (%s) — вакансия пропущена", exc)
-        return
+        return False
     # #179: таймаут/ошибка ожидания URL сама по себе не означает, что клик не
     # сработал — не крашим весь pipeline необработанным исключением, а
     # логируем и отдаём управление дальше. fill_response_form (через
-    # отсутствие APPLY_SUBMIT_BUTTON) и detect_questions сами вернут
-    # корректный fail/skip, если форма реально не загрузилась.
+    # отсутствие APPLY_SUBMIT_BUTTON) и последующая проверка рендера формы
+    # различат навигационный сбой и реально загрузившуюся форму.
     try:
         page.wait_for_url(
             "**/applicant/vacancy_response**", wait_until="commit", timeout=GOTO_TIMEOUT_MS
@@ -189,9 +193,11 @@ def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> None
         )
     except PlaywrightError as exc:
         _dump_navigation_diagnostics(page, "form_timeout", vacancy_id)
-        # Форма не загрузилась — fill_response_form всё равно вернёт причину отказа
-        # (submit не найден), логируем для диагностики устаревшего селектора.
+        # Форма не загрузилась — сообщаем pipeline отдельно от детекции вопросов,
+        # чтобы таймаут рендера не выглядел как неверная граница <form>.
         logger.warning("Форма отклика не отрисовалась (%s)", exc)
+        return False
+    return True
 
 
 def _is_visible(page: Page, selector: str, *, timeout_ms: int) -> bool:

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -580,8 +580,31 @@ def test_apply_non_dry_run_indeterminate_is_fail_not_skip():
     result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
     assert result.success is False
     assert result.skipped is False
-    assert "границы формы" in result.reason
+    assert "состояние формы" in result.reason
     assert result.acted is False  # #163: indeterminate — до submit, без паузы
+
+
+def test_apply_form_render_failure_does_not_run_question_detection(monkeypatch):
+    """A missing rendered form must not be misreported as a missing form scope."""
+    page = FakePage(apply_button=True, success=False)
+    detected = False
+    monkeypatch.setattr(
+        pipeline_module.apply_steps, "_dump_navigation_diagnostics", lambda *_args: None
+    )
+
+    def fail_if_detected(_page):
+        nonlocal detected
+        detected = True
+        raise AssertionError("question detection must wait for confirmed form render")
+
+    monkeypatch.setattr(pipeline_module, "detect_questions", fail_if_detected)
+
+    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=False)
+
+    assert result.success is False
+    assert result.acted is False
+    assert "форма отклика не отрисовалась" in result.reason
+    assert detected is False
 
 
 # --- #176: окно действия — исключение Playwright не теряет acted/запись --------

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -262,7 +262,7 @@ def test_probe_indeterminate_saves_partial_dump(tmp_path: Path):
 
     assert result.success is False
     assert result.skipped is True
-    assert "не удалось определить" in result.reason
+    assert "форма отклика не отрисовалась" in result.reason
     partial_html = tmp_path / "probe_42_form_indeterminate.html"
     assert partial_html.exists()
     assert "probe dump" in partial_html.read_text(encoding="utf-8")

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -271,7 +271,7 @@ def test_navigate_clicks_apply_button_and_waits_submit():
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
-    steps.navigate_to_response_form(page)
+    assert steps.navigate_to_response_form(page) is True
 
     # Клик по apply-кнопке + ожидание URL через wait_for_url (#179).
     assert page.navigation_entered == 1
@@ -284,7 +284,7 @@ def test_navigate_does_not_raise_when_form_never_renders():
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     # submit намеренно отсутствует
 
-    steps.navigate_to_response_form(page)  # не должен бросать
+    assert steps.navigate_to_response_form(page) is False
 
     assert page.navigation_entered == 1
 


### PR DESCRIPTION
Closes #341

## Summary
- propagate response-form render failure from navigation to the apply pipeline
- avoid running question detection on an unrendered form
- replace the misleading missing-`<form>` reason with a state-confirmation reason

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q tests/test_apply_steps.py tests/test_apply_questions.py tests/test_apply_pipeline.py`