### PR TITLE
fix(resume): preserve uncertain save outcomes

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -151,8 +151,8 @@ def save_about(page: Page, text: str) -> None:
     save = page.locator(resume_page.RESUME_PARTIAL_EDIT_SAVE)
     if save.count() != 1:
         raise AboutGenerationError("кнопка сохранения «Обо мне» не найдена однозначно")
-    save.click()
     try:
+        save.click()
         field.wait_for(state="hidden", timeout=SAVE_TIMEOUT_MS)
     except PlaywrightError as exc:
         raise AboutGenerationError(

--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from .config_sections.ai_profile import AIProfile
 
 logger = logging.getLogger("hhru_bot.about")
+SAVE_TIMEOUT_MS = 30_000
 
 
 class AboutGenerationError(RuntimeError):
@@ -152,6 +153,8 @@ def save_about(page: Page, text: str) -> None:
         raise AboutGenerationError("кнопка сохранения «Обо мне» не найдена однозначно")
     save.click()
     try:
-        field.wait_for(state="hidden")
+        field.wait_for(state="hidden", timeout=SAVE_TIMEOUT_MS)
     except PlaywrightError as exc:
-        raise AboutGenerationError("сохранение не подтверждено: inline-форма не закрылась") from exc
+        raise AboutGenerationError(
+            "сохранение не подтверждено (uncertain): inline-форма не закрылась после клика"
+        ) from exc

--- a/src/hhru_bot/commands/about.py
+++ b/src/hhru_bot/commands/about.py
@@ -106,7 +106,8 @@ def run(args: argparse.Namespace) -> None:
                 sys.exit(1)
             save_about(page, text)
     except AboutGenerationError as exc:
-        print(f"[FAIL] {resume.id} — {exc}")
+        prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
+        print(f"{prefix} {resume.id} — {exc}")
         sys.exit(1)
 
     print(f"[OK] Раздел «Обо мне» резюме {resume.id} сохранён")

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -192,15 +192,17 @@ def run(args: argparse.Namespace) -> None:
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback contract
         print(f"[FAIL] {resume.id} — {exc}")
         raise SystemExit(1) from exc
+    uncertain = any("uncertain" in item for item in results)
     success = bool(results) and all("сохранено" in item for item in results)
     history.record_action(
         resume.resume_id,
         resume.resume_id,
         "edit_experience",
-        "success" if success else "failed",
+        "uncertain" if uncertain else ("success" if success else "failed"),
         "; ".join(results),
     )
     for item in results:
-        print(f"[OK] {resume.id} — {item}" if success else f"[FAIL] {resume.id} — {item}")
+        prefix = "[FAIL] (uncertain)" if uncertain else ("[OK]" if success else "[FAIL]")
+        print(f"{prefix} {resume.id} — {item}")
     if not success:
         raise SystemExit(1)

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -202,8 +202,8 @@ def run(args: argparse.Namespace) -> bool:
             apply_position(page, plan)
             if page.locator(SAVE).count() != 1:
                 raise RuntimeError("кнопка сохранения формы не подтверждена")
-            page.locator(SAVE).click()
             try:
+                page.locator(SAVE).click()
                 page.locator("[data-qa='resume-edit-position-form']").wait_for(
                     state="hidden", timeout=10_000
                 )

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -203,11 +203,17 @@ def run(args: argparse.Namespace) -> bool:
             if page.locator(SAVE).count() != 1:
                 raise RuntimeError("кнопка сохранения формы не подтверждена")
             page.locator(SAVE).click()
-            page.locator("[data-qa='resume-edit-position-form']").wait_for(
-                state="hidden", timeout=10_000
-            )
+            try:
+                page.locator("[data-qa='resume-edit-position-form']").wait_for(
+                    state="hidden", timeout=10_000
+                )
+            except Exception as exc:  # click already landed; result is uncertain
+                raise RuntimeError(
+                    f"сохранение не подтверждено (uncertain) после клика: {exc}"
+                ) from exc
             print(f"[OK] Раздел желаемой работы резюме '{resume.id}' обновлён.")
             return False
     except Exception as exc:
-        print(f"[FAIL] {exc}")
+        prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
+        print(f"{prefix} {exc}")
         return True

--- a/src/hhru_bot/commands/resume_sections.py
+++ b/src/hhru_bot/commands/resume_sections.py
@@ -156,7 +156,8 @@ def run(args: argparse.Namespace) -> None:
         errors = apply_plan(context.new_page(), resume.resume_id, plan, dry_run=args.dry_run)
     if errors:
         for error in errors:
-            print(f"[FAIL] {error}")
+            prefix = "[FAIL] (uncertain)" if "uncertain" in error else "[FAIL]"
+            print(f"{prefix} {error}")
         sys.exit(1)
     print(
         "[OK] Дополнительные разделы обработаны." if not args.dry_run else "[INFO] План корректен."

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -257,6 +257,7 @@ def edit_experience_on_hh(
                 return results + [f"строка опыта {index}: не удалось открыть новую запись: {exc}"]
         if trigger.count() != 1:
             return results + [f"строка опыта {index}: триггер не найден однозначно"]
+        save_attempted = False
         try:
             trigger.click()
             page.locator(EXPERIENCE_COMPANY.format(index=index)).wait_for(
@@ -277,6 +278,7 @@ def edit_experience_on_hh(
                 save = page.locator(EXPERIENCE_SAVE)
                 if save.count() != 1:
                     return results + [f"строка {index}: save-кнопка не подтверждена"]
+                save_attempted = True
                 save.click()
                 try:
                     page.wait_for_url(
@@ -285,10 +287,15 @@ def edit_experience_on_hh(
                         timeout=SAVE_TIMEOUT_MS,
                     )
                 except PlaywrightError as exc:
-                    return results + [f"строка {index}: сохранение не подтверждено: {exc}"]
+                    return results + [
+                        f"строка {index}: сохранение не подтверждено (uncertain) после клика: {exc}"
+                    ]
                 if not resume_identity_matches(page, resume_id):
-                    return results + [f"строка {index}: после save identity резюме не подтверждён"]
+                    return results + [
+                        f"строка {index}: после save identity резюме не подтверждён (uncertain)"
+                    ]
                 results.append(f"строка {index}: сохранено")
         except (PlaywrightError, ValueError) as exc:
-            return results + [f"строка {index}: {exc}"]
+            suffix = " (uncertain: клик сохранения уже был выполнен)" if save_attempted else ""
+            return results + [f"строка {index}: {exc}{suffix}"]
     return results

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -274,7 +274,12 @@ def _apply_rows(
                 # shared except below and stops the block, rather than
                 # clicking the next row's trigger against an unresolved
                 # editor state (#331, codex+claude cycle-review round 2).
-                save.wait_for(state="hidden", timeout=SAVE_TIMEOUT_MS)
+                try:
+                    save.wait_for(state="hidden", timeout=SAVE_TIMEOUT_MS)
+                except (PlaywrightError, RuntimeError) as exc:
+                    raise PlaywrightError(
+                        f"сохранение не подтверждено (uncertain) после клика: {exc}"
+                    ) from exc
             else:
                 # Leave the row editor before moving to the next row.  Otherwise
                 # the next trigger is queried while the previous form is still open.

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -260,7 +260,6 @@ def _apply_rows(
                     # The row editor is left open in this state; querying the
                     # next trigger against it would be unreliable (#331).
                     break
-                save.click()
                 # The page is already on /resume/{resume_id} before this click
                 # (see apply_plan below), and a successful save closes the
                 # inline editor in place without changing the URL — so
@@ -275,6 +274,7 @@ def _apply_rows(
                 # clicking the next row's trigger against an unresolved
                 # editor state (#331, codex+claude cycle-review round 2).
                 try:
+                    save.click()
                     save.wait_for(state="hidden", timeout=SAVE_TIMEOUT_MS)
                 except (PlaywrightError, RuntimeError) as exc:
                     raise PlaywrightError(


### PR DESCRIPTION
Closes #377

## Summary
- mark post-click save verification failures as uncertain for about, experience, position, and additional sections
- use explicit save timeout for the about editor
- persist and surface uncertain status instead of reporting plain failure

## Verification
- pytest -q tests/test_about.py tests/test_experience.py tests/test_resume_position.py tests/test_resume_sections.py tests/test_resume_sections_apply.py tests/test_manual_input_commands.py
- ruff check (touched files)
- ruff format --check (touched files)