### PR TITLE
fix(resume-position): reject empty title before DOM access

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -279,9 +279,8 @@ def apply_position(page: Page, plan: PositionValues) -> None:
     """Fill fields only. Caller owns confirmation and must click SAVE explicitly."""
     if plan.title == "":
         raise ValueError(
-            "hh.ru не позволяет сохранить пустой title желаемой должности "
-            "(форма отклоняет с 'Пожалуйста, укажите'). Явная очистка title "
-            "невозможна; укажите непустое значение или не трогайте это поле."
+            "Пустой title отклоняется hh.ru. Укажите значение, например: "
+            '--title "Python-разработчик", или не передавайте --title.'
         )
     if plan.specializations:
         raise RuntimeError("селектор specializations не подтверждён на форме hh.ru")

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -280,7 +280,7 @@ def apply_position(page: Page, plan: PositionValues) -> None:
     if plan.title == "":
         raise ValueError(
             "Пустой title отклоняется hh.ru. Укажите значение, например: "
-            '--title "Python-разработчик", или не передавайте --title.'
+            '--title "Python-разработчик". Если title не нужно менять, не передавайте --title.'
         )
     if plan.specializations:
         raise RuntimeError("селектор specializations не подтверждён на форме hh.ru")

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -277,6 +277,12 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
 
 def apply_position(page: Page, plan: PositionValues) -> None:
     """Fill fields only. Caller owns confirmation and must click SAVE explicitly."""
+    if plan.title == "":
+        raise ValueError(
+            "hh.ru не позволяет сохранить пустой title желаемой должности "
+            "(форма отклоняет с 'Пожалуйста, укажите'). Явная очистка title "
+            "невозможна; укажите непустое значение или не трогайте это поле."
+        )
     if plan.specializations:
         raise RuntimeError("селектор specializations не подтверждён на форме hh.ru")
     if plan.title is not None:

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -74,7 +74,7 @@ def test_fill_mode_preserves_existing_values():
 def test_apply_position_rejects_empty_title_without_touching_dom():
     page = MagicMock()
 
-    with pytest.raises(ValueError, match="hh.ru не позволяет сохранить пустой title"):
+    with pytest.raises(ValueError, match="Пустой title отклоняется hh.ru"):
         resume_position.apply_position(page, PositionValues(title=""))
 
     page.locator.assert_not_called()

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -71,16 +71,22 @@ def test_fill_mode_preserves_existing_values():
     assert merged.salary == 100000
 
 
-def test_apply_position_explicit_empty_title_clears_but_none_leaves_unchanged():
+def test_apply_position_rejects_empty_title_without_touching_dom():
+    page = MagicMock()
+
+    with pytest.raises(ValueError, match="hh.ru не позволяет сохранить пустой title"):
+        resume_position.apply_position(page, PositionValues(title=""))
+
+    page.locator.assert_not_called()
+
+
+def test_apply_position_none_title_leaves_unchanged():
     page = MagicMock()
     title = MagicMock()
     page.locator.side_effect = lambda selector: title if selector == TITLE else MagicMock()
 
-    resume_position.apply_position(page, PositionValues(title=""))
-    title.fill.assert_called_once_with("")
-
-    title.reset_mock()
     resume_position.apply_position(page, PositionValues(title=None))
+
     title.fill.assert_not_called()
 
 


### PR DESCRIPTION
Fixes #366

## Summary
- reject explicit empty desired-position titles before any DOM interaction
- preserve `None` as a no-op
- add regression coverage for fail-closed behavior

## Tests
- `pytest -q tests/test_resume_position.py`
- `ruff check src/hhru_bot/resume_position.py tests/test_resume_position.py`
- `ruff format --check src tests`