### PR TITLE
fix(review): close claimed approvals safely (#436)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -655,12 +655,15 @@ def _run_apply_for_resume(
     account_resume_ids = identity.account_resume_ids
 
     approved_item = None
+    approved_duplicate = False
     if getattr(args, "approved", None) is not None:
         if not getattr(args, "permit", None):
-            raise ValueError("для --approved требуется --permit из review approve")
+            print("[FAIL] для --approved требуется --permit из review approve")
+            return True
         candidates = [item for item in history.review_items() if item["id"] == args.approved]
         if not candidates or candidates[0]["resume_id"] != resume.resume_id:
-            raise ValueError("approved-запись принадлежит другому резюме")
+            print("[FAIL] approved-запись принадлежит другому резюме")
+            return True
         approved_item = history.claim_review(args.approved, args.permit)
         cards = [
             VacancyCard(
@@ -670,6 +673,11 @@ def _run_apply_for_resume(
                 url=approved_item["vacancy_url"],
             )
         ]
+        # --approved bypasses the normal search/filter plan, so preserve the
+        # history-based deduplication barrier on this explicit route too.
+        if history.has_applied(resume.resume_id, approved_item["vacancy_id"]):
+            history.finish_review(args.approved, "skipped")
+            approved_duplicate = True
     elif cards_override is None:
         try:
             cards = search_vacancies(page, resume.search, max_pages=args.max_pages)
@@ -692,7 +700,11 @@ def _run_apply_for_resume(
         )
     )
     plan = (
-        ApplyPlan([(cards[0], approved_item["score"], json.loads(approved_item["breakdown"]))])
+        ApplyPlan([], skipped=[], total=len(cards), after_filter=0)
+        if approved_duplicate
+        else ApplyPlan(
+            [(cards[0], approved_item["score"], json.loads(approved_item["breakdown"]))]
+        )
         if approved_item
         else build_apply_plan(
             cards,
@@ -766,6 +778,8 @@ def _run_apply_for_resume(
             throttle.check_apply_limit(resume.resume_id, args.dry_run)
         except LimitReached as e:
             print(f"Дневной лимит достигнут, останавливаюсь: {e}")
+            if approved_item:
+                history.finish_review(args.approved, "skipped")
             break
 
         action_id = None
@@ -837,6 +851,14 @@ def _run_apply_for_resume(
             # the generic crash reason before terminating the whole command.
             if action_id is not None:
                 history.finalize_action(action_id, "uncertain", str(exc))
+            if approved_item:
+                history.finish_review(args.approved, "failed")
+            raise
+        except Exception:
+            # A claimed review must never remain permanently in ``applying``
+            # when the browser/pipeline fails before returning a result.
+            if approved_item:
+                history.finish_review(args.approved, "failed")
             raise
 
         if result.skipped:

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -850,13 +850,26 @@ def _run_apply_for_resume(
             if action_id is not None:
                 history.finalize_action(action_id, "uncertain", str(exc))
             if approved_item:
-                history.finish_review(args.approved, "failed")
+                # #436: the underlying actions row is 'uncertain' (submit may
+                # have gone through) — finish_review has no 'uncertain' state,
+                # and review_queue is a reporting view, not the dedup barrier
+                # (that's has_applied() over actions). Map fail-closed to
+                # 'applied' rather than 'failed', so a re-review of this queue
+                # entry never looks safely retryable.
+                history.finish_review(args.approved, "applied")
             raise
         except Exception:
             # A claimed review must never remain permanently in ``applying``
             # when the browser/pipeline fails before returning a result.
             if approved_item:
-                history.finish_review(args.approved, "failed")
+                # #436: action_id may be None (crash before before_submit) —
+                # then nothing was attempted and 'failed' is correct. If
+                # action_id is set, begin_action() already reserved the
+                # actions row as 'uncertain' and it was never finalized here,
+                # so the same fail-closed mapping applies as above.
+                history.finish_review(
+                    args.approved, "applied" if action_id is not None else "failed"
+                )
             raise
 
         if result.skipped:
@@ -925,7 +938,14 @@ def _run_apply_for_resume(
             print(f"  [FAIL] {card.title} — {result.reason}")
 
         if approved_item:
-            history.finish_review(args.approved, "applied" if result.success else "failed")
+            # #436: 'uncertain' must dedup like 'applied', not read as a safe
+            # retry candidate — finish_review has no 'uncertain' state, and
+            # review_queue is a reporting view, not the dedup barrier (that's
+            # has_applied() over actions, which already treats uncertain like
+            # success). Fail-closed mapping, mirrors the except-branches above.
+            history.finish_review(
+                args.approved, "applied" if (result.success or result.uncertain) else "failed"
+            )
 
         # #163: анти-бан-пауза — только после реальной отправки отклика (submit).
         # Ранние выходы не оставляют на сайте следа, пауза там не от чего не

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -702,9 +702,7 @@ def _run_apply_for_resume(
     plan = (
         ApplyPlan([], skipped=[], total=len(cards), after_filter=0)
         if approved_duplicate
-        else ApplyPlan(
-            [(cards[0], approved_item["score"], json.loads(approved_item["breakdown"]))]
-        )
+        else ApplyPlan([(cards[0], approved_item["score"], json.loads(approved_item["breakdown"]))])
         if approved_item
         else build_apply_plan(
             cards,

--- a/tests/test_apply_limit.py
+++ b/tests/test_apply_limit.py
@@ -394,3 +394,39 @@ def test_daily_limit_exhausted_mid_wave_stops_lazy_paging(tmp_path, monkeypatch)
     # exhaustion inside that wave must stop the loop before a second
     # _load_apply_page (next page) call.
     assert loaded == [0]
+
+
+def test_approved_uncertain_result_finishes_review_as_applied_not_failed(tmp_path, monkeypatch):
+    # #436: an --approved apply that ends in an ``uncertain`` ApplyResult
+    # (submit may have gone through, Playwright failed to confirm) must NOT
+    # finish the claimed review_queue row as "failed" — finish_review has no
+    # 'uncertain' state, and a row left/reported as "failed" reads as safely
+    # retryable even though the underlying actions row (has_applied's real
+    # dedup barrier) is already 'uncertain'. Fail-closed: map to "applied".
+    config, resume, history, throttle = _setup(tmp_path)
+    card = _cards(1)[0]
+
+    item_id = history.enqueue_review(resume.resume_id, card, 10, {}, "hello")
+    permit = history.approve_review(item_id)
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+    monkeypatch.setattr(Throttle, "wait", lambda *a, **k: None)
+    monkeypatch.setattr(
+        _common,
+        "apply_to_vacancy",
+        lambda *a, **k: ApplyResult(card, False, "неопределённо", acted=True, uncertain=True),
+    )
+
+    args = argparse.Namespace(
+        dry_run=False,
+        limit=1,
+        max_pages=1,
+        headless=True,
+        approved=item_id,
+        permit=permit,
+        force=False,
+    )
+    _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    row = next(r for r in history.review_items() if r["id"] == item_id)
+    assert row["status"] == "applied"


### PR DESCRIPTION
Closes #436

## Summary
- apply history-based deduplication to the explicit `--approved` path
- finalize claimed review rows instead of leaving them stuck in `applying` on throttle/pipeline failures
- report invalid approval arguments through the CLI `[FAIL]` contract

## Verification
- `python -m compileall -q src`
- `pytest -q tests/test_apply_limit.py tests/test_history_schema.py tests/test_apply_audit.py`
- `ruff check src/hhru_bot/commands/_common.py`