### PR TITLE
test(audit): invert resume save outcome characterization

### DIFF
--- a/docs/research/reference-audit-full-sweep.md
+++ b/docs/research/reference-audit-full-sweep.md
@@ -77,9 +77,8 @@ CLI (CLAUDE.md: только `[OK]/[INFO]/[FAIL]/[DRY-RUN]/[skip]`).
 
 **Отягчающее.** Тестов на `launch_browser`/`BrowserLaunchError` не было **ни одного**.
 
-Тесты (после фикса инвертированы):
-`test_headless_sandbox_failure_is_classified_as_browser_launch_error`,
-`test_permission_denied_mach_port_failure_is_a_sandbox_marker`,
+Тесты: `test_headless_sandbox_failure_is_not_classified_as_browser_launch_error`,
+`test_permission_denied_is_absent_from_sandbox_markers`,
 `test_headed_sandbox_failure_is_classified` (контроль: headed-путь работает).
 
 ---
@@ -135,10 +134,8 @@ PlaywrightError)` (`:168`) и **возвращает** `(False, ...)`, то ес
 `uncertain` дедупликацию не даёт — она требует отдельного history-guard'а перед кликом.
 Статус и guard — две разные части фикса, и путать их нельзя.
 
-Тесты (после фикса инвертированы):
-`test_withdraw_failure_after_destructive_click_is_recorded_as_uncertain`
-(на реальной SQLite во временной директории),
-`test_withdraw_module_implements_the_uncertain_invariant`.
+Тесты: `test_withdraw_failure_after_destructive_click_is_recorded_as_failed_not_uncertain`
+(на реальной SQLite во временной директории), `test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks`.
 
 ---
 

--- a/docs/research/reference-audit-full-sweep.md
+++ b/docs/research/reference-audit-full-sweep.md
@@ -158,8 +158,8 @@ except PlaywrightError as exc:
 Побочно: `field.wait_for(state="hidden")` вызван **без** `timeout` — в отличие от соседних
 редакторов, где стоит явный `SAVE_TIMEOUT_MS`.
 
-Тесты: `test_save_about_reports_plain_failure_after_the_save_click_already_landed`,
-`test_about_module_has_no_uncertain_concept_at_all`.
+Тесты (после фикса инвертированы): `test_save_about_marks_post_click_timeout_as_uncertain`,
+`test_about_module_marks_post_click_save_failures_as_uncertain`.
 
 ---
 
@@ -175,8 +175,9 @@ except PlaywrightError as exc:
 любое исключение печатается как голый `[FAIL] {exc}` и команда возвращает `True`, хотя
 сохранение уже могло примениться.
 
-Тест: `test_write_modules_click_save_but_never_mark_the_outcome_uncertain` (параметризован по
-четырём модулям).
+Тест (после фикса инвертирован):
+`test_write_modules_mark_post_click_save_failures_as_uncertain` (параметризован по четырём
+модулям).
 
 ---
 

--- a/docs/research/reference-audit-full-sweep.md
+++ b/docs/research/reference-audit-full-sweep.md
@@ -77,8 +77,9 @@ CLI (CLAUDE.md: только `[OK]/[INFO]/[FAIL]/[DRY-RUN]/[skip]`).
 
 **Отягчающее.** Тестов на `launch_browser`/`BrowserLaunchError` не было **ни одного**.
 
-Тесты: `test_headless_sandbox_failure_is_not_classified_as_browser_launch_error`,
-`test_permission_denied_is_absent_from_sandbox_markers`,
+Тесты (после фикса инвертированы):
+`test_headless_sandbox_failure_is_classified_as_browser_launch_error`,
+`test_permission_denied_mach_port_failure_is_a_sandbox_marker`,
 `test_headed_sandbox_failure_is_classified` (контроль: headed-путь работает).
 
 ---
@@ -134,8 +135,10 @@ PlaywrightError)` (`:168`) и **возвращает** `(False, ...)`, то ес
 `uncertain` дедупликацию не даёт — она требует отдельного history-guard'а перед кликом.
 Статус и guard — две разные части фикса, и путать их нельзя.
 
-Тесты: `test_withdraw_failure_after_destructive_click_is_recorded_as_failed_not_uncertain`
-(на реальной SQLite во временной директории), `test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks`.
+Тесты (после фикса инвертированы):
+`test_withdraw_failure_after_destructive_click_is_recorded_as_uncertain`
+(на реальной SQLite во временной директории),
+`test_withdraw_module_implements_the_uncertain_invariant`.
 
 ---
 

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -44,28 +44,24 @@ class _FakePlaywright:
         self.chromium = _FailingChromium(message)
 
 
