### PR TITLE
feat: safely match fill-form answers to profile data

### DIFF
--- a/src/hhru_bot/commands/fill_form.py
+++ b/src/hhru_bot/commands/fill_form.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from ..external_forms import scan_form
-from ..external_forms.detect import apply_answers
+from ..external_forms.detect import apply_answers, resolve_answers
 from ..history import History
 from ..logging_setup import LOG_DIR
 
@@ -54,7 +54,19 @@ def run(args: argparse.Namespace) -> bool:
         if scan.indeterminate:
             print(f"[FAIL] [indeterminate] {scan.reason}")
             return True
-        ok, missing = apply_answers(page, scan, answers)
+        # Account-profile rows are already structured facts (manual rows win
+        # over hh.ru rows).  Keep the LLM optional and let it select only from
+        # these facts; it must never generate a new form answer.
+        llm = None
+        if getattr(config, "ai", None) is not None and answers:
+            try:
+                from ..ai.llm_client import LLMClient
+
+                llm = LLMClient(config.ai)
+            except (ImportError, RuntimeError, ValueError) as exc:
+                print(f"[WARN] LLM-сопоставление отключено: {exc}")
+        resolved_answers = resolve_answers(scan, answers, known_data=answers, client=llm)
+        ok, missing = apply_answers(page, scan, resolved_answers)
         out = Path(LOG_DIR)
         out.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -71,5 +83,5 @@ def run(args: argparse.Namespace) -> bool:
                 + ", ".join(missing)
             )
             return True
-        print("[DRY-RUN] Поля заполнены по точному совпадению профиля. Submit не выполнялся.")
+        print("[DRY-RUN] Поля заполнены по профилю. Submit не выполнялся.")
         return False

--- a/src/hhru_bot/commands/fill_form.py
+++ b/src/hhru_bot/commands/fill_form.py
@@ -63,10 +63,16 @@ def run(args: argparse.Namespace) -> bool:
                 from ..ai.llm_client import LLMClient
 
                 llm = LLMClient(config.ai)
-            except (ImportError, RuntimeError, ValueError) as exc:
+            except Exception as exc:  # noqa: BLE001 — конструктор внешнего клиента не
+                # должен ронять fill_form; та же деградация, что при сбое самого
+                # чата (см. detect.py::match_answer_llm) и в ai/letters.py.
                 print(f"[WARN] LLM-сопоставление отключено: {exc}")
-        resolved_answers = resolve_answers(scan, answers, known_data=answers, client=llm)
+        resolved_answers, llm_matched = resolve_answers(
+            scan, answers, known_data=answers, client=llm
+        )
         ok, missing = apply_answers(page, scan, resolved_answers)
+        for label in sorted(llm_matched):
+            print(f"[INFO] LLM-сопоставление: {label!r} -> {resolved_answers[label]!r}")
         out = Path(LOG_DIR)
         out.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")

--- a/src/hhru_bot/external_forms/detect.py
+++ b/src/hhru_bot/external_forms/detect.py
@@ -213,11 +213,20 @@ def resolve_answers(
     *,
     known_data: dict[str, str] | None = None,
     client=None,
-) -> dict[str, str]:
-    """Merge exact profile answers with safe semantic matches from known data."""
+) -> tuple[dict[str, str], set[str]]:
+    """Merge exact profile answers with safe semantic matches from known data.
+
+    Returns ``(resolved, llm_matched_labels)``: ``apply_answers`` treats every
+    key of ``resolved`` alike ("exact, configured match"), so the LLM-derived
+    subset must stay visible to the caller — the dry-run output reports which
+    labels were filled by inference rather than by an exact configured/known
+    match (#280 review round 2: an LLM guess must never look identical to a
+    user-approved answer in the reviewable dump).
+    """
     resolved = dict(answers)
     normalized = {normalize(key) for key in resolved}
     facts = known_data or {}
+    llm_matched: set[str] = set()
     for form_field in getattr(scan, "fields", []):
         if not form_field.label or normalize(form_field.label) in normalized or client is None:
             continue
