### PR TITLE
feat(apply): reuse account profile for question answers

### DIFF
--- a/src/hhru_bot/ai/questions.py
+++ b/src/hhru_bot/ai/questions.py
@@ -158,11 +158,12 @@ class AIQuestionAnswerer:
             return None
         normalized = {normalize(key): value for key, value in self._known_data.items()}
         value = normalized.get(normalize(question.text))
-        if value is not None:
+        if isinstance(value, str) and value.strip():
             return value
         # This classifier receives field names only; values stay local.  The
         # external-form matcher owns the sensitive-field denylist (#361).
-        return match_answer_llm(question.text, self._known_data, self._llm)
+        value = match_answer_llm(question.text, self._known_data, self._llm)
+        return value if isinstance(value, str) and value.strip() else None
 
     @staticmethod
     def _choice_indices(question: Question, value: str) -> tuple[int, ...]:

--- a/src/hhru_bot/ai/questions.py
+++ b/src/hhru_bot/ai/questions.py
@@ -7,6 +7,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from ..external_forms.detect import match_answer_llm, normalize
 from ..selector_groups import apply_form
 
 if TYPE_CHECKING:
@@ -141,11 +142,39 @@ def _prompt(question: Question, profile: AIProfile | None) -> list[dict[str, str
 
 
 class AIQuestionAnswerer:
-    def __init__(self, llm: LLMClient, profile: AIProfile | None = None):
+    def __init__(
+        self,
+        llm: LLMClient,
+        profile: AIProfile | None = None,
+        known_data: dict[str, str] | None = None,
+    ):
         self._llm = llm
         self._profile = profile
+        self._known_data = known_data or {}
+
+    def _profile_answer(self, question: Question) -> str | None:
+        """Resolve a question from account facts before asking the generator."""
+        if not self._known_data:
+            return None
+        normalized = {normalize(key): value for key, value in self._known_data.items()}
+        value = normalized.get(normalize(question.text))
+        if value is not None:
+            return value
+        # This classifier receives field names only; values stay local.  The
+        # external-form matcher owns the sensitive-field denylist (#361).
+        return match_answer_llm(question.text, self._known_data, self._llm)
+
+    @staticmethod
+    def _choice_indices(question: Question, value: str) -> tuple[int, ...]:
+        wanted = normalize(value)
+        return tuple(i for i, option in enumerate(question.options) if normalize(option) == wanted)
 
     def propose(self, question: Question) -> AnswerProposal:
+        profile_answer = self._profile_answer(question)
+        if profile_answer is not None:
+            indices = self._choice_indices(question, profile_answer)
+            if question.kind != "choice" or indices:
+                return AnswerProposal(question, profile_answer, 1.0, indices)
         try:
             response = self._llm.chat(_prompt(question, self._profile), temperature=0.2)
             payload: Any = json.loads((response.content or "").strip())

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -155,7 +155,9 @@ def _build_letter_provider(
     )
 
 
-def _build_question_answerer(config: AppConfig, resume: ResumeConfig):
+def _build_question_answerer(
+    config: AppConfig, resume: ResumeConfig, known_data: dict[str, str] | None = None
+):
     """Build the opt-in LLM question answerer, if configured."""
     ai_config = getattr(config, "ai", None)
     if ai_config is None or not ai_config.answer_questions:
@@ -168,7 +170,7 @@ def _build_question_answerer(config: AppConfig, resume: ResumeConfig):
     except ImportError as exc:
         logger.warning("LLM-ответы на вопросы недоступны: %s", exc)
         return None
-    return AIQuestionAnswerer(client, getattr(resume, "ai_profile", None))
+    return AIQuestionAnswerer(client, getattr(resume, "ai_profile", None), known_data)
 
 
 def _build_scoring_provider(
@@ -415,7 +417,7 @@ def run_apply_for_resume(
 
     cover_letter_template = config.cover_letter_for(resume)
     letter_provider = _build_letter_provider(config, resume, cover_letter_template)
-    question_answerer = _build_question_answerer(config, resume)
+    question_answerer = _build_question_answerer(config, resume, history.get_profile_answers())
     # M6 cycle-review #373: no longer blocks the whole run when
     # ai.answer_questions=true but --force is missing — pipeline.py gates
     # --force per vacancy, only once a questionnaire is actually detected, so

--- a/tests/test_ai_questions.py
+++ b/tests/test_ai_questions.py
@@ -33,6 +33,17 @@ def test_exact_account_profile_answer_skips_llm_matching():
     assert llm.messages == []
 
 
+def test_blank_account_profile_answer_does_not_get_confidence_one():
+    llm = _LLM({"answer": "generated", "confidence": 0.9})
+    question = Question(0, "Ваш телефон?", "text")
+
+    proposal = AIQuestionAnswerer(llm, known_data={"Ваш телефон?": "  "}).propose(question)
+
+    assert proposal.answer == "generated"
+    assert proposal.confidence == 0.9
+    assert len(llm.messages) == 2
+
+
 def test_account_profile_semantic_match_precedes_generated_answer():
     llm = _LLM({"key": "город", "confidence": 0.99})
     question = Question(0, "В каком городе вы живёте?", "text")

--- a/tests/test_ai_questions.py
+++ b/tests/test_ai_questions.py
@@ -22,6 +22,28 @@ class _LLM:
         )
 
 
+def test_exact_account_profile_answer_skips_llm_matching():
+    llm = _LLM({"answer": "generated", "confidence": 1.0})
+    question = Question(0, "Ваш телефон?", "text")
+
+    proposal = AIQuestionAnswerer(llm, known_data={"Ваш телефон?": "+7 900"}).propose(question)
+
+    assert proposal.answer == "+7 900"
+    assert proposal.confidence == 1.0
+    assert llm.messages == []
+
+
+def test_account_profile_semantic_match_precedes_generated_answer():
+    llm = _LLM({"key": "город", "confidence": 0.99})
+    question = Question(0, "В каком городе вы живёте?", "text")
+
+    proposal = AIQuestionAnswerer(llm, known_data={"город": "Москва"}).propose(question)
+
+    assert proposal.answer == "Москва"
+    assert proposal.confidence == 1.0
+    assert len(llm.messages) == 1
+
+
 def test_choice_answer_uses_zero_based_index_and_confidence():
     llm = _LLM({"answer": "Python", "confidence": 0.91, "indices": [1]})
     question = Question(0, "Опыт с Python?", "choice", ("Нет", "Да"))


### PR DESCRIPTION
Closes #390

## Summary
- pass account_profile facts into internal hh.ru question answerer
- resolve exact profile answers without an LLM call
- reuse the external-form semantic matcher and its sensitive-field denylist for uncovered questions

## Tests
- `ruff format --check src tests`
- `ruff check src tests`
- `PYTHONPATH=src pytest -q tests/test_ai_questions.py tests/test_ai_config.py tests/test_apply_pipeline.py tests/test_fill_form.py`

Stacked on #373.