-def test_headless_sandbox_failure_is_not_classified_as_browser_launch_error():
-    """B1: headless-сбой песочницы уходит сырым PlaywrightError → traceback в CLI.
-
-    cli.py ловит BrowserLaunchError и печатает [ENVIRONMENT]; всё остальное
-    долетает до `raise` в cli.py:190 и печатается Python-ом как traceback.
-    """
+def test_headless_sandbox_failure_is_classified_as_browser_launch_error():
+    """B1: headless sandbox failures are normalized for the CLI."""
     playwright = _FakePlaywright(_LIVE_HEADLESS_SANDBOX_ERROR)
 
-    with pytest.raises(PlaywrightError) as excinfo:
+    with pytest.raises(BrowserLaunchError) as excinfo:
         launch_browser(playwright, headless=True)
 
-    # Дефект: это НЕ BrowserLaunchError, поэтому cli.py напечатает traceback.
-    assert not isinstance(excinfo.value, BrowserLaunchError)
-    assert "Permission denied (1100)" in str(excinfo.value)
+    assert "CODEX_SANDBOX_BROWSER_FAILURE" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, PlaywrightError)
 
 
-def test_permission_denied_is_absent_from_sandbox_markers():
-    """B1, вторая причина: маркера живого сбоя нет в списке классификации."""
+def test_permission_denied_mach_port_failure_is_a_sandbox_marker():
+    """B1: the observed macOS permission failure is recognized."""
     source = inspect.getsource(launch_browser)
 
     assert "Operation not permitted" in source, "список маркеров изменился — пересмотреть тест"
-    assert "Permission denied" not in source
+    assert "Permission denied" in source
+    assert "mach_port_rendezvous_mac" in source
 
 
 def test_headed_sandbox_failure_is_classified():
@@ -148,18 +144,16 @@ def test_apply_daily_limit_is_per_resume_so_account_total_multiplies():
 # --- B4: необратимый отзыв отклика не умеет статус 'uncertain' ---------------
 
 
-def test_withdraw_failure_after_destructive_click_is_recorded_as_failed_not_uncertain(
-    monkeypatch, tmp_path
-):
-    """B4: сбой ПОСЛЕ необратимого клика отзыва пишется как 'failed' (= не произошло).
+def test_withdraw_failure_after_destructive_click_is_recorded_as_uncertain(monkeypatch, tmp_path):
+    """B4: a post-click withdrawal failure is recorded as ``uncertain``.
 
     Тест проходит РЕАЛЬНЫЙ путь `_withdraw_topic`: фейковая страница отдаёт
     валидный SSR с одним топиком, уникальную карточку и уникальную кнопку
     отзыва, клик действительно выполняется (`clicked` фиксируется), и только
     затем падает ожидание позитивного маркера — ровно «серая зона» #207.
 
-    `_withdraw_topic` возвращает (False, ...), а `_run_topics` (:304) знает
-    только два статуса, поэтому необратимое действие записывается как `failed`.
+    `_withdraw_topic` returns a failed confirmation, but the completed click
+    must make `_run_topics` record the destructive action as `uncertain`.
     Для обратимого bump тот же проект реализует инвариант #176/#207 полностью
     (bump.py:102-119: acted=True + uncertain=True); в этом модуле слова
     'uncertain' нет вовсе.
@@ -239,13 +233,11 @@ def test_withdraw_failure_after_destructive_click_is_recorded_as_failed_not_unce
         ).fetchall()
     statuses = [row["status"] for row in rows]
 
-    # Дефект: состоявшийся необратимый клик записан как 'failed' (= не произошёл).
-    assert statuses == ["failed"]
-    assert "uncertain" not in statuses
+    assert statuses == ["uncertain"]
 
 
-def test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks():
-    """Контроль: инвариант в проекте есть — он просто не применён к отзыву."""
+def test_withdraw_module_implements_the_uncertain_invariant():
+    """B4: destructive withdrawal shares the existing uncertain invariant."""
     from pathlib import Path as _Path
 
     from hhru_bot import bump as bump_module
@@ -256,7 +248,7 @@ def test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks():
     ).read_text(encoding="utf-8")
 
     assert "uncertain=True" in bump_source
-    assert "uncertain" not in withdraw_source
+    assert "uncertain" in withdraw_source
 
 
 # --- B5: save_about теряет факт состоявшегося клика сохранения ---------------

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -262,14 +262,12 @@ def test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks():
 # --- B5: save_about теряет факт состоявшегося клика сохранения ---------------
 
 
-def test_save_about_reports_plain_failure_after_the_save_click_already_landed():
-    """B5: таймаут ПОСЛЕ save.click() выдаётся как «сохранение не подтверждено».
+def test_save_about_marks_post_click_timeout_as_uncertain():
+    """B5: a timeout after save.click() is explicitly uncertain.
 
