### PR TITLE
fix(resume): centralize hydrated editor retries

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -127,6 +127,13 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
             trigger_selector=resume_page.RESUME_EDIT_ABOUT_BUTTON,
             editor_selector=resume_page.RESUME_ABOUT_EDITOR,
             profile_path=f"/resume/{resume.resume_id}",
+            # Pre-#339 behavior clicked unconditionally: the editor marker can
+            # be present in the DOM before React hydrates it, so count() == 1
+            # does not mean it is visible/functional yet. Without this, a
+            # hidden-but-present field skips both the click and the
+            # wait_for(visible), and input_value() silently reads "" from an
+            # unhydrated textarea instead of the real "Обо мне" text.
+            click_trigger=True,
             trigger_error="кнопка редактирования «Обо мне» не найдена однозначно",
             open_error="форма «Обо мне» не открылась",
             wrong_route_error="форма «Обо мне» открыта не для того резюме",

--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import goto_hh
+from .browser import goto_hh, open_hydrated_resume_editor
 from .selector_groups import resume_page
 
 if TYPE_CHECKING:
@@ -121,12 +121,18 @@ def _fallback_about(existing: str, profile: AIProfile | None, mode: str) -> Abou
 def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     """Open the confirmed inline editor and return its current textarea value."""
     goto_hh(page, resume.resume_url, ready_selector=resume_page.RESUME_EDIT_ABOUT_BUTTON)
-    trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
-    if trigger.count() != 1:
-        raise AboutGenerationError("кнопка редактирования «Обо мне» не найдена однозначно")
-    trigger.click()
-    field = page.locator(resume_page.RESUME_ABOUT_EDITOR)
-    field.wait_for(state="visible")
+    try:
+        field = open_hydrated_resume_editor(
+            page,
+            trigger_selector=resume_page.RESUME_EDIT_ABOUT_BUTTON,
+            editor_selector=resume_page.RESUME_ABOUT_EDITOR,
+            profile_path=f"/resume/{resume.resume_id}",
+            trigger_error="кнопка редактирования «Обо мне» не найдена однозначно",
+            open_error="форма «Обо мне» не открылась",
+            wrong_route_error="форма «Обо мне» открыта не для того резюме",
+        )
+    except RuntimeError as exc:
+        raise AboutGenerationError(str(exc)) from exc
     return field.input_value()
 
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -78,6 +78,46 @@ class NotAuthenticated(PageStateIndeterminate):
     """The current page does not prove that the hh.ru session is valid."""
 
 
