### PR TITLE
feat(apply): handle hh response blockers and limits

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -60,6 +60,7 @@ resumes:
       salary_from: 200000
       experience: "between3And6"
       schedule: "remote"
+      allow_relocation: false
       exclude_employers:
         - "Компания А"
         - "Компания Б"
@@ -142,6 +143,7 @@ resumes:
       salary_from: null
       experience: null
       schedule: null
+      allow_relocation: false
       exclude_employers: []
       # По умолчанию стоп-слова не включены: задайте их отдельно для каждого
       # резюме в поле exclude_keywords (пример выше).

--- a/src/hhru_bot/apply/blockers.py
+++ b/src/hhru_bot/apply/blockers.py
@@ -30,6 +30,10 @@ class PostClickBlocker:
     reason: str
     skip_reason: str | None = None
     stop_run: bool = False
+    #: True, если блокер найден уже ПОСЛЕ навигации на форму отклика — там
+    #: отклик мог физически уйти, поэтому вердикт обязан пройти через
+    #: внешнюю проверку #207 (/applicant/negotiations).
+    post_navigation: bool = False
 
 
 class PostSubmitLimitExceeded(RuntimeError):
@@ -88,6 +92,7 @@ def handle_post_click_blockers(
     *,
     allow_relocation: bool,
     render_timeout_ms: int = BLOCKER_RENDER_TIMEOUT_MS,
+    post_navigation: bool = False,
 ) -> PostClickBlocker | None:
     """Handle one post-click DOM state and return a terminal blocker if any.
 
@@ -101,12 +106,17 @@ def handle_post_click_blockers(
     if _visible(page, vacancy_page.VACANCY_RELOCATION_CONFIRM):
         if allow_relocation:
             _close_specific(page, vacancy_page.VACANCY_RELOCATION_CONFIRM)
+            # Подтверждение переезда — это клик, запускающий свой ре-рендер:
+            # следующие строгие проверки нельзя делать по неотстоявшемуся DOM
+            # (CLAUDE.md п.4), иначе терминальная модалка будет пропущена.
+            _wait_for_any_blocker(page, render_timeout_ms)
         else:
             return PostClickBlocker(
                 "relocation_not_allowed",
                 "HH запросил подтверждение готовности к переезду; "
                 "подтверждение отключено настройками проекта",
                 SKIP_REASONS.RELOCATION_NOT_ALLOWED,
+                post_navigation=post_navigation,
             )
 
     if _visible(page, vacancy_page.VACANCY_LIMIT_ERROR):
@@ -114,6 +124,7 @@ def handle_post_click_blockers(
             "limit_exceeded",
             "HH.ru сообщил об исчерпанном лимите откликов; текущий прогон остановлен",
             stop_run=True,
+            post_navigation=post_navigation,
         )
 
     if _visible(page, vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL):
@@ -123,6 +134,7 @@ def handle_post_click_blockers(
                 "direct_application",
                 "вакансия требует отклика на сайте работодателя",
                 SKIP_REASONS.DIRECT_APPLICATION,
+                post_navigation=post_navigation,
             )
 
     # В отличие от direct-application, здесь текстовый гейт не нужен: оба
@@ -135,6 +147,7 @@ def handle_post_click_blockers(
             "response_rejected",
             "HH.ru показал предупреждение или ошибку отклика",
             SKIP_REASONS.RESPONSE_REJECTED,
+            post_navigation=post_navigation,
         )
 
     # This popup only covers the form; close it and let normal form detection

--- a/src/hhru_bot/apply/blockers.py
+++ b/src/hhru_bot/apply/blockers.py
@@ -1,0 +1,112 @@
+"""Post-click HH.ru response blockers.
+
+These checks deliberately live between the apply click and form processing.  A
+missing response form is not enough evidence to classify the outcome: HH can
+render a terminal popup instead.  Selectors are intentionally exact; generic
+modal close buttons can close the response form itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+
+from ..history import SKIP_REASONS
+from ..selector_groups import vacancy_page
+
+
+@dataclass(frozen=True)
+class PostClickBlocker:
+    kind: str
+    reason: str
+    skip_reason: str | None = None
+    stop_run: bool = False
+
+
+class PostSubmitLimitExceeded(RuntimeError):
+    """HH rendered the account response limit immediately after submit."""
+
+
+def _visible(page: Page, selector: str) -> bool:
+    try:
+        locator = page.locator(selector).first
+        return locator.is_visible()
+    except (PlaywrightError, AttributeError):
+        return False
+
+
+def _text(page: Page, selector: str) -> str:
+    try:
+        return page.locator(selector).first.inner_text().lower()
+    except (PlaywrightError, AttributeError):
+        return ""
+
+
+def _close_specific(page: Page, selector: str) -> None:
+    try:
+        locator = page.locator(selector).first
+        if locator.is_visible():
+            locator.click()
+    except (PlaywrightError, AttributeError):
+        return
+
+
+def handle_post_click_blockers(page: Page, *, allow_relocation: bool) -> PostClickBlocker | None:
+    """Handle one post-click DOM state and return a terminal blocker if any.
+
+    ``None`` means the caller may continue to form detection.  Similar-vacancy
+    overlays are non-terminal and are closed using only their dedicated
+    selectors.  Every terminal state is fail-closed and performs no submit.
+    """
+
+    if _visible(page, vacancy_page.VACANCY_RELOCATION_CONFIRM):
+        if allow_relocation:
+            _close_specific(page, vacancy_page.VACANCY_RELOCATION_CONFIRM)
+        else:
+            return PostClickBlocker(
+                "relocation_not_allowed",
+                "HH запросил подтверждение готовности к переезду; "
+                "подтверждение отключено настройками проекта",
+                SKIP_REASONS.RELOCATION_NOT_ALLOWED,
+            )
+
+    if _visible(page, vacancy_page.VACANCY_LIMIT_ERROR):
+        return PostClickBlocker(
+            "limit_exceeded",
+            "HH.ru сообщил об исчерпанном лимите откликов; текущий прогон остановлен",
+            stop_run=True,
+        )
+
+    if _visible(page, vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL):
+        alert_text = _text(page, vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT)
+        if any(marker in alert_text for marker in ("прямым откликом", "сайте работодателя")):
+            return PostClickBlocker(
+                "direct_application",
+                "вакансия требует отклика на сайте работодателя",
+                SKIP_REASONS.DIRECT_APPLICATION,
+            )
+
+    if _visible(page, vacancy_page.VACANCY_RESPONSE_REJECT_WARNING) or _visible(
+        page, vacancy_page.VACANCY_RESPONSE_ERROR
+    ):
+        return PostClickBlocker(
+            "response_rejected",
+            "HH.ru показал предупреждение или ошибку отклика",
+            SKIP_REASONS.RESPONSE_REJECTED,
+        )
+
+    # This popup only covers the form; close it and let normal form detection
+    # continue.  Never broaden this to a generic close button.
+    _close_specific(page, vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE)
+    _close_specific(page, 'button:has-text("Не сейчас")')
+    return None
+
+
+def raise_if_post_submit_limit(page: Page) -> None:
+    """Raise when HH shows the response limit after the submit click."""
+    if _visible(page, vacancy_page.VACANCY_LIMIT_ERROR):
+        raise PostSubmitLimitExceeded(
+            "HH.ru сообщил об исчерпанном лимите откликов после submit; текущий прогон остановлен"
+        )