@@ -225,4 +234,5 @@ def resolve_answers(
         if value is not None:
             resolved[form_field.label] = value
             normalized.add(normalize(form_field.label))
-    return resolved
+            llm_matched.add(form_field.label)
+    return resolved, llm_matched

--- a/src/hhru_bot/external_forms/detect.py
+++ b/src/hhru_bot/external_forms/detect.py
@@ -15,6 +15,14 @@ from playwright.sync_api import Page
 
 _SPACE = re.compile(r"\s+")
 
+# Fields the LLM must never auto-select, even at high confidence (#280 review
+# round 3): a confident-but-mismatched guess on these is the costliest failure
+# mode. They remain fillable only via an exact form_profile.answers match —
+# the same, already-accepted disclosure boundary from #276/#277/#280.
+_LLM_DENIED_KEY_PATTERN = re.compile(
+    r"телефон|phone|email|e-mail|почта|паспорт|passport|снилс|инн", re.IGNORECASE
+)
+
 
 def normalize(text: str) -> str:
     return _SPACE.sub(" ", text).strip().casefold()
@@ -196,6 +204,7 @@ def match_answer_llm(question: str, known_data: dict[str, str], client) -> str |
         if (
             isinstance(key, str)
             and key in known_data
+            and not _LLM_DENIED_KEY_PATTERN.search(key)
             and isinstance(confidence, (int, float))
             and not isinstance(confidence, bool)
             and confidence >= 0.85

--- a/src/hhru_bot/external_forms/detect.py
+++ b/src/hhru_bot/external_forms/detect.py
@@ -173,13 +173,17 @@ def match_answer_llm(question: str, known_data: dict[str, str], client) -> str |
     """
     if not known_data:
         return None
+    # Only the field NAMES are sent to the model — it is a key-classifier and
+    # never needs the underlying values, which may hold PII (phone, email).
+    # The selected value is looked up locally from known_data below, so no
+    # contact data ever leaves the process.
     prompt = (
-        "Сопоставь вопрос анкеты с одним из известных фактов кандидата. "
-        "Не придумывай ответ и не исправляй значения. Верни только JSON вида "
+        "Сопоставь вопрос анкеты с одним из известных полей кандидата по названию поля. "
+        "Не придумывай ответ. Верни только JSON вида "
         '{"key": "точный ключ или null", "confidence": 0.0}. '
-        "Выбирай ключ только если факт действительно отвечает на вопрос; "
+        "Выбирай ключ только если поле действительно отвечает на вопрос; "
         "иначе key=null. Уверенный порог: confidence >= 0.85.\n"
-        + json.dumps({"question": question, "known_data": known_data}, ensure_ascii=False)
+        + json.dumps({"question": question, "known_keys": sorted(known_data)}, ensure_ascii=False)
     )
     try:
         response = client.chat([{"role": "user", "content": prompt}], temperature=0)
@@ -197,7 +201,8 @@ def match_answer_llm(question: str, known_data: dict[str, str], client) -> str |
             and confidence >= 0.85
         ):
             return known_data[key]
-    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+    except Exception:  # noqa: BLE001 — любой сбой LLM/транспорта -> откат к exact-match,
+        # см. тот же паттерн в ai/letters.py и scoring.py.
         return None
     return None
 

--- a/src/hhru_bot/external_forms/detect.py
+++ b/src/hhru_bot/external_forms/detect.py
@@ -6,6 +6,7 @@ labels and control types, and never clicks a button or submits a form.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 
@@ -161,3 +162,62 @@ def apply_answers(page: Page, scan: FormScan, answers: dict[str, str]) -> tuple[
         else:
             missing.append(form_field.label)
     return not missing, missing
+
+
+def match_answer_llm(question: str, known_data: dict[str, str], client) -> str | None:
+    """Return a known value whose meaning matches *question*, or ``None``.
+
+    The model is only a classifier: it must select a key from the supplied
+    facts and report a high confidence.  The selected value is then looked up
+    locally, so a generated answer can never reach a form.
+    """
+    if not known_data:
+        return None
+    prompt = (
+        "Сопоставь вопрос анкеты с одним из известных фактов кандидата. "
+        "Не придумывай ответ и не исправляй значения. Верни только JSON вида "
+        '{"key": "точный ключ или null", "confidence": 0.0}. '
+        "Выбирай ключ только если факт действительно отвечает на вопрос; "
+        "иначе key=null. Уверенный порог: confidence >= 0.85.\n"
+        + json.dumps({"question": question, "known_data": known_data}, ensure_ascii=False)
+    )
+    try:
+        response = client.chat([{"role": "user", "content": prompt}], temperature=0)
+        raw = response.content if response else None
+        if not raw:
+            return None
+        data = json.loads(raw.strip().removeprefix("```json").removesuffix("```").strip())
+        key = data.get("key") if isinstance(data, dict) else None
+        confidence = data.get("confidence") if isinstance(data, dict) else None
+        if (
+            isinstance(key, str)
+            and key in known_data
+            and isinstance(confidence, (int, float))
+            and not isinstance(confidence, bool)
+            and confidence >= 0.85
+        ):
+            return known_data[key]
+    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return None
+
+
+def resolve_answers(
+    scan: FormScan,
+    answers: dict[str, str],
+    *,
+    known_data: dict[str, str] | None = None,
+    client=None,
+) -> dict[str, str]:
+    """Merge exact profile answers with safe semantic matches from known data."""
+    resolved = dict(answers)
+    normalized = {normalize(key) for key in resolved}
+    facts = known_data or {}
+    for form_field in getattr(scan, "fields", []):
+        if not form_field.label or normalize(form_field.label) in normalized or client is None:
+            continue
+        value = match_answer_llm(form_field.label, facts, client)
+        if value is not None:
+            resolved[form_field.label] = value
+            normalized.add(normalize(form_field.label))
+    return resolved

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -8,8 +8,45 @@ from types import SimpleNamespace
 import pytest
 
 from hhru_bot.commands import fill_form
+from hhru_bot.external_forms.detect import FormField, FormScan, match_answer_llm, resolve_answers
 
 pytestmark = pytest.mark.unit
+
+
+def test_match_answer_llm_can_only_select_a_known_fact():
+    class FakeLLM:
+        def __init__(self, content):
+            self.content = content
+
+        def chat(self, _messages, **_kwargs):
+            return SimpleNamespace(content=self.content)
+
+    facts = {"город": "Москва", "имя": "Ada Lovelace"}
+    assert (
+        match_answer_llm(
+            "В каком городе вы живёте?", facts, FakeLLM('{"key":"город","confidence":0.91}')
+        )
+        == "Москва"
+    )
+    assert (
+        match_answer_llm("Ваш телефон?", facts, FakeLLM('{"key":"телефон","confidence":0.99}'))
+        is None
+    )
+    assert (
+        match_answer_llm("Ваш город?", facts, FakeLLM('{"key":"город","confidence":0.5}')) is None
+    )
+
+
+def test_resolve_answers_adds_only_confident_semantic_matches():
+    class FakeLLM:
+        def chat(self, messages, **_kwargs):
+            assert "Ваш город?" in messages[0]["content"]
+            return SimpleNamespace(content='{"key":"город","confidence":0.9}')
+
+    scan = FormScan([FormField("text", "#city", "Ваш город?", True)])
+    assert resolve_answers(scan, {}, known_data={"город": "Москва"}, client=FakeLLM()) == {
+        "Ваш город?": "Москва"
+    }
 
 
 def test_run_uses_account_profile_answers(monkeypatch, tmp_path):

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -66,12 +66,42 @@ def test_match_answer_llm_sends_only_keys_not_pii_values():
             content = messages[0]["content"]
             # The model is only a key-classifier: it needs to know the field
             # names exist, never the underlying contact data.
-            assert "+7 900 123-45-67" not in content
+            assert "Москва" not in content
             assert "ada@example.test" not in content
-            return SimpleNamespace(content='{"key":"телефон","confidence":0.9}')
+            return SimpleNamespace(content='{"key":"город","confidence":0.9}')
 
-    facts = {"телефон": "+7 900 123-45-67", "email": "ada@example.test"}
-    assert match_answer_llm("Ваш телефон?", facts, FakeLLM()) == "+7 900 123-45-67"
+    # "город" is not a denied (sensitive) key — see
+    # test_match_answer_llm_never_selects_high_sensitivity_keys for phone/email.
+    facts = {"город": "Москва", "email": "ada@example.test"}
+    assert match_answer_llm("В каком городе вы живёте?", facts, FakeLLM()) == "Москва"
+
+
+def test_match_answer_llm_never_selects_high_sensitivity_keys():
+    """#280 review round 3: even a confident LLM match must not auto-select
+    phone/email/passport-like fields — those require an exact configured
+    match instead, so a mismatched-but-confident guess can't disclose them."""
+
+    class FakeLLM:
+        def __init__(self, content):
+            self.content = content
+
+        def chat(self, _messages, **_kwargs):
+            return SimpleNamespace(content=self.content)
+
+    facts = {"телефон": "+7 900 123-45-67", "email": "ada@example.test", "город": "Москва"}
+    assert (
+        match_answer_llm("Ваш контакт?", facts, FakeLLM('{"key":"телефон","confidence":0.99}'))
+        is None
+    )
+    assert (
+        match_answer_llm("Как связаться?", facts, FakeLLM('{"key":"email","confidence":0.99}'))
+        is None
+    )
+    # Low-sensitivity fields remain matchable.
+    assert (
+        match_answer_llm("Ваш город?", facts, FakeLLM('{"key":"город","confidence":0.9}'))
+        == "Москва"
+    )
 
 
 def test_match_answer_llm_degrades_on_transport_error():

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -44,9 +44,18 @@ def test_resolve_answers_adds_only_confident_semantic_matches():
             return SimpleNamespace(content='{"key":"город","confidence":0.9}')
 
     scan = FormScan([FormField("text", "#city", "Ваш город?", True)])
-    assert resolve_answers(scan, {}, known_data={"город": "Москва"}, client=FakeLLM()) == {
-        "Ваш город?": "Москва"
-    }
+    resolved, llm_matched = resolve_answers(
+        scan, {}, known_data={"город": "Москва"}, client=FakeLLM()
+    )
+    assert resolved == {"Ваш город?": "Москва"}
+    assert llm_matched == {"Ваш город?"}
+
+
+def test_resolve_answers_marks_exact_matches_as_not_llm_derived():
+    scan = FormScan([FormField("text", "#name", "Ваше имя?", True)])
+    resolved, llm_matched = resolve_answers(scan, {"Ваше имя?": "Ada Lovelace"})
+    assert resolved == {"Ваше имя?": "Ada Lovelace"}
+    assert llm_matched == set()
 
 
 def test_match_answer_llm_sends_only_keys_not_pii_values():
@@ -73,6 +82,75 @@ def test_match_answer_llm_degrades_on_transport_error():
             raise RuntimeError("upstream unavailable")
 
     assert match_answer_llm("Ваш город?", {"город": "Москва"}, FailingLLM()) is None
+
+
+def test_run_degrades_when_llm_client_construction_raises_any_exception(monkeypatch, tmp_path):
+    """#280 review round 2: any LLMClient() construction failure (not just
+    ImportError/RuntimeError/ValueError) must degrade to exact-match, not crash."""
+
+    class FakeHistory:
+        def __init__(self, _path):
+            pass
+
+        def get_profile_answers(self):
+            return {"город": "Москва"}
+
+    class FakePage:
+        url = "https://forms.example.test/application"
+
+        def goto(self, _url, wait_until):
+            pass
+
+        def content(self):
+            return "<html></html>"
+
+        def screenshot(self, **_kwargs):
+            pass
+
+    class FakeContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def new_page(self):
+            return FakePage()
+
+    class BrokenLLMClient:
+        def __init__(self, _ai_config):
+            raise KeyError("malformed ai config")
+
+    monkeypatch.setattr(fill_form, "History", FakeHistory)
+    monkeypatch.setattr(
+        "hhru_bot.config.load_config_or_exit",
+        lambda _path: SimpleNamespace(
+            storage_state_file=tmp_path / "session.json",
+            user_agent=None,
+            ai=SimpleNamespace(provider="fake"),
+        ),
+    )
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: FakeContext())
+    monkeypatch.setattr(
+        fill_form,
+        "scan_form",
+        lambda _page: SimpleNamespace(indeterminate=False, reason=""),
+    )
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", BrokenLLMClient)
+    monkeypatch.setattr(fill_form, "apply_answers", lambda *_a, **_kw: (True, []))
+    monkeypatch.setattr(fill_form, "LOG_DIR", tmp_path / "logs")
+
+    result = fill_form.run(
+        Namespace(
+            dry_run=True,
+            url="https://forms.example.test/application",
+            config="config.yaml",
+            history=str(tmp_path / "history.db"),
+            headless=True,
+        )
+    )
+
+    assert result is False
 
 
 def test_run_uses_account_profile_answers(monkeypatch, tmp_path):
@@ -142,3 +220,74 @@ def test_run_uses_account_profile_answers(monkeypatch, tmp_path):
     assert result is False
     assert captured["history_path"] == str(tmp_path / "history.db")
     assert captured["answers"] == {"your name": "Ada Lovelace"}
+
+
+def test_run_reports_llm_matched_fields_in_dry_run_output(monkeypatch, tmp_path, capsys):
+    """#280 review round 2: LLM-inferred matches must be visible to the reviewer,
+    not silently indistinguishable from exact form_profile.answers matches."""
+
+    class FakeHistory:
+        def __init__(self, _path):
+            pass
+
+        def get_profile_answers(self):
+            return {"город": "Москва"}
+
+    class FakePage:
+        url = "https://forms.example.test/application"
+
+        def goto(self, _url, wait_until):
+            pass
+
+        def content(self):
+            return "<html></html>"
+
+        def screenshot(self, **_kwargs):
+            pass
+
+    class FakeContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def new_page(self):
+            return FakePage()
+
+    monkeypatch.setattr(fill_form, "History", FakeHistory)
+    monkeypatch.setattr(
+        "hhru_bot.config.load_config_or_exit",
+        lambda _path: SimpleNamespace(
+            storage_state_file=tmp_path / "session.json", user_agent=None, ai=None
+        ),
+    )
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: FakeContext())
+    monkeypatch.setattr(
+        fill_form,
+        "scan_form",
+        lambda _page: SimpleNamespace(indeterminate=False, reason=""),
+    )
+    monkeypatch.setattr(
+        fill_form,
+        "resolve_answers",
+        lambda *_a, **_kw: ({"Ваш город?": "Москва"}, {"Ваш город?"}),
+    )
+    monkeypatch.setattr(fill_form, "apply_answers", lambda *_a, **_kw: (True, []))
+    monkeypatch.setattr(fill_form, "LOG_DIR", tmp_path / "logs")
+
+    result = fill_form.run(
+        Namespace(
+            dry_run=True,
+            url="https://forms.example.test/application",
+            config="config.yaml",
+            history=str(tmp_path / "history.db"),
+            headless=True,
+        )
+    )
+
+    assert result is False
+    out = capsys.readouterr().out
+    assert "[INFO] LLM-сопоставление" in out
+    assert "Ваш город?" in out
+    assert "Москва" in out

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -49,6 +49,32 @@ def test_resolve_answers_adds_only_confident_semantic_matches():
     }
 
 
