### PR TITLE
fix(throttle): enforce account-wide apply limit

### DIFF
--- a/src/hhru_bot/commands/whoami.py
+++ b/src/hhru_bot/commands/whoami.py
@@ -125,9 +125,10 @@ def run(args: argparse.Namespace) -> None:
         )
 
     # 2) Счётчики из локальной истории (НЕ с hh.ru).
-    # Откликов сегодня — сумма по выбранным резюме, под resume.resume_id
-    # (числовой id hh.ru — тот же ключ, что apply/bump пишут в БД).
-    applied_today = sum(history.count_today(r.resume_id, "apply") for r in resumes)
+    # Лимит откликов account-wide: не сужаем счётчик по --resume, иначе
+    # summary может показать запас, хотя следующий отклик уже заблокирован
+    # throttle после откликов другого резюме.
+    applied_today = history.count_today("", "apply")
     apply_limit = config.throttle.daily_apply_limit
 
     # Responses — account-scope (#12): страница /applicant/negotiations общая,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -416,15 +416,20 @@ class History:
     def count_today(self, resume_id: str, action: str) -> int:
         # #176: 'uncertain' расходует дневной лимит — действие могло выполниться
         # на hh.ru, fail-closed считает его состоявшимся (dry_run/failed — нет).
+        # Пустой resume_id — account-wide sentinel (так replies не привязаны к
+        # конкретному резюме). Для apply это также важно: дневной лимит
+        # относится к аккаунту, даже если действия в истории привязаны к
+        # отдельным резюме.
         today = datetime.now().date().isoformat()
         with self._connect() as conn:
             row = conn.execute(
                 """
                 SELECT COUNT(*) AS cnt FROM actions
-                WHERE resume_id = ? AND action = ? AND status IN ('success', 'uncertain')
+                WHERE (? = '' OR resume_id = ?) AND action = ?
+                  AND status IN ('success', 'uncertain')
                   AND created_at >= ?
                 """,
-                (resume_id, action, today),
+                (resume_id, resume_id, action, today),
             ).fetchone()
             return row["cnt"] if row else 0
 

--- a/src/hhru_bot/throttle.py
+++ b/src/hhru_bot/throttle.py
@@ -42,9 +42,12 @@ class Throttle:
     def check_apply_limit(self, resume_id: str, dry_run: bool) -> None:
         if dry_run:
             return
-        done = self.history.count_today(resume_id, "apply")
+        # The limit protects the whole account.  Apply may iterate over every
+        # configured resume, so checking each resume independently multiplies
+        # the configured allowance by the number of resumes.
+        done = self.history.count_today("", "apply")
         if done >= self.config.daily_apply_limit:
-            raise LimitReached(resume_id, "apply", self.config.daily_apply_limit)
+            raise LimitReached("account", "apply", self.config.daily_apply_limit)
 
     def check_bump_limit(self, resume_id: str, dry_run: bool) -> None:
         if dry_run:

--- a/tests/test_throttle_policy.py
+++ b/tests/test_throttle_policy.py
@@ -22,7 +22,7 @@ import pytest
 
 from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
 from hhru_bot.search import VacancyCard
-from hhru_bot.throttle import Throttle
+from hhru_bot.throttle import LimitReached, Throttle
 
 pytestmark = pytest.mark.integration
 
@@ -185,6 +185,19 @@ def test_non_success_rows_do_not_affect_limits(tmp_path):
     throttle = Throttle(ThrottleConfig(), history)
     assert history.count_today("AAA111", "bump") == 0
     assert throttle.can_bump_now("AAA111") == (True, None)
+
+
+def test_apply_limit_is_account_wide_across_resumes(tmp_path):
+    """The daily apply allowance must not multiply with configured resumes."""
+    from hhru_bot.history import History
+
+    history = History(tmp_path / "history.db")
+    history.record_action("AAA111", "1", "apply", "success")
+    history.record_action("BBB222", "2", "apply", "uncertain")
+    throttle = Throttle(ThrottleConfig(daily_apply_limit=2), history)
+
+    with pytest.raises(LimitReached, match="account"):
+        throttle.check_apply_limit("CCC333", dry_run=False)
 
 
 # --- apply: командный цикл ---------------------------------------------------

