### PR TITLE
fix(negotiations): avoid false-positive external test links

### DIFF
--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -45,6 +45,22 @@ class NoReplyForm(RuntimeError):
 _URL_RE = re.compile(r"https?://[^\s<>\"']+", re.IGNORECASE)
 _TRAILING_URL_PUNCTUATION = ".,;:!?)]}>\"'»"
 _HH_DOMAINS = ("hh.ru", "hhcdn.ru")
+_TEST_PLATFORM_DOMAINS = (
+    "codeforces.com",
+    "coderbyte.com",
+    "codility.com",
+    "devskiller.com",
+    "forms.gle",
+    "hackerrank.com",
+    "mettl.com",
+    "testdome.com",
+    "testgorilla.com",
+    "typeform.com",
+)
+_TEST_CONTEXT_RE = re.compile(
+    r"(?:тест\w*|задан\w*|assignment|assessment|coding\s+challenge|technical\s+task|case\s+study)",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -136,12 +152,21 @@ def _is_hh_domain(hostname: str | None) -> bool:
     return any(host == domain or host.endswith(f".{domain}") for domain in _HH_DOMAINS)
 
 
+def _is_test_platform(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    host = hostname.rstrip(".").lower()
+    return any(host == domain or host.endswith(f".{domain}") for domain in _TEST_PLATFORM_DOMAINS)
+
+
 def extract_external_test_link(message_text: str) -> str | None:
-    """Return the first non-hh.ru HTTP(S) URL in an employer message.
+    """Return a likely external test URL in an employer message.
 
     ``hh.ru`` and ``hhcdn.ru`` (including their subdomains) are internal links
-    and are ignored.  If a message contains multiple links, the first external
-    one is returned.  The function only parses text; it never makes a request.
+    and are ignored.  Known testing platforms are accepted without further
+    context; other domains require a nearby test-assignment phrase.  This
+    avoids treating a company homepage or tracking link as a test assignment.
+    The function only parses text; it never makes a request.
     """
     for match in _URL_RE.finditer(message_text):
         url = match.group(0).rstrip(_TRAILING_URL_PUNCTUATION)
@@ -149,7 +174,15 @@ def extract_external_test_link(message_text: str) -> str | None:
             parsed = urlsplit(url)
         except ValueError:
             continue
-        if parsed.scheme.lower() in {"http", "https"} and not _is_hh_domain(parsed.hostname):
+        if parsed.scheme.lower() not in {"http", "https"} or _is_hh_domain(parsed.hostname):
+            continue
+        if _is_test_platform(parsed.hostname):
+            return url
+        # Keep the context on the URL's left side.  Looking arbitrarily far
+        # past the URL can associate a company link with a test phrase that
+        # belongs to a later, separate link in the same message.
+        context_start = max(0, match.start() - 120)
+        if _TEST_CONTEXT_RE.search(message_text[context_start : match.start()]):
             return url
     return None
 

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -58,9 +58,12 @@ _TEST_PLATFORM_DOMAINS = (
     "typeform.com",
 )
 _TEST_CONTEXT_RE = re.compile(
-    r"(?:тест\w*|задан\w*|assignment|assessment|coding\s+challenge|technical\s+task|case\s+study)",
+    r"(?:тест(?:а|е|ом|у|ы)?|тестов(?:ое|ого|ому|ым|ые|ых|ыми)?|"
+    r"задан(?:ие|ия|ию|ием|ии|иями|иях)|assignment|assessment|"
+    r"coding\s+challenge|technical\s+task|case\s+study)\b",
     re.IGNORECASE,
 )
+_CONTEXT_BOUNDARY_RE = re.compile(r"[.!?;\n]")
 
 
 @dataclass(frozen=True)
@@ -178,11 +181,25 @@ def extract_external_test_link(message_text: str) -> str | None:
             continue
         if _is_test_platform(parsed.hostname):
             return url
-        # Keep the context on the URL's left side.  Looking arbitrarily far
-        # past the URL can associate a company link with a test phrase that
-        # belongs to a later, separate link in the same message.
+        # Look left, plus a bounded right-hand fragment for messages such as
+        # "перейдите по ссылке <URL> и выполните тестовое задание".  Do not
+        # inspect right-hand context when another URL comes first: the phrase
+        # may belong to that later link rather than this one.
         context_start = max(0, match.start() - 120)
-        if _TEST_CONTEXT_RE.search(message_text[context_start : match.start()]):
+        left_context = message_text[context_start : match.start()]
+        right_start = match.end()
+        next_url = _URL_RE.search(message_text, right_start)
+        sentence_boundary = _CONTEXT_BOUNDARY_RE.search(message_text, right_start)
+        right_end = min(
+            len(message_text),
+            right_start + 120,
+            next_url.start() if next_url else len(message_text),
+            sentence_boundary.start() if sentence_boundary else len(message_text),
+        )
+        right_context = message_text[right_start:right_end]
+        if _TEST_CONTEXT_RE.search(left_context) or (
+            next_url is None and _TEST_CONTEXT_RE.search(right_context)
+        ):
             return url
     return None
 

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -74,6 +74,22 @@ def test_external_link_with_nearby_test_context_is_detected():
     )
 
 
+def test_external_link_with_following_test_context_is_detected():
+    assert (
+        extract_external_test_link(
+            "Перейдите по ссылке https://example.com/quiz и выполните тестовое задание"
+        )
+        == "https://example.com/quiz"
+    )
+
+
+def test_unrelated_word_does_not_count_as_test_context():
+    assert (
+        extract_external_test_link("В заданное время подключитесь: https://meet.example/abc")
+        is None
+    )
+
+
 def test_known_test_platform_is_detected_without_context():
     assert extract_external_test_link("https://candidate.typeform.com/to/abc") == (
         "https://candidate.typeform.com/to/abc"

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -59,8 +59,33 @@ def test_message_without_link_returns_none():
 
 
 def test_returns_first_external_link_when_message_has_several():
-    assert extract_external_test_link("https://example.com/a и https://other.test/b") == (
+    assert extract_external_test_link("Тест: https://example.com/a и https://other.test/b") == (
         "https://example.com/a"
+    )
+
+
+def test_company_link_without_test_context_is_ignored():
+    assert extract_external_test_link("Сайт компании: https://example.com/careers") is None
+
+
+def test_external_link_with_nearby_test_context_is_detected():
+    assert extract_external_test_link("Пройдите тест по ссылке: https://example.com/test") == (
+        "https://example.com/test"
+    )
+
+
+def test_known_test_platform_is_detected_without_context():
+    assert extract_external_test_link("https://candidate.typeform.com/to/abc") == (
+        "https://candidate.typeform.com/to/abc"
+    )
+
+
+def test_skips_unrelated_external_link_before_test_link():
+    assert (
+        extract_external_test_link(
+            "Сайт компании https://example.com и тестовое задание https://other.example/task"
+        )
+        == "https://other.example/task"
     )
 
 


### PR DESCRIPTION
Closes #388

## Summary
- require test-assignment context for unknown external domains
- allow known assessment platforms without context
- skip unrelated links and continue scanning later URLs

## Verification
- `pytest -q tests/test_negotiations_chat.py tests/test_responses_command.py`
- `ruff check src/hhru_bot/negotiations_chat.py tests/test_negotiations_chat.py`
- `ruff format --check src tests`

The available accumulated `data/history.db` contains zero `test_assignments` rows, so there is no historical sample to quantify false-positive frequency; the fix targets the demonstrated unsafe heuristic directly.