### PR TITLE
fix(fill-form): allow contact field LLM matching

### DIFF
--- a/src/hhru_bot/external_forms/detect.py
+++ b/src/hhru_bot/external_forms/detect.py
@@ -19,9 +19,7 @@ _SPACE = re.compile(r"\s+")
 # round 3): a confident-but-mismatched guess on these is the costliest failure
 # mode. They remain fillable only via an exact form_profile.answers match —
 # the same, already-accepted disclosure boundary from #276/#277/#280.
-_LLM_DENIED_KEY_PATTERN = re.compile(
-    r"телефон|phone|email|e-mail|почта|паспорт|passport|снилс|инн", re.IGNORECASE
-)
+_LLM_DENIED_KEY_PATTERN = re.compile(r"паспорт|passport|снилс|инн", re.IGNORECASE)
 
 
 def normalize(text: str) -> str:

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -70,16 +70,14 @@ def test_match_answer_llm_sends_only_keys_not_pii_values():
             assert "ada@example.test" not in content
             return SimpleNamespace(content='{"key":"город","confidence":0.9}')
 
-    # "город" is not a denied (sensitive) key — see
-    # test_match_answer_llm_never_selects_high_sensitivity_keys for phone/email.
+    # "город" is not a denied (sensitive) key; contact values are also kept
+    # out of the prompt even though their field names may be classified.
     facts = {"город": "Москва", "email": "ada@example.test"}
     assert match_answer_llm("В каком городе вы живёте?", facts, FakeLLM()) == "Москва"
 
 
-def test_match_answer_llm_never_selects_high_sensitivity_keys():
-    """#280 review round 3: even a confident LLM match must not auto-select
-    phone/email/passport-like fields — those require an exact configured
-    match instead, so a mismatched-but-confident guess can't disclose them."""
+def test_match_answer_llm_allows_contact_fields_but_denies_document_ids():
+    """Contact fields are safe to infer; document identifiers still require exact answers."""
 
     class FakeLLM:
         def __init__(self, content):
@@ -88,15 +86,27 @@ def test_match_answer_llm_never_selects_high_sensitivity_keys():
         def chat(self, _messages, **_kwargs):
             return SimpleNamespace(content=self.content)
 
-    facts = {"телефон": "+7 900 123-45-67", "email": "ada@example.test", "город": "Москва"}
+    facts = {
+        "телефон": "+7 900 123-45-67",
+        "email": "ada@example.test",
+        "паспорт": "0000 000000",
+        "СНИЛС": "000-000-000 00",
+        "ИНН": "000000000000",
+        "город": "Москва",
+    }
     assert (
         match_answer_llm("Ваш контакт?", facts, FakeLLM('{"key":"телефон","confidence":0.99}'))
-        is None
+        == "+7 900 123-45-67"
     )
     assert (
         match_answer_llm("Как связаться?", facts, FakeLLM('{"key":"email","confidence":0.99}'))
-        is None
+        == "ada@example.test"
     )
+    for key in ("паспорт", "СНИЛС", "ИНН"):
+        assert (
+            match_answer_llm("Документ?", facts, FakeLLM(f'{{"key":"{key}","confidence":0.99}}'))
+            is None
+        )
     # Low-sensitivity fields remain matchable.
     assert (
         match_answer_llm("Ваш город?", facts, FakeLLM('{"key":"город","confidence":0.9}'))


### PR DESCRIPTION
Closes #361

## Summary
- remove phone/email field names from the LLM denylist
- retain passport/SNILS/INN protections
- update match_answer_llm coverage for contact and document fields

## Tests
- ruff check src tests
- ruff format --check src tests
- pytest -q tests/test_fill_form.py tests/test_account_profile.py