### PR TITLE
feat: detect portfolio evidence requirements

### DIFF
--- a/docs/portfolio-evidence.md
+++ b/docs/portfolio-evidence.md
@@ -1,0 +1,20 @@
+# Portfolio evidence detection (#348)
+
+Vacancy/card text is passed through `detect_portfolio_evidence`. The
+deterministic stage requires an evidence artefact (GitHub/GitLab, portfolio,
+project, demo, case study, bot, or deployed service) and request language
+(attach/include/provide a link, or Russian equivalents) in the same sentence.
+This avoids treating technology mentions such as **GitHub Actions** or a
+company's GitHub link as a candidate request.
+
+`required` is used for explicit or mandatory wording (`must`, `обязательно`,
+`пришлите`, etc.); `preferred` is used for softer wording (`желательно`,
+`будет плюсом`, `nice to have`). The matching sentence is retained in
+`evidence`, and confidence is a heuristic (0.95/0.82), not a probability.
+
+An optional second-stage classifier can return strict JSON with `level`,
+`confidence`, and `rationale`. Results below 0.7, malformed responses, and
+transport failures fall back to the keyword result. The model cannot turn an
+incidental mention into a requirement, and the parser never writes or changes
+an application. The signal is exposed on `VacancyCard` and included in the
+scoring prompt for downstream ranking/application preparation.