+def open_hydrated_resume_editor(
+    page: Page,
+    *,
+    trigger_selector: str,
+    editor_selector: str,
+    profile_path: str,
+    edit_path: str | None = None,
+    click_trigger: bool = False,
+    timeout: int = 30_000,
+    trigger_error: str = "кнопка редактирования не подтверждена",
+    open_error: str = "форма редактирования не открылась",
+    wrong_route_error: str = "форма редактирования открыта не для того резюме",
+):
+    """Open a resume editor only after its hydrated DOM marker appears.
+
+    Resume pages render edit triggers before React attaches their handlers. A
+    click can therefore succeed at the DOM level while doing nothing. Retry
+    only while still on the profile page and require the editor marker as the
+    positive result; callers may additionally bind the editor to a dedicated
+    edit route.
+    """
+    editor = page.locator(editor_selector)
+    if click_trigger or editor.count() == 0:
+        for attempt in range(2):
+            trigger = page.locator(trigger_selector)
+            if trigger.count() != 1:
+                raise RuntimeError(trigger_error)
+            try:
+                trigger.click()
+                editor.wait_for(state="visible", timeout=timeout)
+                break
+            except PlaywrightError as exc:
+                if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
+                    raise RuntimeError(open_error) from exc
+    expected_path = edit_path or profile_path
+    if urlsplit(page.url).path.rstrip("/") != expected_path:
+        raise RuntimeError(wrong_route_error)
+    return editor
+
+
 def require_authenticated_page(
     page: Page,
     *,

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -13,12 +13,10 @@ import json
 import re
 from dataclasses import asdict, dataclass
 from typing import Any
-from urllib.parse import urlsplit
 
-from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import HH_BASE_URL, goto_hh, has_login_form
+from .browser import HH_BASE_URL, goto_hh, has_login_form, open_hydrated_resume_editor
 from .config import ResumeConfig
 from .responses import NotAuthenticated
 
@@ -235,30 +233,16 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionValues:
         raise NotAuthenticated("страница содержит форму входа — сессия отвергнута")
     current = read_display_position(page)
     edit_path = f"/resume/edit/{resume.resume_id}/position"
-    if page.locator(FORM).count() == 0:
-        # The server-rendered trigger is visible before React attaches its
-        # click handler.  A click in that window is a no-op on live hh.ru, so
-        # retry once only when the positive form marker did not appear (#337).
-        profile_path = f"/resume/{resume.resume_id}"
-        for attempt in range(2):
-            trigger = page.locator(EDIT)
-            if trigger.count() != 1:
-                raise RuntimeError("кнопка редактирования позиции не подтверждена")
-            trigger.click()
-            try:
-                page.locator(FORM).wait_for(state="visible", timeout=30_000)
-                break
-            except PlaywrightError as exc:
-                if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
-                    raise RuntimeError("форма редактирования позиции не открылась") from exc
-    # A visible FORM alone does not prove it belongs to `resume.resume_id` —
-    # hh.ru always routes this editor to its own dedicated edit route (never
-    # mounts inline, confirmed by the #328 live audit), so require that route
-    # as a post-condition unconditionally, including when the form was
-    # already mounted before this call (#337 follow-up: the pre-#337
-    # wait_for_url enforced this binding and must not be dropped with it).
-    if urlsplit(page.url).path.rstrip("/") != edit_path:
-        raise RuntimeError("форма редактирования позиции открыта не для того резюме")
+    open_hydrated_resume_editor(
+        page,
+        trigger_selector=EDIT,
+        editor_selector=FORM,
+        profile_path=f"/resume/{resume.resume_id}",
+        edit_path=edit_path,
+        trigger_error="кнопка редактирования позиции не подтверждена",
+        open_error="форма редактирования позиции не открылась",
+        wrong_route_error="форма редактирования позиции открыта не для того резюме",
+    )
     form_values = read_position(page)
     return PositionValues(
         title=form_values.title or current.title,

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -6,12 +6,17 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
+from .browser import (
+    HH_BASE_URL,
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+    open_hydrated_resume_editor,
+)
 from .config import ResumeConfig
 from .selector_groups import resume_page
 
@@ -136,28 +141,22 @@ def edit_skills_on_hh(
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     if not has_auth_cookie(page) or has_login_form(page):
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
-    editor = page.locator(resume_page.RESUME_SKILLS_INPUT)
-    profile_path = f"/resume/{resume.resume_id}"
     edit_path = f"/resume/edit/{resume.resume_id}/keySkills"
-    # As with position (#337), the visible SSR trigger can precede React event
-    # hydration.  Only the editor becoming visible confirms that a click worked.
-    for attempt in range(2):
-        trigger = page.locator(resume_page.RESUME_SKILLS_EDIT_BUTTON)
-        if trigger.count() != 1:
-            return SkillsResult(False, reason="кнопка редактирования навыков не найдена однозначно")
-        trigger.click()
-        try:
-            editor.wait_for(state="visible", timeout=EDITOR_MOUNT_TIMEOUT_MS)
-            break
-        except PlaywrightError:
-            if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
-                return SkillsResult(False, reason="форма навыков не открылась")
-    # A visible editor alone does not prove it belongs to `resume.resume_id` —
-    # hh.ru routes the editor to its own dedicated edit route, so require that
-    # route as a post-condition (#337 follow-up: the pre-#337 wait_for_url
-    # enforced this binding and must not be dropped with it).
-    if urlsplit(page.url).path.rstrip("/") != edit_path:
-        return SkillsResult(False, reason="форма навыков открыта не для того резюме")
+    try:
+        editor = open_hydrated_resume_editor(
+            page,
+            trigger_selector=resume_page.RESUME_SKILLS_EDIT_BUTTON,
+            editor_selector=resume_page.RESUME_SKILLS_INPUT,
+            profile_path=f"/resume/{resume.resume_id}",
+            edit_path=edit_path,
+            click_trigger=True,
+            timeout=EDITOR_MOUNT_TIMEOUT_MS,
+            trigger_error="кнопка редактирования навыков не найдена однозначно",
+            open_error="форма навыков не открылась",
+            wrong_route_error="форма навыков открыта не для того резюме",
+        )
+    except RuntimeError as exc:
+        return SkillsResult(False, reason=str(exc))
     existing = read_skills(page)
     existing_keys = {skill.casefold() for skill in existing}
     additions = tuple(skill for skill in skills if skill.name.casefold() not in existing_keys)

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -115,3 +115,29 @@ def test_open_about_editor_retries_pre_hydration_noop_click(monkeypatch):
     assert open_about_editor(page, bare_resume("resume-id")) == ""
     assert trigger.click.call_count == 2
     assert field.wait_for.call_count == 2
+
+
+def test_open_about_editor_waits_for_hidden_but_present_field(monkeypatch):
+    """A pre-hydration editor already in the DOM (count==1, not visible) must
+    still be clicked and waited on, not returned unread (#339)."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    # Present in the DOM before hydration — count() == 1, but not yet visible.
+    field.count.return_value = 1
+    field.input_value.return_value = "Реальный текст, который уже был в поле."
+    field.wait_for.return_value = None
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    result = open_about_editor(page, bare_resume("resume-id"))
+
+    assert trigger.click.call_count == 1
+    assert field.wait_for.call_count == 1
+    assert result == "Реальный текст, который уже был в поле."

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -1,9 +1,18 @@
 """Pure tests for the LLM-assisted inline about-section flow."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from hhru_bot.about import AboutGenerationError, build_about_prompt, generate_about
+import hhru_bot.about as about_module
+from hhru_bot.about import (
+    AboutGenerationError,
+    build_about_prompt,
+    generate_about,
+    open_about_editor,
+)
 from hhru_bot.commands.about import draft_prefix
+from hhru_bot.config import bare_resume
 
 pytestmark = pytest.mark.unit
 
@@ -77,3 +86,32 @@ def test_prompt_does_not_include_emoji_or_unscoped_portfolio_instruction():
 def test_dry_run_marker_is_not_used_for_write_mode():
     assert draft_prefix(True) == "[DRY-RUN]"
     assert draft_prefix(False) == "[INFO] Предложение"
+
+
+def test_open_about_editor_retries_pre_hydration_noop_click(monkeypatch):
+    """The about editor marker must positively confirm a functional click."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    field.count.return_value = 0
+    field.input_value.return_value = ""
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    field.wait_for.side_effect = [PlaywrightTimeoutError("not hydrated"), None]
+
+    def click_side_effect():
+        if trigger.click.call_count == 2:
+            page.url = "https://hh.ru/resume/resume-id"
+
+    trigger.click.side_effect = click_side_effect
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    assert open_about_editor(page, bare_resume("resume-id")) == ""
+    assert trigger.click.call_count == 2
+    assert field.wait_for.call_count == 2


### PR DESCRIPTION
Fixes #339

## Summary
- extract the shared post-hydration editor opener with retry and positive editor-marker confirmation
- use it for About, desired position, and key skills editors while preserving fail-closed route checks
- add a regression test for the About pre-hydration no-op click

## Audit
Other resume edit-click paths reviewed: `resume_education.py`, `experience.py`, and `resume_sections.py`. They use separate profile/editing flows and confirmed route/form handling; this change does not broaden their behavior or selectors.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `python -m pytest -q tests/test_resume_position.py tests/test_skills.py tests/test_about.py`
