### PR TITLE
ci: enforce pytest suite time budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Ruff format check
         run: ruff format --check src tests
 
-      - name: Pytest
-        run: pytest
+      - name: Pytest suite budget
+        run: python scripts/check_pytest_budget.py
 
       - name: CLI docs in sync with argparse
         # Справочник команд в README автогенерируется из argparse. Если кто-то

--- a/scripts/check_pytest_budget.py
+++ b/scripts/check_pytest_budget.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Run the complete test suite and enforce its wall-time budget."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+SUITE_BUDGET_SECONDS = 20.0
+
+
+def main() -> int:
+    started = time.monotonic()
+    result = subprocess.run([sys.executable, "-m", "pytest", "-q"], check=False)
+    elapsed = time.monotonic() - started
+
+    print(f"pytest suite wall time: {elapsed:.2f}s (budget: {SUITE_BUDGET_SECONDS:.0f}s)")
+    if result.returncode != 0:
+        return result.returncode
+    if elapsed > SUITE_BUDGET_SECONDS:
+        print("pytest suite exceeded its wall-time budget", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pytest_budget.py
+++ b/tests/test_pytest_budget.py
@@ -1,0 +1,55 @@
+"""Tests for the CI suite-wide pytest budget guard."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "check_pytest_budget.py"
+_SPEC = importlib.util.spec_from_file_location("check_pytest_budget", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+check_pytest_budget = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_pytest_budget)
+
+pytestmark = pytest.mark.unit
+
+
+def test_main_runs_full_suite_and_accepts_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(
+        check_pytest_budget.subprocess,
+        "run",
+        lambda command, check: calls.append((command, check)) or SimpleNamespace(returncode=0),
+    )
+    clock = iter((10.0, 29.9))
+    monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
+
+    assert check_pytest_budget.main() == 0
+    assert calls == [([check_pytest_budget.sys.executable, "-m", "pytest", "-q"], False)]
+
+
+def test_main_fails_when_suite_exceeds_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        check_pytest_budget.subprocess,
+        "run",
+        lambda _command, check: SimpleNamespace(returncode=0),
+    )
+    clock = iter((10.0, 30.1))
+    monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
+
+    assert check_pytest_budget.main() == 1
+
+
+def test_main_preserves_pytest_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        check_pytest_budget.subprocess,
+        "run",
+        lambda _command, check: SimpleNamespace(returncode=pytest.ExitCode.TESTS_FAILED),
+    )
+    clock = iter((10.0, 10.1))
+    monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
+
+    assert check_pytest_budget.main() == pytest.ExitCode.TESTS_FAILED


### PR DESCRIPTION
Closes #376

## Summary
- run the full pytest suite through a wall-time budget guard
- fail CI when the suite exceeds 20 seconds while preserving pytest failures
- cover the guard behavior with focused unit tests

## Tests
- pytest -q tests/test_pytest_budget.py
- ruff check scripts/check_pytest_budget.py tests/test_pytest_budget.py
- ruff format --check scripts/check_pytest_budget.py tests/test_pytest_budget.py
- python scripts/check_pytest_budget.py (13.46s)

## Risks
- CI now runs the same full suite through a Python wrapper; the measured budget includes pytest process startup.