--- a/src/hhru_bot/apply/blockers.py
+++ b/src/hhru_bot/apply/blockers.py
@@ -16,6 +16,13 @@ from playwright.sync_api import Page
 from ..history import SKIP_REASONS
 from ..selector_groups import vacancy_page
 
+# CLAUDE.md п.4: клик по кнопке отклика запускает асинхронный React-рендер,
+# поэтому сразу после него DOM ещё пуст.  Терминальные модалки проверяем только
+# после короткого явного ожидания — иначе проверка систематически ничего не
+# видит.  Таймаут намеренно мал: отсутствие модалки — штатный (частый) случай,
+# и ждать её полный APPLY_TIMEOUT_MS на каждой вакансии нельзя.
+BLOCKER_RENDER_TIMEOUT_MS = 1_500
+
 
 @dataclass(frozen=True)
 class PostClickBlocker:
@@ -53,13 +60,43 @@ def _close_specific(page: Page, selector: str) -> None:
         return
 
 
-def handle_post_click_blockers(page: Page, *, allow_relocation: bool) -> PostClickBlocker | None:
+def _wait_for_any_blocker(page: Page, timeout_ms: int) -> None:
+    """Даёт модалке отрисоваться до строгих проверок видимости.
+
+    Ждём первый попавшийся из терминальных якорей; отсутствие всех — штатный
+    исход (форма отрисовалась нормально), поэтому таймаут проглатывается.
+    """
+
+    selector = ", ".join(
+        (
+            vacancy_page.VACANCY_RELOCATION_CONFIRM,
+            vacancy_page.VACANCY_LIMIT_ERROR,
+            vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL,
+            vacancy_page.VACANCY_RESPONSE_REJECT_WARNING,
+            vacancy_page.VACANCY_RESPONSE_ERROR,
+            vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE,
+        )
+    )
+    try:
+        page.locator(selector).first.wait_for(state="visible", timeout=timeout_ms)
+    except (PlaywrightError, AttributeError):
+        return
+
+
+def handle_post_click_blockers(
+    page: Page,
+    *,
+    allow_relocation: bool,
+    render_timeout_ms: int = BLOCKER_RENDER_TIMEOUT_MS,
+) -> PostClickBlocker | None:
     """Handle one post-click DOM state and return a terminal blocker if any.
 
     ``None`` means the caller may continue to form detection.  Similar-vacancy
     overlays are non-terminal and are closed using only their dedicated
     selectors.  Every terminal state is fail-closed and performs no submit.
     """
+
+    _wait_for_any_blocker(page, render_timeout_ms)
 
     if _visible(page, vacancy_page.VACANCY_RELOCATION_CONFIRM):
         if allow_relocation:
@@ -88,6 +125,9 @@ def handle_post_click_blockers(page: Page, *, allow_relocation: bool) -> PostCli
                 SKIP_REASONS.DIRECT_APPLICATION,
             )
 
+    # В отличие от direct-application, здесь текстовый гейт не нужен: оба
+    # data-qa специфичны для отклика, тогда как ``magritte-alert`` выше —
+    # generic-контейнер дизайн-системы и без проверки текста дал бы ложный скип.
     if _visible(page, vacancy_page.VACANCY_RESPONSE_REJECT_WARNING) or _visible(
         page, vacancy_page.VACANCY_RESPONSE_ERROR
     ):

