### PR TITLE
Clarify Chromium sandbox launch errors

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -49,9 +49,11 @@ def launch_browser(playwright, *, headless: bool) -> Browser:
         )
         if apple_mach_port_failure or any(marker in details for marker in sandbox_markers):
             raise BrowserLaunchError(
-                "CODEX_SANDBOX_BROWSER_FAILURE: Chromium was blocked by the "
-                "execution sandbox (macOS/Crashpad permission). Retry this same "
-                "command with elevated system permission."
+                "CODEX_SANDBOX_BROWSER_FAILURE: Chromium заблокирован sandbox "
+                "среды выполнения (macOS/Crashpad permission). Это ограничение "
+                "среды, а не hh.ru или сессии. Повторите ту же команду вне sandbox "
+                "с системным разрешением (elevated); переключение headed/headless "
+                "причину не меняет."
             ) from exc
         raise
 

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -45,13 +45,16 @@ class _FakePlaywright:
 
 
 def test_headless_sandbox_failure_is_classified_as_browser_launch_error():
-    """B1: headless-сбой песочницы превращается в контролируемую ошибку CLI."""
+    """B1: headless-сбой получает понятную общую диагностику sandbox."""
     playwright = _FakePlaywright(_LIVE_HEADLESS_SANDBOX_ERROR)
 
     with pytest.raises(BrowserLaunchError) as excinfo:
         launch_browser(playwright, headless=True)
 
-    assert "CODEX_SANDBOX_BROWSER_FAILURE" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "CODEX_SANDBOX_BROWSER_FAILURE" in message
+    assert "вне sandbox" in message
+    assert "headed/headless" in message
 
 
 def test_permission_denied_mach_port_failure_is_a_sandbox_marker():
@@ -64,11 +67,15 @@ def test_permission_denied_mach_port_failure_is_a_sandbox_marker():
 
 
 def test_headed_sandbox_failure_is_classified():
-    """Контроль: headed-путь с известным маркером работает — дефект именно в двух условиях."""
+    """Headed получает ту же общую диагностику, что и headless."""
     playwright = _FakePlaywright("Operation not permitted while starting Crashpad")
 
-    with pytest.raises(BrowserLaunchError):
+    with pytest.raises(BrowserLaunchError) as excinfo:
         launch_browser(playwright, headless=False)
+
+    message = str(excinfo.value)
+    assert "вне sandbox" in message
+    assert "headed/headless" in message
 
 
 # --- B2 ОТКЛОНЕНА -------------------------------------------------------------

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -38,8 +38,13 @@ def test_sandbox_failure_is_classified_for_headless_and_headed(headless):
         "Permission denied (1100)"
     )
 
-    with pytest.raises(browser.BrowserLaunchError, match="CODEX_SANDBOX_BROWSER_FAILURE"):
+    with pytest.raises(browser.BrowserLaunchError) as excinfo:
         browser.launch_browser(playwright, headless=headless)
+
+    message = str(excinfo.value)
+    assert "CODEX_SANDBOX_BROWSER_FAILURE" in message
+    assert "вне sandbox" in message
+    assert "headed/headless" in message
 
 
 def test_non_sandbox_launch_failure_is_not_reclassified():


### PR DESCRIPTION
## Summary
- show one clear sandbox error for both headed and headless Chromium
- explain that the cause is execution-environment permissions, not hh.ru or the session
- direct users to rerun outside the sandbox with elevated permissions

## Verification
- `PYTHONPATH=src python3 -m pytest -q tests/test_audit_launch_and_navigation.py tests/test_browser_navigation.py`
- 32 passed