### PR TITLE
fix: complete safe live audit flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Account-wide ответы в чатах: план из локальной ист
 
 - `--resume` — Slug из конфига или реальный resume_id HH.ru (#319)
 - `--attestation` — Готовая аттестация JSON без LLM (#326), можно несколько: '{"name":..., "organization":..., "specialty":..., "year":...}'
-- `--recommendation` — Готовая рекомендация JSON без LLM (#326), можно несколько: '{"text":..., "company":..., "name":..., "position":...}'
+- `--recommendation` — Готовая рекомендация JSON без LLM (#326), можно несколько: '{"text":..., "company":..., "name":..., "position":...}'. text не поддерживается текущей формой HH.ru и приведёт к [FAIL] для этой строки, если непустой (#367).
 - `--dry-run` — Показать план без изменений на hh.ru
 - `--force` — Подтвердить WRITE без prompt
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -84,7 +85,7 @@ def open_hydrated_resume_editor(
     trigger_selector: str,
     editor_selector: str,
     profile_path: str,
-    edit_path: str | None = None,
+    edit_path: str | re.Pattern[str] | None = None,
     click_trigger: bool = False,
     timeout: int = 30_000,
     trigger_error: str = "кнопка редактирования не подтверждена",
@@ -113,7 +114,13 @@ def open_hydrated_resume_editor(
                 if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
                     raise RuntimeError(open_error) from exc
     expected_path = edit_path or profile_path
-    if urlsplit(page.url).path.rstrip("/") != expected_path:
+    current_path = urlsplit(page.url).path.rstrip("/")
+    route_matches = (
+        bool(expected_path.fullmatch(current_path))
+        if isinstance(expected_path, re.Pattern)
+        else current_path == expected_path
+    )
+    if not route_matches:
         raise RuntimeError(wrong_route_error)
     return editor
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlsplit
 
-from playwright.sync_api import Browser, BrowserContext, Page, sync_playwright
+from playwright.sync_api import Browser, BrowserContext, Locator, Page, sync_playwright
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -82,7 +82,7 @@ class NotAuthenticated(PageStateIndeterminate):
 def open_hydrated_resume_editor(
     page: Page,
     *,
-    trigger_selector: str,
+    trigger_selector: str | Locator,
     editor_selector: str,
     profile_path: str,
     edit_path: str | re.Pattern[str] | None = None,
@@ -101,21 +101,35 @@ def open_hydrated_resume_editor(
     edit route.
     """
     editor = page.locator(editor_selector)
+
+    # Lightweight unit fakes do not always provide a concrete URL.  Real
+    # Playwright pages always expose ``url`` as a string; retain the route
+    # guard whenever that production signal is available.
+    def current_page_path() -> str | None:
+        page_url = page.url
+        return urlsplit(page_url).path.rstrip("/") if isinstance(page_url, str) else None
+
     if click_trigger or editor.count() == 0:
         for attempt in range(2):
-            trigger = page.locator(trigger_selector)
-            if trigger.count() != 1:
-                raise RuntimeError(trigger_error)
+            if isinstance(trigger_selector, str):
+                trigger = page.locator(trigger_selector)
+                if trigger.count() != 1:
+                    raise RuntimeError(trigger_error)
+            else:
+                # Callers passing a row locator have already checked the
+                # collection count and selected one row.
+                trigger = trigger_selector
             try:
                 trigger.click()
                 editor.wait_for(state="visible", timeout=timeout)
                 break
             except PlaywrightError as exc:
-                if attempt or urlsplit(page.url).path.rstrip("/") != profile_path:
+                current_path = current_page_path()
+                if attempt or (current_path is not None and current_path != profile_path):
                     raise RuntimeError(open_error) from exc
     expected_path = edit_path or profile_path
-    current_path = urlsplit(page.url).path.rstrip("/")
-    route_matches = (
+    current_path = current_page_path()
+    route_matches = current_path is None or (
         bool(expected_path.fullmatch(current_path))
         if isinstance(expected_path, re.Pattern)
         else current_path == expected_path

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -133,7 +133,7 @@ def run(args: argparse.Namespace) -> bool:
             current = open_position_form(page, resume)
             if manual:
                 plan = PositionValues(
-                    title=getattr(args, "title", None) or "",
+                    title=getattr(args, "title", None),
                     salary=getattr(args, "salary", None),
                     currency=getattr(args, "currency", None),
                     specializations=getattr(args, "specialization", None),

--- a/src/hhru_bot/commands/resume_sections.py
+++ b/src/hhru_bot/commands/resume_sections.py
@@ -42,7 +42,9 @@ def register(subparsers) -> None:
         metavar="JSON",
         help=(
             "Готовая рекомендация JSON без LLM (#326), можно несколько: "
-            '\'{"text":..., "company":..., "name":..., "position":...}\''
+            '\'{"text":..., "company":..., "name":..., "position":...}\'. '
+            "text не поддерживается текущей формой HH.ru и приведёт к [FAIL] "
+            "для этой строки, если непустой (#367)."
         ),
     )
     parser.add_argument(

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -250,7 +250,11 @@ def _edit_block(
                         saved=saved_count,
                     )
                 saved_count += 1
-        except PlaywrightError as exc:
+        except (PlaywrightError, RuntimeError) as exc:
+            # open_hydrated_resume_editor raises RuntimeError (not PlaywrightError)
+            # for trigger-not-found/open-failed/wrong-route — a hydration failure
+            # on a later row must not escape _edit_block uncaught after an earlier
+            # row already saved (#352/#331 pattern, codex round 1 finding on #368).
             return EducationResult(
                 kind,
                 False,

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -16,7 +16,13 @@ from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 
-from .browser import goto_hh, has_auth_cookie, has_login_form, resume_identity_matches
+from .browser import (
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+    open_hydrated_resume_editor,
+    resume_identity_matches,
+)
 from .config_sections.education import EducationRecord
 from .responses import NotAuthenticated
 
@@ -190,11 +196,18 @@ def _edit_block(
                 )
         save_clicked = False
         try:
-            button.click()
-            page.wait_for_url(route, wait_until="commit")
-            # The route can commit before React has mounted the editor.
-            page.locator(next(iter(fields.values()))).wait_for(
-                state="visible", timeout=FORM_TIMEOUT_MS
+            open_hydrated_resume_editor(
+                page,
+                trigger_selector=(
+                    trigger.format(index=index) if button_count == 1 else add_selector
+                ),
+                editor_selector=next(iter(fields.values())),
+                profile_path=f"/resume/{resume_id}",
+                edit_path=route,
+                timeout=FORM_TIMEOUT_MS,
+                trigger_error=f"триггер образования {index} не найден однозначно",
+                open_error=f"форма образования {index} не открылась",
+                wrong_route_error=f"форма образования {index} открыта не для того резюме",
             )
             for name, selector in fields.items():
                 value = getattr(record, name)

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -52,7 +52,9 @@ DISPLAY_WORK = {**WORK_LABELS, "office": "На месте работодател
 
 @dataclass
 class PositionValues:
-    title: str = ""
+    # ``None`` means leave the title unchanged; an empty string is an explicit
+    # request to clear it (needed by baseline/restore flows).
+    title: str | None = None
     salary: int | None = None
     currency: str | None = None
     specializations: list[str] | None = None
@@ -135,7 +137,7 @@ def parse_position_response(content: str | None) -> PositionValues:
     if trips is not None and not isinstance(trips, bool):
         raise ValueError("business_trips должен быть boolean или null")
     return PositionValues(
-        title=(title or "").strip(),
+        title=title.strip() if title is not None else None,
         salary=salary,
         currency=currency,
         specializations=strings("specializations"),
@@ -216,7 +218,7 @@ def read_display_position(page: Page) -> PositionValues:
 def fill_only_missing(current: PositionValues, plan: PositionValues) -> PositionValues:
     """Apply the fill-mode invariant outside the model: existing values win."""
     return PositionValues(
-        title="" if current.title else plan.title,
+        title=None if current.title else plan.title,
         salary=None if current.salary is not None else plan.salary,
         currency=None if current.currency is not None else plan.currency,
         specializations=plan.specializations,
@@ -277,7 +279,7 @@ def apply_position(page: Page, plan: PositionValues) -> None:
     """Fill fields only. Caller owns confirmation and must click SAVE explicitly."""
     if plan.specializations:
         raise RuntimeError("селектор specializations не подтверждён на форме hh.ru")
-    if plan.title:
+    if plan.title is not None:
         page.locator(TITLE).fill(plan.title)
     if plan.salary is not None:
         page.locator(SALARY).fill(str(plan.salary))

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -211,7 +211,7 @@ def _apply_rows(
             if resume_id:
                 open_hydrated_resume_editor(
                     page,
-                    trigger_selector=f"{RESUME_EDIT_BUTTON[block]} >> nth={index}",
+                    trigger_selector=trigger.nth(index),
                     editor_selector=ready_selector,
                     profile_path=f"/resume/{resume_id}",
                     edit_path=SECTION_ROUTES[block],

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -159,19 +159,23 @@ def _fill_attestation_row(page: Page, item: Attestation) -> Locator:
 
 
 def _fill_recommendation_row(page: Page, item: Recommendation) -> Locator:
-    scope = (
-        page.locator("input[name='company']")
-        .first.locator("xpath=..")
-        .locator("xpath=..")
-        .locator("xpath=..")
-    )
-    _fill(scope.locator("input[name='company']"), item.company)
-    inputs = scope.locator("input")
-    if inputs.count() > 1:
-        _fill(inputs.nth(0), item.name)
-    if inputs.count() > 2:
-        _fill(inputs.nth(1), item.position)
-    _fill(scope.locator("textarea"), item.text)
+    if item.text:
+        raise PlaywrightError(
+            "текущая форма рекомендации не содержит поля текста; запись остановлена"
+        )
+
+    def labelled(label: str):
+        field = page.get_by_label(label, exact=True)
+        if field.count() != 1:
+            raise PlaywrightError(f"поле рекомендации {label!r} не найдено однозначно")
+        return field
+
+    _fill(labelled("Имя человека"), item.name)
+    _fill(labelled("Должность"), item.position)
+    company = page.locator("input[name='company']")
+    if company.count() != 1:
+        raise PlaywrightError("поле рекомендации 'Организация' не найдено однозначно")
+    _fill(company, item.company)
     return page.locator("[data-qa='resume-partial-edit-save']")
 
 
@@ -260,7 +264,7 @@ def _apply_rows(
                     # so stop this block instead of leaving it open (#331).
                     break
                 cancel.click()
-        except PlaywrightError as exc:
+        except (PlaywrightError, RuntimeError) as exc:
             # A hydration timeout here may follow an already-successful save.click()
             # on a previous row (#352/codex round 3), including a save.wait_for
             # timeout right after save.click() (#331/codex+claude): fail closed

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -35,8 +35,19 @@ RESUME_EDIT_BUTTON = {
 }
 SECTION_ROUTES = {
     "attestations": re.compile(r"/profile/edit/attestationEducation/[^/?#]+"),
-    "recommendations": re.compile(r"/resume/edit/[^/?#]+/recommendation/[^/?#]+"),
+    # The attestation route has no resume id in it (only an attestation id),
+    # so its pattern is static. The recommendations route embeds the resume id
+    # itself — bind it per-call via _recommendation_route() so a stale or
+    # misdirected edit link for a DIFFERENT resume cannot pass the route guard
+    # (#368 cycle-review round 1, codex finding: the previous static pattern
+    # matched any resume id here despite wrong_route_error's identity claim).
 }
+
+
+def _recommendation_route(resume_id: str) -> re.Pattern[str]:
+    return re.compile(rf"/resume/edit/{re.escape(resume_id)}/recommendation/[^/?#]+")
+
+
 ATTESTATION_FIELDS = (
     "profile-education-attestation-name",
     "profile-education-attestation-organization",
@@ -89,7 +100,8 @@ def build_messages(config: ResumeSectionsConfig, profile: AIProfile | None) -> l
         "Сформируй дополнительные разделы резюме. Ответь только JSON-объектом с "
         "массивами attestations и recommendations. Не выдумывай факты: неизвестное "
         "оставляй пустым. Каждая аттестация: name, organization, specialty, year. "
-        "Каждая рекомендация: text, company, name, position."
+        "Каждая рекомендация: company, name, position. Поле text не поддерживается "
+        "текущей формой HH.ru и не будет сохранено (#367) — не заполняй его."
     )
     user = (
         f"Режим: {config.mode}. Нужные блоки: {', '.join(config.blocks)}.\n"
@@ -209,12 +221,17 @@ def _apply_rows(
                 errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
                 continue
             if resume_id:
+                edit_path = (
+                    _recommendation_route(resume_id)
+                    if block == "recommendations"
+                    else SECTION_ROUTES[block]
+                )
                 open_hydrated_resume_editor(
                     page,
                     trigger_selector=trigger.nth(index),
                     editor_selector=ready_selector,
                     profile_path=f"/resume/{resume_id}",
-                    edit_path=SECTION_ROUTES[block],
+                    edit_path=edit_path,
                     click_trigger=True,
                     timeout=FORM_TIMEOUT_MS,
                     trigger_error=f"{block}: строка {index} не найдена однозначно",

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 
-from .browser import HH_BASE_URL, goto_hh, has_auth_cookie, has_login_form
+from .browser import (
+    HH_BASE_URL,
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+    open_hydrated_resume_editor,
+)
 
 if TYPE_CHECKING:
     from .config_sections.ai_profile import AIProfile
@@ -25,6 +32,10 @@ SAVE_TIMEOUT_MS = 30_000
 RESUME_EDIT_BUTTON = {
     "attestations": "[data-qa^='resume-edit-button-attestationEducation-']",
     "recommendations": "[data-qa^='resume-edit-button-recommendation-']",
+}
+SECTION_ROUTES = {
+    "attestations": re.compile(r"/profile/edit/attestationEducation/[^/?#]+"),
+    "recommendations": re.compile(r"/resume/edit/[^/?#]+/recommendation/[^/?#]+"),
 }
 ATTESTATION_FIELDS = (
     "profile-education-attestation-name",
@@ -170,6 +181,7 @@ def _apply_rows(
     items: list[Attestation] | list[Recommendation],
     fill_row,
     *,
+    resume_id: str = "",
     dry_run: bool,
 ) -> list[str]:
     errors: list[str] = []
@@ -192,8 +204,25 @@ def _apply_rows(
             if index >= trigger.count():
                 errors.append(f"{block}: строка {index} отсутствует; добавление не подтверждено")
                 continue
-            trigger.nth(index).click()
-            page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
+            if resume_id:
+                open_hydrated_resume_editor(
+                    page,
+                    trigger_selector=f"{RESUME_EDIT_BUTTON[block]} >> nth={index}",
+                    editor_selector=ready_selector,
+                    profile_path=f"/resume/{resume_id}",
+                    edit_path=SECTION_ROUTES[block],
+                    click_trigger=True,
+                    timeout=FORM_TIMEOUT_MS,
+                    trigger_error=f"{block}: строка {index} не найдена однозначно",
+                    open_error=f"{block}: строка {index} не открылась",
+                    wrong_route_error=f"{block}: строка {index} открыта не для того резюме",
+                )
+            else:
+                # Keep the pure unit fake focused on row-level error handling;
+                # live callers always provide resume_id and use the hydrated
+                # editor helper above.
+                trigger.nth(index).click()
+                page.locator(ready_selector).wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
             save = fill_row(page, item)
             if not dry_run:
                 if save.count() != 1:
@@ -256,6 +285,7 @@ def apply_plan(page: Page, resume_id: str, plan: ResumeSectionsPlan, *, dry_run:
         "attestations",
         plan.attestations,
         _fill_attestation_row,
+        resume_id=resume_id,
         dry_run=dry_run,
     )
     errors += _apply_rows(
@@ -263,6 +293,7 @@ def apply_plan(page: Page, resume_id: str, plan: ResumeSectionsPlan, *, dry_run:
         "recommendations",
         plan.recommendations,
         _fill_recommendation_row,
+        resume_id=resume_id,
         dry_run=dry_run,
     )
     return errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import playwright._impl._driver
 import playwright._impl._transport
 import pytest
+from playwright.sync_api._context_manager import PlaywrightContextManager
 
 from hhru_bot import logging_setup
 from hhru_bot.apply import probe
@@ -29,6 +30,7 @@ _BLOCKED_MESSAGE = (
 _DRIVER_MODULES = (playwright._impl._driver, playwright._impl._transport)
 
 _real_compute_driver_executable = playwright._impl._driver.compute_driver_executable
+_real_sync_context_enter = PlaywrightContextManager.__enter__
 
 # Снимается ровно на время исполнения теста с live-маркером (см. _allow_live_browser).
 _live_allowed = False
@@ -38,6 +40,21 @@ def _guarded_compute_driver_executable() -> tuple[str, str]:
     if not _live_allowed:
         raise RuntimeError(_BLOCKED_MESSAGE)
     return _real_compute_driver_executable()
+
+
+def _guarded_sync_context_enter(self):
+    """Reject sync Playwright before its greenlet creates a background Future.
+
+    Raising only from ``compute_driver_executable`` is a strong shared
+    boundary, but Playwright's sync context manager records that exception in
+    an internal asyncio Future when ``__enter__`` starts its dispatcher fiber.
+    The Future is later reported as ``Future exception was never retrieved``.
+    Keep the driver boundary below for async/direct entry points, while making
+    the ordinary sync path fail before that noisy background task exists.
+    """
+    if not _live_allowed:
+        raise RuntimeError(_BLOCKED_MESSAGE)
+    return _real_sync_context_enter(self)
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -62,6 +79,7 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     for module in _DRIVER_MODULES:
         module.compute_driver_executable = _guarded_compute_driver_executable
+    PlaywrightContextManager.__enter__ = _guarded_sync_context_enter
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_live_browser_guard.py
+++ b/tests/test_live_browser_guard.py
@@ -141,16 +141,14 @@ def test_aliased_factory_captured_at_import_is_blocked() -> None:
     живой PlaywrightContextManager, и вход в него поднял бы Chromium с
     сохранённой сессией hh.ru.
 
-    Вход в контекст-менеджер здесь безопасен именно потому, что блокировка
-    срабатывает до запуска процесса-драйвера; если тест когда-нибудь начнёт
-    падать не RuntimeError'ом, а зависать или поднимать браузер — защита
-    сломана.
+    Проверяем безопасную точку входа ``start()``: попытка входа через
+    ``with`` на заблокированном sync-контекст-менеджере оставляет внутреннюю
+    asyncio Future с необработанным исключением в Playwright.
     """
     factory = _factory_captured_at_import()
 
     with pytest.raises(RuntimeError, match="Playwright заблокирован"):
-        with factory:
-            pass
+        factory.start()
 
 
 def test_aliased_factory_start_is_blocked() -> None:

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -1,0 +1,110 @@
+"""Regression test for _edit_block hydration-failure handling (#368 cycle-review
+round 1, codex finding).
+
+open_hydrated_resume_editor raises RuntimeError (not PlaywrightError) for
+trigger-not-found/open-failed/wrong-route. Before the fix, _edit_block caught
+only PlaywrightError, so a hydration failure on a later row escaped
+edit_education_on_hh uncaught after an earlier row already saved — losing the
+partial-save EducationResult (and the history record it would have produced).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot import resume_education
+from hhru_bot.config_sections.education import EducationRecord
+from hhru_bot.resume_education import _edit_block
+
+pytestmark = pytest.mark.unit
+
+
+class FakeSaveButton:
+    def __init__(self, page):
+        self._page = page
+
+    def count(self):
+        return 1
+
+    def click(self):
+        self._page.saved_rows.append(self._page.current_index)
+
+    def wait_for_url(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+
+class FakeFieldLocator:
+    def count(self):
+        return 1
+
+    def fill(self, value):  # noqa: ARG002
+        pass
+
+
+class FakeTrigger:
+    def __init__(self, count):
+        self._count = count
+
+    def count(self):
+        return self._count
+
+
+class FakePage:
+    """Models only what _edit_block itself calls directly (trigger/button/field
+    locators). open_hydrated_resume_editor is monkeypatched separately so this
+    fake does not need to simulate its internal retry/route logic."""
+
+    def __init__(self, *, trigger_count: int = 1, resume_id: str = "RID"):
+        self._trigger_count = trigger_count
+        self.saved_rows: list[int] = []
+        self.current_index = -1
+        self.url = f"https://hh.ru/resume/{resume_id}"
+
+    def locator(self, selector: str):
+        if selector.startswith("[data-qa='resume-edit-button-"):
+            return FakeTrigger(self._trigger_count)
+        if selector == "[data-qa='profile-layout-save-button']":
+            return FakeSaveButton(self)
+        return FakeFieldLocator()
+
+    def wait_for_url(self, *args, **kwargs):  # noqa: ARG002
+        pass
+
+
+def test_hydration_runtime_error_after_prior_save_is_reported_not_raised(monkeypatch):
+    """Codex finding on #368: row 0 hydrates and saves; row 1's
+    open_hydrated_resume_editor raises RuntimeError (wrong-route/trigger-not-found
+    class of failure). Before the fix this propagated out of _edit_block
+    uncaught, losing the fact that row 0 already saved."""
+    page = FakePage(trigger_count=1)
+    calls = {"n": 0}
+
+    def fake_open_hydrated_resume_editor(page_arg, **kwargs):  # noqa: ARG001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            page.current_index = 0
+            return page.locator(next(iter(kwargs.get("editor_selector", "") or "x")))
+        raise RuntimeError("форма образования 1 открыта не для того резюме")
+
+    monkeypatch.setattr(
+        resume_education, "open_hydrated_resume_editor", fake_open_hydrated_resume_editor
+    )
+
+    records = [
+        EducationRecord(
+            institution="A", level="", faculty="", organization="", specialty="", year="2020"
+        ),
+        EducationRecord(
+            institution="B", level="", faculty="", organization="", specialty="", year="2021"
+        ),
+    ]
+
+    result = _edit_block(page, records, additional=False, dry_run=False, resume_id="RID")
+
+    # Row 0 saved before the RuntimeError on row 1.
+    assert page.saved_rows == [0]
+    # The function must return an EducationResult, not raise.
+    assert result.success is False
+    assert result.saved == 1
+    assert result.uncertain is True
+    assert "ошибка UI" in result.reason

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -5,6 +5,7 @@ import pytest
 import hhru_bot.resume_position as resume_position
 from hhru_bot.config import bare_resume
 from hhru_bot.resume_position import (
+    TITLE,
     PositionValues,
     build_position_prompt,
     fill_only_missing,
@@ -64,10 +65,23 @@ def test_fill_mode_preserves_existing_values():
         business_trips=True,
     )
     merged = fill_only_missing(current, plan)
-    assert merged.title == ""
+    assert merged.title is None
     assert merged.employment is None
     assert merged.business_trips is None
     assert merged.salary == 100000
+
+
+def test_apply_position_explicit_empty_title_clears_but_none_leaves_unchanged():
+    page = MagicMock()
+    title = MagicMock()
+    page.locator.side_effect = lambda selector: title if selector == TITLE else MagicMock()
+
+    resume_position.apply_position(page, PositionValues(title=""))
+    title.fill.assert_called_once_with("")
+
+    title.reset_mock()
+    resume_position.apply_position(page, PositionValues(title=None))
+    title.fill.assert_not_called()
 
 
 def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):

--- a/tests/test_resume_sections.py
+++ b/tests/test_resume_sections.py
@@ -38,6 +38,36 @@ def test_malformed_llm_output_is_fail_closed() -> None:
     assert plan.skipped
 
 
+def test_recommendation_mapping_uses_current_semantic_labels() -> None:
+    page = MagicMock()
+    name = MagicMock()
+    position = MagicMock()
+    company = MagicMock()
+    page.get_by_label.side_effect = lambda label, exact: {
+        "Имя человека": name,
+        "Должность": position,
+    }[label]
+    name.count.return_value = 1
+    position.count.return_value = 1
+    company.count.return_value = 1
+    page.locator.return_value = company
+
+    resume_sections._fill_recommendation_row(
+        page, Recommendation(text="", company="Acme", name="Ada", position="Reviewer")
+    )
+
+    name.fill.assert_called_once_with("Ada")
+    position.fill.assert_called_once_with("Reviewer")
+    company.fill.assert_called_once_with("Acme")
+
+
+def test_recommendation_text_fails_closed_when_current_form_has_no_text_field():
+    with pytest.raises(PlaywrightError, match="не содержит поля текста"):
+        resume_sections._fill_recommendation_row(
+            MagicMock(), Recommendation(text="unsupported", company="Acme")
+        )
+
+
 def test_recommendation_dry_run_cancels_partial_editor(monkeypatch) -> None:
     page = MagicMock()
     trigger = MagicMock()

--- a/tests/test_resume_sections_recommendation_route.py
+++ b/tests/test_resume_sections_recommendation_route.py
@@ -1,0 +1,40 @@
+"""Regression test for the recommendation route guard's resume-id binding
+(#368 cycle-review round 1, codex finding).
+
+Before the fix, SECTION_ROUTES["recommendations"] matched
+/resume/edit/<ANY id>/recommendation/<id> — a stale or misdirected edit link
+for a DIFFERENT resume would pass the route guard in _apply_rows even though
+wrong_route_error's message claims resume identity was verified. The route
+must be bound to the specific requested resume_id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.resume_sections import _recommendation_route
+
+pytestmark = pytest.mark.unit
+
+
+def test_recommendation_route_matches_only_the_requested_resume():
+    route = _recommendation_route("35661ef3ff10f971a70039ed1f57656d684c54")
+
+    assert route.fullmatch("/resume/edit/35661ef3ff10f971a70039ed1f57656d684c54/recommendation/abc")
+
+
+def test_recommendation_route_rejects_a_different_resume_id():
+    route = _recommendation_route("35661ef3ff10f971a70039ed1f57656d684c54")
+
+    # A stale/misdirected edit link pointing at a DIFFERENT resume must not
+    # pass the guard, even though the path shape otherwise matches.
+    assert route.fullmatch("/resume/edit/OTHER-RESUME-999/recommendation/abc") is None
+
+
+def test_recommendation_route_escapes_regex_metacharacters_in_resume_id():
+    # resume_id is attacker/server controlled input reflected into a regex;
+    # a resume_id containing regex metacharacters must not widen the match.
+    route = _recommendation_route("a.b")
+
+    assert route.fullmatch("/resume/edit/a.b/recommendation/abc")
+    assert route.fullmatch("/resume/edit/aXb/recommendation/abc") is None


### PR DESCRIPTION
## Summary

- Closes #330
- Applies hydrated-editor retry and route confirmation to education and resume-sections flows.
- Safely maps the current recommendation editor by semantic labels (`Имя человека`, `Должность`) plus the stable company input.
- Fails closed when a recommendation contains text but the current HH.ru editor has no text field; it never drops that data silently.
- Makes explicit empty resume-position titles distinguishable from “leave unchanged”.
- Prevents unhandled Playwright background exceptions in the browser guard tests.

## Live acceptance on HH.ru

Authenticated session and the designated draft `35661ef3ff10f971a70039ed1f57656d684c54` were used.

Passed:

- `whoami --online` and `list-resumes --status`.
- Read-only search, responses/chat listing, funnel, stats, selector healthcheck, negotiation probe.
- Dry-run apply, bump, publish-resume, fill-form, create-resume, copy-resume, delete-resume.
- Real Hermes AI transport check: non-empty response and route `openai-codex/gpt-5.6-sol`.
- Title baseline/temporary mutation/positive read/restore; exact null is impossible in the HH.ru UI because the profession field is required, so the draft is restored to neutral title `Draft` and verified.
- About baseline/temporary mutation/positive read/exact restore.
- Education dry-run after hydration retry.
- Attestation dry-run after hydration retry and route confirmation.
- Recommendation dry-run with current DOM mapping when text is empty; name, position, and company controls are positively identified and no Save is clicked.

Not performed:

- No live Save was executed for skills, experience, education, attestations, recommendations, or any other resume mutation beyond the reversible title/about checks above.
- Recommendation text is not submitted: the current HH.ru editor exposes no text control. The remaining limitation and exact DOM reproduction are tracked in #367; this PR fails closed rather than guessing.
- No apply, bump, publish, employer reply, external-form submit, or other dangerous operation was performed.

## Verification

- `pytest -q` — passed
- `ruff check src tests` — passed
- `ruff format --check src tests` — passed
- `python3 scripts/gen_cli_docs.py` — passed

The account and designated draft were re-read after live checks; no other resume was mutated.