--- a/src/hhru_bot/apply/blockers.py
+++ b/src/hhru_bot/apply/blockers.py
@@ -71,6 +71,11 @@ def _wait_for_any_blocker(page: Page, timeout_ms: int) -> None:
     исход (форма отрисовалась нормально), поэтому таймаут проглатывается.
     """
 
+    # ВАЖНО: в Playwright ``timeout=0`` значит «таймаут отключён» (ждать
+    # бесконечно), а не «не ждать». Пропуск ожидания выражается только явным
+    # ранним выходом, иначе штатная страница без модалки повесила бы прогон.
+    if timeout_ms <= 0:
+        return
     selector = ", ".join(
         (
             vacancy_page.VACANCY_RELOCATION_CONFIRM,

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -24,6 +24,7 @@ from ..history import SKIP_REASONS
 from ..search import VacancyCard
 from . import steps as apply_steps
 from .antibot import AntiBotChallengeDetected, detect_antibot_on_page
+from .blockers import PostClickBlocker, PostSubmitLimitExceeded
 from .dedup import check_already_responded
 from .letter import VARIANT_TEMPLATE, CoverLetterProvider, render_cover_letter
 from .probe import NOOP_PROBE, ProbeHook
@@ -66,6 +67,7 @@ class ApplyResult:
     # (дедупликация has_applied его видит — без этого возможен повторный
     # отклик на ту же вакансию) и выдерживал троттл-паузу.
     uncertain: bool = False
+    stop_run: bool = False
 
 
 @dataclass
@@ -98,6 +100,7 @@ class ApplyContext:
     before_submit: Callable[[], None] | None = None
     question_answerer: AIQuestionAnswerer | None = None
     force: bool = False
+    allow_relocation: bool = False
 
     def fail(self, reason: str) -> ApplyResult:
         return ApplyResult(
@@ -107,6 +110,17 @@ class ApplyContext:
             letter_variant=self.letter_variant,
             acted=self.acted,
             uncertain=self.uncertain,
+        )
+
+    def stop(self, reason: str) -> ApplyResult:
+        return ApplyResult(
+            self.vacancy,
+            False,
+            reason,
+            letter_variant=self.letter_variant,
+            acted=self.acted,
+            uncertain=self.uncertain,
+            stop_run=True,
         )
 
     def ok(self, reason: str) -> ApplyResult:
@@ -147,6 +161,7 @@ def apply_to_vacancy(
     before_submit: Callable[[], None] | None = None,
     question_answerer: AIQuestionAnswerer | None = None,
     force: bool = False,
+    allow_relocation: bool = False,
 ) -> ApplyResult:
     ctx = ApplyContext(
         page=page,
@@ -160,6 +175,7 @@ def apply_to_vacancy(
         before_submit=before_submit,
         question_answerer=question_answerer,
         force=force,
+        allow_relocation=allow_relocation,
     )
     return _run(ctx)
 
@@ -289,13 +305,24 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     # #207: с клика по кнопке отклика начинается «серая зона» — дальнейшие
     # fail-исходы финализируются через _finalize_post_click_failure (внешняя
     # проверка /applicant/negotiations), а не сразу ctx.fail.
-    navigation_result = apply_steps.navigate_to_response_form(ctx.page, ctx.vacancy.vacancy_id)
+    navigation_result = apply_steps.navigate_to_response_form(
+        ctx.page,
+        ctx.vacancy.vacancy_id,
+        allow_relocation=ctx.allow_relocation,
+    )
     _halt_if_antibot(ctx)
     if isinstance(navigation_result, str):
         # #350: развёрнутое предупреждение о видимости резюме — недвусмысленный,
         # неисполнимый пропуск; не форма не отрисовалась, а hh.ru дал определённый
         # ответ прямо на странице вакансии.
         return ctx.skip(navigation_result, skip_reason=SKIP_REASONS.RESUME_VISIBILITY)
+    if isinstance(navigation_result, PostClickBlocker):
+        if navigation_result.stop_run:
+            return ctx.stop(navigation_result.reason)
+        return ctx.skip(
+            navigation_result.reason,
+            skip_reason=navigation_result.skip_reason or SKIP_REASONS.RESPONSE_REJECTED,
+        )
     if not navigation_result:
         reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
         logger.warning("[FAIL] %s — %s", ctx.vacancy.title, reason)
@@ -427,6 +454,9 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         return _finalize_post_click_failure(
             ctx, "submit-клик упал с исключением — отправка могла уйти, исход неопределён"
         )
+    except PostSubmitLimitExceeded as exc:
+        ctx.acted = True
+        return ctx.stop(str(exc))
     except PlaywrightError as exc:
         logger.warning(
             "[FAIL] %s — ошибка Playwright при заполнении формы (%s)", ctx.vacancy.title, exc

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -180,6 +180,60 @@ def apply_to_vacancy(
     return _run(ctx)
 
 
+def _finalize_blocker(ctx: ApplyContext, blocker: PostClickBlocker) -> ApplyResult:
+    """Финализирует терминальный post-click блокер (#342) с учётом #207.
+
+    Блокер, найденный ДО навигации на форму, отклик отправить не мог — его
+    вердикт терминален сам по себе (как #350). Блокер, найденный ПОСЛЕ
+    навигации, попадает в «серую зону» #207: hh.ru мог принять отклик и
+    одновременно показать модалку, поэтому сначала спрашиваем внешний источник
+    истины. Отклик найден — это success, а не потерянный skip; иначе вердикт
+    блокера сохраняется.
+    """
+
+    def _verdict() -> ApplyResult:
+        if blocker.stop_run:
+            return ctx.stop(blocker.reason)
+        return ctx.skip(
+            blocker.reason,
+            skip_reason=blocker.skip_reason or SKIP_REASONS.RESPONSE_REJECTED,
+        )
+
+    if not blocker.post_navigation or ctx.dry_run or ctx.verifier is None:
+        return _verdict()
+    try:
+        verified = ctx.verifier(ctx.page, ctx.vacancy.vacancy_id, ctx.resume_id)
+    except AntiBotChallengeDetected:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        # Как и в _finalize_post_click_failure: сбой самой проверки — это
+        # «не смогли проверить», а не «отклика нет». Fail-closed.
+        ctx.acted = True
+        ctx.uncertain = True
+        logger.warning("%s — внешняя проверка упала: %s", ctx.vacancy.title, exc)
+        return ctx.fail(f"{blocker.reason}; внешняя проверка упала ({exc}) — исход неопределён")
+    if verified.found:
+        ctx.acted = True
+        ctx.uncertain = False
+        logger.info(
+            "[OK] %s — блокер показан, но внешний источник подтвердил отклик: %s",
+            ctx.vacancy.title,
+            verified.detail,
+        )
+        return ctx.ok(
+            f"{blocker.reason}; внешняя проверка: отклик присутствует "
+            f"в /applicant/negotiations ({verified.detail})"
+        )
+    if verified.indeterminate:
+        ctx.acted = True
+        ctx.uncertain = True
+        logger.warning("%s — внешняя проверка недоступна: %s", ctx.vacancy.title, verified.detail)
+        return ctx.fail(
+            f"{blocker.reason}; внешняя проверка недоступна ({verified.detail}) — исход неопределён"
+        )
+    return _verdict()
+
+
 def _finalize_post_click_failure(ctx: ApplyContext, reason: str) -> ApplyResult:
     """#207: финализация fail-вердикта ПОСЛЕ клика по кнопке отклика.
 
@@ -317,12 +371,7 @@ def _run(ctx: ApplyContext) -> ApplyResult:
         # ответ прямо на странице вакансии.
         return ctx.skip(navigation_result, skip_reason=SKIP_REASONS.RESUME_VISIBILITY)
     if isinstance(navigation_result, PostClickBlocker):
-        if navigation_result.stop_run:
-            return ctx.stop(navigation_result.reason)
-        return ctx.skip(
-            navigation_result.reason,
-            skip_reason=navigation_result.skip_reason or SKIP_REASONS.RESPONSE_REJECTED,
-        )
+        return _finalize_blocker(ctx, navigation_result)
     if not navigation_result:
         reason = "форма отклика не отрисовалась — состояние формы не подтверждено"
         logger.warning("[FAIL] %s — %s", ctx.vacancy.title, reason)

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -199,6 +199,18 @@ def _finalize_blocker(ctx: ApplyContext, blocker: PostClickBlocker) -> ApplyResu
             skip_reason=blocker.skip_reason or SKIP_REASONS.RESPONSE_REJECTED,
         )
 
+    def _keep_stop(result: ApplyResult) -> ApplyResult:
+        """Сохраняет остановку прогона независимо от вердикта проверки.
+
+        Лимит откликов аккаунта — свойство аккаунта, а не конкретной вакансии:
+        подтверждённый отклик (found) или неудавшаяся проверка не отменяют его.
+        Без этого прогон продолжил бы долбиться в исчерпанный лимит — ровно тот
+        сценарий, ради которого #342 и заводился.
+        """
+        if blocker.stop_run and not result.stop_run:
+            return replace(result, stop_run=True)
+        return result
+
     if not blocker.post_navigation or ctx.dry_run or ctx.verifier is None:
         return _verdict()
     try:
@@ -211,7 +223,9 @@ def _finalize_blocker(ctx: ApplyContext, blocker: PostClickBlocker) -> ApplyResu
         ctx.acted = True
         ctx.uncertain = True
         logger.warning("%s — внешняя проверка упала: %s", ctx.vacancy.title, exc)
-        return ctx.fail(f"{blocker.reason}; внешняя проверка упала ({exc}) — исход неопределён")
+        return _keep_stop(
+            ctx.fail(f"{blocker.reason}; внешняя проверка упала ({exc}) — исход неопределён")
+        )
     if verified.found:
         ctx.acted = True
         ctx.uncertain = False
@@ -220,16 +234,21 @@ def _finalize_blocker(ctx: ApplyContext, blocker: PostClickBlocker) -> ApplyResu
             ctx.vacancy.title,
             verified.detail,
         )
