### PR TITLE
fix(browser): classify headless sandbox failures

### DIFF
--- a/skills/hhru/SKILL.md
+++ b/skills/hhru/SKILL.md
@@ -76,17 +76,22 @@ hhru <command> [flags]
 
 ## Диагностика sandbox Codex
 
-Если запуск headed Chromium завершается с маркером
-`CODEX_SANDBOX_BROWSER_FAILURE` или в выводе есть сочетание
+Если запуск Chromium (headed или headless) завершается с маркером
+`CODEX_SANDBOX_BROWSER_FAILURE` или в выводе есть
 `Operation not permitted`, `Crashpad`, `NSApplication` или
 `NSMenuBarPresentationInstance`, это проблема разрешений sandbox среды
 исполнения Codex, а не Chromium, Playwright, hh.ru или сессии аккаунта.
+Сочетание `Permission denied` считается таким сбоем только вместе с Apple
+Mach-port диагностикой (`mach_port_rendezvous_mac` или
+`MachPortRendezvousServer`).
 
 В этом случае не переустанавливай Chromium и не объявляй багом проекта:
-повтори ту же read-only-команду с elevated/system permission. Если elevated
-запуск недоступен, используй `hhru --headless <command>` как безопасный
-обход. Сообщи пользователю, что причина классифицирована как
-`CODEX_SANDBOX_BROWSER_FAILURE`.
+повтори ту же read-only-команду с elevated/system permission. Для headed
+команды, если elevated-запуск недоступен, можно использовать
+`hhru --headless <command>` как безопасный обход. Если сбой произошёл уже в
+headless-режиме, повторять `--headless` бессмысленно — нужен elevated/system
+permission или решение проблемы разрешений среды. Сообщи пользователю, что
+причина классифицирована как `CODEX_SANDBOX_BROWSER_FAILURE`.
 
 ## Справочник команд
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -36,16 +36,16 @@ def launch_browser(playwright, *, headless: bool) -> Browser:
         details = str(exc)
         sandbox_markers = (
             "Operation not permitted",
+            "Permission denied",
             "Crashpad",
             "NSApplication",
             "NSMenuBarPresentationInstance",
         )
-        if not headless and any(marker in details for marker in sandbox_markers):
+        if any(marker in details for marker in sandbox_markers):
             raise BrowserLaunchError(
-                "CODEX_SANDBOX_BROWSER_FAILURE: headed Chromium was blocked by "
-                "the execution sandbox (macOS GUI/Crashpad permission). "
-                "Retry this same command with elevated system permission; "
-                "for read-only work, use 'hhru --headless ...'."
+                "CODEX_SANDBOX_BROWSER_FAILURE: Chromium was blocked by the "
+                "execution sandbox (macOS/Crashpad permission). Retry this same "
+                "command with elevated system permission."
             ) from exc
         raise
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -36,12 +36,18 @@ def launch_browser(playwright, *, headless: bool) -> Browser:
         details = str(exc)
         sandbox_markers = (
             "Operation not permitted",
-            "Permission denied",
             "Crashpad",
             "NSApplication",
             "NSMenuBarPresentationInstance",
         )
-        if any(marker in details for marker in sandbox_markers):
+        apple_mach_port_failure = "Permission denied" in details and any(
+            marker in details
+            for marker in (
+                "mach_port_rendezvous_mac",
+                "MachPortRendezvousServer",
+            )
+        )
+        if apple_mach_port_failure or any(marker in details for marker in sandbox_markers):
             raise BrowserLaunchError(
                 "CODEX_SANDBOX_BROWSER_FAILURE: Chromium was blocked by the "
                 "execution sandbox (macOS/Crashpad permission). Retry this same "

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -50,6 +50,16 @@ def test_non_sandbox_launch_failure_is_not_reclassified():
         browser.launch_browser(playwright, headless=True)
 
 
+def test_generic_permission_denied_launch_failure_is_not_reclassified():
+    playwright = MagicMock(name="Playwright")
+    playwright.chromium.launch.side_effect = PlaywrightError(
+        "Permission denied opening browser profile"
+    )
+
+    with pytest.raises(PlaywrightError, match="Permission denied opening"):
+        browser.launch_browser(playwright, headless=True)
+
+
 def test_goto_timeout_constant_is_90_seconds():
     """Эталон из исследования референсов #80: 90с под DDoS-Guard (Steev193)."""
     assert GOTO_TIMEOUT_MS == 90_000

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot import browser
@@ -24,6 +25,29 @@ from hhru_bot.browser import (
 )
 
 pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize("headless", [True, False])
+def test_sandbox_failure_is_classified_for_headless_and_headed(headless):
+    """Chromium sandbox diagnostics must keep the CLI output structured."""
+    playwright = MagicMock(name="Playwright")
+    playwright.chromium.launch.side_effect = PlaywrightError(
+        "FATAL:base/apple/mach_port_rendezvous_mac.cc:159 "
+        "Check failed: kr == KERN_SUCCESS. "
+        "bootstrap_check_in org.chromium.Chromium.MachPortRendezvousServer.13682: "
+        "Permission denied (1100)"
+    )
+
+    with pytest.raises(browser.BrowserLaunchError, match="CODEX_SANDBOX_BROWSER_FAILURE"):
+        browser.launch_browser(playwright, headless=headless)
+
+
+def test_non_sandbox_launch_failure_is_not_reclassified():
+    playwright = MagicMock(name="Playwright")
+    playwright.chromium.launch.side_effect = PlaywrightError("browser executable missing")
+
+    with pytest.raises(PlaywrightError, match="browser executable missing"):
+        browser.launch_browser(playwright, headless=True)
 
 
 def test_goto_timeout_constant_is_90_seconds():


### PR DESCRIPTION
Closes #378

## Summary
- classify macOS Chromium sandbox failures in both headless and headed launches
- recognize the observed `Permission denied` diagnostic
- add focused regression coverage and preserve propagation of unrelated launch errors

## Tests
- `pytest -q tests/test_browser_navigation.py`
- `ruff check src/hhru_bot/browser.py tests/test_browser_navigation.py`
- `ruff format --check src tests`