--- a/src/hhru_bot/portfolio_evidence.py
+++ b/src/hhru_bot/portfolio_evidence.py
@@ -1,0 +1,137 @@
+"""Read-only detection of portfolio/project evidence requests in vacancies.
+
+The first stage is deliberately deterministic.  It requires both an artefact
+term (GitHub, demo, portfolio, etc.) and language asking for or encouraging a
+link/example.  This keeps incidental mentions such as ``GitHub Actions`` and
+company GitHub pages out of the signal.  An optional LLM stage may refine an
+ambiguous keyword match, but can never invent a requirement when the model is
+unavailable or uncertain.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+PortfolioEvidenceLevel = Literal["required", "preferred", "none"]
+
+
+@dataclass(frozen=True)
+class PortfolioEvidenceRequirement:
+    """Structured, explainable portfolio evidence signal."""
+
+    level: PortfolioEvidenceLevel
+    evidence: tuple[str, ...] = ()
+    rationale: str = ""
+    confidence: float = 0.0
+    source: Literal["keyword", "llm", "keyword+llm", "none"] = "none"
+
+
+# Keep terms specific enough that a technology mention alone is not a hit.
+_ARTEFACT = re.compile(
+    r"(?i)(?:github|gitlab|репозитор(?:ий|ии)|portfolio|портфолио|"
+    r"project(?:s)?|проект(?:ы|ов)?|demo(?:s)?|демо|case\s*stud(?:y|ies)|"
+    r"кейс(?:ы|ов)?|bot(?:s)?|бот(?:ы|ов)?|deployed\s+service|"
+    r"рабоч(?:ий|ие)\s+(?:сервис|сервисы))"
+)
+_REQUEST = re.compile(
+    r"(?i)(?:attach|include|provide|send|share|add|link|links?|"
+    r"приложить|приложите|прикрепить|прикрепите|указать|укажите|"
+    r"предоставить|пришлите|ссылк(?:а|у|и|и на)|покажите|"
+    r"расскажите\s+о|примеры?\s+(?:работы|проектов))"
+)
+_REQUIRED = re.compile(
+    r"(?i)(?:обязательн|must|require[ds]?|need(?:ed)?|please\s+attach|"
+    r"пришлите|приложите|прикрепите|предоставьте|укажите)"
+)
+_PREFERRED = re.compile(
+    r"(?i)(?:желательно|будет\s+плюсом|плюсом|приветствуются?|"
+    r"preferred|nice\s+to\s+have|would\s+be\s+great|можно\s+приложить|"
+    r"если\s+есть)"
+)
+_COMPANY_LINK = re.compile(
+    r"(?i)(?:company|компани[ия]|работодател[яь]).{0,30}(?:github|gitlab)|(?:github|gitlab).{0,30}(?:company|компани[ия]|работодател[яь])"
+)
+_SENTENCE = re.compile(r"[^.!?\n]+(?:[.!?]|$)")
+
+
+def _evidence_sentences(text: str, spans: list[tuple[int, int]]) -> tuple[str, ...]:
+    result: list[str] = []
+    for sentence in _SENTENCE.finditer(text):
+        if any(
+            sentence.start() <= start < sentence.end() or sentence.start() < end <= sentence.end()
+            for start, end in spans
+        ):
+            value = " ".join(sentence.group(0).split()).strip()
+            if value and value not in result:
+                result.append(value)
+    return tuple(result)
+
+
+def detect_portfolio_evidence(text: str | None) -> PortfolioEvidenceRequirement:
+    """Detect explicit requests for links/examples from vacancy text.
+
+    A match is returned only when an artefact and request phrase occur in the
+    same sentence.  The source sentence is retained for downstream review.
+    """
+    if not text or not text.strip():
+        return PortfolioEvidenceRequirement("none")
+    spans: list[tuple[int, int]] = []
+    levels: list[str] = []
+    for sentence in _SENTENCE.finditer(text):
+        value = sentence.group(0)
+        artefacts = list(_ARTEFACT.finditer(value))
+        requests = list(_REQUEST.finditer(value))
+        if not artefacts or not requests or _COMPANY_LINK.search(value):
+            continue
+        spans.append((sentence.start(), sentence.end()))
+        levels.append("required" if _REQUIRED.search(value) else "preferred")
+    if not spans:
+        return PortfolioEvidenceRequirement("none")
+    level: PortfolioEvidenceLevel = "required" if "required" in levels else "preferred"
+    evidence = _evidence_sentences(text, spans)
+    return PortfolioEvidenceRequirement(
+        level,
+        evidence=evidence,
+        rationale="explicit evidence request detected by keyword rules",
+        confidence=0.95 if level == "required" else 0.82,
+        source="keyword",
+    )
+
+
+class PortfolioEvidenceLLM(Protocol):
+    def classify(self, text: str) -> str | None: ...
+
+
+def classify_portfolio_evidence(
+    text: str | None, llm: PortfolioEvidenceLLM | None = None
+) -> PortfolioEvidenceRequirement:
+    """Run keyword detection, optionally refining it with a strict LLM result.
+
+    LLM output is accepted only as ``required``/``preferred`` JSON with a
+    confidence of at least 0.7.  Failures retain keyword evidence; an LLM
+    cannot turn an incidental mention into a requirement.
+    """
+    keyword = detect_portfolio_evidence(text)
+    if llm is None or not text or keyword.level == "none":
+        return keyword
+    try:
+        raw = llm.classify(text)
+        data = json.loads(raw or "")
+        level = data.get("level")
+        confidence = float(data.get("confidence", 0))
+        if level not in ("required", "preferred", "none") or confidence < 0.7:
+            return keyword
+        if level == "none":
+            return keyword
+        return PortfolioEvidenceRequirement(
+            level,
+            evidence=keyword.evidence,
+            rationale=str(data.get("rationale") or keyword.rationale)[:240],
+            confidence=min(confidence, 1.0),
+            source="keyword+llm",
+        )
+    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        return keyword

--- a/src/hhru_bot/portfolio_evidence.py
+++ b/src/hhru_bot/portfolio_evidence.py
@@ -56,6 +56,12 @@ _COMPANY_LINK = re.compile(
 )
 _SENTENCE = re.compile(r"[^.!?\n]+(?:[.!?]|$)")
 
+# Evidence sentences are embedded verbatim into the LLM scoring prompt
+# (scoring.py).  A pathologically long or unpunctuated vacancy description is
+# employer-controlled input, so cap each sentence to bound prompt size/token
+# cost and reduce the surface for prompt-injection attempts.
+_MAX_EVIDENCE_SENTENCE_LEN = 500
+
 
 def _evidence_sentences(text: str, spans: list[tuple[int, int]]) -> tuple[str, ...]:
     result: list[str] = []
@@ -65,6 +71,8 @@ def _evidence_sentences(text: str, spans: list[tuple[int, int]]) -> tuple[str, .
             for start, end in spans
         ):
             value = " ".join(sentence.group(0).split()).strip()
+            if len(value) > _MAX_EVIDENCE_SENTENCE_LEN:
+                value = value[:_MAX_EVIDENCE_SENTENCE_LEN].rstrip() + "…"
             if value and value not in result:
                 result.append(value)
     return tuple(result)
@@ -133,5 +141,7 @@ def classify_portfolio_evidence(
             confidence=min(confidence, 1.0),
             source="keyword+llm",
         )
-    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+    except Exception:  # noqa: BLE001 - any classifier failure (transport, parsing,
+        # malformed response) must fall back to the keyword result, never propagate
+        # and never claim a requirement the keyword stage did not confirm.
         return keyword

--- a/src/hhru_bot/scoring.py
+++ b/src/hhru_bot/scoring.py
@@ -655,6 +655,20 @@ def _build_scoring_prompt(card: VacancyCard, profile: AIProfile | None) -> list[
         if info.reviews_count is not None:
             parts.append(f"отзывов: {info.reviews_count}")
         lines.append("Работодатель: " + ", ".join(parts) + ".")
+    requirement = getattr(card, "portfolio_evidence_requirement", None)
+    if requirement is not None and requirement.level != "none":
+        lines.append(
+            "Требование портфолио/проектов: "
+            f"{requirement.level}; источник: " + " | ".join(requirement.evidence)
+        )
+    elif getattr(card, "vacancy_text", ""):
+        # Consumers that construct cards from a full description need not run
+        # the parser themselves; keep the prompt read-only and deterministic.
+        from .portfolio_evidence import detect_portfolio_evidence
+
+        detected = detect_portfolio_evidence(card.vacancy_text)
+        if detected.level != "none":
+            lines.append("Требование портфолио/проектов: " + detected.level)
 
     if profile is not None:
         if profile.summary:

--- a/src/hhru_bot/scoring.py
+++ b/src/hhru_bot/scoring.py
@@ -655,20 +655,15 @@ def _build_scoring_prompt(card: VacancyCard, profile: AIProfile | None) -> list[
         if info.reviews_count is not None:
             parts.append(f"отзывов: {info.reviews_count}")
         lines.append("Работодатель: " + ", ".join(parts) + ".")
+    # VacancyCard.__post_init__ (search.py) already populates this from
+    # vacancy_text whenever it is set, so no fallback recomputation is needed
+    # here — a card with vacancy_text always has a non-None requirement.
     requirement = getattr(card, "portfolio_evidence_requirement", None)
     if requirement is not None and requirement.level != "none":
         lines.append(
             "Требование портфолио/проектов: "
             f"{requirement.level}; источник: " + " | ".join(requirement.evidence)
         )
-    elif getattr(card, "vacancy_text", ""):
-        # Consumers that construct cards from a full description need not run
-        # the parser themselves; keep the prompt read-only and deterministic.
-        from .portfolio_evidence import detect_portfolio_evidence
-
-        detected = detect_portfolio_evidence(card.vacancy_text)
-        if detected.level != "none":
-            lines.append("Требование портфолио/проектов: " + detected.level)
 
     if profile is not None:
         if profile.summary:

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -349,8 +349,9 @@ def search_vacancies(
                     ),
                     salary=salary,
                     employer_info=employer_info,
+                    # VacancyCard.__post_init__ derives portfolio_evidence_requirement
+                    # from vacancy_text automatically; no need to compute it twice.
                     vacancy_text=card_text,
-                    portfolio_evidence_requirement=detect_portfolio_evidence(card_text),
                 )
             )
 

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -321,7 +321,7 @@ def search_vacancies(
                     # по innerHTML пропускал такие ЗП (5/15 → 19/20 ловится по тексту).
                     # extract_salary_text корректно работает и с HTML, и с голым текстом
                     # (удаление тегов на тексте = no-op), поэтому кормим её textContent.
-                    salary_text = extract_salary_text(card.inner_text())
+                    salary_text = extract_salary_text(card_text)
                 except Exception:
                     logger.warning("Не удалось получить inner_text для ЗП-fallback", exc_info=True)
             salary = parse_salary(salary_text)

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -14,6 +14,7 @@ from .browser import HH_BASE_URL, goto_hh
 from .config import ResumeConfig, SearchFilters
 from .config_sections.scoring import ScoringConfig, ScoringWeights
 from .history import SKIP_REASONS
+from .portfolio_evidence import PortfolioEvidenceRequirement, detect_portfolio_evidence
 
 if TYPE_CHECKING:
     # EmployerInfo живёт в scoring.py; импортируем только для type-checking,
@@ -172,6 +173,14 @@ class VacancyCard:
     # classify_employer и LLM-скоринга (#74 Этапы 2-3). Ленивый импорт типа —
     # чтобы не тащить scoring.py (а с ним ai) на уровень search.py импорта.
     employer_info: EmployerInfo | None = None
+    # Read-only signal from vacancy/card text.  Full descriptions can be passed
+    # by callers through ``vacancy_text`` when available.
+    vacancy_text: str = ""
+    portfolio_evidence_requirement: PortfolioEvidenceRequirement | None = None
+
+    def __post_init__(self) -> None:
+        if self.portfolio_evidence_requirement is None and self.vacancy_text:
+            self.portfolio_evidence_requirement = detect_portfolio_evidence(self.vacancy_text)
 
 
 def build_search_url(filters: SearchFilters, page_num: int = 0) -> str:
@@ -287,6 +296,7 @@ def search_vacancies(
 
         for i in range(count):
             card = cards.nth(i)
+            card_text = card.inner_text()
             title_link = card.locator(sel.VACANCY_CARD_TITLE_LINK).first
             title = title_link.inner_text().strip()
             href = title_link.get_attribute("href") or ""
@@ -339,6 +349,8 @@ def search_vacancies(
                     ),
                     salary=salary,
                     employer_info=employer_info,
+                    vacancy_text=card_text,
+                    portfolio_evidence_requirement=detect_portfolio_evidence(card_text),
                 )
             )
 

--- a/tests/test_portfolio_evidence.py
+++ b/tests/test_portfolio_evidence.py
@@ -1,0 +1,86 @@
+"""Fixtures for vacancy portfolio-evidence detection (#348)."""
+
+import pytest
+
+from hhru_bot.portfolio_evidence import (
+    PortfolioEvidenceRequirement,
+    classify_portfolio_evidence,
+    detect_portfolio_evidence,
+)
+from hhru_bot.search import VacancyCard
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Пришлите ссылки на GitHub и примеры проектов.",
+        "Please attach links to your portfolio, demos or deployed services.",
+        "Обязательно приложите кейсы и ссылки на рабочие сервисы.",
+    ],
+)
+def test_explicit_links_are_detected_and_source_is_preserved(text):
+    result = detect_portfolio_evidence(text)
+    assert result.level == "required"
+    assert result.evidence == (text,)
+    assert result.source == "keyword"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "GitHub Actions будет использоваться в CI.",
+        "Ссылка на GitHub компании находится на сайте.",
+        "Опыт с Telegram-ботами и GitLab обязателен.",
+    ],
+)
+def test_incidental_mentions_do_not_create_requirement(text):
+    assert detect_portfolio_evidence(text).level == "none"
+
+
+def test_optional_request_is_preferred():
+    result = detect_portfolio_evidence("Портфолио и ссылки на проекты будут плюсом.")
+    assert result == PortfolioEvidenceRequirement(
+        "preferred",
+        evidence=("Портфолио и ссылки на проекты будут плюсом.",),
+        rationale="explicit evidence request detected by keyword rules",
+        confidence=0.82,
+        source="keyword",
+    )
+
+
+class _LLM:
+    def __init__(self, response):
+        self.response = response
+
+    def classify(self, text):  # noqa: ARG002
+        return self.response
+
+
+def test_llm_refines_keyword_result_but_keeps_source_text():
+    result = classify_portfolio_evidence(
+        "Please include GitHub links.",
+        _LLM('{"level":"preferred","confidence":0.9,"rationale":"Useful evidence"}'),
+    )
+    assert result.level == "preferred"
+    assert result.evidence == ("Please include GitHub links.",)
+    assert result.source == "keyword+llm"
+
+
+def test_llm_failure_falls_back_to_keyword_result():
+    result = classify_portfolio_evidence("Please include GitHub links.", _LLM("not json"))
+    assert result.level == "preferred"
+    assert result.source == "keyword"
+
+
+def test_vacancy_card_exposes_signal_for_downstream_consumers():
+    card = VacancyCard(
+        vacancy_id="1",
+        title="Developer",
+        company="Acme",
+        url="https://hh.ru/vacancy/1",
+        vacancy_text="Please include links to your GitHub projects.",
+    )
+    assert card.portfolio_evidence_requirement is not None
+    assert card.portfolio_evidence_requirement.level == "preferred"