-    about.py:153-156 кликает сохранение, затем ждёт закрытия формы. Таймаут в
-    этой точке — ровно «серая зона» #176/#207: клик уже ушёл на hh.ru. Модуль
-    сообщает об этом как об обычной ошибке (в about.py слова 'uncertain' нет),
-    а команда печатает [FAIL] и завершает процесс с кодом 1 — пользователь
-    делает вывод, что текст не сохранён.
+    about.py clicks save and then waits for the form to close. A timeout at
+    this point is the #176/#207 grey zone: the click may already have reached
+    hh.ru, so the error must retain the ``uncertain`` marker.
 
     Для сравнения: bump.py и reply_employers.py в тех же условиях возвращают
     acted=True + uncertain=True.
@@ -308,26 +306,27 @@ def test_save_about_reports_plain_failure_after_the_save_click_already_landed():
 
     # Клик сохранения СОСТОЯЛСЯ...
     assert save.clicked is True
-    # ...но исход подан как «не подтверждено», без признака состоявшегося действия.
+    # ...и исход явно сохраняет признак состоявшегося действия.
     assert "не подтверждено" in str(excinfo.value)
-    assert "uncertain" not in str(excinfo.value).lower()
+    assert "uncertain" in str(excinfo.value).lower()
 
 
-def test_about_module_has_no_uncertain_concept_at_all():
-    """B5, вторая половина: в about.py признака состоявшегося клика нет вовсе."""
+def test_about_module_marks_post_click_save_failures_as_uncertain():
+    """B5: about.py keeps the save click visible in the uncertain outcome."""
     from pathlib import Path as _Path
 
     from hhru_bot import about as about_module
 
     source = _Path(about_module.__file__).read_text(encoding="utf-8")
     assert "save.click()" in source
-    assert "uncertain" not in source
+    assert "uncertain" in source
+    assert "SAVE_TIMEOUT_MS" in source
 
 
 # --- B6: тот же разрыв инварианта в редакторах резюме -----------------------
 
 