-        return ctx.ok(
-            f"{blocker.reason}; внешняя проверка: отклик присутствует "
-            f"в /applicant/negotiations ({verified.detail})"
+        return _keep_stop(
+            ctx.ok(
+                f"{blocker.reason}; внешняя проверка: отклик присутствует "
+                f"в /applicant/negotiations ({verified.detail})"
+            )
         )
     if verified.indeterminate:
         ctx.acted = True
         ctx.uncertain = True
         logger.warning("%s — внешняя проверка недоступна: %s", ctx.vacancy.title, verified.detail)
-        return ctx.fail(
-            f"{blocker.reason}; внешняя проверка недоступна ({verified.detail}) — исход неопределён"
+        return _keep_stop(
+            ctx.fail(
+                f"{blocker.reason}; внешняя проверка недоступна ({verified.detail}) — "
+                "исход неопределён"
+            )
         )
     return _verdict()
 

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -21,6 +21,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from ..browser import GOTO_TIMEOUT_MS
 from ..logging_setup import LOG_DIR
 from ..selector_groups import vacancy_page
+from .blockers import PostClickBlocker, handle_post_click_blockers, raise_if_post_submit_limit
 
 logger = logging.getLogger("hhru_bot.apply.steps")
 
@@ -135,7 +136,8 @@ def navigate_to_response_form(
     navigation_timeout_ms: int = GOTO_TIMEOUT_MS,
     form_timeout_ms: int = APPLY_TIMEOUT_MS,
     dump_diagnostics: bool = True,
-) -> str | bool:
+    allow_relocation: bool = False,
+) -> str | bool | PostClickBlocker:
     """Кликает кнопку отклика и дожидается навигации на форму отклика.
 
     Возвращает:
@@ -204,6 +206,9 @@ def navigate_to_response_form(
         # нет, не крашим цикл откликов необработанным исключением.
         logger.warning("Клик по кнопке отклика упал с ошибкой (%s) — вакансия пропущена", exc)
         return False
+    blocker = handle_post_click_blockers(page, allow_relocation=allow_relocation)
+    if blocker is not None:
+        return blocker
     # #350: some accounts receive a modal on the vacancy URL instead of a form
     # navigation.  Its expanded warning is a definitive, non-actionable skip.
     if _hidden_resume_warning_is_expanded(page):
@@ -227,6 +232,9 @@ def navigate_to_response_form(
             "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
             exc,
         )
+    blocker = handle_post_click_blockers(page, allow_relocation=allow_relocation)
+    if blocker is not None:
+        return blocker
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
     try:
         page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(
@@ -340,6 +348,7 @@ def fill_response_form(page: Page, resume_id: str, letter: str) -> str | None:
     except PlaywrightError as exc:
         logger.warning("Submit-клик упал с исключением (%s) — отправка могла уйти", exc)
         raise SubmitClickUncertain(exc) from exc
+    raise_if_post_submit_limit(page)
     return None
 
 

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -232,7 +232,15 @@ def navigate_to_response_form(
             "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
             exc,
         )
-    blocker = handle_post_click_blockers(page, allow_relocation=allow_relocation)
+    # Второй проход: модалка могла отрисоваться уже после навигации. Ждать
+    # повторно не нужно — первый проход выше уже отдал ей render-таймаут, а
+    # штатный путь без модалки не должен платить его дважды на каждой вакансии.
+    blocker = handle_post_click_blockers(
+        page,
+        allow_relocation=allow_relocation,
+        render_timeout_ms=0,
+        post_navigation=True,
+    )
     if blocker is not None:
         return blocker
     # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hhru_bot.cli")
 
 
+class ApplyRunStopped(RuntimeError):
+    """Terminal account-level condition requiring the whole apply run to stop."""
+
+
 def add_common_args(p: argparse.ArgumentParser) -> None:
     """Общие аргументы для команд, работающих по резюме/поиску."""
     p.add_argument(
@@ -536,6 +540,8 @@ def run_apply_for_resume(
         apply_kwargs: dict[str, Any] = {
             "letter_provider": effective_letter_provider,
         }
+        if resume.search.allow_relocation:
+            apply_kwargs["allow_relocation"] = True
         if not args.dry_run:
             # #207: fail-вердикты после клика по кнопке отклика подтверждаются
             # внешней проверкой /applicant/negotiations до записи в history.
@@ -617,6 +623,9 @@ def run_apply_for_resume(
                 result.reason,
                 letter_variant=result.letter_variant,
             )
+        if getattr(result, "stop_run", False):
+            print(f"  [STOP] {card.title} — {result.reason}")
+            raise ApplyRunStopped(result.reason)
         if result.success:
             applied_count += 1
             print(f"  [OK] {card.title} — {card.company}")

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -588,6 +588,12 @@ def run_apply_for_resume(
             if action_id is not None:
                 history.finalize_action(action_id, "failed", result.reason)
             print(f"  [skip] {card.title} — {result.reason}")
+            # #342: сегодня терминальные блокеры приходят через ctx.stop()
+            # (skipped=False) и до сюда не доходят. Проверка стоит и здесь,
+            # чтобы будущий skip-путь с stop_run не проглотился этим continue.
+            if getattr(result, "stop_run", False):
+                print(f"  [STOP] {card.title} — {result.reason}")
+                raise ApplyRunStopped(result.reason)
             continue
 
         # #163: actions — журнал реальных взаимодействий с hh.ru. Запись только
@@ -623,9 +629,6 @@ def run_apply_for_resume(
                 result.reason,
                 letter_variant=result.letter_variant,
             )
-        if getattr(result, "stop_run", False):
-            print(f"  [STOP] {card.title} — {result.reason}")
-            raise ApplyRunStopped(result.reason)
         if result.success:
             applied_count += 1
             print(f"  [OK] {card.title} — {card.company}")
@@ -640,6 +643,15 @@ def run_apply_for_resume(
         # защищает; после submit (включая неподтверждённый успех) — обязательна.
         if result.acted:
             throttle.wait(f"после отклика на '{card.title}'")
+
+        # #342: остановка прогона выполняется ПОСЛЕДНЕЙ. Терминальный лимит
+        # аккаунта может сопровождаться реально ушедшим откликом (внешняя
+        # проверка #207 вернула found), поэтому сначала учитываем его в
+        # счётчике и выдерживаем анти-бан-паузу, и только потом прерываем
+        # прогон — иначе после submit паузы не будет вовсе.
+        if getattr(result, "stop_run", False):
+            print(f"  [STOP] {card.title} — {result.reason}")
+            raise ApplyRunStopped(result.reason)
 
     print(f"Итого откликов за этот запуск: {applied_count}")
     return False

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ._common import (
+    ApplyRunStopped,
     _build_scoring_provider,
     add_common_args,
     add_force_arg,
@@ -139,20 +140,23 @@ def run(args: argparse.Namespace) -> bool:
         else:
             cards_by_resume = None
             ranked_by_resume = None
-        for resume in resumes:
-            if cards_by_resume is None:
-                result = run_apply_for_resume(page, config, resume, history, throttle, args)
-            else:
-                result = run_apply_for_resume(
-                    page,
-                    config,
-                    resume,
-                    history,
-                    throttle,
-                    args,
-                    cards_by_resume[resume.id],
-                    True,
-                    ranked_by_resume[resume.id],
-                )
-            failed = result or failed
+        try:
+            for resume in resumes:
+                if cards_by_resume is None:
+                    result = run_apply_for_resume(page, config, resume, history, throttle, args)
+                else:
+                    result = run_apply_for_resume(
+                        page,
+                        config,
+                        resume,
+                        history,
+                        throttle,
+                        args,
+                        cards_by_resume[resume.id],
+                        True,
+                        ranked_by_resume[resume.id],
+                    )
+                failed = result or failed
+        except ApplyRunStopped:
+            failed = True
     return failed

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -47,6 +47,9 @@ class SearchFilters:
     salary_from: int | None = None
     experience: str | None = None
     schedule: str | None = None
+    # Explicitly permit confirming HH's relocation warning.  The safe default
+    # is false; remote-only profiles must never silently accept relocation.
+    allow_relocation: bool = False
     exclude_employers: list[str] = field(default_factory=list)
     exclude_keywords: list[str] = field(default_factory=list)
     # Опциональные поля ранжирования (#15): буст за совпадение в title.

--- a/src/hhru_bot/config_sections/search.py
+++ b/src/hhru_bot/config_sections/search.py
@@ -22,6 +22,7 @@ def parse_search(raw, context: str) -> SearchFilters:
         salary_from=raw.get("salary_from"),
         experience=raw.get("experience"),
         schedule=raw.get("schedule"),
+        allow_relocation=bool(raw.get("allow_relocation", False)),
         exclude_employers=raw.get("exclude_employers") or [],
         exclude_keywords=raw.get("exclude_keywords") or [],
         must_have=raw.get("must_have") or [],

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -309,6 +309,9 @@ class _SkipReasons:
     QUESTION_LOW_CONFIDENCE = "question_skipped_low_confidence"
     RESUME_VISIBILITY = "resume_visibility"  # отклик заблокирован видимостью резюме
     DUPLICATE = "duplicate"  # дубликат вакансии в одном сборе
+    RELOCATION_NOT_ALLOWED = "relocation_not_allowed"
+    DIRECT_APPLICATION = "direct_application"
+    RESPONSE_REJECTED = "response_rejected"
 
 
 #: Enum-объект причин отсева. Используется как ``SKIP_REASONS.STOPWORD_TITLE``
@@ -328,6 +331,9 @@ SKIP_REASON_VALUES = (
     _SkipReasons.QUESTION_LOW_CONFIDENCE,
     _SkipReasons.RESUME_VISIBILITY,
     _SkipReasons.DUPLICATE,
+    _SkipReasons.RELOCATION_NOT_ALLOWED,
+    _SkipReasons.DIRECT_APPLICATION,
+    _SkipReasons.RESPONSE_REJECTED,
 )
 
 

--- a/src/hhru_bot/selector_groups/vacancy_page.py
+++ b/src/hhru_bot/selector_groups/vacancy_page.py
@@ -10,6 +10,13 @@ VACANCY_ALREADY_RESPONDED_CHAT = "[data-qa='vacancy-response-link-view-topic']"
 # Rendered in the response modal when the selected resume is not visible to
 # client companies.  This can appear while the URL remains the vacancy URL.
 VACANCY_HIDDEN_RESUME_WARNING = "[data-qa='hidden-resume-warning']"
+VACANCY_RELOCATION_CONFIRM = '[data-qa="relocation-warning-confirm"]'
+VACANCY_SIMILAR_VACANCIES_CLOSE = '[data-qa="vacancy-response-similar-vacancies-close"]'
+VACANCY_DIRECT_APPLICATION_CANCEL = '[data-qa="vacancy-response-link-advertising-cancel"]'
+VACANCY_DIRECT_APPLICATION_ALERT = '[data-qa="magritte-alert"]'
+VACANCY_LIMIT_ERROR = '[data-qa-popup-error-code="negotiations-limit-exceeded"]'
+VACANCY_RESPONSE_REJECT_WARNING = '[data-qa="response-reject-warning"]'
+VACANCY_RESPONSE_ERROR = '[data-qa="vacancy-response-error-notification"]'
 VACANCY_TITLE = "[data-qa='vacancy-title']"
 VACANCY_COMPANY_NAME = "[data-qa='vacancy-company-name']"
 

--- a/tests/test_apply_blockers.py
+++ b/tests/test_apply_blockers.py
@@ -233,3 +233,43 @@ def test_render_wait_never_passes_zero_timeout_to_playwright():
     handle_post_click_blockers(page, allow_relocation=False)
 
     assert page.wait_timeouts and all(t > 0 for t in page.wait_timeouts)
+
+
+def test_account_limit_stops_the_run_even_when_the_response_went_out():
+    # Лимит откликов — свойство аккаунта: подтверждённый отклик его не отменяет.
+    # Без этого прогон продолжил бы долбиться в исчерпанный лимит.
+    from hhru_bot.apply.pipeline import _finalize_blocker
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+
+    ctx = _blocker_ctx(verifier=lambda *_: NegotiationsVerifyResult("found", "topic=42"))
+    blocker = PostClickBlocker(
+        "limit_exceeded",
+        "лимит откликов исчерпан",
+        stop_run=True,
+        post_navigation=True,
+    )
+
+    result = _finalize_blocker(ctx, blocker)
+
+    assert result.success is True
+    assert result.stop_run is True
+
+
+def test_account_limit_stops_the_run_when_verification_is_unavailable():
+    from hhru_bot.apply.pipeline import _finalize_blocker
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+
+    ctx = _blocker_ctx(
+        verifier=lambda *_: NegotiationsVerifyResult("indeterminate", "список не прочитан")
+    )
+    blocker = PostClickBlocker(
+        "limit_exceeded",
+        "лимит откликов исчерпан",
+        stop_run=True,
+        post_navigation=True,
+    )
+
+    result = _finalize_blocker(ctx, blocker)
+
+    assert result.stop_run is True
+    assert result.uncertain is True

--- a/tests/test_apply_blockers.py
+++ b/tests/test_apply_blockers.py
@@ -213,12 +213,23 @@ def test_pre_navigation_blocker_does_not_call_the_verifier():
     assert result.skip_reason == SKIP_REASONS.RELOCATION_NOT_ALLOWED
 
 
-def test_second_pass_does_not_pay_the_render_timeout_again():
+def test_second_pass_does_not_wait_at_all():
     # Штатный путь без модалки не должен ждать render-таймаут дважды.
+    # ВАЖНО: пропуск выражается отсутствием вызова wait_for, а НЕ timeout=0 —
+    # в Playwright 0 означает «таймаут отключён», то есть бесконечное ожидание.
     page = _Page()
 
     handle_post_click_blockers(
         page, allow_relocation=False, render_timeout_ms=0, post_navigation=True
     )
 
-    assert page.wait_timeouts == [0]
+    assert page.wait_timeouts == []
+
+
+def test_render_wait_never_passes_zero_timeout_to_playwright():
+    # Страж от зависания: 0 в Playwright = ждать вечно.
+    page = _Page((vacancy_page.VACANCY_LIMIT_ERROR, "Лимит откликов"))
+
+    handle_post_click_blockers(page, allow_relocation=False)
+
+    assert page.wait_timeouts and all(t > 0 for t in page.wait_timeouts)

--- a/tests/test_apply_blockers.py
+++ b/tests/test_apply_blockers.py
@@ -6,6 +6,7 @@ import pytest
 from playwright.sync_api import Error as PlaywrightError
 
 from hhru_bot.apply.blockers import (
+    PostClickBlocker,
     PostSubmitLimitExceeded,
     handle_post_click_blockers,
     raise_if_post_submit_limit,
@@ -14,6 +15,21 @@ from hhru_bot.history import SKIP_REASONS
 from hhru_bot.selector_groups import vacancy_page
 
 pytestmark = pytest.mark.integration
+
+
+def _blocker_ctx(*, verifier):
+    """Минимальный ApplyContext для проверки финализации блокеров."""
+    from hhru_bot.apply.pipeline import ApplyContext
+    from hhru_bot.search import VacancyCard
+
+    return ApplyContext(
+        page=_Page(),
+        vacancy=VacancyCard("1", "Вакансия", "Компания", "https://hh.ru/vacancy/1"),
+        resume_id="RID",
+        cover_letter_template="письмо",
+        dry_run=False,
+        verifier=verifier,
+    )
 
 
 class _Locator:
@@ -33,6 +49,7 @@ class _Locator:
 
     def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:
         self.page.waited.append(self.selector)
+        self.page.wait_timeouts.append(timeout)
         # Совокупный селектор ждёт первый видимый якорь; в фикстурах DOM
         # синхронный, поэтому достаточно проверить любую из частей.
         if not any(
@@ -51,6 +68,7 @@ class _Page:
         self.elements = {selector: (True, text) for selector, text in elements}
         self.clicked: list[str] = []
         self.waited: list[str] = []
+        self.wait_timeouts: list[float] = []
 
     def locator(self, selector: str) -> _Locator:
         return _Locator(self, selector)
@@ -130,3 +148,77 @@ def test_blockers_wait_for_render_before_strict_checks():
     handle_post_click_blockers(page, allow_relocation=False)
 
     assert page.waited, "терминальные проверки выполнены без ожидания рендера"
+
+
+def test_post_navigation_blocker_recovers_a_response_that_actually_went_out():
+    # #207: после навигации отклик мог уйти, а модалка показаться поверх.
+    # Без внешней проверки такой исход молча стал бы skip и потерял отклик.
+    from hhru_bot.apply.pipeline import _finalize_blocker
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+
+    ctx = _blocker_ctx(verifier=lambda *_: NegotiationsVerifyResult("found", "topic=42"))
+    blocker = PostClickBlocker(
+        "response_rejected",
+        "HH.ru показал предупреждение",
+        SKIP_REASONS.RESPONSE_REJECTED,
+        post_navigation=True,
+    )
+
+    result = _finalize_blocker(ctx, blocker)
+
+    assert result.success is True
+    assert result.acted is True
+    assert result.skipped is False
+
+
+def test_post_navigation_blocker_keeps_its_verdict_when_no_response_found():
+    from hhru_bot.apply.pipeline import _finalize_blocker
+    from hhru_bot.apply.verify import NegotiationsVerifyResult
+
+    ctx = _blocker_ctx(verifier=lambda *_: NegotiationsVerifyResult("not_found", "нет карточки"))
+    blocker = PostClickBlocker(
+        "direct_application",
+        "отклик на сайте работодателя",
+        SKIP_REASONS.DIRECT_APPLICATION,
+        post_navigation=True,
+    )
+
+    result = _finalize_blocker(ctx, blocker)
+
+    assert result.success is False
+    assert result.skip_reason == SKIP_REASONS.DIRECT_APPLICATION
+
+
+def test_pre_navigation_blocker_does_not_call_the_verifier():
+    # До навигации отклик физически невозможен — лишний поход в negotiations
+    # был бы чистой тратой запроса на каждую такую вакансию.
+    from hhru_bot.apply.pipeline import _finalize_blocker
+
+    calls = []
+
+    def verifier(*args):
+        calls.append(args)
+        raise AssertionError("verifier must not be called before navigation")
+
+    ctx = _blocker_ctx(verifier=verifier)
+    blocker = PostClickBlocker(
+        "relocation_not_allowed",
+        "переезд не разрешён",
+        SKIP_REASONS.RELOCATION_NOT_ALLOWED,
+    )
+
+    result = _finalize_blocker(ctx, blocker)
+
+    assert calls == []
+    assert result.skip_reason == SKIP_REASONS.RELOCATION_NOT_ALLOWED
+
+
+def test_second_pass_does_not_pay_the_render_timeout_again():
+    # Штатный путь без модалки не должен ждать render-таймаут дважды.
+    page = _Page()
+
+    handle_post_click_blockers(
+        page, allow_relocation=False, render_timeout_ms=0, post_navigation=True
+    )
+
+    assert page.wait_timeouts == [0]

--- a/tests/test_apply_blockers.py
+++ b/tests/test_apply_blockers.py
@@ -1,0 +1,110 @@
+"""Fixture-level tests for HH post-click response blockers."""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.apply.blockers import (
+    PostSubmitLimitExceeded,
+    handle_post_click_blockers,
+    raise_if_post_submit_limit,
+)
+from hhru_bot.history import SKIP_REASONS
+from hhru_bot.selector_groups import vacancy_page
+
+pytestmark = pytest.mark.integration
+
+
+class _Locator:
+    def __init__(self, page: _Page, selector: str) -> None:
+        self.page = page
+        self.selector = selector
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self) -> bool:
+        return self.page.elements.get(self.selector, (False, ""))[0]
+
+    def inner_text(self) -> str:
+        return self.page.elements.get(self.selector, (False, ""))[1]
+
+    def click(self) -> None:
+        self.page.clicked.append(self.selector)
+        self.page.elements[self.selector] = (False, self.inner_text())
+
+
+class _Page:
+    def __init__(self, *elements: tuple[str, str]) -> None:
+        self.elements = {selector: (True, text) for selector, text in elements}
+        self.clicked: list[str] = []
+
+    def locator(self, selector: str) -> _Locator:
+        return _Locator(self, selector)
+
+
+def test_relocation_is_skipped_by_default_without_click():
+    page = _Page((vacancy_page.VACANCY_RELOCATION_CONFIRM, "Готовы к переезду?"))
+
+    result = handle_post_click_blockers(page, allow_relocation=False)
+
+    assert result is not None
+    assert result.skip_reason == SKIP_REASONS.RELOCATION_NOT_ALLOWED
+    assert page.clicked == []
+
+
+def test_relocation_can_be_confirmed_only_by_explicit_policy():
+    page = _Page((vacancy_page.VACANCY_RELOCATION_CONFIRM, "Готовы к переезду?"))
+
+    result = handle_post_click_blockers(page, allow_relocation=True)
+
+    assert result is None
+    assert page.clicked == [vacancy_page.VACANCY_RELOCATION_CONFIRM]
+
+
+def test_similar_popup_is_closed_without_becoming_terminal():
+    page = _Page((vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE, "Не сейчас"))
+
+    result = handle_post_click_blockers(page, allow_relocation=False)
+
+    assert result is None
+    assert page.clicked == [vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE]
+
+
+def test_direct_application_requires_alert_text():
+    page = _Page(
+        (vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL, "Отменить"),
+        (vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT, "Вакансия с прямым откликом"),
+    )
+
+    result = handle_post_click_blockers(page, allow_relocation=False)
+
+    assert result is not None
+    assert result.skip_reason == SKIP_REASONS.DIRECT_APPLICATION
+
+
+def test_limit_stops_run_before_submit():
+    page = _Page((vacancy_page.VACANCY_LIMIT_ERROR, "Лимит откликов"))
+
+    result = handle_post_click_blockers(page, allow_relocation=False)
+
+    assert result is not None
+    assert result.kind == "limit_exceeded"
+    assert result.stop_run is True
+
+
+def test_limit_is_checked_again_after_submit():
+    page = _Page((vacancy_page.VACANCY_LIMIT_ERROR, "Лимит откликов"))
+
+    with pytest.raises(PostSubmitLimitExceeded):
+        raise_if_post_submit_limit(page)
+
+
+def test_response_warning_is_a_terminal_skip():
+    page = _Page((vacancy_page.VACANCY_RESPONSE_REJECT_WARNING, "Скорее всего, будет отказ"))
+
+    result = handle_post_click_blockers(page, allow_relocation=False)
+
+    assert result is not None
+    assert result.skip_reason == SKIP_REASONS.RESPONSE_REJECTED

--- a/tests/test_apply_blockers.py
+++ b/tests/test_apply_blockers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 from hhru_bot.apply.blockers import (
     PostSubmitLimitExceeded,
@@ -30,6 +31,16 @@ class _Locator:
     def inner_text(self) -> str:
         return self.page.elements.get(self.selector, (False, ""))[1]
 
+    def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:
+        self.page.waited.append(self.selector)
+        # Совокупный селектор ждёт первый видимый якорь; в фикстурах DOM
+        # синхронный, поэтому достаточно проверить любую из частей.
+        if not any(
+            self.page.elements.get(part.strip(), (False, ""))[0]
+            for part in self.selector.split(",")
+        ):
+            raise PlaywrightError("locator.wait_for: Timeout exceeded")
+
     def click(self) -> None:
         self.page.clicked.append(self.selector)
         self.page.elements[self.selector] = (False, self.inner_text())
@@ -39,6 +50,7 @@ class _Page:
     def __init__(self, *elements: tuple[str, str]) -> None:
         self.elements = {selector: (True, text) for selector, text in elements}
         self.clicked: list[str] = []
+        self.waited: list[str] = []
 
     def locator(self, selector: str) -> _Locator:
         return _Locator(self, selector)
@@ -108,3 +120,13 @@ def test_response_warning_is_a_terminal_skip():
 
     assert result is not None
     assert result.skip_reason == SKIP_REASONS.RESPONSE_REJECTED
+
+
+def test_blockers_wait_for_render_before_strict_checks():
+    # CLAUDE.md п.4: без явного ожидания проверка читает ещё не отрисованный
+    # React-DOM и систематически не видит модалку.
+    page = _Page((vacancy_page.VACANCY_LIMIT_ERROR, "Лимит откликов"))
+
+    handle_post_click_blockers(page, allow_relocation=False)
+
+    assert page.waited, "терминальные проверки выполнены без ожидания рендера"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,7 @@ def test_load_config_full_search_filters(tmp_path):
               salary_from: 200000
               experience: "between3And6"
               schedule: "remote"
+              allow_relocation: true
               exclude_employers: ["BadCorp"]
               exclude_keywords: ["1С"]
     """,
@@ -106,6 +107,7 @@ def test_load_config_full_search_filters(tmp_path):
     assert search.salary_from == 200000
     assert search.experience == "between3And6"
     assert search.schedule == "remote"
+    assert search.allow_relocation is True
     assert search.exclude_employers == ["BadCorp"]
     assert search.exclude_keywords == ["1С"]
 


### PR DESCRIPTION
## Summary
- detect HH post-click relocation, similar-vacancy, direct-application, reject/error, and response-limit states
- derive relocation confirmation from explicit `search.allow_relocation` (default false)
- stop the entire apply run on `negotiations-limit-exceeded`
- route post-navigation blockers through the #207 external verifier before any terminal verdict
- add fixture-level coverage for terminal and non-terminal blocker handling

Closes #342

## Waiver: приёмочный пункт 1 issue #342 отменён владельцем

Issue #342, пункт 1 требовал: «Каждую модалку добавлять **только** после
подтверждения селектора на живом DOM». **Этот пункт waived по решению владельца
репозитория; PR мерджится с неподтверждёнными селекторами.**

Обоснование:

1. **Подтверждение недостижимо в разрешённых рамках.** Live-разведка в #342
   проверила два authenticated-дампа живых вакансий: все семь селекторов в них
   отсутствуют, потому что оба работодателя отдали обычную форму. Чтобы увидеть
   `negotiations-limit-exceeded`, нужно искусственно исчерпать лимит откликов
   аккаунта; чтобы увидеть relocation-warning — менять профиль. И то, и другое —
   мутация аккаунта, запрещённая рамками задачи. Требование пункта 1 в read-only
   режиме невыполнимо в принципе, а не «не выполнено по недосмотру».

2. **Цена ошибки асимметрична и смещена в безопасную сторону.** Селектор,
   который не совпадает ни с чем, безвреден: код проваливается в существующее
   поведение, как будто фичи нет. Единственный реальный риск — ложное
   срабатывание, и он закрыт точечно: `magritte-alert` (generic-контейнер
   дизайн-системы) не может дать терминальный вердикт без совпадения текста
   алерта; остальные селекторы специфичны для отклика. Все терминальные исходы
   fail-closed и ни один не выполняет submit.

3. **Обратная сторона — реальный ущерб.** Без распознавания лимита hh.ru бот
   продолжает отправлять отклики в исчерпанный лимит: серия необъяснимых отказов
   подряд, которую наш собственный дневной тормоз не останавливает (`count_today()`
   считает `success`). Это тот самый сценарий, ради которого issue заводился.

4. **Селекторы не выдуманы:** каждый взят из reference-проектов, а
   `relocation-warning-confirm` подтверждён двумя независимыми источниками
   (см. таблицу в #342). Это заимствованные наблюдения, а не догадки.

**Что это значит практически:** поведение блокеров не верифицировано живым DOM.
При первом боевом прогоне первый подозреваемый в странном поведении apply —
именно эти селекторы. Подтвердить их следует при первом же естественно
возникшем live-случае (исчерпанный лимит, вакансия из другого города, вакансия
с откликом на сайте работодателя), без искусственного создания состояния.

## Дефекты, найденные и исправленные в cycle-review

| Коммит | Дефект |
|---|---|
| `3fa113f` | Проверка блокеров шла сразу после клика, до React-рендера (CLAUDE.md п.4) — модалка систематически не обнаруживалась бы |
| `6d1454b` | Блокер после навигации обходил #207-верификацию: hh.ru мог принять отклик и показать модалку, отклик молча терялся как `skip` |
| `264b20c` | **CRITICAL:** `timeout=0` в Playwright значит «таймаут отключён» (ждать вечно), а не «не ждать» — бот повис бы на первой обычной вакансии |
| `184d46e` | При исчерпанном лимите и подтверждённом отклике терялся `stop_run` — прогон продолжал долбиться в закрытую дверь. Попутно: `raise` стоял до `throttle.wait`, анти-бан-пауза после submit не выдерживалась |

Финальный adversarial-прогон по всем фиксам — дефектов не найдено.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- полный `pytest` (сюита целиком, не точечно), включая wall-time гейт: 9.46s при бюджете 30s
- CI: `lint-test` SUCCESS, `packaging` SUCCESS, `mergeStateStatus: CLEAN`

## Risks
- **Семь селекторов не подтверждены живым DOM** (см. waiver выше) и уязвимы к дрейфу разметки hh.ru.
- Live-write проверок не выполнялось; submit ни разу не нажимался.
- Relocation fail-closed: подтверждение переезда кликается только при явном `search.allow_relocation: true`.
- Штатный путь без модалки платит до 1.5с ожидания на вакансию.
