### PR TITLE
fix(list-resumes): fail closed on malformed SSR status data

### DIFF
--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -351,19 +351,33 @@ def list_resume_cards(
         state = None
         ssr_unavailable = True
 
-    if not ssr_unavailable and isinstance(state, dict):
+    if not ssr_unavailable and not isinstance(state, dict):
+        # Valid JSON can still have the wrong top-level shape (for example an
+        # interstitial payload such as null or a list).
+        ssr_unavailable = True
+    elif not ssr_unavailable:
         resumes = state.get("applicantResumes")
-        if not isinstance(resumes, list):
-            # applicantResumes отсутствует или имеет неправильный тип
+        if not isinstance(resumes, list) or not resumes:
+            # applicantResumes отсутствует, пуст или имеет неправильный тип:
+            # пустой список неотличим от SSR, который не загрузился.
             ssr_unavailable = True
         else:
             for item in resumes:
                 attrs = item.get("_attributes") if isinstance(item, dict) else None
-                if isinstance(attrs, dict):
-                    resume_hash = attrs.get("hash")
-                    status = attrs.get("status")
-                    if resume_hash and status is not None:
-                        status_by_hash[str(resume_hash)] = str(status)
+                resume_hash = attrs.get("hash") if isinstance(attrs, dict) else None
+                status = attrs.get("status") if isinstance(attrs, dict) else None
+                if (
+                    not isinstance(resume_hash, str)
+                    or not resume_hash
+                    or not isinstance(status, str)
+                    or not status
+                ):
+                    # A partially valid SSR payload must not be presented as a
+                    # complete status read: callers need to know that status
+                    # data is unavailable or schema-drifted.
+                    ssr_unavailable = True
+                    continue
+                status_by_hash[resume_hash] = status
 
     cards: list[ResumeCard] = []
     for card in cards_locator.all():

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -278,6 +278,7 @@ def test_lists_cards_with_status_from_ssr(monkeypatch):
     assert len(cards) == 2
     assert cards[0].status == "not_finished"
     assert cards[1].status == "modified"
+    assert not any(card.ssr_unavailable for card in cards)
 
 
 def test_missing_ssr_does_not_fail(monkeypatch):
@@ -289,6 +290,47 @@ def test_missing_ssr_does_not_fail(monkeypatch):
 
     assert len(cards) == 1
     assert cards[0].status is None
+    assert cards[0].ssr_unavailable
+
+
+@pytest.mark.parametrize(
+    "resumes",
+    [
+        [],
+        [{"_attributes": {"hash": ID_A}}],
+        [{"_attributes": {"status": "modified"}}],
+        [{"_attributes": {"hash": ID_A, "status": None}}],
+        [{"_attributes": None}],
+        ["not a resume"],
+    ],
+)
+def test_schema_drift_marks_ssr_unavailable(monkeypatch, resumes):
+    """A malformed or empty SSR payload must not look like a valid status read."""
+    state = json.dumps({"applicantResumes": resumes}, ensure_ascii=False)
+    html = (
+        f"<html><body><template id='HH-Lux-InitialState'>{escape(state)}</template></body></html>"
+    )
+    page = StubPage([StubCard(ID_A, title_text="Backend developer")])
+    _patch_goto(monkeypatch, page)
+    monkeypatch.setattr(page, "content", lambda: html)
+
+    cards = cr.list_resume_cards(page)
+
+    assert cards[0].status is None
+    assert cards[0].ssr_unavailable
+
+
+@pytest.mark.parametrize("raw_state", ["null", "[1, 2]", '"string"'])
+def test_non_dict_ssr_state_marks_unavailable(monkeypatch, raw_state):
+    html = f"<html><body><template id='HH-Lux-InitialState'>{raw_state}</template></body></html>"
+    page = StubPage([StubCard(ID_A, title_text="Backend developer")])
+    _patch_goto(monkeypatch, page)
+    monkeypatch.setattr(page, "content", lambda: html)
+
+    cards = cr.list_resume_cards(page)
+
+    assert cards[0].status is None
+    assert cards[0].ssr_unavailable
 
 
 # --- resolve_numeric_resume_ids (#212) ----------------------------------------


### PR DESCRIPTION
Closes #318

## Summary
- mark SSR unavailable for non-object, empty, or malformed applicant resume data
- add regression coverage for schema drift and missing status fields

## Tests
- TMPDIR=/tmp pytest -q tests/test_list_resume_cards.py tests/test_list_resumes_command.py
- ruff check src/hhru_bot/copy_resume.py tests/test_list_resume_cards.py
- ruff format --check src/hhru_bot/copy_resume.py tests/test_list_resume_cards.py