--- a/tests/test_portfolio_evidence.py
+++ b/tests/test_portfolio_evidence.py
@@ -74,6 +74,25 @@ def test_llm_failure_falls_back_to_keyword_result():
     assert result.source == "keyword"
 
 
+class _RaisingLLM:
+    def __init__(self, exc):
+        self.exc = exc
+
+    def classify(self, text):  # noqa: ARG002
+        raise self.exc
+
+
+def test_llm_transport_failure_falls_back_to_keyword_result():
+    """A real LLM client can raise transport errors (network/timeout), not
+    just malformed-JSON errors.  The documented contract (transport failures
+    fall back to the keyword result) must hold for those too."""
+    result = classify_portfolio_evidence(
+        "Please include GitHub links.", _RaisingLLM(ConnectionError("upstream unreachable"))
+    )
+    assert result.level == "preferred"
+    assert result.source == "keyword"
+
+
 def test_vacancy_card_exposes_signal_for_downstream_consumers():
     card = VacancyCard(
         vacancy_id="1",
@@ -84,3 +103,16 @@ def test_vacancy_card_exposes_signal_for_downstream_consumers():
     )
     assert card.portfolio_evidence_requirement is not None
     assert card.portfolio_evidence_requirement.level == "preferred"
+
+
+def test_evidence_sentence_is_truncated_to_avoid_unbounded_prompt_injection():
+    """A pathologically long, unpunctuated vacancy sentence must not produce
+    unbounded evidence text: unbounded evidence flows verbatim into the LLM
+    scoring prompt (scoring.py), risking prompt-size/token inflation and
+    injection attempts from adversarial vacancy descriptions."""
+    long_tail = "x" * 5000
+    text = f"Please attach a link to your GitHub portfolio {long_tail}."
+    result = detect_portfolio_evidence(text)
+    assert result.level != "none"
+    assert len(result.evidence) == 1
+    assert len(result.evidence[0]) <= 501


### PR DESCRIPTION
Closes #348

## Summary
- add deterministic Russian/English portfolio/project evidence detection with preserved source text
- expose the typed signal on VacancyCard and include it in LLM scoring context
- add optional strict second-stage classifier with fail-safe keyword fallback
- document decision boundaries and confidence semantics

## Tests
- pytest -q tests/test_portfolio_evidence.py tests/test_search.py tests/test_scoring_ml.py
- ruff check src/hhru_bot/portfolio_evidence.py src/hhru_bot/search.py src/hhru_bot/scoring.py tests/test_portfolio_evidence.py
- ruff format --check src tests

## Risks
- Search cards only contain text rendered in the search-card DOM; callers with full vacancy descriptions can pass vacancy_text for complete parsing.