### PR TITLE
fix(apply): detect hidden resume warning

### DIFF
--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -261,7 +261,13 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     # #207: с клика по кнопке отклика начинается «серая зона» — дальнейшие
     # fail-исходы финализируются через _finalize_post_click_failure (внешняя
     # проверка /applicant/negotiations), а не сразу ctx.fail.
-    if not apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id):
+    navigation_result = apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
+    if isinstance(navigation_result, str):
+        # #350: развёрнутое предупреждение о видимости резюме — недвусмысленный,
+        # неисполнимый пропуск; не форма не отрисовалась, а hh.ru дал определённый
+        # ответ прямо на странице вакансии.
+        return ctx.skip(navigation_result, skip_reason=SKIP_REASONS.RESUME_VISIBILITY)
+    if not navigation_result:
         reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
         logger.warning("[FAIL] %s — %s", ctx.vacancy.title, reason)
         return _finalize_post_click_failure(ctx, reason)

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -185,7 +185,12 @@ def probe_vacancy(
             return ProbeResult(vacancy, False, reason, skipped=True)
         return ProbeResult(vacancy, False, "кнопка отклика не найдена на странице")
 
-    if not apply_steps.navigate_to_response_form(page, vacancy.vacancy_id):
+    navigation_result = apply_steps.navigate_to_response_form(page, vacancy.vacancy_id)
+    if isinstance(navigation_result, str):
+        # #350: развёрнутое предупреждение о видимости резюме — недвусмысленный
+        # пропуск, без дампа (hh.ru дал определённый ответ прямо на странице).
+        return ProbeResult(vacancy, False, navigation_result, skipped=True)
+    if not navigation_result:
         reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
         partial_ctx = ProbeContext(
             vacancy_id=vacancy.vacancy_id,

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -30,6 +30,10 @@ APPLY_TIMEOUT_MS = 10_000
 # отсутствовать — это нормально, а не ошибка). Ждать полной APPLY_TIMEOUT_MS тут
 # бессмысленно: отсутствие поля детерминировано почти сразу.
 OPTIONAL_FIELD_TIMEOUT_MS = 1_500
+# The response modal is rendered on the vacancy page in this failure mode, so
+# do not spend the full navigation timeout waiting for a URL that will never
+# change.
+RESUME_WARNING_TIMEOUT_MS = 1_500
 # Таймаут ожидания селектора выбора резюме. Это НЕ опциональное поле вроде
 # cover-letter: если на multi-resume аккаунте селектор резюме не успел отрисоваться
 # за короткий OPTIONAL_FIELD_TIMEOUT_MS (медленный JS-рендер залогиненной формы),
@@ -108,12 +112,36 @@ def wait_apply_button(page: Page) -> bool:
     return apply_button.count() > 0
 
 
-def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> bool:
+def _hidden_resume_warning_is_expanded(page: Page) -> bool:
+    """Return whether hh.ru has expanded the resume-visibility warning."""
+    try:
+        page.wait_for_function(
+            """selector => [...document.querySelectorAll(selector)].some(el => {
+                const style = getComputedStyle(el);
+                return style.display !== 'none' && style.visibility !== 'hidden'
+                    && style.maxHeight !== '0px';
+            })""",
+            vacancy_page.VACANCY_HIDDEN_RESUME_WARNING,
+            timeout=RESUME_WARNING_TIMEOUT_MS,
+        )
+    except (PlaywrightError, AttributeError):
+        return False
+    return True
+
+
+def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> str | bool:
     """Кликает кнопку отклика и дожидается навигации на форму отклика.
 
-    Возвращает ``True``, если submit-кнопка формы стала видимой, иначе ``False``.
+    Возвращает:
+    - ``str`` — причина недвусмысленного, неисполнимого пропуска (#350: развёрнутое
+      предупреждение о видимости резюме прямо на странице вакансии вместо перехода
+      на форму отклика);
+    - ``True`` — submit-кнопка формы стала видимой;
+    - ``False`` — рендер формы не подтверждён (навигация/рендер не удались).
+
     Это различие важно: pipeline не должен запускать детекцию вопросов для формы,
-    рендер которой не подтверждён.
+    рендер которой не подтверждён, и не должен ждать полный таймаут навигации,
+    если hh.ru уже дал определённый ответ прямо на странице вакансии.
 
     ``vacancy_id`` (опционален — probe.py его тоже передаёт, но не обязан) даёт
     диагностическим дампам таймаутов отдельное имя на вакансию, чтобы не терять
@@ -170,6 +198,12 @@ def navigate_to_response_form(page: Page, vacancy_id: str | None = None) -> bool
         # нет, не крашим цикл откликов необработанным исключением.
         logger.warning("Клик по кнопке отклика упал с ошибкой (%s) — вакансия пропущена", exc)
         return False
+    # #350: some accounts receive a modal on the vacancy URL instead of a form
+    # navigation.  Its expanded warning is a definitive, non-actionable skip.
+    if _hidden_resume_warning_is_expanded(page):
+        reason = "видимость резюме недостаточна для отклика"
+        logger.info("Вакансия пропущена: %s", reason)
+        return reason
     # #179: таймаут/ошибка ожидания URL сама по себе не означает, что клик не
     # сработал — не крашим весь pipeline необработанным исключением, а
     # логируем и отдаём управление дальше. fill_response_form (через

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -247,6 +247,7 @@ class _SkipReasons:
     LOW_EMPLOYER_SIGNAL = "low_employer_signal"  # #85 pre-LLM фильтр (зарезервирован)
     LOW_LLM_SCORE = "low_llm_score"  # будущий отсев по LLM-скорингу #74
     HAS_QUESTIONS = "has_questions"  # #84 идея №7 (зарезервирован)
+    RESUME_VISIBILITY = "resume_visibility"  # отклик заблокирован видимостью резюме
     DUPLICATE = "duplicate"  # дубликат вакансии в одном сборе
 
 
@@ -264,6 +265,7 @@ SKIP_REASON_VALUES = (
     _SkipReasons.LOW_EMPLOYER_SIGNAL,
     _SkipReasons.LOW_LLM_SCORE,
     _SkipReasons.HAS_QUESTIONS,
+    _SkipReasons.RESUME_VISIBILITY,
     _SkipReasons.DUPLICATE,
 )
 

--- a/src/hhru_bot/selector_groups/vacancy_page.py
+++ b/src/hhru_bot/selector_groups/vacancy_page.py
@@ -7,6 +7,9 @@ VACANCY_APPLY_BUTTON = "[data-qa='vacancy-response-link-top']"
 # The "again" control opens a modal with a separate repeat-submit action.
 VACANCY_ALREADY_RESPONDED_AGAIN = "[data-qa='vacancy-response-link-top-again']"
 VACANCY_ALREADY_RESPONDED_CHAT = "[data-qa='vacancy-response-link-view-topic']"
+# Rendered in the response modal when the selected resume is not visible to
+# client companies.  This can appear while the URL remains the vacancy URL.
+VACANCY_HIDDEN_RESUME_WARNING = "[data-qa='hidden-resume-warning']"
 VACANCY_TITLE = "[data-qa='vacancy-title']"
 VACANCY_COMPANY_NAME = "[data-qa='vacancy-company-name']"
 

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -196,6 +196,7 @@ class FakeStepsPage:
         self.wait_for_url_error: Exception | None = None
         self.screenshot_calls = 0
         self.content_calls = 0
+        self.wait_for_function_calls: list[tuple[str, str | None, int | None]] = []
 
     def screenshot(self, **_kwargs) -> bytes:
         self.screenshot_calls += 1
@@ -204,6 +205,11 @@ class FakeStepsPage:
     def content(self) -> str:
         self.content_calls += 1
         return "<html>diagnostic</html>"
+
+    def wait_for_function(self, _expression, arg=None, timeout=None):
+        self.wait_for_function_calls.append(("function", arg, timeout))
+        if not self._state(arg).visible:
+            raise PlaywrightTimeoutError("condition not met")
 
     def _state(self, selector: str) -> _SelectorState:
         return self.states.setdefault(selector, _SelectorState())
@@ -276,6 +282,17 @@ def test_navigate_clicks_apply_button_and_waits_submit():
     # Клик по apply-кнопке + ожидание URL через wait_for_url (#179).
     assert page.navigation_entered == 1
     assert page._state(vacancy_page.VACANCY_APPLY_BUTTON).clicks == 1
+
+
+def test_navigate_skips_expanded_hidden_resume_warning_without_url_wait():
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(vacancy_page.VACANCY_HIDDEN_RESUME_WARNING, True)
+
+    reason = steps.navigate_to_response_form(page, "136173988")
+
+    assert reason == "видимость резюме недостаточна для отклика"
+    assert page.navigation_entered == 0
 
 
 def test_navigate_does_not_raise_when_form_never_renders():


### PR DESCRIPTION
Closes #350

## Summary
- detect the expanded `hidden-resume-warning` modal before waiting for response-form navigation
- classify the vacancy as a persistent `resume_visibility` skip in apply and probe flows
- add focused fixture-style coverage

## Tests
- `pytest -q tests/test_apply_steps.py tests/test_apply_pipeline.py tests/test_apply_probe.py`
- `ruff check src tests`
- `ruff format --check src tests`

## Risks
- The warning check is bounded to 1.5s and fails open to the existing navigation handling when the selector is absent or the page API is unavailable.