### PR TITLE
fix: attribute apply funnel actions to search query

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -799,7 +799,12 @@ def _run_apply_for_resume(
             # would make the next run send a duplicate. Keeping this hook after
             # navigation/questions preserves the old no-action semantics for
             # confirmed pre-submit exits.
-            action_id = history.begin_action(resume.resume_id, vacancy_id, "apply")
+            action_id = history.begin_action(
+                resume.resume_id,
+                vacancy_id,
+                "apply",
+                search_query=resume.search.text,
+            )
 
         # dict value type intentionally broad — **apply_kwargs spreads several
         # unrelated kwarg types (provider/verifier/callable/bool) into
@@ -895,6 +900,7 @@ def _run_apply_for_resume(
                 "uncertain" if result.uncertain else ("success" if result.success else "failed"),
                 result.reason,
                 letter_variant=result.letter_variant,
+                search_query=resume.search.text,
             )
         if result.success:
             applied_count += 1

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -776,7 +776,14 @@ def _run_apply_for_resume(
             snapshot_source = letter_provider or TemplateCoverLetterProvider(cover_letter_template)
             snapshot_outcome = snapshot_source.render(card)
             snapshot_letter = snapshot_outcome.text
-            history.enqueue_review(resume.resume_id, card, _score, _breakdown, snapshot_letter)
+            history.enqueue_review(
+                resume.resume_id,
+                card,
+                _score,
+                _breakdown,
+                snapshot_letter,
+                search_query=resume.search.text,
+            )
 
             class _DryRunLetter:
                 def render(
@@ -799,18 +806,20 @@ def _run_apply_for_resume(
             # would make the next run send a duplicate. Keeping this hook after
             # navigation/questions preserves the old no-action semantics for
             # confirmed pre-submit exits.
-            # #420 follow-up (Codex adversarial-review, PR #449): review_queue
-            # (#414 schema) doesn't persist the search_query the card was found
-            # under, and the config's resume.search.text can have changed
-            # between the dry-run that queued it and this --approved run —
-            # attributing to the *current* query would silently mislabel the
-            # funnel. Provenance is unknown for approved items, so leave
-            # search_query NULL/unattributed rather than guess.
+            # #420 follow-up (Codex adversarial-review round 1+2, PR #449): the
+            # config's resume.search.text can have changed between the dry-run
+            # that queued an --approved card and this run — attributing to the
+            # *current* query would silently mislabel the funnel. Use the query
+            # review_queue recorded at enqueue time instead; a pre-fix queue row
+            # has none stored (NULL), which stays genuinely unattributed rather
+            # than falling back to an unrelated vacancies_seen query (round 2).
             action_id = history.begin_action(
                 resume.resume_id,
                 vacancy_id,
                 "apply",
-                search_query=None if approved_item else resume.search.text,
+                search_query=(
+                    approved_item["search_query"] if approved_item else resume.search.text
+                ),
             )
 
         # dict value type intentionally broad — **apply_kwargs spreads several
@@ -900,9 +909,9 @@ def _run_apply_for_resume(
             # The verifier can positively reconcile an external submit even
             # when the pre-submit hook was not reached (for example, a
             # transitional page exposed the post-click state directly).
-            # #420 follow-up: same approved-item provenance caveat as
-            # _before_submit above — review_queue doesn't record the
-            # original search_query, so don't guess it from the current config.
+            # #420 follow-up: same approved-item provenance handling as
+            # _before_submit above — use the query review_queue recorded at
+            # enqueue time, not the current config's.
             history.record_action(
                 resume.resume_id,
                 card.vacancy_id,
@@ -910,7 +919,9 @@ def _run_apply_for_resume(
                 "uncertain" if result.uncertain else ("success" if result.success else "failed"),
                 result.reason,
                 letter_variant=result.letter_variant,
-                search_query=None if approved_item else resume.search.text,
+                search_query=(
+                    approved_item["search_query"] if approved_item else resume.search.text
+                ),
             )
         if result.success:
             applied_count += 1

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -799,11 +799,18 @@ def _run_apply_for_resume(
             # would make the next run send a duplicate. Keeping this hook after
             # navigation/questions preserves the old no-action semantics for
             # confirmed pre-submit exits.
+            # #420 follow-up (Codex adversarial-review, PR #449): review_queue
+            # (#414 schema) doesn't persist the search_query the card was found
+            # under, and the config's resume.search.text can have changed
+            # between the dry-run that queued it and this --approved run —
+            # attributing to the *current* query would silently mislabel the
+            # funnel. Provenance is unknown for approved items, so leave
+            # search_query NULL/unattributed rather than guess.
             action_id = history.begin_action(
                 resume.resume_id,
                 vacancy_id,
                 "apply",
-                search_query=resume.search.text,
+                search_query=None if approved_item else resume.search.text,
             )
 
         # dict value type intentionally broad — **apply_kwargs spreads several
@@ -893,6 +900,9 @@ def _run_apply_for_resume(
             # The verifier can positively reconcile an external submit even
             # when the pre-submit hook was not reached (for example, a
             # transitional page exposed the post-click state directly).
+            # #420 follow-up: same approved-item provenance caveat as
+            # _before_submit above — review_queue doesn't record the
+            # original search_query, so don't guess it from the current config.
             history.record_action(
                 resume.resume_id,
                 card.vacancy_id,
@@ -900,7 +910,7 @@ def _run_apply_for_resume(
                 "uncertain" if result.uncertain else ("success" if result.success else "failed"),
                 result.reason,
                 letter_variant=result.letter_variant,
-                search_query=resume.search.text,
+                search_query=None if approved_item else resume.search.text,
             )
         if result.success:
             applied_count += 1

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -654,7 +654,10 @@ class History:
             cursor = conn.execute(
                 """
                 INSERT INTO actions
-                    (resume_id, vacancy_id, action, status, reason, letter_variant, search_query, created_at)
+                    (
+                        resume_id, vacancy_id, action, status, reason,
+                        letter_variant, search_query, created_at
+                    )
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS actions (
     action TEXT NOT NULL,
     status TEXT NOT NULL,
     reason TEXT,
+    search_query TEXT,
     created_at TEXT NOT NULL
 );
 
@@ -435,6 +436,7 @@ class History:
         with self._connect() as conn:
             conn.executescript(SCHEMA)
             _ensure_column(conn, "actions", "letter_variant", "TEXT")
+            _ensure_column(conn, "actions", "search_query", "TEXT")
             # #93: employer_tier в vacancies_seen (для estimate_salary). CREATE TABLE
             # IF NOT EXISTS не добавит колонку в уже существующую таблицу (#51) —
             # поэтому ALTER'ом идемпотентно доводим старые базы.
@@ -646,13 +648,14 @@ class History:
         status: str,
         reason: str | None = None,
         letter_variant: str | None = None,
+        search_query: str | None = None,
     ) -> int:
         with self._connect() as conn:
             cursor = conn.execute(
                 """
                 INSERT INTO actions
-                    (resume_id, vacancy_id, action, status, reason, letter_variant, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                    (resume_id, vacancy_id, action, status, reason, letter_variant, search_query, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     resume_id,
@@ -661,6 +664,7 @@ class History:
                     status,
                     reason,
                     letter_variant,
+                    search_query,
                     datetime.now().isoformat(),
                 ),
             )
@@ -731,7 +735,14 @@ class History:
         with self._connect() as conn:
             return [dict(row) for row in conn.execute(query, params).fetchall()]
 
-    def begin_action(self, resume_id: str, vacancy_id: str, action: str) -> int:
+    def begin_action(
+        self,
+        resume_id: str,
+        vacancy_id: str,
+        action: str,
+        *,
+        search_query: str | None = None,
+    ) -> int:
         """Durably reserve a potentially external action before browser work.
 
         ``uncertain`` is deliberate: if the process disappears after the browser
@@ -745,6 +756,7 @@ class History:
             action,
             "uncertain",
             reason="действие начато, результат не зафиксирован",
+            search_query=search_query,
         )
 
     def finalize_action(
@@ -1281,7 +1293,7 @@ class History:
             rows = conn.execute(
                 f"""
                 SELECT
-                    v.search_query AS search_query,
+                    COALESCE(a.search_query, v.search_query) AS search_query,
                     COUNT(DISTINCT a.resume_id || ':' || a.vacancy_id) AS sent,
                     COUNT(DISTINCT CASE WHEN EXISTS (
                         SELECT 1 FROM responses r
@@ -1319,9 +1331,10 @@ class History:
                         WHERE m.resume_id = a.resume_id AND m.vacancy_id = a.vacancy_id
                     ) THEN a.resume_id || ':' || a.vacancy_id END) AS replied
                 FROM actions AS a
-                JOIN vacancies_seen AS v ON v.vacancy_id = a.vacancy_id
+                LEFT JOIN vacancies_seen AS v
+                  ON v.vacancy_id = a.vacancy_id AND a.search_query IS NULL
                 {clause}
-                GROUP BY v.search_query
+                GROUP BY COALESCE(a.search_query, v.search_query)
                 """,
                 params,
             ).fetchall()
@@ -1383,6 +1396,7 @@ class History:
                 SELECT COUNT(*) AS n
                 FROM actions AS a
                 {clause}
+                AND a.search_query IS NULL
                 AND NOT EXISTS (
                     SELECT 1 FROM vacancies_seen AS v WHERE v.vacancy_id = a.vacancy_id
                 )

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -1362,7 +1362,11 @@ class History:
             )
         return sorted(
             funnel,
-            key=lambda row: (-row["invite_rate"], -row["offer_rate"], row["search_query"]),
+            key=lambda row: (
+                -row["invite_rate"],
+                -row["offer_rate"],
+                row["search_query"] or "",
+            ),
         )
 
     def count_unattributed_applies(

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -226,6 +226,7 @@ CREATE TABLE IF NOT EXISTS review_queue (
     status TEXT NOT NULL DEFAULT 'pending',
     permit_hash TEXT,
     permit_expires_at TEXT,
+    search_query TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
@@ -437,6 +438,11 @@ class History:
             conn.executescript(SCHEMA)
             _ensure_column(conn, "actions", "letter_variant", "TEXT")
             _ensure_column(conn, "actions", "search_query", "TEXT")
+            # #420 follow-up (Codex adversarial-review, PR #449): review_queue
+            # rows created before this column existed have no stored search_query
+            # — they stay NULL and are legacy-attributed via the existing
+            # vacancies_seen fallback in funnel_by_search_query, same as actions.
+            _ensure_column(conn, "review_queue", "search_query", "TEXT")
             # #93: employer_tier в vacancies_seen (для estimate_salary). CREATE TABLE
             # IF NOT EXISTS не добавит колонку в уже существующую таблицу (#51) —
             # поэтому ALTER'ом идемпотентно доводим старые базы.
@@ -514,14 +520,23 @@ class History:
             rows = conn.execute(query + " ORDER BY viewed_at DESC, id DESC", params).fetchall()
         return [dict(row) for row in rows]
 
-    def enqueue_review(self, resume_id, card, score, breakdown, letter) -> int:
-        """Store the exact dry-run candidate and letter for later approval."""
+    def enqueue_review(
+        self, resume_id, card, score, breakdown, letter, *, search_query: str | None = None
+    ) -> int:
+        """Store the exact dry-run candidate and letter for later approval.
+
+        ``search_query`` (#420 follow-up, PR #449 Codex adversarial-review) is the
+        query the card was found under at enqueue time — persisted so a later
+        `apply --approved` attributes the resulting action to it, not to whatever
+        the config's search text says by the time it's approved (config drift).
+        """
         now = datetime.now().isoformat()
         with self._connect() as conn:
             cur = conn.execute(
                 """INSERT INTO review_queue
-                (resume_id,vacancy_id,vacancy_url,title,company,score,breakdown,letter,created_at,updated_at)
-                VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (resume_id,vacancy_id,vacancy_url,title,company,score,breakdown,letter,
+                 search_query,created_at,updated_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     resume_id,
                     card.vacancy_id,
@@ -531,6 +546,7 @@ class History:
                     score,
                     json.dumps(breakdown, sort_keys=True),
                     letter,
+                    search_query,
                     now,
                     now,
                 ),
@@ -1272,7 +1288,14 @@ class History:
     ) -> list[dict]:
         """Воронка отправлено → оффер с группировкой по поисковому запросу.
 
-        Отклик учитывается в каждом запросе, в котором была найдена его
+        Атрибуция запроса (#420, PR #449) — сперва ``actions.search_query``,
+        записанный в момент самого отклика (apply/run передают текущий
+        ``resume.search.text``, approved-заявки — запрос, сохранённый в
+        ``review_queue`` на момент постановки в очередь). Если он ``NULL``
+        (строки, созданные до появления колонки — миграционное окно, а не
+        дефект — см. #420: "не бэкафилить исторические actions"), запрос
+        берётся через ``LEFT JOIN`` из ``vacancies_seen`` по ``vacancy_id`` —
+        так отклик учитывается в каждом запросе, в котором была найдена его
         вакансия (``vacancies_seen`` допускает несколько таких строк). Внутри
         запроса счётчики дедуплицируются по паре (resume_id, vacancy_id), а не
         только по vacancy_id: ``idx_resume_vacancy_apply`` — UNIQUE по этой

--- a/tests/test_apply_audit.py
+++ b/tests/test_apply_audit.py
@@ -166,3 +166,69 @@ def test_post_submit_challenge_finalizes_uncertain_marker_before_stopping(tmp_pa
     assert row is not None
     assert row["status"] == "uncertain"
     assert "обнаружена анти-бот проверка" in row["reason"]
+
+
+def test_approved_apply_does_not_attribute_to_unrelated_current_search_query(tmp_path, monkeypatch):
+    """#420 follow-up (Codex adversarial-review, PR #449): review_queue не хранит
+    search_query карточки на момент постановки в очередь (#414 schema). Между
+    dry-run (enqueue_review) и последующим `apply --approved` конфиг резюме мог
+    смениться на другой поисковый запрос — код не должен подписывать чужой
+    отклик текущим resume.search.text: это тихо искажает funnel-атрибуцию.
+    Провенанс неизвестен -> search_query обязан остаться NULL/unattributed.
+    """
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="devops"),  # запрос сменился после enqueue_review
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="hello",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    card = VacancyCard(
+        vacancy_id="123",
+        title="Python developer",
+        company="Acme",
+        url="https://hh.ru/vacancy/123",
+    )
+    # dry-run под "python" поставил карточку в очередь; исходный запрос нигде не сохранён.
+    item_id = history.enqueue_review("AAA111", card, 1.0, {}, "cover letter")
+    permit = history.approve_review(item_id)
+    args = argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=False,
+        headless=True,
+        max_pages=1,
+        limit=1,
+        approved=item_id,
+        permit=permit,
+    )
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+
+    def succeeds_after_reservation(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs["before_submit"]()
+        return SimpleNamespace(
+            success=True,
+            reason="success",
+            letter_variant="approved",
+            skipped=False,
+            acted=True,
+            uncertain=False,
+            skip_reason=None,
+        )
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", succeeds_after_reservation)
+
+    _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    with history._connect() as conn:
+        row = conn.execute("SELECT search_query FROM actions WHERE vacancy_id='123'").fetchone()
+
+    assert row is not None
+    assert row["search_query"] is None

--- a/tests/test_apply_audit.py
+++ b/tests/test_apply_audit.py
@@ -168,18 +168,18 @@ def test_post_submit_challenge_finalizes_uncertain_marker_before_stopping(tmp_pa
     assert "обнаружена анти-бот проверка" in row["reason"]
 
 
-def test_approved_apply_does_not_attribute_to_unrelated_current_search_query(tmp_path, monkeypatch):
-    """#420 follow-up (Codex adversarial-review, PR #449): review_queue не хранит
-    search_query карточки на момент постановки в очередь (#414 schema). Между
-    dry-run (enqueue_review) и последующим `apply --approved` конфиг резюме мог
-    смениться на другой поисковый запрос — код не должен подписывать чужой
-    отклик текущим resume.search.text: это тихо искажает funnel-атрибуцию.
-    Провенанс неизвестен -> search_query обязан остаться NULL/unattributed.
+def test_approved_apply_attributes_to_the_query_recorded_at_enqueue_time(tmp_path, monkeypatch):
+    """#420 follow-up (Codex adversarial-review round 1, PR #449): review_queue
+    (#414 schema) didn't persist the search_query a card was found under, so
+    the config's *current* resume.search.text got written instead — wrong
+    whenever the config changed between the dry-run that queued the card and
+    a later `apply --approved` run. The fix persists the query at enqueue
+    time and uses that stored value, not whatever the config says now.
     """
     resume = ResumeConfig(
         id="python",
         resume_url="https://hh.ru/resume/AAA111",
-        search=SearchFilters(text="devops"),  # запрос сменился после enqueue_review
+        search=SearchFilters(text="devops"),  # config changed after enqueue_review
     )
     config = AppConfig(
         storage_state_file=tmp_path / "state.json",
@@ -195,8 +195,9 @@ def test_approved_apply_does_not_attribute_to_unrelated_current_search_query(tmp
         company="Acme",
         url="https://hh.ru/vacancy/123",
     )
-    # dry-run под "python" поставил карточку в очередь; исходный запрос нигде не сохранён.
-    item_id = history.enqueue_review("AAA111", card, 1.0, {}, "cover letter")
+    # dry-run under "python" queued the card; that query must survive to the
+    # later approved apply, made under a config that now says "devops".
+    item_id = history.enqueue_review("AAA111", card, 1.0, {}, "cover letter", search_query="python")
     permit = history.approve_review(item_id)
     args = argparse.Namespace(
         config=None,
@@ -231,4 +232,92 @@ def test_approved_apply_does_not_attribute_to_unrelated_current_search_query(tmp
         row = conn.execute("SELECT search_query FROM actions WHERE vacancy_id='123'").fetchone()
 
     assert row is not None
-    assert row["search_query"] is None
+    assert row["search_query"] == "python"
+
+
+def test_approved_apply_from_pre_migration_queue_row_falls_back_to_vacancies_seen(
+    tmp_path, monkeypatch
+):
+    """Codex adversarial-review round 2 (PR #449): review_queue rows created
+    before this fix shipped have no stored search_query (the column didn't
+    exist yet) and are attributed via the existing vacancies_seen fallback in
+    funnel_by_search_query — exactly the pre-PR `main` behavior for every
+    action (#420: "keep vacancies_seen as fallback rather than backfilling
+    historical actions"). This is a one-time migration-window case, not a new
+    defect: rows enqueued *after* this fix always carry their real query (see
+    test_approved_apply_attributes_to_the_query_recorded_at_enqueue_time), so
+    the fallback here only ever applies to the finite backlog of queue
+    entries that predate the column.
+    """
+    resume = ResumeConfig(
+        id="python",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="devops"),
+    )
+    config = AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(min_delay_seconds=0, max_delay_seconds=0),
+        cover_letter_default="hello",
+        resumes=[resume],
+    )
+    history = History(tmp_path / "history.db")
+    throttle = Throttle(config.throttle, history)
+    card = VacancyCard(
+        vacancy_id="123",
+        title="Python developer",
+        company="Acme",
+        url="https://hh.ru/vacancy/123",
+    )
+    # This vacancy was independently seen by `search` under two unrelated queries.
+    now = "2026-01-01T00:00:00"
+    with history._connect() as conn:
+        conn.execute(
+            "INSERT INTO vacancies_seen (vacancy_id, search_query, first_seen_at, last_seen_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("123", "python", now, now),
+        )
+        conn.execute(
+            "INSERT INTO vacancies_seen (vacancy_id, search_query, first_seen_at, last_seen_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("123", "backend", now, now),
+        )
+    # Pre-fix queue row: no search_query recorded (legacy row, provenance unknown).
+    item_id = history.enqueue_review("AAA111", card, 1.0, {}, "cover letter")
+    permit = history.approve_review(item_id)
+    args = argparse.Namespace(
+        config=None,
+        resume=None,
+        dry_run=False,
+        headless=True,
+        max_pages=1,
+        limit=1,
+        approved=item_id,
+        permit=permit,
+    )
+
+    monkeypatch.setattr(_common, "resolve_numeric_resume_ids", lambda _page: None)
+
+    def succeeds_after_reservation(*args, **kwargs):  # noqa: ANN002, ANN003
+        kwargs["before_submit"]()
+        return SimpleNamespace(
+            success=True,
+            reason="success",
+            letter_variant="approved",
+            skipped=False,
+            acted=True,
+            uncertain=False,
+            skip_reason=None,
+        )
+
+    monkeypatch.setattr(_common, "apply_to_vacancy", succeeds_after_reservation)
+
+    _common.run_apply_for_resume(object(), config, resume, history, throttle, args)
+
+    funnel = history.funnel_by_search_query()
+    attributed_to_seen_queries = {
+        row["search_query"] for row in funnel if row["search_query"] in {"python", "backend"}
+    }
+    assert attributed_to_seen_queries == {"python", "backend"}, (
+        "pre-migration queue row should still fall back to vacancies_seen, "
+        f"got {attributed_to_seen_queries}"
+    )

--- a/tests/test_history_funnel.py
+++ b/tests/test_history_funnel.py
@@ -254,6 +254,17 @@ def test_funnel_by_search_query_joins_seen_vacancies_and_sorts_by_invite_rate(tm
     assert funnel[1]["invite_rate"] == 0.0
 
 
+def test_funnel_by_search_query_uses_apply_time_attribution_without_seen_row(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success", search_query="python")
+    h.record_action("r1", "v2", "apply", "success", search_query="backend")
+
+    funnel = h.funnel_by_search_query()
+
+    assert {row["search_query"]: row["sent"] for row in funnel} == {"python": 1, "backend": 1}
+    assert h.count_unattributed_applies() == 0
+
+
 def test_funnel_by_search_query_counts_distinct_resumes_per_vacancy(tmp_path):
     """Два резюме, откликнувшиеся на одну вакансию, — два разных отклика (#411 CR).
 

--- a/tests/test_history_schema.py
+++ b/tests/test_history_schema.py
@@ -74,6 +74,16 @@ def test_history_creates_letter_variant_column(tmp_path):
     assert "letter_variant" in cols
 
 
+def test_history_creates_search_query_column(tmp_path):
+    History(tmp_path / "h.db")
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(actions)")}
+    finally:
+        conn.close()
+    assert "search_query" in cols
+
+
 def test_letter_variant_added_idempotently_on_reopen(tmp_path):
     # CAVEAT #51: повторное открытие той же БД не падает на 'duplicate column'.
     History(tmp_path / "h.db")
@@ -96,6 +106,17 @@ def test_record_action_persists_letter_variant(tmp_path):
     finally:
         conn.close()
     assert row[0] == "ai"
+
+
+def test_record_action_persists_search_query(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.record_action("r1", "v1", "apply", "success", search_query="python")
+    conn = sqlite3.connect(tmp_path / "h.db")
+    try:
+        row = conn.execute("SELECT search_query FROM actions WHERE action='apply'").fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "python"
 
 
 def test_record_action_letter_variant_defaults_to_none(tmp_path):


### PR DESCRIPTION
## Summary
- persist the resume search query on apply actions at apply time
- group funnel data from action-time attribution, with legacy vacancies_seen fallback
- retain the unattributed warning only for legacy actions without either source

Closes #420

## Tests
- ruff check src/hhru_bot/history.py src/hhru_bot/commands/_common.py tests/test_history_funnel.py tests/test_history_schema.py
- pytest -q tests/test_history_funnel.py tests/test_history_schema.py tests/test_apply_audit.py