### PR TITLE
feat(probe): group duplicate questionnaire questions across vacancies (#443)

### DIFF
--- a/src/hhru_bot/apply/questionnaire.py
+++ b/src/hhru_bot/apply/questionnaire.py
@@ -87,7 +87,14 @@ def group_questions(results: list[QuestionnaireScanResult]) -> list[QuestionGrou
         if result.status != QUESTIONNAIRE:
             continue
         for question in result.questions:
-            normalized_options = tuple(normalize(option) for option in question.options)
+            # #444 cycle-review: sort the normalized options for the key — the
+            # key must match on the SET of options, not their on-page order
+            # (the docstring's own contract). hh.ru can render the same
+            # option set in a different order across vacancies; without
+            # sorting, that alone would split one duplicate question into two
+            # groups and undercount it. Display order (`question.options`) is
+            # kept as-is in `display`, only the matching key is canonicalized.
+            normalized_options = tuple(sorted(normalize(option) for option in question.options))
             key = (normalize(question.text), question.kind, question.is_radio, normalized_options)
             if key not in vacancy_ids:
                 vacancy_ids[key] = []

--- a/src/hhru_bot/apply/questionnaire.py
+++ b/src/hhru_bot/apply/questionnaire.py
@@ -20,6 +20,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from ..ai.questions import Question, extract_questions
 from ..browser import NotAuthenticated, goto_hh, require_authenticated_page
+from ..external_forms.detect import normalize
 from ..search import VacancyCard
 from .dedup import check_already_responded
 from .questions import detect_questions
@@ -43,6 +44,68 @@ class QuestionnaireScanResult:
     questions: tuple[Question, ...] = ()
     total_bodies: int = 0
     retryable: bool = False
+
+
+@dataclass(frozen=True)
+class QuestionGroup:
+    """One distinct question, merged across vacancies that ask it verbatim.
+
+    #443 Этап 2: hh.ru repeats the same questionnaire question across many
+    vacancies (screening questions are per-employer templates, not
+    per-vacancy). Without grouping, a bulk scan's report is just a flat list
+    of (vacancy, questions) pairs — every duplicate has to be spotted by eye,
+    and there is no single place that says "this question appeared in N
+    vacancies". Grouping is keyed on normalized text + kind + (for choice
+    questions) the normalized option set: two questions with the same text
+    but different answer choices are NOT the same question — merging them
+    would make the group's `options` field lie about what a candidate can
+    actually pick for any single vacancy in it.
+    """
+
+    text: str
+    kind: str
+    is_radio: bool
+    options: tuple[str, ...]
+    vacancy_ids: tuple[str, ...]
+
+
+_GroupKey = tuple[str, str, bool, tuple[str, ...]]
+
+
+def group_questions(results: list[QuestionnaireScanResult]) -> list[QuestionGroup]:
+    """Group identical questions across scan results without losing the
+    vacancy link (#443 acceptance: "повторяющиеся вопросы объединяются без
+    потери связи с вакансиями"). Pure function — no browser, no I/O.
+    """
+    order: list[_GroupKey] = []
+    # Original (non-normalized) display text/options are kept alongside the
+    # normalized key on first sight, so the report can show what a candidate
+    # actually reads on the page rather than the casefolded matching key.
+    display: dict[_GroupKey, tuple[str, tuple[str, ...]]] = {}
+    vacancy_ids: dict[_GroupKey, list[str]] = {}
+    for result in results:
+        if result.status != QUESTIONNAIRE:
+            continue
+        for question in result.questions:
+            normalized_options = tuple(normalize(option) for option in question.options)
+            key = (normalize(question.text), question.kind, question.is_radio, normalized_options)
+            if key not in vacancy_ids:
+                vacancy_ids[key] = []
+                display[key] = (question.text, question.options)
+                order.append(key)
+            vacancy_id = result.vacancy.vacancy_id
+            if vacancy_id not in vacancy_ids[key]:
+                vacancy_ids[key].append(vacancy_id)
+    return [
+        QuestionGroup(
+            text=display[key][0],
+            kind=key[1],
+            is_radio=key[2],
+            options=display[key][1],
+            vacancy_ids=tuple(vacancy_ids[key]),
+        )
+        for key in order
+    ]
 
 
 def _set_page_timeout(page: Page, timeout_ms: int) -> None:

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -515,7 +515,7 @@ def _dedupe_vacancies(vacancies):
 
 
 def _format_questionnaire_report(results) -> str:
-    from ..apply.questionnaire import QUESTIONNAIRE
+    from ..apply.questionnaire import QUESTIONNAIRE, group_questions
     from ..report import _ascii_table
 
     rows = [
@@ -537,6 +537,23 @@ def _format_questionnaire_report(results) -> str:
             report += f"\n  {index}. {question.text}"
             if question.options:
                 report += "\n     options: " + " | ".join(question.options)
+    # #443 Этап 2: те же вопросы объединены по нормализованному тексту/типу —
+    # это то, что реально повторяется у разных вакансий (шаблон работодателя),
+    # без потери связи с исходными vacancy_id.
+    groups = group_questions(list(results))
+    if groups:
+        report += "\n\n=== Уникальные вопросы (объединены по тексту) ==="
+        group_rows = [
+            [group.kind, group.text.replace("\n", " "), str(len(group.vacancy_ids))]
+            for group in groups
+        ]
+        report += "\n" + _ascii_table(["kind", "question", "vacancies"], group_rows)
+        for group in groups:
+            if len(group.vacancy_ids) < 2:
+                continue
+            report += f"\n\n[{', '.join(group.vacancy_ids)}] {group.text}"
+            if group.options:
+                report += "\n  options: " + " | ".join(group.options)
     return report
 
 

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -381,6 +381,26 @@ def test_group_questions_normalizes_whitespace_and_case():
     assert groups[0].vacancy_ids == ("1", "2")
 
 
+def test_group_questions_merges_same_options_in_different_order():
+    # cycle-review PR #444: same text, same OPTION SET, but different order —
+    # the key must canonicalize (sort) options, otherwise identical questions
+    # split into separate groups whenever hh.ru renders options in a
+    # different order across vacancies (undercounting duplicate questions).
+    q1 = Question(0, "Готовы к переезду?", "choice", ("Да", "Нет"), is_radio=True)
+    q2 = Question(0, "Готовы к переезду?", "choice", ("Нет", "Да"), is_radio=True)
+    results = [
+        questionnaire.QuestionnaireScanResult(
+            _card("1"), questionnaire.QUESTIONNAIRE, "", (q1,), 1
+        ),
+        questionnaire.QuestionnaireScanResult(
+            _card("2"), questionnaire.QUESTIONNAIRE, "", (q2,), 1
+        ),
+    ]
+    groups = questionnaire.group_questions(results)
+    assert len(groups) == 1
+    assert groups[0].vacancy_ids == ("1", "2")
+
+
 def test_group_questions_keeps_same_text_with_different_options_separate():
     # Same wording, different answer choices for two different employers —
     # merging would falsely claim both vacancies accept the same options.

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -347,3 +347,71 @@ def test_bulk_already_responded_does_not_fail_the_scan(monkeypatch, capsys):
     assert probe.run_questionnaires(args) is False
     output = capsys.readouterr().out
     assert "already_responded" in output
+
+
+# --- #443 Этап 2: группировка одинаковых вопросов между вакансиями ---
+
+
+def test_group_questions_merges_identical_text_and_options_across_vacancies():
+    q = Question(0, "Готовы к переезду?", "choice", ("Да", "Нет"), is_radio=True)
+    results = [
+        questionnaire.QuestionnaireScanResult(_card("1"), questionnaire.QUESTIONNAIRE, "", (q,), 1),
+        questionnaire.QuestionnaireScanResult(_card("2"), questionnaire.QUESTIONNAIRE, "", (q,), 1),
+    ]
+    groups = questionnaire.group_questions(results)
+    assert len(groups) == 1
+    assert groups[0].vacancy_ids == ("1", "2")
+    assert groups[0].text == "Готовы к переезду?"
+    assert groups[0].options == ("Да", "Нет")
+
+
+def test_group_questions_normalizes_whitespace_and_case():
+    q1 = Question(0, "  Готовы к переезду?  ", "text")
+    q2 = Question(0, "готовы к переезду?", "text")
+    results = [
+        questionnaire.QuestionnaireScanResult(
+            _card("1"), questionnaire.QUESTIONNAIRE, "", (q1,), 1
+        ),
+        questionnaire.QuestionnaireScanResult(
+            _card("2"), questionnaire.QUESTIONNAIRE, "", (q2,), 1
+        ),
+    ]
+    groups = questionnaire.group_questions(results)
+    assert len(groups) == 1
+    assert groups[0].vacancy_ids == ("1", "2")
+
+
+def test_group_questions_keeps_same_text_with_different_options_separate():
+    # Same wording, different answer choices for two different employers —
+    # merging would falsely claim both vacancies accept the same options.
+    q1 = Question(0, "Готовы к переезду?", "choice", ("Да", "Нет"), is_radio=True)
+    q2 = Question(0, "Готовы к переезду?", "choice", ("Да", "Нет", "Обсудим"), is_radio=True)
+    results = [
+        questionnaire.QuestionnaireScanResult(
+            _card("1"), questionnaire.QUESTIONNAIRE, "", (q1,), 1
+        ),
+        questionnaire.QuestionnaireScanResult(
+            _card("2"), questionnaire.QUESTIONNAIRE, "", (q2,), 1
+        ),
+    ]
+    groups = questionnaire.group_questions(results)
+    assert len(groups) == 2
+    assert {g.vacancy_ids for g in groups} == {("1",), ("2",)}
+
+
+def test_group_questions_ignores_duplicate_vacancy_id_and_non_questionnaire_status():
+    q = Question(0, "Готовы к переезду?", "text")
+    results = [
+        questionnaire.QuestionnaireScanResult(_card("1"), questionnaire.QUESTIONNAIRE, "", (q,), 1),
+        # Same vacancy re-scanned (retry path) must not double-count.
+        questionnaire.QuestionnaireScanResult(_card("1"), questionnaire.QUESTIONNAIRE, "", (q,), 1),
+        questionnaire.QuestionnaireScanResult(_card("2"), questionnaire.NO_QUESTIONNAIRE),
+        questionnaire.QuestionnaireScanResult(_card("3"), questionnaire.UNKNOWN, "timeout"),
+    ]
+    groups = questionnaire.group_questions(results)
+    assert len(groups) == 1
+    assert groups[0].vacancy_ids == ("1",)
+
+
+def test_group_questions_empty_input_returns_empty_list():
+    assert questionnaire.group_questions([]) == []


### PR DESCRIPTION
## Что сделано

Реализует недостающую часть Этапа 2 из #443 — группировку одинаковых вопросов анкеты между вакансиями без потери связи с исходными вакансиями.

- `apply/questionnaire.py::group_questions()` — чистая функция без браузера/I/O: объединяет вопросы из `list[QuestionnaireScanResult]` по ключу (нормализованный текст + тип поля + нормализованный набор вариантов ответа), хранит список `vacancy_id`, которые задавали каждый вопрос. Вопросы с одинаковым текстом, но разными вариантами ответа НЕ объединяются (иначе группа лгала бы о доступных вариантах для конкретной вакансии).
- `commands/probe.py::_format_questionnaire_report` — добавлена секция отчёта "Уникальные вопросы (объединены по тексту)" с ASCII-таблицей (тип/текст/кол-во вакансий) и детализацией для вопросов, встретившихся в 2+ вакансиях.
- 5 unit-тестов в `tests/test_questionnaire_bulk.py`: слияние по тексту+вариантам, нормализация пробелов/регистра, разделение при разных вариантах ответа, игнорирование дублей vacancy_id/не-анкетных статусов, пустой вход.

## Что уже было реализовано (проверено по коду/тестам до начала работы)

- **Этап 1** (read-only bulk-скан анкет) — закрыт в #433: `probe --questionnaires-only`, `scan_questionnaire`, `extract_questions`, дедупликация вакансий, fail-closed при системном unknown.
- **Этап 3** (preview/dry-run, явное подтверждение перед заполнением, fail-closed) — уже в `apply/pipeline.py`: `detect_questions`/`extract_questions` перед любой записью в форму, `AIQuestionAnswerer.propose_all` в dry-run логирует вопрос/ответ/confidence с префиксом `[DRY-RUN]`/`[FORCE]`, реальное заполнение требует явного `--force`, низкая уверенность/расхождение эвристики и парсера — fail-closed skip. Аудит (вакансия, вопрос, источник ответа, уверенность, результат) уже пишется в `data/logs/hhru_bot.log`.

## Осознанно не сделано в этом PR

- **Профиль ответов с ручным приоритетом** (Этап 2, "профиль ответов... приоритет над автоматически предложенными значениями") пересекается с открытым issue #390 ("переиспользовать account_profile в LLM-ответах на тест-вопросы вместо параллельного механизма"). Строить здесь параллельный механизм — прямой конфликт с #390.
- **Критерий "исследованы анкеты минимум из нескольких поисковых направлений"** требует живого прогона `probe --questionnaires-only` под наблюдением человека против hh.ru — это невозможно произвести из этого воркера, и я не стал фабриковать тестовые данные анкет вместо реального сбора. Нужен отдельный ручной прогон после мерджа.

## Тесты

```
pytest -q                    # весь набор — зелёный
ruff check src tests         # чисто
ruff format --check src tests  # чисто
```

Closes #443 частично (Stage 2 grouping) — issue стоит держать открытым до живого исследовательского прогона (Этап 1 критерий) и до решения по #390 (Этап 2 профиль ответов).

🤖 Generated with [Claude Code](https://claude.com/claude-code)