-_WRITE_MODULES_WITHOUT_UNCERTAIN = (
+_WRITE_MODULES_WITH_SAVE_OUTCOME = (
     "about.py",
     "experience.py",
     "resume_position.py",
@@ -335,18 +334,15 @@ _WRITE_MODULES_WITHOUT_UNCERTAIN = (
 )
 
 
-@pytest.mark.parametrize("filename", _WRITE_MODULES_WITHOUT_UNCERTAIN)
-def test_write_modules_click_save_but_never_mark_the_outcome_uncertain(filename):
-    """B6: WRITE-модули кликают сохранение, но статуса «клик мог уйти» не имеют.
+@pytest.mark.parametrize("filename", _WRITE_MODULES_WITH_SAVE_OUTCOME)
+def test_write_modules_mark_post_click_save_failures_as_uncertain(filename):
+    """B6: every WRITE module preserves an uncertain post-click outcome.
 
-    Систематический разрыв инварианта #176/#207, а не единичный промах:
-    pipeline.py (19 упоминаний 'uncertain'), publish_resume.py (10),
-    resume_education.py (7), copy_resume.py (6), bump.py и reply_employers.py (5)
-    его соблюдают; перечисленные здесь модули — нет ни одного упоминания.
+    This is the shared #176/#207 invariant: a save click followed by an
+    exception must not be reported as an ordinary pre-click failure.
 
-    Наиболее наглядно в commands/resume_position.py:205-213: после
-    `page.locator(SAVE).click()` любое исключение печатается как голый [FAIL],
-    хотя сохранение уже могло примениться на hh.ru.
+    The source-level assertion covers all four editors, including the command
+    wrappers that turn the marker into the user-visible result.
     """
     from pathlib import Path as _Path
 
@@ -357,4 +353,4 @@ def test_write_modules_click_save_but_never_mark_the_outcome_uncertain(filename)
 
     combined = "\n".join(sources)
     assert ".click()" in combined, f"{filename}: клика нет — находка требует пересмотра"
-    assert "uncertain" not in combined
+    assert "uncertain" in combined

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -44,24 +44,28 @@ class _FakePlaywright:
         self.chromium = _FailingChromium(message)
 
 
-def test_headless_sandbox_failure_is_classified_as_browser_launch_error():
-    """B1: headless sandbox failures are normalized for the CLI."""
+def test_headless_sandbox_failure_is_not_classified_as_browser_launch_error():
+    """B1: headless-сбой песочницы уходит сырым PlaywrightError → traceback в CLI.
+
+    cli.py ловит BrowserLaunchError и печатает [ENVIRONMENT]; всё остальное
+    долетает до `raise` в cli.py:190 и печатается Python-ом как traceback.
+    """
     playwright = _FakePlaywright(_LIVE_HEADLESS_SANDBOX_ERROR)
 
-    with pytest.raises(BrowserLaunchError) as excinfo:
+    with pytest.raises(PlaywrightError) as excinfo:
         launch_browser(playwright, headless=True)
 
-    assert "CODEX_SANDBOX_BROWSER_FAILURE" in str(excinfo.value)
-    assert isinstance(excinfo.value.__cause__, PlaywrightError)
+    # Дефект: это НЕ BrowserLaunchError, поэтому cli.py напечатает traceback.
+    assert not isinstance(excinfo.value, BrowserLaunchError)
+    assert "Permission denied (1100)" in str(excinfo.value)
 
 
-def test_permission_denied_mach_port_failure_is_a_sandbox_marker():
-    """B1: the observed macOS permission failure is recognized."""
+def test_permission_denied_is_absent_from_sandbox_markers():
+    """B1, вторая причина: маркера живого сбоя нет в списке классификации."""
     source = inspect.getsource(launch_browser)
 
     assert "Operation not permitted" in source, "список маркеров изменился — пересмотреть тест"
-    assert "Permission denied" in source
-    assert "mach_port_rendezvous_mac" in source
+    assert "Permission denied" not in source
 
 
 def test_headed_sandbox_failure_is_classified():
@@ -144,16 +148,18 @@ def test_apply_daily_limit_is_per_resume_so_account_total_multiplies():
 # --- B4: необратимый отзыв отклика не умеет статус 'uncertain' ---------------
 
 
-def test_withdraw_failure_after_destructive_click_is_recorded_as_uncertain(monkeypatch, tmp_path):
-    """B4: a post-click withdrawal failure is recorded as ``uncertain``.
+def test_withdraw_failure_after_destructive_click_is_recorded_as_failed_not_uncertain(
+    monkeypatch, tmp_path
+):
+    """B4: сбой ПОСЛЕ необратимого клика отзыва пишется как 'failed' (= не произошло).
 
     Тест проходит РЕАЛЬНЫЙ путь `_withdraw_topic`: фейковая страница отдаёт
     валидный SSR с одним топиком, уникальную карточку и уникальную кнопку
     отзыва, клик действительно выполняется (`clicked` фиксируется), и только
     затем падает ожидание позитивного маркера — ровно «серая зона» #207.
 
-    `_withdraw_topic` returns a failed confirmation, but the completed click
-    must make `_run_topics` record the destructive action as `uncertain`.
+    `_withdraw_topic` возвращает (False, ...), а `_run_topics` (:304) знает
+    только два статуса, поэтому необратимое действие записывается как `failed`.
     Для обратимого bump тот же проект реализует инвариант #176/#207 полностью
     (bump.py:102-119: acted=True + uncertain=True); в этом модуле слова
     'uncertain' нет вовсе.
@@ -233,11 +239,13 @@ def test_withdraw_failure_after_destructive_click_is_recorded_as_uncertain(monke
         ).fetchall()
     statuses = [row["status"] for row in rows]
 
-    assert statuses == ["uncertain"]
+    # Дефект: состоявшийся необратимый клик записан как 'failed' (= не произошёл).
+    assert statuses == ["failed"]
+    assert "uncertain" not in statuses
 
 
-def test_withdraw_module_implements_the_uncertain_invariant():
-    """B4: destructive withdrawal shares the existing uncertain invariant."""
+def test_bump_module_implements_the_uncertain_invariant_that_withdraw_lacks():
+    """Контроль: инвариант в проекте есть — он просто не применён к отзыву."""
     from pathlib import Path as _Path
 
     from hhru_bot import bump as bump_module
@@ -248,7 +256,7 @@ def test_withdraw_module_implements_the_uncertain_invariant():
     ).read_text(encoding="utf-8")
 
     assert "uncertain=True" in bump_source
-    assert "uncertain" in withdraw_source
+    assert "uncertain" not in withdraw_source
 
 
 # --- B5: save_about теряет факт состоявшегося клика сохранения ---------------


### PR DESCRIPTION
## Summary

- invert B5 save_about characterization to require explicit `uncertain` after a post-click timeout
- invert B6 source checks for all four resume WRITE editors
- update audit documentation with the new test names

Closes #377

## Tests

- `pytest -q tests/test_audit_launch_and_navigation.py -k "about or write_modules"`
- `ruff check tests/test_audit_launch_and_navigation.py`
- `ruff format --check tests/test_audit_launch_and_navigation.py`
- `git diff --check`

The old characterization assertions failed against the already-fixed main code; the inverted assertions pass.