### PR TITLE
test: parallelize CI pytest suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
 
       - name: Pytest suite budget
         run: python scripts/check_pytest_budget.py
-        env:
-          # Avoid loading unrelated third-party pytest plugins in every xdist
-          # worker; the suite only needs xdist itself.
-          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 
       - name: CLI docs in sync with argparse
         # Справочник команд в README автогенерируется из argparse. Если кто-то

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff pytest
+          pip install ruff pytest pytest-xdist
 
       - name: Ruff check
         run: ruff check src tests
@@ -31,6 +31,10 @@ jobs:
 
       - name: Pytest suite budget
         run: python scripts/check_pytest_budget.py
+        env:
+          # Avoid loading unrelated third-party pytest plugins in every xdist
+          # worker; the suite only needs xdist itself.
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 
       - name: CLI docs in sync with argparse
         # Справочник команд в README автогенерируется из argparse. Если кто-то

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ hhru = "hhru_bot.cli:main"
 [project.optional-dependencies]
 dev = [
     "pytest>=8",
+    "pytest-xdist>=3",
     "ruff>=0.6",
 ]
 # AI/LLM-функциональность (issue #230). Не входит в базовые dependencies —

--- a/scripts/check_pytest_budget.py
+++ b/scripts/check_pytest_budget.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 # The suite runs under xdist (see the argv below), which puts CI wall time at
 # 12-15s and local wall time at ~4s.
@@ -23,9 +25,18 @@ import time
 SUITE_BUDGET_SECONDS = 60.0
 
 
