### PR TITLE
test: contract-тест на сигнатуры fake Playwright-объектов

### DIFF
--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -36,13 +36,13 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self, **_kwargs) -> None:
+    def click(self, *, timeout: float = 0, force: bool = False) -> None:  # noqa: ARG002
         return None
 
     def fill(self, _value: str) -> None:
@@ -72,7 +72,7 @@ class _ApplyFakePage:
     def __init__(self):
         self.goto_calls: list[str] = []
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
 
     def locator(self, selector: str):  # noqa: ARG002
@@ -82,7 +82,7 @@ class _ApplyFakePage:
             return _FakeLocator(present=True)
         return _FakeLocator(present=False)
 
-    def wait_for_url(self, _url_pattern, **_kwargs):  # noqa: ARG002
+    def wait_for_url(self, _url_pattern, *, wait_until: str = "", timeout: float = 0):  # noqa: ARG002
         # #179: navigate_to_response_form больше не использует expect_navigation.
         # Этот путь — dry-run, до формы не доходим (см. докстринг класса), метод
         # не должен вызываться, но определён для консистентности с реальным Page.

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -51,7 +51,7 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         self._wait_for_calls.append(1)
         self._wait_for_timeouts.append(timeout)
         if not self._present:
@@ -59,12 +59,12 @@ class _FakeLocator:
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self, **_kwargs) -> None:
+    def click(self, *, timeout=None, no_wait_after=None) -> None:
         if self._click_error is not None:
             raise self._click_error
         return None
 
-    def fill(self, _value: str) -> None:
+    def fill(self, _value: str, *, timeout=None, no_wait_after=None, force=None) -> None:
         return None
 
     def get_attribute(self, name: str) -> str | None:
@@ -132,7 +132,7 @@ class FakePage:
         # проверяет, что они всегда равны полному _VISIBILITY_CHECK_TIMEOUT_MS.
         self.already_responded_wait_for_timeouts: list[float] = []
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         self.url = url
 
@@ -167,7 +167,7 @@ class FakePage:
             return _FakeLocator(present=self._success, click_error=self._submit_click_error)
         return _FakeLocator(present=False)
 
-    def wait_for_url(self, _url_pattern, **_kwargs):
+    def wait_for_url(self, _url_pattern, *, wait_until=None, timeout=None):
         # #179: navigate_to_response_form больше не использует expect_navigation.
         return None
 
