### PR TITLE
fix(skills): confirm resume route before AI planning

### DIFF
--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from urllib.parse import urlsplit
 
 from .copy_resume import confirm_write
 
@@ -96,6 +97,8 @@ def run(args: argparse.Namespace) -> None:
                 goto_hh(page, goto)
                 if not has_auth_cookie(page) or has_login_form(page):
                     raise RuntimeError("сессия hh.ru не подтверждена")
+                if urlsplit(page.url).path != f"/resume/{resume.resume_id}":
+                    raise RuntimeError("страница нужного резюме не подтверждена")
                 existing = read_skills(page)
                 response = LLMClient(config.ai).chat(
                     build_skills_prompt(page.locator("body").inner_text(), existing, args.mode),

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -1,0 +1,56 @@
+"""Regression tests for the resume-scoped edit-skills command."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import hhru_bot.commands.edit_skills as command
+
+pytestmark = pytest.mark.unit
+
+
+class _Page:
+    url = "https://hh.ru/resume/wrong-resume"
+
+
+@contextmanager
+def _launch_context(*_args, **_kwargs):
+    yield SimpleNamespace(new_page=lambda: _Page())
+
+
+def test_ai_planning_rejects_wrong_resume_route_before_read_or_llm(monkeypatch, capsys):
+    resume = SimpleNamespace(id="requested", resume_id="requested")
+    config = SimpleNamespace(ai=object(), storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_args: resume)
+    monkeypatch.setattr("hhru_bot.browser.launch_context", _launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_args: None)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+    monkeypatch.setattr(
+        "hhru_bot.skills.read_skills",
+        lambda _page: pytest.fail("wrong-resume page was read"),
+    )
+    monkeypatch.setattr(
+        "hhru_bot.ai.llm_client.LLMClient",
+        lambda _config: pytest.fail("LLM was called before route confirmation"),
+    )
+
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="requested",
+        mode="append",
+        skill=[],
+        dry_run=True,
+        force=False,
+    )
+    with pytest.raises(SystemExit) as exc:
+        command.run(args)
+
+    assert exc.value.code == 1
+    assert "страница нужного резюме не подтверждена" in capsys.readouterr().out


### PR DESCRIPTION
Closes #363

## Summary
- verify the exact requested resume route after navigation and authentication
- fail closed before reading skills or sending page content to the LLM when redirected
- add a regression test for a wrong-resume page

## Tests
- pytest -q tests/test_edit_skills_command.py tests/test_skills.py
- ruff check src tests
- ruff format --check src tests