-def main() -> int:
-    started = time.monotonic()
-    result = subprocess.run(
+def run_suite(cwd: Path | None = None) -> subprocess.CompletedProcess[bytes]:
+    """Запустить сюиту под xdist так, чтобы гейт был исполним в любом окружении.
+
+    `-p xdist.plugin` обязателен при выключенном autoload и приводит к
+    повторной регистрации плагина при включённом (`ValueError: Plugin already
+    registered`). Раньше autoload выключался переменной окружения в шаге
+    `ci.yml`, поэтому вне этого шага скрипт падал всегда. Переменная выставляется
+    здесь же, в окружении подпроцесса, — гейт больше не зависит от того, кто и
+    откуда его вызвал.
+    """
+    env = {**os.environ, "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"}
+    return subprocess.run(
         [
             sys.executable,
             "-m",
@@ -39,7 +50,14 @@ def main() -> int:
             "worksteal",
         ],
         check=False,
+        env=env,
+        cwd=cwd,
     )
+
+
+def main() -> int:
+    started = time.monotonic()
+    result = run_suite()
     elapsed = time.monotonic() - started
 
     print(f"pytest suite wall time: {elapsed:.2f}s (budget: {SUITE_BUDGET_SECONDS:.0f}s)")

--- a/scripts/check_pytest_budget.py
+++ b/scripts/check_pytest_budget.py
@@ -7,27 +7,39 @@ import subprocess
 import sys
 import time
 
-# CI runners have variable startup/load time.  A tight 20s threshold made a
-# passing suite fail intermittently (the suite itself is normally ~10-15s).
-# Raised 30s -> 90s (#428): the suite grew to 1500+ tests and a loaded shared
-# runner took 50-67s wall time with zero failing tests two runs in a row —
-# not a regression in test cost (local wall time stayed ~9s), just less
-# headroom against runner variance.
-# Raised 90s -> 240s (#428, same day): with many PRs/sessions queuing CI
-# concurrently on this repo, a single shared runner hit 143s wall time with
-# zero failing tests — local wall time stayed ~10s throughout. The dominant
-# variable here is runner queue contention, not test cost, and that
-# contention scales with how many PRs are active at once rather than with
-# anything this suite controls. 240s keeps a real regression (e.g. a
-# introduced O(n^2) or a hung fixture) clearly detectable — that would blow
-# past it by many multiples — while giving CI-queue variance real headroom
-# instead of chasing it fix-by-fix.
-SUITE_BUDGET_SECONDS = 240.0
+# The suite runs under xdist (see the argv below), which puts CI wall time at
+# 12-15s and local wall time at ~4s.
+#
+# The budget is deliberately far above that. This gate measures wall time on a
+# shared GitHub runner, so it also captures queue contention: #428 recorded a
+# 143s run with zero failing tests while local wall time stayed ~10s. That is
+# why the threshold was escalated 20 -> 30 -> 90 -> 240 fix-by-fix.
+#
+# 60s is the middle ground: a real regression (an accidental O(n^2), a hung
+# fixture) blows past it by multiples and is caught far earlier than 240s would
+# catch it, while ordinary runner variance stays under it. The gate still
+# measures runner noise rather than a property of the code — that design flaw
+# is tracked in #438, not worked around here.
+SUITE_BUDGET_SECONDS = 60.0
 
 
 def main() -> int:
     started = time.monotonic()
-    result = subprocess.run([sys.executable, "-m", "pytest", "-q"], check=False)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-p",
+            "xdist.plugin",
+            "-n",
+            "4",
+            "--dist",
+            "worksteal",
+        ],
+        check=False,
+    )
     elapsed = time.monotonic() - started
 
     print(f"pytest suite wall time: {elapsed:.2f}s (budget: {SUITE_BUDGET_SECONDS:.0f}s)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import hashlib
 
 import playwright._impl._driver
 import playwright._impl._transport
@@ -104,23 +104,42 @@ def _allow_live_browser(request: pytest.FixtureRequest) -> object:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_log_dir(
+    tmp_path_factory: pytest.TempPathFactory,
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Страховка от записи тестов в реальный data/logs/hhru_bot.log (#131).
 
     До этой фикстуры изоляция держалась на дисциплине каждого отдельного теста
     (см. локальный monkeypatch в test_log_command_does_not_create_log, #129/#130) —
-    не на инварианте. Здесь уводим LOG_DIR на tmp_path для ВСЕХ тестов сессии.
+    не на инварианте. Здесь уводим LOG_DIR в свой каталог для ВСЕХ тестов сессии.
 
     DEFAULT_LOG_PATH (log_cmd.py), PROBE_LOG_DIR (apply/probe.py) и steps.LOG_DIR
     (apply/steps.py, дампы #195/#207) вычисляются/импортируются на импорте модуля
     как `LOG_DIR / ...` / `from ..logging_setup import LOG_DIR` и сами не
-    пересчитаются при подмене LOG_DIR — патчим их отдельно тем же tmp_path.
+    пересчитаются при подмене LOG_DIR — патчим их отдельно тем же путём.
+
+    Почему не `tmp_path` (#439): эта фикстура autouse, то есть выполняется для
+    всех ~1500 тестов, а `tmp_path` СОЗДАЁТ каталог на диске при каждом запросе
+    (~1.4 мс на тест — заметная доля прогона). Каталог логов при этом реально
+    нужен единицам: остальным важно лишь, чтобы LOG_DIR не указывал на
+    настоящий data/logs. Поэтому путь вычисляется от общей базы
+    `tmp_path_factory`, но не создаётся — его создаст тот код, который в него
+    действительно пишет. Тесты, которым нужен собственный каталог, как и
+    раньше просят `tmp_path` явно.
+
+    Ключ уникальности — sha1 полного `nodeid`, а не усечённое `node.name`:
+    у параметризованных тестов имена длинные и различаются хвостом, поэтому
+    обрезка давала бы коллизию, два теста делили бы каталог логов и протечка
+    между тестами вернулась бы — ровно то, от чего фикстура защищает.
 
     Монки этой фикстуры и локальные monkeypatch внутри отдельных тестов
     накладываются безопасно (LIFO): более специфичный тестовый monkeypatch
     отменяется первым при teardown, эта фикстура — последней.
     """
-    log_dir = tmp_path / "logs"
+    node_key = hashlib.sha1(request.node.nodeid.encode()).hexdigest()[:16]
+    log_dir = tmp_path_factory.getbasetemp() / "isolated_logs" / node_key
     monkeypatch.setattr(logging_setup, "LOG_DIR", log_dir)
     monkeypatch.setattr(log_cmd, "DEFAULT_LOG_PATH", log_dir / "hhru_bot.log")
     monkeypatch.setattr(probe, "PROBE_LOG_DIR", log_dir)

--- a/tests/test_pytest_budget.py
+++ b/tests/test_pytest_budget.py
@@ -66,9 +66,42 @@ def test_gate_command_runs_without_external_env(tmp_path: Path) -> None:
     pytest бросает `ValueError: Plugin already registered`. Здесь команда
     исполняется по-настоящему на игрушечной сюите, поэтому тест держит
     инвариант «гейт работает в любом окружении», а не «argv выглядит верно».
+
+    Игрушечная сюита — 4 теста, каждый пишет id своего xdist-воркера
+    (`PYTEST_XDIST_WORKER`) в отдельный файл-маркер. Под реальным
+    `-n 4 --dist worksteal` появится больше одного различного worker id; при
+    серийном запуске (флаги параллелизма потеряны в регрессии) переменной
+    окружения не будет вовсе — воркеров ровно 0. Число маркеров и их
+    отличность друг от друга не зависит от абсолютного тайминга раннера,
+    поэтому не флейкает так, как сравнение с порогом по wall time.
     """
-    (tmp_path / "test_toy.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    markers_dir = tmp_path / "workers"
+    markers_dir.mkdir()
+    toy = tmp_path / "test_toy.py"
+    toy.write_text(
+        "import os\nimport uuid\nfrom pathlib import Path\n\n\n"
+        f"MARKERS_DIR = Path({str(markers_dir)!r})\n\n\n"
+        + "\n\n".join(
+            f"def test_marks_worker_{i}():\n"
+            f"    worker = os.environ.get('PYTEST_XDIST_WORKER', 'none')\n"
+            f'    (MARKERS_DIR / f"{{worker}}-{{uuid.uuid4().hex}}").write_text("")\n'
+            for i in range(4)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     completed = check_pytest_budget.run_suite(cwd=tmp_path)
 
     assert completed.returncode == 0, completed
+    marker_names = [p.name for p in markers_dir.iterdir()]
+    workers_seen = {name.split("-", 1)[0] for name in marker_names}
+    assert len(marker_names) == 4, marker_names
+    assert workers_seen != {"none"}, (
+        "no PYTEST_XDIST_WORKER seen — parallelism flags (-n 4 --dist worksteal) "
+        "may have been dropped from run_suite()"
+    )
+    assert len(workers_seen) > 1, (
+        f"only one xdist worker handled all 4 tests ({workers_seen}) — "
+        "parallel distribution may be broken"
+    )

--- a/tests/test_pytest_budget.py
+++ b/tests/test_pytest_budget.py
@@ -24,11 +24,27 @@ def test_main_runs_full_suite_and_accepts_budget(monkeypatch: pytest.MonkeyPatch
         "run",
         lambda command, check: calls.append((command, check)) or SimpleNamespace(returncode=0),
     )
-    clock = iter((10.0, 239.9))
+    clock = iter((10.0, 69.9))
     monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
 
     assert check_pytest_budget.main() == 0
-    assert calls == [([check_pytest_budget.sys.executable, "-m", "pytest", "-q"], False)]
+    assert calls == [
+        (
+            [
+                check_pytest_budget.sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "-p",
+                "xdist.plugin",
+                "-n",
+                "4",
+                "--dist",
+                "worksteal",
+            ],
+            False,
+        )
+    ]
 
 
 def test_main_fails_when_suite_exceeds_budget(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,7 +53,7 @@ def test_main_fails_when_suite_exceeds_budget(monkeypatch: pytest.MonkeyPatch) -
         "run",
         lambda _command, check: SimpleNamespace(returncode=0),
     )
-    clock = iter((10.0, 250.1))
+    clock = iter((10.0, 70.1))
     monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
 
     assert check_pytest_budget.main() == 1

--- a/tests/test_pytest_budget.py
+++ b/tests/test_pytest_budget.py
@@ -17,42 +17,32 @@ _SPEC.loader.exec_module(check_pytest_budget)
 pytestmark = pytest.mark.unit
 
 
-def test_main_runs_full_suite_and_accepts_budget(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[list[str], bool]] = []
+def _fake_suite(monkeypatch: pytest.MonkeyPatch, returncode: int) -> None:
+    """Подменить сам запуск сюиты, оставив на проверку решение о бюджете.
+
+    Мокается `run_suite`, а не `subprocess.run`: раньше моки сверяли СПИСОК
+    аргументов, и это было единственной их проверкой — команда, падавшая при
+    реальном запуске, всё равно давала зелёный тест (#440). Исполнимость
+    команды теперь держит test_gate_command_runs_without_external_env, а здесь
+    остаётся только арифметика бюджета.
+    """
     monkeypatch.setattr(
-        check_pytest_budget.subprocess,
-        "run",
-        lambda command, check: calls.append((command, check)) or SimpleNamespace(returncode=0),
+        check_pytest_budget,
+        "run_suite",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=returncode),
     )
+
+
+def test_main_accepts_run_within_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_suite(monkeypatch, returncode=0)
     clock = iter((10.0, 69.9))
     monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
 
     assert check_pytest_budget.main() == 0
-    assert calls == [
-        (
-            [
-                check_pytest_budget.sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "-p",
-                "xdist.plugin",
-                "-n",
-                "4",
-                "--dist",
-                "worksteal",
-            ],
-            False,
-        )
-    ]
 
 
 def test_main_fails_when_suite_exceeds_budget(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        check_pytest_budget.subprocess,
-        "run",
-        lambda _command, check: SimpleNamespace(returncode=0),
-    )
+    _fake_suite(monkeypatch, returncode=0)
     clock = iter((10.0, 70.1))
     monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
 
@@ -60,12 +50,25 @@ def test_main_fails_when_suite_exceeds_budget(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_main_preserves_pytest_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        check_pytest_budget.subprocess,
-        "run",
-        lambda _command, check: SimpleNamespace(returncode=pytest.ExitCode.TESTS_FAILED),
-    )
+    _fake_suite(monkeypatch, returncode=pytest.ExitCode.TESTS_FAILED)
     clock = iter((10.0, 10.1))
     monkeypatch.setattr(check_pytest_budget.time, "monotonic", lambda: next(clock))
 
     assert check_pytest_budget.main() == pytest.ExitCode.TESTS_FAILED
+
+
+def test_gate_command_runs_without_external_env(tmp_path: Path) -> None:
+    """Гейт исполним сам по себе, без переменной окружения из ci.yml (#440).
+
+    Мок-тесты выше сверяют только СПИСОК аргументов и потому зелёные даже
+    тогда, когда собранная команда при реальном запуске падает: `-p
+    xdist.plugin` поверх включённого autoload регистрирует плагин повторно и
+    pytest бросает `ValueError: Plugin already registered`. Здесь команда
+    исполняется по-настоящему на игрушечной сюите, поэтому тест держит
+    инвариант «гейт работает в любом окружении», а не «argv выглядит верно».
+    """
+    (tmp_path / "test_toy.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+    completed = check_pytest_budget.run_suite(cwd=tmp_path)
+
+    assert completed.returncode == 0, completed


### PR DESCRIPTION
Closes #439

## Что сделано

1. **pytest под xdist в CI** (`-n 4 --dist worksteal`, autoload сторонних плагинов выключен).
2. **Порог гейта 240s → 60s.**
3. **Убрано создание tmp-каталога на каждый тест** в autouse-фикстуре `_isolate_log_dir`.

## Тайминги (факт из CI)

| Ветка | wall time шага бюджета |
|---|---|
| `main` (без xdist) | 21.9s / 25.5s |
| `ao/hhru-215/root` | 23.9s / 38.1s |
| **эта ветка** | **12.3 – 15.1s** |

Локально: 6.5s серийно, 4.8s под xdist.

## Про порог 60s

`main` эскалировал `SUITE_BUDGET_SECONDS` 20 → 30 → 90 → 240 (#428), догоняя очередь
на shared-раннере — был зафиксирован прогон 143s при нуле упавших тестов, тогда как
локально те же тесты шли ~10s.

С xdist база 12-15s, поэтому 60s ловит настоящий регресс (случайный O(n^2), зависшая
фикстура — они пробивают порог кратно) сильно раньше, чем 240s, и при этом переживает
обычный разброс раннера. То, что гейт в принципе меряет шум раннера, а не свойство
кода, остаётся предметом #438 и здесь не обходится.

## Про фикстуру логов

`_isolate_log_dir` — autouse, то есть `tmp_path` создавал каталог на диске для каждого
из ~1500 тестов (~1.4 мс на тест), хотя логи реально пишут единицы. Путь теперь
вычисляется от `tmp_path_factory`, но не создаётся — его создаст тот код, который в
него пишет.

Ключ — sha1 полного `nodeid`, а не усечённое `node.name`: обрезка давала бы коллизию
у параметризованных тестов, два теста делили бы каталог логов, и протечка, от которой
защищает #131, вернулась бы.

## Цель 10s из #439 не достигнута — и недостижима этой архитектурой

Профиль ровный, лишних тестов нет: коллекция 1.35s, сумма всех call/setup/teardown фаз
5.4s, все «медленные» тесты вместе < 1.5s. Локально уже 4.8s под xdist — разрыв с CI
(13.9s) это скорость раннера и старт интерпретаторов/воркеров, а не тело тестов.
Реалистичный потолок — 12-15s.

## Проверка

- полный suite зелёный серийно и под `-n 4 --dist worksteal` (1557 тестов);
- `tests/test_pytest_budget.py` — смысл гейта сохранён (accept/fail/пробрасывание падения);
- `tests/test_log_command.py` — инвариант изоляции логов (#131) держится;
- риск xdist из #439 (гонка воркеров за общими путями в `data/`) проверен: совпадения
  по `data/` в тестах — строковые ассерты и мок-пути, записи на диск нет;
- `ruff check` + `ruff format --check` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)