### PR TITLE
perf(apply): shorten form-render and success-confirmation timeouts

### DIFF
--- a/src/hhru_bot/apply/questionnaire.py
+++ b/src/hhru_bot/apply/questionnaire.py
@@ -90,7 +90,6 @@ def scan_questionnaire(
         form_state = navigate_to_response_form(
             page,
             vacancy.vacancy_id,
-            navigation_timeout_ms=timeout_ms,
             form_timeout_ms=form_timeout_ms,
             dump_diagnostics=False,
         )

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -142,8 +142,7 @@ def navigate_to_response_form(
     page: Page,
     vacancy_id: str | None = None,
     *,
-    navigation_timeout_ms: int | None = None,
-    form_timeout_ms: int = APPLY_TIMEOUT_MS,
+    form_timeout_ms: int | None = None,
     dump_diagnostics: bool = True,
     allow_relocation: bool = False,
 ) -> str | bool | PostClickBlocker:
@@ -169,7 +168,11 @@ def navigate_to_response_form(
     Клик вызывает обычную навигацию — дожидаемся её перед поиском полей формы.
 
     Фиксированный sleep после навигации заменён на явное ожидание готовности DOM:
-    ждём любого индикатора формы (кнопка отправки), максимум APPLY_TIMEOUT_MS.
+    ждём любого индикатора формы (кнопка отправки). ``form_timeout_ms`` управляет
+    этим ожиданием напрямую — если не задан явно (``None``), таймаут выбирается
+    случайно в диапазоне ``RESPONSE_READY_MIN_TIMEOUT_MS``..``RESPONSE_READY_MAX_TIMEOUT_MS``
+    для обычного apply-цикла; probe/questionnaire передают явное значение для
+    своих быстрых режимов (см. ``FAST_FORM_TIMEOUT_MS`` в questionnaire.py).
 
     #179: раньше ожидание было ``page.expect_navigation(wait_until="domcontentloaded")``.
     Живая диагностика (боевой аккаунт, vacancy_id 136221532) показала: кнопка
@@ -226,9 +229,13 @@ def navigate_to_response_form(
         return reason
     # URL не является обязательным: hh.ru может оставить нас на vacancy URL и
     # открыть форму модалкой. В обычном apply-цикле используем bounded jitter;
-    # probe/questionnaire могут передать явный timeout для своих быстрых режимов.
-    ready_timeout_ms = navigation_timeout_ms or random.randint(
-        RESPONSE_READY_MIN_TIMEOUT_MS, RESPONSE_READY_MAX_TIMEOUT_MS
+    # probe/questionnaire могут передать явный form_timeout_ms для своих
+    # быстрых режимов — `is not None`, а не truthy-проверка: 0 валидное
+    # значение таймаута в этом файле (см. render_timeout_ms=0 ниже).
+    ready_timeout_ms = (
+        form_timeout_ms
+        if form_timeout_ms is not None
+        else random.randint(RESPONSE_READY_MIN_TIMEOUT_MS, RESPONSE_READY_MAX_TIMEOUT_MS)
     )
     logger.debug("Ожидание формы отклика: %d мс", ready_timeout_ms)
     blocker = handle_post_click_blockers(

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -13,12 +13,12 @@
 from __future__ import annotations
 
 import logging
+import random
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from ..browser import GOTO_TIMEOUT_MS
 from ..logging_setup import LOG_DIR
 from ..selector_groups import vacancy_page
 from .blockers import PostClickBlocker, handle_post_click_blockers, raise_if_post_submit_limit
@@ -26,6 +26,10 @@ from .blockers import PostClickBlocker, handle_post_click_blockers, raise_if_pos
 logger = logging.getLogger("hhru_bot.apply.steps")
 
 APPLY_TIMEOUT_MS = 10_000
+# The response page may be rendered as a SPA modal, so waiting for its URL can
+# block for the global 90s navigation timeout even when the form is ready.
+RESPONSE_READY_MIN_TIMEOUT_MS = 5_000
+RESPONSE_READY_MAX_TIMEOUT_MS = 15_000
 # Короткий таймаут для проверки опциональных полей формы (резюме/письмо могут
 # отсутствовать — это нормально, а не ошибка). Ждать полной APPLY_TIMEOUT_MS тут
 # бессмысленно: отсутствие поля детерминировано почти сразу.
@@ -138,7 +142,7 @@ def navigate_to_response_form(
     page: Page,
     vacancy_id: str | None = None,
     *,
-    navigation_timeout_ms: int = GOTO_TIMEOUT_MS,
+    navigation_timeout_ms: int | None = None,
     form_timeout_ms: int = APPLY_TIMEOUT_MS,
     dump_diagnostics: bool = True,
     allow_relocation: bool = False,
@@ -220,26 +224,13 @@ def navigate_to_response_form(
         reason = "видимость резюме недостаточна для отклика"
         logger.info("Вакансия пропущена: %s", reason)
         return reason
-    # #179: таймаут/ошибка ожидания URL сама по себе не означает, что клик не
-    # сработал — не крашим весь pipeline необработанным исключением, а
-    # логируем и отдаём управление дальше. fill_response_form (через
-    # отсутствие APPLY_SUBMIT_BUTTON) и последующая проверка рендера формы
-    # различат навигационный сбой и реально загрузившуюся форму.
-    try:
-        page.wait_for_url(
-            "**/applicant/vacancy_response**", wait_until="commit", timeout=navigation_timeout_ms
-        )
-    except PlaywrightError as exc:
-        if dump_diagnostics:
-            _dump_navigation_diagnostics(page, "navigation_timeout", vacancy_id)
-        logger.warning(
-            "Навигация на форму отклика не подтвердилась (%s) — "
-            "продолжаю, дальнейшие шаги определят, загрузилась ли форма",
-            exc,
-        )
-    # Второй проход: модалка могла отрисоваться уже после навигации. Ждать
-    # повторно не нужно — первый проход выше уже отдал ей render-таймаут, а
-    # штатный путь без модалки не должен платить его дважды на каждой вакансии.
+    # URL не является обязательным: hh.ru может оставить нас на vacancy URL и
+    # открыть форму модалкой. В обычном apply-цикле используем bounded jitter;
+    # probe/questionnaire могут передать явный timeout для своих быстрых режимов.
+    ready_timeout_ms = navigation_timeout_ms or random.randint(
+        RESPONSE_READY_MIN_TIMEOUT_MS, RESPONSE_READY_MAX_TIMEOUT_MS
+    )
+    logger.debug("Ожидание формы отклика: %d мс", ready_timeout_ms)
     blocker = handle_post_click_blockers(
         page,
         allow_relocation=allow_relocation,
@@ -248,10 +239,10 @@ def navigate_to_response_form(
     )
     if blocker is not None:
         return blocker
-    # Форма рендерится после навигации — ждём её индикатор, а не слепую паузу.
+    # Форма рендерится после клика — ждём её индикатор, а не URL и не sleep.
     try:
         page.locator(apply_form.APPLY_SUBMIT_BUTTON).wait_for(
-            state="visible", timeout=form_timeout_ms
+            state="visible", timeout=ready_timeout_ms
         )
     except PlaywrightError as exc:
         if dump_diagnostics:

--- a/src/hhru_bot/apply/success.py
+++ b/src/hhru_bot/apply/success.py
@@ -30,6 +30,7 @@ Multi-signal success: один отклик может подтверждать�
 from __future__ import annotations
 
 import logging
+import random
 import re
 import time
 from collections.abc import Callable
@@ -96,14 +97,16 @@ def _sleep(page: Page, ms: float) -> None:
 # async-рендер, больше — меньше накладных. 80 мс — баланс для ручного CLI.
 _POLL_INTERVAL_MS = 80
 # Success UI is rendered asynchronously after the submit/navigation completes.
-# Keep this bounded, but allow the same slow hh.ru/DDoS-Guard responses that
-# motivated the 90-second navigation timeout to finish rendering their signal.
-SUCCESS_CONFIRMATION_TIMEOUT_MS = 30_000
+# It is only a fast-path: when the marker does not appear, the pipeline checks
+# /applicant/negotiations, which is the authoritative post-submit source. Keep
+# this interval short and varied without increasing the request rate to hh.ru.
+SUCCESS_CONFIRMATION_MIN_TIMEOUT_MS = 3_000
+SUCCESS_CONFIRMATION_MAX_TIMEOUT_MS = 8_000
 
 
 def wait_success_confirmation(
     page: Page,
-    timeout_ms: int = SUCCESS_CONFIRMATION_TIMEOUT_MS,
+    timeout_ms: int | None = None,
     terminal_check: Callable[[], None] | None = None,
 ) -> bool:
     """Подтверждает успех отклика по позитивным сигналам.
@@ -115,13 +118,18 @@ def wait_success_confirmation(
     (основной data-qa может не появиться или задержаться на непроверенной
     JS-форме). Отрицательный признак (исчезновение submit) успехом НЕ считается.
 
-    Таймаут возвращает False (сигналов нет — локально успех не подтверждён),
+    Если timeout_ms не задан, ожидание выбирается случайно в диапазоне 3–8
+    секунд. Таймаут возвращает False (сигналов нет — локально успех не подтверждён),
     но с #207 это НЕ финальный вердикт: pipeline перед записью 'failed'
     перепроверяет отклик внешним источником (/applicant/negotiations, см.
-    apply/verify.py) — найденный там отклик финализируется как success.
-    Окно подтверждения — 30 секунд: это снижает false-negative на медленном
-    hh.ru, оставаясь ограниченным и не меняя fail-closed правило для сигналов.
+    apply/verify.py) — найденный там отклик финализируется как success. Короткое
+    окно не меняет fail-closed правило для сигналов и не повышает частоту submit.
     """
+    if timeout_ms is None:
+        timeout_ms = random.randint(
+            SUCCESS_CONFIRMATION_MIN_TIMEOUT_MS,
+            SUCCESS_CONFIRMATION_MAX_TIMEOUT_MS,
+        )
     deadline = time.monotonic() + timeout_ms / 1000
     while True:
         # #344: a challenge may be the submit response itself. Check on every

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -67,7 +67,8 @@ class _FakeLocator:
             ids = self._state.reorder_to
         return ids
 
-    def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:  # noqa: ARG002
+    def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:
+        self._state.wait_for_timeout = timeout
         if self._state.wait_error:
             # Cycle-5: имитация не-timeout PlaywrightError (runtime/selector failure).
             raise Error(f"runtime error waiting for {self.selector}")
@@ -214,6 +215,10 @@ class _SelectorState:
         # (`subtree intercepts pointer events`) и падал в SubmitClickUncertain.
         # True → wait_for(state="hidden") на опции не дождётся закрытия.
         self.dropdown_stays_open = False
+        # #442 cycle-review (F6): последний timeout, переданный в wait_for() —
+        # проверяет, что вызывающий контролирует ожидание submit-кнопки через
+        # form_timeout_ms, а не через jitter/другой параметр.
+        self.wait_for_timeout: float | None = None
 
 
 class FakeStepsPage:
@@ -368,16 +373,59 @@ def test_navigate_does_not_raise_when_form_never_renders():
     assert page.navigation_entered == 0
 
 
-def test_navigate_uses_bounded_random_dom_timeout(monkeypatch):
-    monkeypatch.setattr(steps.random, "randint", lambda minimum, maximum: maximum)
+def test_navigate_uses_bounded_random_dom_timeout_by_default(monkeypatch):
+    # form_timeout_ms не передан -> должен выбираться jitter, а не фиксированный
+    # APPLY_TIMEOUT_MS (обычный apply-цикл использует bounded random, не detect).
+    randint_calls: list[tuple[int, int]] = []
+
+    def _randint(minimum: int, maximum: int) -> int:
+        randint_calls.append((minimum, maximum))
+        return maximum
+
+    monkeypatch.setattr(steps.random, "randint", _randint)
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
     steps.navigate_to_response_form(page)
 
-    assert steps.RESPONSE_READY_MIN_TIMEOUT_MS == 5_000
-    assert steps.RESPONSE_READY_MAX_TIMEOUT_MS == 15_000
+    assert randint_calls == [
+        (steps.RESPONSE_READY_MIN_TIMEOUT_MS, steps.RESPONSE_READY_MAX_TIMEOUT_MS)
+    ]
+
+
+def test_navigate_honors_explicit_form_timeout_ms_without_jitter(monkeypatch):
+    # #442 cycle-review (F6): form_timeout_ms ранее принимался, но игнорировался
+    # в теле функции — только navigation_timeout_ms реально влиял на ожидание
+    # submit-кнопки. questionnaire.py/probe.py передают form_timeout_ms=5_000/
+    # 10_000 рассчитывая управлять именно этим ожиданием — регрессия должна
+    # провалить этот тест, если jitter снова перекроет явное значение.
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("random.randint не должен вызываться при явном form_timeout_ms")
+
+    monkeypatch.setattr(steps.random, "randint", _fail_if_called)
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    assert steps.navigate_to_response_form(page, form_timeout_ms=5_000) is True
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).wait_for_timeout == 5_000
+
+
+def test_navigate_form_timeout_ms_zero_is_honored_not_treated_as_falsy(monkeypatch):
+    # 0 — валидное значение таймаута в этом файле (см. render_timeout_ms=0);
+    # `form_timeout_ms or random.randint(...)` молча подменил бы 0 на jitter.
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("random.randint не должен вызываться при form_timeout_ms=0")
+
+    monkeypatch.setattr(steps.random, "randint", _fail_if_called)
+    page = FakeStepsPage()
+    page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    steps.navigate_to_response_form(page, form_timeout_ms=0)
+
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).wait_for_timeout == 0
 
 
 def test_navigate_uses_wait_for_url_not_expect_navigation():

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -2,7 +2,7 @@
 
 Без браузера — через FakePage, имитирующий минимальный Playwright API, который
 использует steps.py: locator(...).wait_for(state='visible', timeout=...),
-click(), fill(), wait_for_url(). Страхуют поведение wait'ов: time.sleep
+click(), fill(). Страхуют поведение wait'ов: time.sleep
 убран, опциональные поля определяются ловом PlaywrightTimeoutError, обязательный
 submit даёт отказ при отсутствии.
 """
@@ -17,7 +17,6 @@ from playwright.sync_api import Error, sync_playwright
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from hhru_bot.apply import steps
-from hhru_bot.browser import GOTO_TIMEOUT_MS
 from hhru_bot.selector_groups import apply_form, vacancy_page
 
 pytestmark = pytest.mark.integration
@@ -324,8 +323,8 @@ def test_navigate_clicks_apply_button_and_waits_submit():
 
     assert steps.navigate_to_response_form(page) is True
 
-    # Клик по apply-кнопке + ожидание URL через wait_for_url (#179).
-    assert page.navigation_entered == 1
+    # Для SPA-модалки URL не обязан меняться.
+    assert page.navigation_entered == 0
     assert page._state(vacancy_page.VACANCY_APPLY_BUTTON).clicks == 1
 
 
@@ -366,21 +365,19 @@ def test_navigate_does_not_raise_when_form_never_renders():
 
     assert steps.navigate_to_response_form(page) is False
 
-    assert page.navigation_entered == 1
+    assert page.navigation_entered == 0
 
 
-def test_navigate_uses_goto_timeout_for_form_navigation():
-    # #80 регрессия: двухшаговая навигация на форму отклика (wait_for_url после
-    # клика по apply-кнопке, #179) — это сетевая навигация hh.ru, которая под
-    # DDoS-Guard грузится 33с+. Де­фолт/короткий APPLY_TIMEOUT_MS (10с) тут
-    # падает; потолок должен быть GOTO_TIMEOUT_MS, как и у всех goto в проекте.
+def test_navigate_uses_bounded_random_dom_timeout(monkeypatch):
+    monkeypatch.setattr(steps.random, "randint", lambda minimum, maximum: maximum)
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
     steps.navigate_to_response_form(page)
 
-    assert page.last_navigation_timeout == GOTO_TIMEOUT_MS
+    assert steps.RESPONSE_READY_MIN_TIMEOUT_MS == 5_000
+    assert steps.RESPONSE_READY_MAX_TIMEOUT_MS == 15_000
 
 
 def test_navigate_uses_wait_for_url_not_expect_navigation():
@@ -397,9 +394,7 @@ def test_navigate_uses_wait_for_url_not_expect_navigation():
 
     steps.navigate_to_response_form(page)
 
-    assert page.wait_for_url_calls == [
-        ("**/applicant/vacancy_response**", "commit", GOTO_TIMEOUT_MS)
-    ]
+    assert page.wait_for_url_calls == []
 
 
 def test_navigate_wait_for_url_uses_commit_not_default_load():
@@ -414,7 +409,7 @@ def test_navigate_wait_for_url_uses_commit_not_default_load():
 
     steps.navigate_to_response_form(page)
 
-    assert page.last_navigation_wait_until == "commit"
+    assert page.last_navigation_wait_until is None
 
 
 def test_navigate_wait_for_url_timeout_does_not_raise():
@@ -428,8 +423,6 @@ def test_navigate_wait_for_url_timeout_does_not_raise():
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
-    page.wait_for_url_error = PlaywrightTimeoutError("Timeout 90000ms exceeded.")
-
     steps.navigate_to_response_form(page)  # не должен бросать
 
     apply_state = page._state(vacancy_page.VACANCY_APPLY_BUTTON)
@@ -439,24 +432,23 @@ def test_navigate_wait_for_url_timeout_does_not_raise():
 def test_navigate_wait_for_url_timeout_saves_diagnostics(tmp_path: Path, monkeypatch):
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
-    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
-    page.wait_for_url_error = PlaywrightTimeoutError("navigation timeout")
+    # submit intentionally absent: the form readiness timeout is diagnostic.
     monkeypatch.setattr(steps, "LOG_DIR", tmp_path)
 
     steps.navigate_to_response_form(page)
 
     assert page.screenshot_calls == 1
     assert page.content_calls == 1
-    assert (tmp_path / "apply_navigation_timeout.png").exists()
-    assert (tmp_path / "apply_navigation_timeout.html").exists()
+    assert (tmp_path / "apply_form_timeout.png").exists()
+    assert (tmp_path / "apply_form_timeout.html").exists()
 
     # Повторный таймаут БЕЗ vacancy_id перезаписывает те же файлы (идемпотентно
     # по stage, как probe.dump_probe_snapshot), а не копит файл на каждый retry.
     steps.navigate_to_response_form(page)
 
     assert page.screenshot_calls == 2
-    assert len(list(tmp_path.glob("apply_navigation_timeout*.png"))) == 1
-    assert len(list(tmp_path.glob("apply_navigation_timeout*.html"))) == 1
+    assert len(list(tmp_path.glob("apply_form_timeout*.png"))) == 1
+    assert len(list(tmp_path.glob("apply_form_timeout*.html"))) == 1
 
 
 def test_navigate_wait_for_url_timeout_keeps_diagnostics_per_vacancy(tmp_path: Path, monkeypatch):
@@ -467,15 +459,14 @@ def test_navigate_wait_for_url_timeout_keeps_diagnostics_per_vacancy(tmp_path: P
     # per-vacancy.
     page = FakeStepsPage()
     page.set_visible(vacancy_page.VACANCY_APPLY_BUTTON, True)
-    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
-    page.wait_for_url_error = PlaywrightTimeoutError("navigation timeout")
+    # submit intentionally absent: each vacancy gets its own form diagnostic.
     monkeypatch.setattr(steps, "LOG_DIR", tmp_path)
 
     steps.navigate_to_response_form(page, "111")
     steps.navigate_to_response_form(page, "222")
 
-    assert (tmp_path / "apply_111_navigation_timeout.png").exists()
-    assert (tmp_path / "apply_222_navigation_timeout.png").exists()
+    assert (tmp_path / "apply_111_form_timeout.png").exists()
+    assert (tmp_path / "apply_222_form_timeout.png").exists()
 
 
 def test_navigate_wait_for_url_non_timeout_error_does_not_raise():

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -9,8 +9,6 @@
 
 from __future__ import annotations
 
-import inspect
-
 import pytest
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -20,10 +18,24 @@ from hhru_bot.apply.locators import first_locator
 pytestmark = pytest.mark.integration
 
 
-def test_default_confirmation_timeout_is_bounded_and_explicit():
-    """Медленный UI получает больше времени, но не неограниченное ожидание."""
-    default = inspect.signature(success.wait_success_confirmation).parameters["timeout_ms"].default
-    assert default == success.SUCCESS_CONFIRMATION_TIMEOUT_MS == 30_000
+def test_default_confirmation_timeout_is_short_and_randomized(monkeypatch):
+    """Локальный UI — быстрый путь перед авторитетной внешней проверкой."""
+    chosen: list[tuple[int, int]] = []
+
+    def _randint(lower: int, upper: int) -> int:
+        chosen.append((lower, upper))
+        return lower
+
+    monkeypatch.setattr(success.random, "randint", _randint)
+    page = _FakePage(markers={success.APPLY_SUCCESS_MARKER})
+
+    assert success.wait_success_confirmation(page) is True
+    assert chosen == [
+        (
+            success.SUCCESS_CONFIRMATION_MIN_TIMEOUT_MS,
+            success.SUCCESS_CONFIRMATION_MAX_TIMEOUT_MS,
+        )
+    ]
 
 
 class _FakeLocator:


### PR DESCRIPTION
## Summary
- `navigate_to_response_form` больше не ждёт `page.wait_for_url()` — hh.ru с 2026-08-16 стабильно рендерит модалку без смены URL (см. CLAUDE.md), поэтому этот wait всегда впустую исчерпывал полный таймаут перед fallback на `APPLY_SUBMIT_BUTTON`. Теперь готовность формы проверяется только через `locator.wait_for` на submit-кнопку, с bounded jitter 5-15с.
- `wait_success_confirmation` аналогично сокращён с фиксированных 30с до случайных 3-8с — это лишь fast-path перед внешней проверкой через `/applicant/negotiations` (#207), а не единственный источник истины об успехе отклика.
- Обновлены тесты `test_apply_steps.py`/`test_apply_success.py` под новое поведение.

## Известный риск (не блокирует, но стоит держать в уме)
Старый комментарий в файле упоминает боевое наблюдение "форма грузится 33с+ под DDoS-Guard" — новый потолок ожидания (15с максимум) короче этого наблюдения. При реальном обнаружении такой медленной загрузки вакансия будет ошибочно пропущена как "форма не отрисовалась", а не подхвачена увеличенным таймаутом. Последствие безопасное (skip, а не некорректная отправка), но стоит понаблюдать на боевых логах после мерджа.

Выделено из #441 отдельным PR — там эти изменения были случайно замешаны в `--limit`/`--max-pages` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)