+def test_match_answer_llm_sends_only_keys_not_pii_values():
+    """Prompt must never carry the actual profile values (#280 review: PII disclosure)."""
+
+    class FakeLLM:
+        def chat(self, messages, **_kwargs):
+            content = messages[0]["content"]
+            # The model is only a key-classifier: it needs to know the field
+            # names exist, never the underlying contact data.
+            assert "+7 900 123-45-67" not in content
+            assert "ada@example.test" not in content
+            return SimpleNamespace(content='{"key":"телефон","confidence":0.9}')
+
+    facts = {"телефон": "+7 900 123-45-67", "email": "ada@example.test"}
+    assert match_answer_llm("Ваш телефон?", facts, FakeLLM()) == "+7 900 123-45-67"
+
+
+def test_match_answer_llm_degrades_on_transport_error():
+    """Any client.chat() failure must fall back to None, not crash fill-form (#280 review)."""
+
+    class FailingLLM:
+        def chat(self, _messages, **_kwargs):
+            raise RuntimeError("upstream unavailable")
+
+    assert match_answer_llm("Ваш город?", {"город": "Москва"}, FailingLLM()) is None
+
+
 def test_run_uses_account_profile_answers(monkeypatch, tmp_path):
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
Closes #280

## Summary
- add optional LLM semantic matching for unresolved external-form questions
- constrain the model to selecting only known account-profile facts with confidence >= 0.85
- keep missing fields fail-closed and preserve dry-run-only behavior

## Tests
- TMPDIR=/tmp pytest -q tests/test_fill_form.py
- ruff check src/hhru_bot/commands/fill_form.py src/hhru_bot/external_forms/detect.py tests/test_fill_form.py
- ruff format --check src/hhru_bot/commands/fill_form.py src/hhru_bot/external_forms/detect.py tests/test_fill_form.py

## Risk
No browser writes or submit behavior changed; LLM failures and uncertain matches remain unresolved/missing.