### PR TITLE
fix(resume): wait for committed routes and hydrated forms

### DIFF
--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -679,7 +679,7 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
 
         new_id = ""
         try:
-            page.wait_for_url(_RESUME_HASH_RE, timeout=COPY_TIMEOUT_MS)
+            page.wait_for_url(_RESUME_HASH_RE, wait_until="commit", timeout=COPY_TIMEOUT_MS)
             m = _RESUME_HASH_RE.search(page.url)
             if m:
                 new_id = m.group(1)

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -32,6 +32,7 @@ from .selector_groups.resume_experience import (
 
 logger = logging.getLogger("hhru_bot.experience")
 SAVE_TIMEOUT_MS = 30_000
+FORM_TIMEOUT_MS = 10_000
 
 
 @dataclass
@@ -257,6 +258,9 @@ def edit_experience_on_hh(
             return results + [f"строка опыта {index}: триггер не найден однозначно"]
         try:
             trigger.click()
+            page.locator(EXPERIENCE_COMPANY.format(index=index)).wait_for(
+                state="visible", timeout=FORM_TIMEOUT_MS
+            )
             _fill(page.locator(EXPERIENCE_COMPANY.format(index=index)), entry.company)
             _fill(page.locator(EXPERIENCE_POSITION.format(index=index)), entry.position)
             _fill(page.locator(EXPERIENCE_START_YEAR), entry.start_year)

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -12,10 +12,11 @@ import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 
-from .browser import goto_hh, has_auth_cookie, has_login_form
+from .browser import goto_hh, has_auth_cookie, has_login_form, resume_identity_matches
 from .config_sections.education import EducationRecord
 from .responses import NotAuthenticated
 
@@ -45,7 +46,7 @@ _ADDITIONAL_FIELDS = {
     "specialty": "[data-qa='profile-education-additional-specialty']",
     "year": "[data-qa='profile-education-year-input']",
 }
-_RESUME_ROUTE = re.compile(r"/resume/[^/?#]+(?:\?.*)?$")
+FORM_TIMEOUT_MS = 15_000
 
 
 @dataclass(frozen=True)
@@ -148,7 +149,12 @@ def generate_education_plan(
 
 
 def _edit_block(
-    page, records: list[EducationRecord], *, additional: bool, dry_run: bool
+    page,
+    records: list[EducationRecord],
+    *,
+    additional: bool,
+    dry_run: bool,
+    resume_id: str,
 ) -> EducationResult:
     trigger = ADDITIONAL_TRIGGER if additional else PRIMARY_TRIGGER
     add_selector = ADDITIONAL_ADD if additional else PRIMARY_ADD
@@ -185,7 +191,11 @@ def _edit_block(
         save_clicked = False
         try:
             button.click()
-            page.wait_for_url(route)
+            page.wait_for_url(route, wait_until="commit")
+            # The route can commit before React has mounted the editor.
+            page.locator(next(iter(fields.values()))).wait_for(
+                state="visible", timeout=FORM_TIMEOUT_MS
+            )
             for name, selector in fields.items():
                 value = getattr(record, name)
                 # Empty LLM fields mean "unknown", not "erase the current value".
@@ -217,7 +227,15 @@ def _edit_block(
                     )
                 save_clicked = True
                 save.click()
-                page.wait_for_url(_RESUME_ROUTE)
+                page.wait_for_url(f"**/resume/{resume_id}", wait_until="commit")
+                if not resume_identity_matches(page, resume_id):
+                    return EducationResult(
+                        kind,
+                        False,
+                        "после сохранения identity резюме не подтверждён",
+                        uncertain=True,
+                        saved=saved_count,
+                    )
                 saved_count += 1
         except PlaywrightError as exc:
             return EducationResult(
@@ -251,10 +269,20 @@ def edit_education_on_hh(
     """Apply selected blocks through the confirmed UI flow; never HTTP."""
     if not has_auth_cookie(page) or has_login_form(page):
         raise NotAuthenticated("сессия hh.ru не подтверждена")
+    path_parts = [part for part in urlsplit(resume_url).path.split("/") if part]
+    if len(path_parts) != 2 or path_parts[0] != "resume" or not path_parts[1]:
+        raise ValueError("resume_url не содержит однозначный resume_id")
+    resume_id = path_parts[1]
     goto_hh(page, resume_url)
     results = []
     if section in ("primary", "both"):
-        results.append(_edit_block(page, plan.primary, additional=False, dry_run=dry_run))
+        results.append(
+            _edit_block(page, plan.primary, additional=False, dry_run=dry_run, resume_id=resume_id)
+        )
     if section in ("additional", "both"):
-        results.append(_edit_block(page, plan.additional, additional=True, dry_run=dry_run))
+        results.append(
+            _edit_block(
+                page, plan.additional, additional=True, dry_run=dry_run, resume_id=resume_id
+            )
+        )
     return results

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -7,6 +7,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 
 from .browser import HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
@@ -180,13 +181,21 @@ def _apply_rows(
             if block == "attestations"
             else "input[name='company']"
         )
-        page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
-        save = fill_row(page, item)
-        if not dry_run:
-            if save.count() != 1:
-                errors.append(f"{block}: неоднозначная кнопка сохранения")
-                continue
-            save.click()
+        try:
+            page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
+            save = fill_row(page, item)
+            if not dry_run:
+                if save.count() != 1:
+                    errors.append(f"{block}: неоднозначная кнопка сохранения")
+                    continue
+                save.click()
+        except PlaywrightError as exc:
+            # A hydration timeout here may follow an already-successful save.click()
+            # on a previous row (#352/codex): fail closed with an explicit error for
+            # this row and stop the block instead of letting the exception escape
+            # apply_plan and hide which earlier rows already saved.
+            errors.append(f"{block}: строка {index} не подтверждена: {exc}")
+            break
     return errors
 
 

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -172,15 +172,20 @@ def _apply_rows(
     errors: list[str] = []
     trigger = page.locator(RESUME_EDIT_BUTTON[block])
     for index, item in enumerate(items):
-        if index >= trigger.count():
-            errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
-            continue
         ready_selector = (
             f"[data-qa='{ATTESTATION_FIELDS[0]}']"
             if block == "attestations"
             else "input[name='company']"
         )
         try:
+            # trigger.count() itself can raise on iterations after a previous
+            # row's save.click() already succeeded (#352/codex round 3) — the
+            # whole per-row body must stay inside this guard, not just the
+            # click/wait_for, so no browser call here can escape apply_plan
+            # uncaught and hide which earlier rows already saved.
+            if index >= trigger.count():
+                errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
+                continue
             trigger.nth(index).click()
             page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
             save = fill_row(page, item)

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -175,13 +175,13 @@ def _apply_rows(
         if index >= trigger.count():
             errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
             continue
-        trigger.nth(index).click()
         ready_selector = (
             f"[data-qa='{ATTESTATION_FIELDS[0]}']"
             if block == "attestations"
             else "input[name='company']"
         )
         try:
+            trigger.nth(index).click()
             page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
             save = fill_row(page, item)
             if not dry_run:

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .config_sections.resume_sections import ResumeSectionsConfig
 
 logger = logging.getLogger("hhru_bot.resume_sections")
+FORM_TIMEOUT_MS = 10_000
 
 RESUME_EDIT_BUTTON = {
     "attestations": "[data-qa^='resume-edit-button-attestationEducation-']",
@@ -174,6 +175,12 @@ def _apply_rows(
             errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
             continue
         trigger.nth(index).click()
+        ready_selector = (
+            f"[data-qa='{ATTESTATION_FIELDS[0]}']"
+            if block == "attestations"
+            else "input[name='company']"
+        )
+        page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
         save = fill_row(page, item)
         if not dry_run:
             if save.count() != 1:

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -191,7 +191,8 @@ class StubPage:
         if selector == DUP_SEL and self._url_after_click:
             self.url = self._url_after_click
 
-    def wait_for_url(self, pattern, timeout=None):
+    def wait_for_url(self, pattern, wait_until=None, timeout=None):
+        assert wait_until == "commit"
         if not pattern.search(self.url):
             raise PlaywrightTimeoutError("wait_for_url timeout")
 

--- a/tests/test_resume_sections_apply.py
+++ b/tests/test_resume_sections_apply.py
@@ -1,0 +1,116 @@
+"""Browser-level тесты _apply_rows/apply_plan (#352 cycle-review round 1, codex).
+
+Стаб Page/Locator моделирует ровно то, что использует _apply_rows: click(),
+locator(...).wait_for(state="visible"), .count(). ``ready_ok=False`` имитирует
+таймаут гидратации (PlaywrightTimeoutError из wait_for) ПОСЛЕ того, как
+предыдущая строка уже была сохранена — это регрессионный сценарий для находки
+codex: до фикса такое исключение вылетало наружу из apply_plan необработанным,
+теряя факт частичного сохранения; после фикса — заносится в errors как
+конкретная строка, и обработка блока останавливается (fail-closed), не давая
+исключению выйти за пределы apply_plan.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from hhru_bot.resume_sections import Attestation, _apply_rows
+
+pytestmark = pytest.mark.unit
+
+
+class FakeSaveButton:
+    def __init__(self, page):
+        self._page = page
+
+    def count(self):
+        return 1
+
+    def click(self):
+        self._page.saved_rows.append(self._page.current_index)
+
+
+class FakeReadyLocator:
+    def __init__(self, page, ready: bool):
+        self._page = page
+        self._ready = ready
+
+    def wait_for(self, *, state="visible", timeout=None):  # noqa: ARG002
+        if not self._ready:
+            raise PlaywrightTimeoutError("гидратация не завершилась вовремя")
+
+
+class FakeTrigger:
+    def __init__(self, page, count):
+        self._page = page
+        self._count = count
+
+    def count(self):
+        return self._count
+
+    def nth(self, index):
+        return FakeTriggerRow(self._page, index)
+
+
+class FakeTriggerRow:
+    def __init__(self, page, index):
+        self._page = page
+        self._index = index
+
+    def click(self):
+        self._page.current_index = self._index
+
+
+class FakePage:
+    """Строка ``ready_by_index[i] = False`` имитирует таймаут гидратации на
+    строке i (после того как строки < i уже были кликнуты save)."""
+
+    def __init__(self, *, trigger_count: int, ready_by_index: dict[int, bool] | None = None):
+        self._trigger_count = trigger_count
+        self._ready_by_index = ready_by_index or {}
+        self.saved_rows: list[int] = []
+        self.current_index = -1
+
+    def locator(self, selector: str):
+        if selector.startswith("[data-qa^="):
+            return FakeTrigger(self, self._trigger_count)
+        if selector == "[data-qa='profile-layout-save-button']":
+            return FakeSaveButton(self)
+        # ready_selector для attestations/recommendations
+        ready = self._ready_by_index.get(self.current_index, True)
+        return FakeReadyLocator(self, ready)
+
+
+def _fill_row(page, item):  # noqa: ARG001
+    return page.locator("[data-qa='profile-layout-save-button']")
+
+
+def test_hydration_timeout_after_prior_save_is_reported_not_raised():
+    """Codex-находка: таймаут wait_for на строке 1 ПОСЛЕ успешного save строки 0
+    должен вернуться как элемент errors, а не всплыть исключением из _apply_rows."""
+    page = FakePage(trigger_count=2, ready_by_index={1: False})
+    items = [Attestation("A", "Org", "Spec", "2020"), Attestation("B", "Org", "Spec", "2021")]
+
+    errors = _apply_rows(page, "attestations", items, _fill_row, dry_run=False)
+
+    # Строка 0 успела сохраниться до таймаута на строке 1.
+    assert page.saved_rows == [0]
+    # Ошибка сообщает именно про строку 1, а не тонет молча и не падает исключением.
+    assert len(errors) == 1
+    assert "строка 1" in errors[0]
+    assert "attestations" in errors[0]
+
+
+def test_all_rows_hydrate_and_save_without_errors():
+    page = FakePage(trigger_count=2)
+    items = [Attestation("A", "Org", "Spec", "2020"), Attestation("B", "Org", "Spec", "2021")]
+
+    errors = _apply_rows(page, "attestations", items, _fill_row, dry_run=False)
+
+    assert errors == []
+    assert page.saved_rows == [0, 1]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_resume_sections_apply.py
+++ b/tests/test_resume_sections_apply.py
@@ -45,8 +45,15 @@ class FakeTrigger:
     def __init__(self, page, count):
         self._page = page
         self._count = count
+        self._calls = 0
 
     def count(self):
+        # nth-й вызов count() (0-indexed) соответствует итерации цикла с тем же
+        # индексом, т.к. _apply_rows зовёт trigger.count() ровно раз за строку.
+        call_index = self._calls
+        self._calls += 1
+        if call_index in self._page._count_fails:
+            raise PlaywrightTimeoutError("count() недоступен")
         return self._count
 
     def nth(self, index):
@@ -76,10 +83,12 @@ class FakePage:
         trigger_count: int,
         ready_by_index: dict[int, bool] | None = None,
         click_fails: set[int] | None = None,
+        count_fails: set[int] | None = None,
     ):
         self._trigger_count = trigger_count
         self._ready_by_index = ready_by_index or {}
         self._click_fails = click_fails or set()
+        self._count_fails = count_fails or set()
         self.saved_rows: list[int] = []
         self.current_index = -1
 
@@ -118,6 +127,20 @@ def test_trigger_click_failure_after_prior_save_is_reported_not_raised():
     успешного save строки 0 — должно вернуться как элемент errors, а не всплыть
     исключением из _apply_rows (клик был вне try/except до этого фикса)."""
     page = FakePage(trigger_count=2, click_fails={1})
+    items = [Attestation("A", "Org", "Spec", "2020"), Attestation("B", "Org", "Spec", "2021")]
+
+    errors = _apply_rows(page, "attestations", items, _fill_row, dry_run=False)
+
+    assert page.saved_rows == [0]
+    assert len(errors) == 1
+    assert "строка 1" in errors[0]
+
+
+def test_trigger_count_failure_after_prior_save_is_reported_not_raised():
+    """cycle 3 (advisor review): trigger.count() строки 1 падает ПОСЛЕ успешного
+    save строки 0 — тот же класс необработанного исключения; count() тоже должен
+    быть внутри try/except, не только click()/wait_for()."""
+    page = FakePage(trigger_count=2, count_fails={1})
     items = [Attestation("A", "Org", "Spec", "2020"), Attestation("B", "Org", "Spec", "2021")]
 
     errors = _apply_rows(page, "attestations", items, _fill_row, dry_run=False)

--- a/tests/test_resume_sections_apply.py
+++ b/tests/test_resume_sections_apply.py
@@ -59,16 +59,27 @@ class FakeTriggerRow:
         self._index = index
 
     def click(self):
+        if self._index in self._page._click_fails:
+            raise PlaywrightTimeoutError("триггер не кликается")
         self._page.current_index = self._index
 
 
 class FakePage:
     """Строка ``ready_by_index[i] = False`` имитирует таймаут гидратации на
-    строке i (после того как строки < i уже были кликнуты save)."""
+    строке i (после того как строки < i уже были кликнуты save). ``click_fails``
+    имитирует таймаут САМОГО клика по триггеру строки i (codex, cycle 2:
+    trigger.nth(index).click() изначально был вне try/except)."""
 
-    def __init__(self, *, trigger_count: int, ready_by_index: dict[int, bool] | None = None):
+    def __init__(
+        self,
+        *,
+        trigger_count: int,
+        ready_by_index: dict[int, bool] | None = None,
+        click_fails: set[int] | None = None,
+    ):
         self._trigger_count = trigger_count
         self._ready_by_index = ready_by_index or {}
+        self._click_fails = click_fails or set()
         self.saved_rows: list[int] = []
         self.current_index = -1
 
@@ -100,6 +111,20 @@ def test_hydration_timeout_after_prior_save_is_reported_not_raised():
     assert len(errors) == 1
     assert "строка 1" in errors[0]
     assert "attestations" in errors[0]
+
+
+def test_trigger_click_failure_after_prior_save_is_reported_not_raised():
+    """Codex-находка cycle 2: trigger.nth(index).click() строки 1 падает ПОСЛЕ
+    успешного save строки 0 — должно вернуться как элемент errors, а не всплыть
+    исключением из _apply_rows (клик был вне try/except до этого фикса)."""
+    page = FakePage(trigger_count=2, click_fails={1})
+    items = [Attestation("A", "Org", "Spec", "2020"), Attestation("B", "Org", "Spec", "2021")]
+
+    errors = _apply_rows(page, "attestations", items, _fill_row, dry_run=False)
+
+    assert page.saved_rows == [0]
+    assert len(errors) == 1
+    assert "строка 1" in errors[0]
 
 
 def test_all_rows_hydrate_and_save_without_errors():


### PR DESCRIPTION
Closes #343

## Summary
- use `wait_until="commit"` for resume education and copy navigation
- bind education save confirmation to the requested resume identity
- wait for editor hydration before reading or filling experience and additional sections

## Tests
- `TMPDIR=/tmp pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`