@@ -323,7 +323,7 @@ def test_apply_rechecks_responded_marker_before_form_submit():
     """
 
     class _MarkerAppearsDuringLetterRender(FakePage):
-        def wait_for_url(self, _url_pattern, **_kwargs):
+        def wait_for_url(self, _url_pattern, *, wait_until=None, timeout=None):
             # navigate_to_response_form lands on the response-form page, where
             # vacancy-page markers are absent.
             self.url = "/applicant/vacancy_response"

--- a/tests/test_apply_probe.py
+++ b/tests/test_apply_probe.py
@@ -51,17 +51,17 @@ class _FakeLocator:
             return 0
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
         self._waited = True
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self, **_kwargs) -> None:
+    def click(self, *, timeout=None, no_wait_after=None) -> None:
         self.click_calls += 1
 
-    def fill(self, value: str) -> None:
+    def fill(self, value: str, *, timeout=None, no_wait_after=None, force=None) -> None:
         self.fill_calls.append(value)
 
     def get_attribute(self, name: str) -> str | None:
@@ -96,7 +96,7 @@ class _ClickTrackingLocator(_FakeLocator):
         super().__init__(present=present)
         self._submit_clicks = submit_clicks
 
-    def click(self, **_kwargs) -> None:
+    def click(self, *, timeout=None, no_wait_after=None) -> None:
         self._submit_clicks.append(1)
         super().click()
 
@@ -124,11 +124,11 @@ class FakeProbePage:
         self.submit_clicks: list[int] = []
         self._textarea_locator: _FakeLocator | None = None
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         self.url = url
 
-    def screenshot(self, **_kwargs) -> bytes:
+    def screenshot(self, *, full_page: bool | None = None, path=None) -> bytes:
         self.screenshot_calls += 1
         return b"\x89PNG probe-bytes"
 
@@ -165,7 +165,7 @@ class FakeProbePage:
             return _FakeLocator(present=False)
         return _FakeLocator(present=False)
 
-    def wait_for_url(self, _url_pattern, **_kwargs):
+    def wait_for_url(self, _url_pattern, *, wait_until=None, timeout=None):
         # #179: navigate_to_response_form больше не использует expect_navigation.
         return None
 

--- a/tests/test_apply_questions.py
+++ b/tests/test_apply_questions.py
@@ -144,7 +144,7 @@ class _Loc:
         loc._wait_error = self._wait_error
         return loc
 
-    def wait_for(self, state="visible", timeout=0):  # noqa: ARG002
+    def wait_for(self, *, state="visible", timeout=0):  # noqa: ARG002
         if self._wait_error:
             raise PlaywrightError("runtime error waiting for locator")
         self._state["waited"] = True

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -63,7 +63,7 @@ class _FakeLocator:
             hrefs = self._state.reorder_to
         return hrefs
 
-    def wait_for(self, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
         # Моделируем реальное поведение Playwright: в strict mode для коллекции
         # (несколько резюме) wait_for кидает обычный Error (НЕ PlaywrightTimeoutError).
         # Через .first strict mode снимается — тогда ждём готовность коллекции.
@@ -89,11 +89,15 @@ class _FakeLocator:
         if not self._state.visible:
             raise PlaywrightTimeoutError(f"{self.selector} not visible")
 
-    def click(self, **kwargs) -> None:
+    def click(self, *, timeout=None, no_wait_after=None) -> None:
         # Фиксируем kwargs клика — регрессия #80: клик apply-кнопки, триггерящий
         # навигацию, должен идти с no_wait_after=True (ожидание навигации владеет
         # внешний 90с expect_navigation, а не внутренний 30с action-timeout клика).
-        self._state.click_kwargs.append(kwargs)
+        # Только src/-вызываемые параметры (timeout, no_wait_after) — реальный
+        # Playwright.click() принимает больше, но в src/hhru_bot их никто не
+        # передаёт (#409 simplification review).
+        passed = {"timeout": timeout, "no_wait_after": no_wait_after}
+        self._state.click_kwargs.append({k: v for k, v in passed.items() if v is not None})
         # #176: имитация Playwright-исключения в момент клика (navigation timeout
         # после POST, target closed) — действие могло уйти на hh.ru.
         if self._state.click_error is not None:
@@ -198,7 +202,7 @@ class FakeStepsPage:
         self.content_calls = 0
         self.wait_for_function_calls: list[tuple[str, str | None, int | None]] = []
 
-    def screenshot(self, **_kwargs) -> bytes:
+    def screenshot(self, *, full_page: bool | None = None, path=None) -> bytes:
         self.screenshot_calls += 1
         return b"png"
 
@@ -206,7 +210,7 @@ class FakeStepsPage:
         self.content_calls += 1
         return "<html>diagnostic</html>"
 
-    def wait_for_function(self, _expression, arg=None, timeout=None):
+    def wait_for_function(self, _expression, *, arg=None, timeout=None, polling=None):
         self.wait_for_function_calls.append(("function", arg, timeout))
         if not self._state(arg).visible:
             raise PlaywrightTimeoutError("condition not met")

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -58,7 +58,7 @@ class _FakeLocator:
             return 1 if self._page._probe_count > self._appear_after else 0
         return self._count
 
-    def wait_for(self, timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0) -> None:  # noqa: ARG002
         if self.count() == 0:
             raise PlaywrightTimeoutError("not present")
 

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -103,7 +103,7 @@ class _FakePage:
             return _FakeLocator(count_value=1)
         return _FakeLocator(count_value=0)
 
-    def get_by_text(self, text, exact: bool = False):  # noqa: ARG002
+    def get_by_text(self, text, *, exact: bool = False):  # noqa: ARG002
         # Playwright get_by_text принимает str | Pattern. Для Pattern ищем
         # по множеству заготовленных фраз (как делает реальный regex-поиск).
         import re

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -128,7 +128,7 @@ class FakeNegotiationsPage:
         self.goto_calls: list[str] = []
         self.wait_for_timeout_calls: list[int] = []
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         if self._goto_error is not None:
             raise self._goto_error
@@ -148,7 +148,7 @@ class FakeNegotiationsPage:
     def wait_for_timeout(self, ms: int) -> None:
         self.wait_for_timeout_calls.append(ms)
 
-    def screenshot(self, full_page: bool = True) -> bytes:  # noqa: ARG002
+    def screenshot(self, *, full_page: bool = True) -> bytes:  # noqa: ARG002
         return b"<png>"
 
 
@@ -480,7 +480,7 @@ class _Page1FailsPage(FakeNegotiationsPage):
     """Страница 0 грузится, переход на страницу 1 падает (goto_hh ретраит и
     пробрасывает PlaywrightError на последней попытке)."""
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         if "?page=1" in url:
             raise PlaywrightError("net::ERR_TIMED_OUT")
@@ -637,7 +637,7 @@ class _AlternatingPaginationPage(FakeNegotiationsPage):
         self._unconfirmed = page0_unconfirmed
         self._page0_gotos = 0
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         if "?page=1" in url:
             raise PlaywrightError("net::ERR_TIMED_OUT")
@@ -674,7 +674,7 @@ class _IncomparableSecondAttemptPage(FakeNegotiationsPage):
         self._incomparable = page0_incomparable
         self._page0_gotos = 0
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
         if url == NEGOTIATIONS_URL:
             self._page0_gotos += 1
@@ -736,13 +736,19 @@ class _SimpleLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self, **_kwargs) -> None:
+    def click(
+        self,
+        *,
+        timeout: float | None = None,
+        force: bool | None = None,
+        no_wait_after: bool | None = None,
+    ) -> None:  # noqa: ARG002
         return None
 
     def get_attribute(self, _name: str) -> str | None:
@@ -770,7 +776,7 @@ class _ApplyPipelineFakePage:
     def __init__(self):
         self.goto_calls: list[str] = []
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
 
     def locator(self, selector: str) -> _SimpleLocator:  # noqa: ARG002
@@ -780,13 +786,15 @@ class _ApplyPipelineFakePage:
             return _SimpleLocator(True)
         return _SimpleLocator(False)
 
-    def wait_for_url(self, _url_pattern, **_kwargs) -> None:
+    def wait_for_url(
+        self, _url_pattern, *, wait_until: str | None = None, timeout: float | None = None
+    ) -> None:  # noqa: ARG002
         return None
 
     def content(self) -> str:
         return "<html></html>"
 
-    def screenshot(self, full_page: bool = True) -> bytes:  # noqa: ARG002
+    def screenshot(self, *, full_page: bool = True) -> bytes:  # noqa: ARG002
         return b""
 
 

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -172,7 +172,7 @@ def test_withdraw_failure_after_destructive_click_is_uncertain_and_not_retried(
         def click(self) -> None:
             withdraw_clicked.append(self.kind)
 
-        def wait_for(self, **_kwargs):
+        def wait_for(self, *, timeout: float | None = None, state: str | None = None):  # noqa: ARG002
             # Позитивный маркер успеха так и не появился: клик уже ушёл на hh.ru.
             raise PlaywrightTimeoutError("Timeout 10000ms exceeded")
 
@@ -292,7 +292,7 @@ def test_save_about_marks_post_click_timeout_as_uncertain():
         def click(self) -> None:
             self.clicked = True
 
-        def wait_for(self, **_kwargs):
+        def wait_for(self, *, timeout: float | None = None, state: str | None = None):  # noqa: ARG002
             if self._on_wait is not None:
                 raise self._on_wait
 

--- a/tests/test_auth_code.py
+++ b/tests/test_auth_code.py
@@ -29,7 +29,7 @@ class _Locator:
     def first(self):
         return self
 
-    def wait_for(self, **_kwargs):
+    def wait_for(self, *, timeout: float | None = None, state: str | None = None):  # noqa: ARG002
         if self.kind == "email-type" and self.page.show_credentials_on_wait:
             self.page.stage = "credentials"
         if self.kind == "code" and self.page.show_code_on_wait:
@@ -44,7 +44,15 @@ class _Locator:
         elif self.kind == "submit":
             self.page.stage = "code"
 
-    def check(self, **_kwargs):
+    def check(
+        self,
+        *,
+        position=None,
+        timeout: float | None = None,
+        force: bool | None = None,
+        no_wait_after: bool | None = None,
+        trial: bool | None = None,
+    ):  # noqa: ARG002
         self.page.email_selected = True
 
     def fill(self, value):

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -63,7 +63,7 @@ class _FakeLocator:
             return 0
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "visible") -> None:  # noqa: ARG002
         # wait_for моделирует реальный рендер: дожидается финального состояния,
         # а не снимка на момент вызова.
         if self._wait_error:
@@ -71,7 +71,13 @@ class _FakeLocator:
         if not self._present:
             raise PlaywrightTimeoutError(f"{self._name} not visible")
 
-    def click(self, **_kwargs) -> None:
+    def click(
+        self,
+        *,
+        timeout: float | None = None,
+        force: bool | None = None,
+        no_wait_after: bool | None = None,
+    ) -> None:  # noqa: ARG002
         if self._click_error:
             # #176: клик «выполняется», но Playwright падает — как navigation
             # timeout/target closed уже после отправки действия на hh.ru.
@@ -100,7 +106,7 @@ class FakeBumpPage:
         self._hint_wait_error = hint_wait_error
         self._button_click_error = button_click_error
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
 
     def locator(self, selector: str):

--- a/tests/test_clear_negotiations_command.py
+++ b/tests/test_clear_negotiations_command.py
@@ -103,7 +103,7 @@ class _Locator:
         if self.clicked is not None:
             self.clicked.append(True)
 
-    def wait_for(self, **kwargs):
+    def wait_for(self, *, timeout: float | None = None, state: str | None = None):  # noqa: ARG002
         return None
 
     def locator(self, selector):

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -80,12 +80,12 @@ class StubLocator:
             )
         self._count = n
 
-    def wait_for(self, timeout=None):
+    def wait_for(self, *, timeout=None):
         if self._page is not None:
             self._page.wait_timeouts.append((self._scope, self.selector, timeout))
         self._resolve()
 
-    def click(self, timeout=None):
+    def click(self, *, timeout=None):
         self._resolve()
         self._page.clicks.append((self._scope, self.selector))
         self._page.on_click(self._scope, self.selector)
@@ -191,7 +191,7 @@ class StubPage:
         if selector == DUP_SEL and self._url_after_click:
             self.url = self._url_after_click
 
-    def wait_for_url(self, pattern, wait_until=None, timeout=None):
+    def wait_for_url(self, pattern, *, wait_until=None, timeout=None):
         assert wait_until == "commit"
         if not pattern.search(self.url):
             raise PlaywrightTimeoutError("wait_for_url timeout")
@@ -263,7 +263,7 @@ def test_duplicate_click_error_is_uncertain(monkeypatch):
         def first(self):
             return self
 
-        def click(self, timeout=None):
+        def click(self, *, timeout=None):
             raise PlaywrightError("navigation interrupted")
 
     page = StubPage(

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -208,7 +208,7 @@ class StubPage:
         if self.tick_actions:
             self.tick_actions.pop(0)()
 
-    def reload(self, wait_until=None):
+    def reload(self, *, wait_until=None):
         self.reloads.append(wait_until)
         if self.reload_action is not None:
             self.reload_action()

--- a/tests/test_fill_form.py
+++ b/tests/test_fill_form.py
@@ -138,13 +138,13 @@ def test_run_degrades_when_llm_client_construction_raises_any_exception(monkeypa
     class FakePage:
         url = "https://forms.example.test/application"
 
-        def goto(self, _url, wait_until):
+        def goto(self, _url, *, wait_until):
             pass
 
         def content(self):
             return "<html></html>"
 
-        def screenshot(self, **_kwargs):
+        def screenshot(self, *, path=None, full_page: bool | None = None):
             pass
 
     class FakeContext:
@@ -206,14 +206,15 @@ def test_run_uses_account_profile_answers(monkeypatch, tmp_path):
     class FakePage:
         url = "https://forms.example.test/application"
 
-        def goto(self, url, wait_until):
+        def goto(self, url, *, wait_until):
             captured["url"] = url
             captured["wait_until"] = wait_until
 
         def content(self):
             return "<html></html>"
 
-        def screenshot(self, **kwargs):
+        def screenshot(self, *, path=None, full_page: bool | None = None):
+            kwargs = {"path": path, "full_page": full_page}
             captured["screenshot"] = kwargs
 
     class FakeContext:
@@ -276,13 +277,13 @@ def test_run_reports_llm_matched_fields_in_dry_run_output(monkeypatch, tmp_path,
     class FakePage:
         url = "https://forms.example.test/application"
 
-        def goto(self, _url, wait_until):
+        def goto(self, _url, *, wait_until):
             pass
 
         def content(self):
             return "<html></html>"
 
-        def screenshot(self, **_kwargs):
+        def screenshot(self, *, path=None, full_page: bool | None = None):
             pass
 
     class FakeContext:

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -50,13 +50,13 @@ class _FakeLocator:
     def count(self) -> int:
         return 1 if self._present else 0
 
-    def wait_for(self, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
+    def wait_for(self, *, timeout: float = 0, state: str = "attached") -> None:  # noqa: ARG002
         if not self._present:
             from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
             raise PlaywrightTimeoutError("not present")
 
-    def click(self, **_kwargs) -> None:
+    def click(self, *, timeout=None, no_wait_after=None) -> None:  # noqa: ARG002
         return None
 
     def fill(self, _value: str) -> None:  # noqa: ARG002
@@ -91,7 +91,7 @@ class _ApplyFakePage:
     def __init__(self):
         self.goto_calls: list[str] = []
 
-    def goto(self, url: str, wait_until: str = "") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)
 
     def locator(self, selector: str):  # noqa: ARG002
@@ -101,7 +101,7 @@ class _ApplyFakePage:
             return _FakeLocator(present=True)
         return _FakeLocator(present=False)
 
-    def wait_for_url(self, _url_pattern, **_kwargs):  # noqa: ARG002
+    def wait_for_url(self, _url_pattern, *, wait_until=None, timeout=None):  # noqa: ARG002
         # #179: navigate_to_response_form больше не использует expect_navigation.
         return None
 

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -106,7 +106,7 @@ class StubFirstCard:
         self._cards_ref = cards_ref
         self._delayed_cards = delayed_cards
 
-    def wait_for(self, timeout=None):
+    def wait_for(self, *, timeout=None):
         if self._cards_ref:
             return
         if self._delayed_cards:
@@ -356,7 +356,7 @@ class StubResumesPage:
         self._authed = authed
         self.gotos: list[str] = []
 
-    def goto(self, url, wait_until=""):  # noqa: ARG002
+    def goto(self, url, *, wait_until=""):  # noqa: ARG002
         self.gotos.append(url)
 
     def content(self):

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -70,7 +70,7 @@ class _FakeLocator:
     def click(self) -> None:
         return None
 
-    def wait_for(self, **kwargs) -> None:
+    def wait_for(self, *, timeout=None, state=None) -> None:
         return None
 
 

--- a/tests/test_playwright_fakes_contract.py
+++ b/tests/test_playwright_fakes_contract.py
@@ -39,8 +39,10 @@ PLAYWRIGHT_CLASSES = (Page, Locator, ElementHandle, Frame)
 # по src/hhru_bot/ на методы Page/Locator с keyword-only параметрами в реальном
 # API; expect_navigation оставлен несмотря на #179 (заменён на wait_for_url) —
 # держим на случай регрессии обратно на него. get_by_text/reload добавлены
-# после cycle-review PR #410 (Codex): оба реально используются в src/ с
+# после cycle-review PR #410 round 1 (Codex): оба реально используются в src/ с
 # keyword-only параметрами (exact/wait_until) и были пропущены исходным grep'ом.
+# get_by_label/get_by_role добавлены после round 2 (Codex) по той же причине —
+# оба вызываются в src/ с exact/name как keyword-only.
 RELEVANT_METHODS = {
     "check",
     "click",
@@ -48,6 +50,8 @@ RELEVANT_METHODS = {
     "expect_navigation",
     "fill",
     "get_attribute",
+    "get_by_label",
+    "get_by_role",
     "get_by_text",
     "goto",
     "inner_text",

--- a/tests/test_playwright_fakes_contract.py
+++ b/tests/test_playwright_fakes_contract.py
@@ -1,0 +1,175 @@
+"""Контракт: фейки Playwright-объектов в tests/ не должны быть мягче реального API.
+
+Регрессия #354/#371: steps.py вызвал ``page.wait_for_function(expr, selector,
+timeout=...)`` — ``arg`` в реальном Playwright API это keyword-only параметр
+(после ``*``), позиционная передача падает с TypeError. tests/test_apply_steps.py
+мокал ``wait_for_function`` сигнатурой ``(self, _expression, arg=None,
+timeout=None)`` — без ``*``, поэтому фейк молча принимал и позиционный, и
+именованный вызов и не поймал регрессию до боевого прогона.
+
+Этот тест статически сверяет сигнатуры одноимённых методов в тестовых fake-классах
+(tests/*.py) с реальными Page/Locator/ElementHandle/Frame из установленного
+Playwright: если параметр в реальном API keyword-only, а в фейке — обычный
+(POSITIONAL_OR_KEYWORD), фейк умеет больше, чем настоящий объект, и маскирует
+именно такие TypeError. Отдельно запрещён голый ``**kwargs`` на месте
+контролируемых параметров — он глушит проверку по построению.
+
+Ложные срабатывания возможны для методов с общими именами, не связанных с
+Playwright (напр. свой ``close()``/``evaluate()`` на невизуальном классе) —
+такие исключаются точечно через ``_IGNORE`` с комментарием-обоснованием.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import ElementHandle, Frame, Locator, Page
+
+pytestmark = pytest.mark.unit
+
+TESTS_DIR = Path(__file__).parent
+PLAYWRIGHT_CLASSES = (Page, Locator, ElementHandle, Frame)
+
+# Методы, реально вызываемые в src/hhru_bot/ на Playwright-объектах (см. #408
+# разбор) — контракт держим именно по ним, чтобы не тащить весь необъятный
+# Playwright API и не плодить шум по несвязанным именам. Список сверен grep'ом
+# по src/hhru_bot/ на методы Page/Locator с keyword-only параметрами в реальном
+# API; expect_navigation оставлен несмотря на #179 (заменён на wait_for_url) —
+# держим на случай регрессии обратно на него.
+RELEVANT_METHODS = {
+    "check",
+    "click",
+    "evaluate",
+    "expect_navigation",
+    "fill",
+    "get_attribute",
+    "goto",
+    "inner_text",
+    "input_value",
+    "press",
+    "screenshot",
+    "select_option",
+    "text_content",
+    "wait_for",
+    "wait_for_function",
+    "wait_for_load_state",
+    "wait_for_selector",
+    "wait_for_url",
+}
+
+# (файл, класс, метод) — точечные, обоснованные исключения из контракта.
+# Пусто по состоянию на #408: ни одного законного случая пока не найдено.
+_IGNORE: set[tuple[str, str, str]] = set()
+
+
+def _real_keyword_only_params() -> dict[str, set[str]]:
+    """method_name -> множество имён параметров, keyword-only хотя бы в одном
+    из отслеживаемых Playwright-классов (Page/Locator/... могут расходиться
+    в деталях — берём union, фейк не должен быть мягче ни для одного из них)."""
+    result: dict[str, set[str]] = {}
+    for method_name in RELEVANT_METHODS:
+        kwonly: set[str] = set()
+        for cls in PLAYWRIGHT_CLASSES:
+            real_fn = getattr(cls, method_name, None)
+            if real_fn is None:
+                continue
+            sig = inspect.signature(real_fn)
+            kwonly |= {
+                p.name for p in sig.parameters.values() if p.kind == inspect.Parameter.KEYWORD_ONLY
+            }
+        if kwonly:
+            result[method_name] = kwonly
+    return result
+
+
+REAL_KWONLY = _real_keyword_only_params()
+
+
+def _iter_fake_methods():
+    """Находит все def <method>(self, ...) в классах внутри tests/*.py, где
+    <method> входит в RELEVANT_METHODS — кандидаты в фейки Playwright-объектов."""
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        if path.name == "test_playwright_fakes_contract.py":
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if not isinstance(item, ast.FunctionDef):
+                    continue
+                if item.name not in RELEVANT_METHODS:
+                    continue
+                yield path, node.name, item
+
+
+def _violations_for(func: ast.FunctionDef, kwonly_in_real: set[str]) -> list[str]:
+    """Возвращает список проблем: параметры, которые в реальном API
+    keyword-only, а в фейке объявлены как обычные (POSITIONAL_OR_KEYWORD),
+    плюс голый **kwargs на месте контролируемых параметров."""
+    problems = []
+
+    args = func.args
+    # args.args включает self первым элементом
+    positional_or_keyword_names = {a.arg for a in args.args[1:]}
+    # параметры после func.args.args, объявленные без "*, " перед ними но
+    # являющиеся *args — не наш случай (args.vararg отдельно)
+    overlap = positional_or_keyword_names & kwonly_in_real
+    for name in sorted(overlap):
+        problems.append(
+            f"параметр '{name}' объявлен как обычный (POSITIONAL_OR_KEYWORD), "
+            f"а в реальном Playwright API он keyword-only — фейк принимает "
+            f"позиционный вызов, который в бою упадёт с TypeError"
+        )
+
+    if args.kwarg is not None and kwonly_in_real:
+        # **kwargs сам по себе не запрещён (напр. **_kwargs для screenshot),
+        # но если это единственная защита для keyword-only параметров реального
+        # метода — он глушит контракт по построению, а не описывает его.
+        # Флагуем только если явных keyword-only параметров в фейке нет вовсе
+        # (иначе это осознанный catch-all поверх уже описанных имён).
+        if not args.kwonlyargs:
+            problems.append(
+                "метод использует **kwargs вместо явных параметров — "
+                "не различает позиционный и именованный вызов, маскирует "
+                "несовместимость с реальным Playwright API по построению"
+            )
+
+    return problems
+
+
+def test_fake_playwright_methods_not_more_permissive_than_real_api():
+    all_problems: list[str] = []
+    checked = 0
+
+    for path, class_name, func in _iter_fake_methods():
+        key = (path.name, class_name, func.name)
+        if key in _IGNORE:
+            continue
+        kwonly_in_real = REAL_KWONLY.get(func.name)
+        if not kwonly_in_real:
+            continue  # метод без keyword-only параметров в реальном API — нечего сверять
+        checked += 1
+        problems = _violations_for(func, kwonly_in_real)
+        for problem in problems:
+            all_problems.append(f"{path.name}:{func.lineno} {class_name}.{func.name}() — {problem}")
+
+    assert checked > 0, (
+        "Контракт не нашёл ни одного fake-метода для сверки — "
+        "вероятно, RELEVANT_METHODS или паттерн поиска классов разошлись "
+        "с реальной структурой tests/. Проверь _iter_fake_methods()."
+    )
+    assert not all_problems, (
+        "Найдены фейки Playwright-методов, которые мягче реального API "
+        "(позволяют то, что в бою упадёт с TypeError, см. #354/#371/#408):\n"
+        + "\n".join(all_problems)
+        + "\n\nЕсли расхождение осознанное и безопасное — добавь точечное "
+        "исключение в _IGNORE с комментарием-обоснованием, не расширяй "
+        "прокладку молча."
+    )

--- a/tests/test_playwright_fakes_contract.py
+++ b/tests/test_playwright_fakes_contract.py
@@ -38,7 +38,9 @@ PLAYWRIGHT_CLASSES = (Page, Locator, ElementHandle, Frame)
 # Playwright API и не плодить шум по несвязанным именам. Список сверен grep'ом
 # по src/hhru_bot/ на методы Page/Locator с keyword-only параметрами в реальном
 # API; expect_navigation оставлен несмотря на #179 (заменён на wait_for_url) —
-# держим на случай регрессии обратно на него.
+# держим на случай регрессии обратно на него. get_by_text/reload добавлены
+# после cycle-review PR #410 (Codex): оба реально используются в src/ с
+# keyword-only параметрами (exact/wait_until) и были пропущены исходным grep'ом.
 RELEVANT_METHODS = {
     "check",
     "click",
@@ -46,10 +48,12 @@ RELEVANT_METHODS = {
     "expect_navigation",
     "fill",
     "get_attribute",
+    "get_by_text",
     "goto",
     "inner_text",
     "input_value",
     "press",
+    "reload",
     "screenshot",
     "select_option",
     "text_content",

--- a/tests/test_probe_healthcheck.py
+++ b/tests/test_probe_healthcheck.py
@@ -55,7 +55,7 @@ class _FakePage:
     def set_content(self, html: str) -> None:
         self._root = _parse_root(html)
 
-    def goto(self, url: str, wait_until: str = "domcontentloaded") -> None:  # noqa: ARG002
+    def goto(self, url: str, *, wait_until: str = "domcontentloaded") -> None:  # noqa: ARG002
         self.last_goto = url
 
     def locator(self, selector: str) -> FakeLocator:

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -71,7 +71,7 @@ class _Page:
     def wait_for_timeout(self, timeout):
         return None
 
-    def reload(self, wait_until=None):
+    def reload(self, *, wait_until=None):
         self.reloaded += 1
         self.markup = self.after_markup
 
@@ -279,7 +279,7 @@ def test_publish_reload_session_rejection_after_click_is_uncertain(monkeypatch):
     # опубликовать поверх уже состоявшейся публикации. Теперь это fail-closed
     # серая зона: uncertain=True, а не необработанное исключение.
     class _AuthRejectedPage(_Page):
-        def reload(self, wait_until=None):
+        def reload(self, *, wait_until=None):
             super().reload(wait_until=wait_until)
             raise NotAuthenticated("сессия отвергнута сервером")
 

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -28,14 +28,14 @@ class _Locator:
     def count(self):
         return self._count
 
-    def wait_for(self, timeout=None):
+    def wait_for(self, *, timeout=None):
         return None
 
     @property
     def first(self):
         return self
 
-    def click(self, timeout=None):
+    def click(self, *, timeout=None):
         self.page.clicked += 1
         self.page.markup = self.page.after_markup
 
@@ -247,7 +247,7 @@ def test_publish_succeeds_only_after_searchable_signal(monkeypatch):
 
 def test_publish_marks_uncertain_on_click_error(monkeypatch):
     class _ErrorLocator(_Locator):
-        def click(self, timeout=None):
+        def click(self, *, timeout=None):
             raise PlaywrightError("navigation interrupted")
 
     class _ErrorPage(_Page):

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -29,7 +29,7 @@ class FakeSaveButton:
     def click(self):
         self._page.saved_rows.append(self._page.current_index)
 
-    def wait_for_url(self, *args, **kwargs):  # noqa: ARG002
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
         pass
 
 
@@ -67,7 +67,7 @@ class FakePage:
             return FakeSaveButton(self)
         return FakeFieldLocator()
 
-    def wait_for_url(self, *args, **kwargs):  # noqa: ARG002
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
         pass
 
 

--- a/tests/test_resume_sections.py
+++ b/tests/test_resume_sections.py
@@ -43,7 +43,11 @@ def test_recommendation_mapping_uses_current_semantic_labels() -> None:
     name = MagicMock()
     position = MagicMock()
     company = MagicMock()
-    page.get_by_label.side_effect = lambda label, exact: {
+    # exact — keyword-only в реальном Page.get_by_label; лямбда повторяет это,
+    # чтобы MagicMock не маскировал позиционный вызов (cycle-review PR #410
+    # round 2, Codex: AST-контракт не видит MagicMock-фейки, здесь сигнатура
+    # держится вручную).
+    page.get_by_label.side_effect = lambda label, *, exact: {
         "Имя человека": name,
         "Должность": position,
     }[label]

--- a/tests/test_search_pagination.py
+++ b/tests/test_search_pagination.py
@@ -105,7 +105,7 @@ class _StaticLocator:
     def first(self):
         return self
 
-    def wait_for(self, **_kwargs):
+    def wait_for(self, *, timeout=None, state=None):
         return None
 
 


### PR DESCRIPTION
## Мотивация

При разборе ложной регрессии в #408 (моя ветка отставала от main — баг был уже исправлен коммитом 6902706/#371) выяснилось: fake-класс `FakeStepsPage.wait_for_function` в `tests/test_apply_steps.py` был мягче реального Playwright API — принимал keyword-only параметр `arg` позиционно. Это тот же класс дефекта, что вызвал регрессию #354.

Аудит показал: не единичный случай — около 70 похожих мест в ~25 файлах `tests/*.py`.

## Что сделано

- `tests/test_playwright_fakes_contract.py` (маркер `unit`) — статически (через `ast`) находит все fake-методы в `tests/*.py`, чьи имена совпадают с методами Playwright `Page`/`Locator`/`ElementHandle`/`Frame`, и падает, если параметр keyword-only в реальном API объявлен обычным в фейке, либо метод использует голый `**kwargs`.
- `RELEVANT_METHODS` сверен grep'ом по фактическим вызовам в `src/hhru_bot/` — не только методы из исходной регрессии (`/simplify` review нашёл, что первая версия списка не соответствовала своему же комментарию про 'реально используемые в src/').
- Починены все найденные нарушения — добавлен `*` перед keyword-only параметрами, `**kwargs` заменён на явные именованные параметры.
- `click()`-фейки сведены к параметрам, которые реально передаёт `src/` (`timeout`, `no_wait_after`) вместо копирования полного 9-параметрового списка Playwright API — упрощение по итогам ревью.
- Только сигнатуры менялись, логика фейков — нет.

## Проверено

- `pytest tests/ -q` — зелёный (весь набор).
- `pytest tests/test_playwright_fakes_contract.py` — зелёный.
- `pytest --collect-only -q` — live-категории не собраны.
- `ruff check`/`ruff format --check` — чисто.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)