--- a/tests/test_whoami_command.py
+++ b/tests/test_whoami_command.py
@@ -241,21 +241,6 @@ def test_summary_counts_from_history(tmp_path, capsys):
     assert "Новых ответов" in out
 
 
-def test_summary_apply_count_is_account_wide_when_resume_selected(tmp_path, capsys):
-    session = _valid_session(tmp_path)
-    cfg = _write_config(tmp_path, _config_body(str(session)))
-
-    h = History(tmp_path / "h.db")
-    for i in range(38):
-        h.record_action("12345", f"v{i}", "apply", "success")
-    h.record_action("67890", "other", "apply", "success")
-    h.record_action("67890", "other-2", "apply", "success")
-
-    out = _run(_args(cfg, tmp_path / "h.db", resume="data"), capsys)
-
-    assert "40 / 40" in out
-
-
 def test_summary_table_has_header_and_borders(tmp_path, capsys):
     session = _valid_session(tmp_path)
     cfg = _write_config(tmp_path, _config_body(str(session)))

--- a/tests/test_whoami_command.py
+++ b/tests/test_whoami_command.py
@@ -241,6 +241,21 @@ def test_summary_counts_from_history(tmp_path, capsys):
     assert "Новых ответов" in out
 
 
+def test_summary_apply_count_is_account_wide_when_resume_selected(tmp_path, capsys):
+    session = _valid_session(tmp_path)
+    cfg = _write_config(tmp_path, _config_body(str(session)))
+
+    h = History(tmp_path / "h.db")
+    for i in range(38):
+        h.record_action("12345", f"v{i}", "apply", "success")
+    h.record_action("67890", "other", "apply", "success")
+    h.record_action("67890", "other-2", "apply", "success")
+
+    out = _run(_args(cfg, tmp_path / "h.db", resume="data"), capsys)
+
+    assert "40 / 40" in out
+
+
 def test_summary_table_has_header_and_borders(tmp_path, capsys):
     session = _valid_session(tmp_path)
     cfg = _write_config(tmp_path, _config_body(str(session)))
@@ -280,7 +295,7 @@ def test_summary_counts_pending_external_tests(tmp_path, capsys):
     assert "| 1            |" in out
 
 
-def test_resume_filter_counts_only_selected(tmp_path, capsys):
+def test_resume_filter_keeps_apply_count_account_wide(tmp_path, capsys):
     session = _valid_session(tmp_path)
     cfg = _write_config(tmp_path, _config_body(str(session)))
     h = History(tmp_path / "h.db")
@@ -289,8 +304,8 @@ def test_resume_filter_counts_only_selected(tmp_path, capsys):
     h.record_action("67890", "v3", "apply", "success")
 
     out = _run(_args(cfg, tmp_path / "h.db", resume="data"), capsys)
-    # "data" → resume_id 67890 → 2 отклика сегодня
-    assert "2 / 40" in out
+    # Лимит откликов account-wide: учитывается также отклик python.
+    assert "3 / 40" in out
     # в строке Резюме фигурирует только выбранный slug
     resume_line = [ln for ln in out.splitlines() if "Резюме" in ln][0]
     assert "data" in resume_line


### PR DESCRIPTION
## Summary
- enforce `daily_apply_limit` across all configured resumes
- preserve account-wide counting via the empty resume sentinel
- add regression coverage for success and uncertain applies across resumes

Closes #375

## Tests
- `pytest -q tests/test_throttle_policy.py tests/test_history_replies.py tests/test_whoami_command.py`
- `ruff check src tests/test_throttle_policy.py`
- `ruff format --check src tests/test_throttle_policy.py`