### PR TITLE
feat: stream bulk questionnaire progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-r
 - `--negotiations` — Read-only дамп списка переговоров или чата без отправки (#107)
 - `--topic` — ID topic из SSR-дампа negotiations для открытия чата (только чтение)
 - `--questionnaires-only` — Read-only bulk-проверка анкет по поиску; без заполнения, AI, submit и PNG/HTML
+- `--limit-questionnaires LIMIT_QUESTIONNAIRES` — Остановить bulk-проверку после N подтверждённых анкет (0 — без лимита)
 
 ### `profile`
 

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -710,6 +710,13 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                     # Позиция самой перепроверяемой вакансии, а не длина списка:
                     # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».
                     _print_questionnaire_progress(result, result_index + 1, len(vacancies))
+                    # cycle-review PR #450 round 3: сама перепроверка тоже
+                    # подтверждает анкеты, поэтому лимит проверяется и здесь —
+                    # иначе --limit-questionnaires 1 прокликает весь накопленный
+                    # retry и вернёт N анкет вместо одной. Пауза ниже — только
+                    # перед следующим реальным действием, а не перед выходом.
+                    if _limit_reached(all_results, limit):
+                        break
                     time.sleep(
                         random.uniform(
                             config.throttle.min_delay_seconds,

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -601,6 +601,11 @@ def _questionnaire_counts(results) -> dict[str, int]:
     }
 
 
+def _limit_reached(results, limit: int) -> bool:
+    """True when --limit-questionnaires is set and already satisfied."""
+    return bool(limit) and _questionnaire_counts(results)["questionnaire"] >= limit
+
+
 def run_questionnaires(args: argparse.Namespace) -> bool:
     """Scan raw search cards in one context/page, without local history."""
     from ..apply.questionnaire import (
@@ -662,7 +667,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                     _print_questionnaire_progress(result, len(resume_results), len(vacancies))
                     if result.status == UNKNOWN and result.retryable:
                         retry_ids.append(vacancy.vacancy_id)
-                    if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                    if _limit_reached(all_results, limit):
                         break
                     time.sleep(
                         random.uniform(
@@ -671,8 +676,11 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                         )
                     )
 
-                if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
-                    break
+                # cycle-review PR #450: лимит — условие «не начинать новые
+                # вакансии», а не повод бросить уже накопленную неопределённость.
+                # retry_ids сливается до выхода, иначе транзиентный unknown
+                # навсегда репортится как unknown (#448: unknown не выдавать за
+                # отсутствие анкеты).
                 for vacancy_id in retry_ids:
                     vacancy = next(v for v in vacancies if v.vacancy_id == vacancy_id)
                     print(f"[INFO] retry вакансии {vacancy_id}: долгий повтор", flush=True)
@@ -689,15 +697,13 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                     # Позиция самой перепроверяемой вакансии, а не длина списка:
                     # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».
                     _print_questionnaire_progress(result, result_index + 1, len(vacancies))
-                    if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
-                        break
                     time.sleep(
                         random.uniform(
                             config.throttle.min_delay_seconds,
                             config.throttle.max_delay_seconds,
                         )
                     )
-                if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                if _limit_reached(all_results, limit):
                     break
     except KeyboardInterrupt:
         interrupted = True
@@ -721,6 +727,13 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
         # стоит ВЫШЕ interrupted: Ctrl-C после потери сессии — это тоже
         # неполный скан, прерывание не отменяет fail-closed инвариант.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
+        return True
+    if interrupted and unknown:
+        # cycle-review PR #450 (Codex): прерывание не отменяет fail-closed —
+        # неразрешённый unknown в частичном прогоне делает результат
+        # неотличимым от полного скана, если выйти с успехом. Retry этих
+        # вакансий не состоялся именно из-за остановки.
+        print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
         return True
     if interrupted:
         # Осознанное прерывание пользователем — не провал: частичный отчёт уже

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -563,7 +563,7 @@ def _format_questionnaire_report(results) -> str:
     return report
 
 
-def _print_questionnaire_progress(result, checked: int, total: int, results) -> None:
+def _print_questionnaire_progress(result, checked: int, total: int) -> None:
     """Print one durable progress line and the result as soon as it is known."""
     from ..apply.questionnaire import QUESTIONNAIRE
 
@@ -659,9 +659,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                     resume_results.append(result)
                     all_results.append(result)
                     result_positions[vacancy.vacancy_id] = len(all_results) - 1
-                    _print_questionnaire_progress(
-                        result, len(resume_results), len(vacancies), all_results
-                    )
+                    _print_questionnaire_progress(result, len(resume_results), len(vacancies))
                     if result.status == UNKNOWN and result.retryable:
                         retry_ids.append(vacancy.vacancy_id)
                     if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
@@ -688,9 +686,9 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                     )
                     resume_results[result_index] = result
                     all_results[result_positions[vacancy_id]] = result
-                    _print_questionnaire_progress(
-                        result, len(resume_results), len(vacancies), all_results
-                    )
+                    # Позиция самой перепроверяемой вакансии, а не длина списка:
+                    # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».
+                    _print_questionnaire_progress(result, result_index + 1, len(vacancies))
                     if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
                         break
                     time.sleep(
@@ -717,13 +715,17 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
         f"unknown {unknown}, "
         f"требует авторизации {unauthenticated}"
     )
-    if interrupted:
-        return False
     if unauthenticated:
         # #433 cycle-review: потеря сессии посреди прогона не должна выглядеть
-        # как успешный полный скан — часть вакансий не проверена.
+        # как успешный полный скан — часть вакансий не проверена. Проверка
+        # стоит ВЫШЕ interrupted: Ctrl-C после потери сессии — это тоже
+        # неполный скан, прерывание не отменяет fail-closed инвариант.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
         return True
+    if interrupted:
+        # Осознанное прерывание пользователем — не провал: частичный отчёт уже
+        # напечатан, а всё проверенное подтверждено (иначе сработал бы гейт выше).
+        return False
     if all_results and unknown == len(all_results):
         # #433 cycle-review round 3 fix-up: единичный unknown по конкретной
         # вакансии (timeout, drift, частично распознанная анкета) — часть

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -89,6 +89,12 @@ def register(subparsers) -> None:
         action="store_true",
         help=("Read-only bulk-проверка анкет по поиску; без заполнения, AI, submit и PNG/HTML"),
     )
+    p.add_argument(
+        "--limit-questionnaires",
+        type=int,
+        default=0,
+        help="Остановить bulk-проверку после N подтверждённых анкет (0 — без лимита)",
+    )
     p.set_defaults(func=run)
 
 
@@ -557,12 +563,49 @@ def _format_questionnaire_report(results) -> str:
     return report
 
 
+def _print_questionnaire_progress(result, checked: int, total: int, results) -> None:
+    """Print one durable progress line and the result as soon as it is known."""
+    from ..apply.questionnaire import QUESTIONNAIRE
+
+    title = result.vacancy.title.replace("\n", " ")
+    print(f"[INFO] проверено {checked}/{total}: {result.status} — {title}", flush=True)
+    if result.status != QUESTIONNAIRE:
+        return
+    print(
+        f"[OK] анкета: {result.vacancy.title}"
+        f"\n  вакансия: {result.vacancy.url}"
+        f"\n  вопросов: {len(result.questions)}",
+        flush=True,
+    )
+    for index, question in enumerate(result.questions, start=1):
+        print(f"  {index}. {question.text}", flush=True)
+        if question.options:
+            print("     options: " + " | ".join(question.options), flush=True)
+
+
+def _questionnaire_counts(results) -> dict[str, int]:
+    from ..apply.questionnaire import (
+        ALREADY_RESPONDED,
+        NO_QUESTIONNAIRE,
+        QUESTIONNAIRE,
+        UNAUTHENTICATED,
+        UNKNOWN,
+    )
+
+    return {
+        "questionnaire": sum(r.status == QUESTIONNAIRE for r in results),
+        "no_questionnaire": sum(r.status == NO_QUESTIONNAIRE for r in results),
+        "already_responded": sum(r.status == ALREADY_RESPONDED for r in results),
+        "unknown": sum(r.status == UNKNOWN for r in results),
+        "unauthenticated": sum(r.status == UNAUTHENTICATED for r in results),
+    }
+
+
 def run_questionnaires(args: argparse.Namespace) -> bool:
-    """Scan all raw search cards in one context/page, without local history."""
+    """Scan raw search cards in one context/page, without local history."""
     from ..apply.questionnaire import (
         FAST_FORM_TIMEOUT_MS,
         FAST_TIMEOUT_MS,
-        UNAUTHENTICATED,
         UNKNOWN,
         QuestionnaireScanResult,
         scan_questionnaire,
@@ -583,73 +626,98 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
     if not resumes:
         print("Ошибка: не выбрано резюме для bulk probe.", file=sys.stderr)
         return True
+    limit = getattr(args, "limit_questionnaires", 0)
+    if limit < 0:
+        print("Ошибка: --limit-questionnaires не может быть отрицательным.", file=sys.stderr)
+        return True
 
     all_results: list[QuestionnaireScanResult] = []
+    interrupted = False
     print("[INFO] questionnaires-only: read-only поиск анкет (без истории и артефактов)")
-    with launch_context(config.storage_state_file, headless=args.headless) as context:
-        page = context.new_page()
-        for resume in resumes:
-            try:
-                vacancies = _dedupe_vacancies(
-                    search_vacancies(page, resume.search, max_pages=args.max_pages)
-                )
-            except VacancySearchIndeterminate as exc:
-                print(f"[FAIL] выдача поиска не подтверждена для {resume.id}: {exc}")
-                return True
-            print(f"[INFO] {resume.id}: найдено уникальных вакансий: {len(vacancies)}")
-
-            by_id = {}
-            retry_ids = []
-            for vacancy in vacancies:
-                result = scan_questionnaire(
-                    page,
-                    vacancy,
-                    timeout_ms=FAST_TIMEOUT_MS,
-                    form_timeout_ms=FAST_FORM_TIMEOUT_MS,
-                )
-                by_id[vacancy.vacancy_id] = result
-                if result.status == UNKNOWN and result.retryable:
-                    retry_ids.append(vacancy.vacancy_id)
-                # #433 cycle-review: клик по кнопке отклика на каждой вакансии
-                # выдачи подряд без пауз выглядит для анти-фрод системы hh.ru
-                # как автоматизация (базовый принцип CLAUDE.md — не убирать
-                # троттлинг). Пауза та же, что и у обычных действий: случайная
-                # min..max из throttle-конфига, без записи в history (это не
-                # отклик, а read-only сканирование).
-                time.sleep(
-                    random.uniform(
-                        config.throttle.min_delay_seconds, config.throttle.max_delay_seconds
+    try:
+        with launch_context(config.storage_state_file, headless=args.headless) as context:
+            page = context.new_page()
+            for resume in resumes:
+                try:
+                    vacancies = _dedupe_vacancies(
+                        search_vacancies(page, resume.search, max_pages=args.max_pages)
                     )
-                )
-
-            for vacancy_id in retry_ids:
-                vacancy = next(v for v in vacancies if v.vacancy_id == vacancy_id)
-                by_id[vacancy_id] = scan_questionnaire(
-                    page,
-                    vacancy,
-                    timeout_ms=GOTO_TIMEOUT_MS,
-                    form_timeout_ms=10_000,
-                )
-                time.sleep(
-                    random.uniform(
-                        config.throttle.min_delay_seconds, config.throttle.max_delay_seconds
+                except VacancySearchIndeterminate as exc:
+                    print(f"[FAIL] выдача поиска не подтверждена для {resume.id}: {exc}")
+                    return True
+                print(f"[INFO] {resume.id}: найдено уникальных вакансий: {len(vacancies)}")
+                retry_ids = []
+                resume_results: list[QuestionnaireScanResult] = []
+                result_positions: dict[str, int] = {}
+                for vacancy in vacancies:
+                    result = scan_questionnaire(
+                        page,
+                        vacancy,
+                        timeout_ms=FAST_TIMEOUT_MS,
+                        form_timeout_ms=FAST_FORM_TIMEOUT_MS,
                     )
-                )
-            all_results.extend(by_id[v.vacancy_id] for v in vacancies)
+                    resume_results.append(result)
+                    all_results.append(result)
+                    result_positions[vacancy.vacancy_id] = len(all_results) - 1
+                    _print_questionnaire_progress(
+                        result, len(resume_results), len(vacancies), all_results
+                    )
+                    if result.status == UNKNOWN and result.retryable:
+                        retry_ids.append(vacancy.vacancy_id)
+                    if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                        break
+                    time.sleep(
+                        random.uniform(
+                            config.throttle.min_delay_seconds,
+                            config.throttle.max_delay_seconds,
+                        )
+                    )
 
-    from ..apply.questionnaire import ALREADY_RESPONDED, QUESTIONNAIRE
+                if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                    break
+                for vacancy_id in retry_ids:
+                    vacancy = next(v for v in vacancies if v.vacancy_id == vacancy_id)
+                    print(f"[INFO] retry вакансии {vacancy_id}: долгий повтор", flush=True)
+                    result = scan_questionnaire(
+                        page, vacancy, timeout_ms=GOTO_TIMEOUT_MS, form_timeout_ms=10_000
+                    )
+                    result_index = next(
+                        index for index, item in enumerate(resume_results)
+                        if item.vacancy.vacancy_id == vacancy_id
+                    )
+                    resume_results[result_index] = result
+                    all_results[result_positions[vacancy_id]] = result
+                    _print_questionnaire_progress(
+                        result, len(resume_results), len(vacancies), all_results
+                    )
+                    if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                        break
+                    time.sleep(
+                        random.uniform(
+                            config.throttle.min_delay_seconds,
+                            config.throttle.max_delay_seconds,
+                        )
+                    )
+                if limit and _questionnaire_counts(all_results)["questionnaire"] >= limit:
+                    break
+    except KeyboardInterrupt:
+        interrupted = True
+        print("\n[INFO] скан прерван пользователем; печатаю итог частичного прохода")
 
     print(_format_questionnaire_report(all_results))
-    unauthenticated = sum(r.status == UNAUTHENTICATED for r in all_results)
-    unknown = sum(r.status == UNKNOWN for r in all_results)
-    already_responded = sum(r.status == ALREADY_RESPONDED for r in all_results)
+    counts = _questionnaire_counts(all_results)
+    unauthenticated = counts["unauthenticated"]
+    unknown = counts["unknown"]
     print(
         f"[INFO] итог: вакансий {len(all_results)}, "
-        f"анкет {sum(r.status == QUESTIONNAIRE for r in all_results)}, "
-        f"не подтверждено {unknown}, "
-        f"уже откликались {already_responded}, "
+        f"анкет {counts['questionnaire']}, "
+        f"без анкеты {counts['no_questionnaire']}, "
+        f"уже откликались {counts['already_responded']}, "
+        f"unknown {unknown}, "
         f"требует авторизации {unauthenticated}"
     )
+    if interrupted:
+        return False
     if unauthenticated:
         # #433 cycle-review: потеря сессии посреди прогона не должна выглядеть
         # как успешный полный скан — часть вакансий не проверена.

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -682,7 +682,8 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                         page, vacancy, timeout_ms=GOTO_TIMEOUT_MS, form_timeout_ms=10_000
                     )
                     result_index = next(
-                        index for index, item in enumerate(resume_results)
+                        index
+                        for index, item in enumerate(resume_results)
                         if item.vacancy.vacancy_id == vacancy_id
                     )
                     resume_results[result_index] = result

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -681,6 +681,19 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
                 # retry_ids сливается до выхода, иначе транзиентный unknown
                 # навсегда репортится как unknown (#448: unknown не выдавать за
                 # отсутствие анкеты).
+                if retry_ids and _limit_reached(all_results, limit):
+                    # cycle-review PR #450 round 2: выход по лимиту происходит до
+                    # паузы основного цикла, поэтому здесь она обязательна — иначе
+                    # клик последней вакансии и первый retry идут подряд без
+                    # задержки (CLAUDE.md: троттлинг не ослабляем). Пауза только
+                    # когда retry реально предстоит: в конце чистого прогона
+                    # ждать не от чего.
+                    time.sleep(
+                        random.uniform(
+                            config.throttle.min_delay_seconds,
+                            config.throttle.max_delay_seconds,
+                        )
+                    )
                 for vacancy_id in retry_ids:
                     vacancy = next(v for v in vacancies if v.vacancy_id == vacancy_id)
                     print(f"[INFO] retry вакансии {vacancy_id}: долгий повтор", flush=True)

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -435,3 +435,241 @@ def test_group_questions_ignores_duplicate_vacancy_id_and_non_questionnaire_stat
 
 def test_group_questions_empty_input_returns_empty_list():
     assert questionnaire.group_questions([]) == []
+
+
+# --- #448: потоковый прогресс, счётчики, лимит, прерывание ---
+
+
+def _bulk_args(**overrides):
+    args = SimpleNamespace(
+        config="config.yaml",
+        resume="python",
+        max_pages=10,
+        headless=True,
+        vacancy_id=None,
+        vacancy_url=None,
+        limit_questionnaires=0,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _bulk_env(monkeypatch, cards, scan, *, events=None):
+    """Wire run_questionnaires to fakes; optionally record a print/scan event log."""
+    resume = SimpleNamespace(id="python", search=object())
+    config = _config([resume])
+    page = object()
+
+    @contextmanager
+    def context_manager(*args, **kwargs):
+        class Context:
+            def new_page(self):
+                return page
+
+        yield Context()
+
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
+    monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
+    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages: cards)
+    monkeypatch.setattr("hhru_bot.apply.questionnaire.scan_questionnaire", scan)
+    monkeypatch.setattr("hhru_bot.commands.probe.time.sleep", lambda seconds: None)
+    if events is not None:
+        import builtins
+
+        real_print = builtins.print
+
+        def recording_print(*args, **kwargs):
+            events.append(("print", " ".join(str(a) for a in args)))
+            real_print(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "print", recording_print)
+    from hhru_bot.commands import probe
+
+    return probe
+
+
+def test_bulk_streams_each_result_before_scanning_the_next_vacancy(monkeypatch, capsys):
+    # #448 headline requirement: результат первой вакансии должен быть напечатан
+    # ДО того, как начнётся проверка второй. Проверка итогового текста этого не
+    # ловит — старая буферизованная реализация печатала бы то же самое в конце,
+    # поэтому тест смотрит на ПОРЯДОК событий, а не на содержимое вывода.
+    cards = [_card("601"), _card("602")]
+    events = []
+    question = Question(0, "Готовы к переезду?", "text")
+
+    def scan(page_arg, vacancy, **kwargs):
+        events.append(("scan", vacancy.vacancy_id))
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (question,), 1
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan, events=events)
+    probe.run_questionnaires(_bulk_args())
+    capsys.readouterr()
+
+    scan_602 = events.index(("scan", "602"))
+    printed_601 = [
+        index
+        for index, (kind, text) in enumerate(events)
+        if kind == "print" and "601" in text and "[OK] анкета" in text
+    ]
+    assert printed_601, "подтверждённая анкета первой вакансии не напечатана"
+    assert printed_601[0] < scan_602
+    # Текст вопроса и ссылка на вакансию печатаются сразу, а не только в итоге.
+    streamed = [text for kind, text in events[:scan_602] if kind == "print"]
+    assert any("Готовы к переезду?" in text for text in streamed)
+    assert any("https://hh.ru/vacancy/601" in text for text in streamed)
+
+
+def test_bulk_prints_retry_progress_with_the_real_vacancy_position(monkeypatch, capsys):
+    # Долгий retry должен быть виден в прогрессе (#448), и номер вакансии в
+    # строке прогресса — её собственная позиция: retry вакансии 1 из 3 не может
+    # печататься как «проверено 3/3».
+    cards = [_card("701"), _card("702"), _card("703")]
+    seen = []
+
+    def scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
+        seen.append((vacancy.vacancy_id, timeout_ms))
+        if vacancy.vacancy_id == "701" and timeout_ms == questionnaire.FAST_TIMEOUT_MS:
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+            )
+        return questionnaire.QuestionnaireScanResult(vacancy, questionnaire.NO_QUESTIONNAIRE)
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    probe.run_questionnaires(_bulk_args())
+    output = capsys.readouterr().out
+
+    assert "[INFO] retry вакансии 701" in output
+    lines = output.splitlines()
+    retry_index = next(i for i, line in enumerate(lines) if "retry вакансии 701" in line)
+    progress_after_retry = next(
+        line for line in lines[retry_index + 1 :] if line.startswith("[INFO] проверено")
+    )
+    # Позиция самой перепроверенной вакансии (1 из 3), а не длина списка
+    # результатов: len(resume_results) напечатал бы «проверено 3/3».
+    assert progress_after_retry.startswith("[INFO] проверено 1/3: ")
+    assert "проверено 3/3: no_questionnaire" in output
+
+
+def test_bulk_final_counters_report_every_status(monkeypatch, capsys):
+    # #448: отдельный счётчик проверено/анкеты/без анкеты/уже откликались/unknown.
+    statuses = {
+        "801": questionnaire.QUESTIONNAIRE,
+        "802": questionnaire.NO_QUESTIONNAIRE,
+        "803": questionnaire.ALREADY_RESPONDED,
+        "804": questionnaire.UNKNOWN,
+    }
+    cards = [_card(vacancy_id) for vacancy_id in statuses]
+
+    def scan(page_arg, vacancy, **kwargs):
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, statuses[vacancy.vacancy_id], "", retryable=False
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    probe.run_questionnaires(_bulk_args())
+    output = capsys.readouterr().out
+
+    assert "вакансий 4" in output
+    assert "анкет 1" in output
+    assert "без анкеты 1" in output
+    assert "уже откликались 1" in output
+    assert "unknown 1" in output
+    assert "требует авторизации 0" in output
+
+
+def test_limit_questionnaires_stops_scanning_after_n_confirmed(monkeypatch, capsys):
+    # #448: --limit-questionnaires N завершает скан. Проверяем число ВЫЗОВОВ
+    # scan_questionnaire — только оно доказывает, что скан остановился, а не
+    # просто напечатал результат раньше.
+    cards = [_card("901"), _card("902"), _card("903")]
+    scanned = []
+
+    def scan(page_arg, vacancy, **kwargs):
+        scanned.append(vacancy.vacancy_id)
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args(limit_questionnaires=1)) is False
+    capsys.readouterr()
+
+    assert scanned == ["901"]
+
+
+def test_limit_zero_scans_every_vacancy(monkeypatch, capsys):
+    cards = [_card("911"), _card("912"), _card("913")]
+    scanned = []
+
+    def scan(page_arg, vacancy, **kwargs):
+        scanned.append(vacancy.vacancy_id)
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    probe.run_questionnaires(_bulk_args(limit_questionnaires=0))
+    capsys.readouterr()
+
+    assert scanned == ["911", "912", "913"]
+
+
+def test_negative_limit_is_rejected_before_launching_a_browser(monkeypatch, capsys):
+    resume = SimpleNamespace(id="python", search=object())
+    config = _config([resume])
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
+
+    @contextmanager
+    def forbidden_context(*args, **kwargs):
+        raise AssertionError("браузер не должен запускаться при неверном лимите")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", forbidden_context)
+    from hhru_bot.commands import probe
+
+    assert probe.run_questionnaires(_bulk_args(limit_questionnaires=-1)) is True
+    assert "--limit-questionnaires" in capsys.readouterr().err
+
+
+def test_keyboard_interrupt_prints_partial_report_without_traceback(monkeypatch, capsys):
+    # #448: прерывание печатает итог уже обработанной части, без traceback.
+    cards = [_card("921"), _card("922"), _card("923")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        if vacancy.vacancy_id == "922":
+            raise KeyboardInterrupt
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args()) is False
+    output = capsys.readouterr().out
+
+    assert "прерван пользователем" in output
+    assert "вакансий 1" in output
+    assert "анкет 1" in output
+
+
+def test_interrupt_does_not_mask_lost_authentication(monkeypatch, capsys):
+    # Fail-closed (CLAUDE.md, #433): Ctrl-C после потери сессии — тоже неполный
+    # скан. Прерывание не должно превращать [FAIL] в успешный выход, иначе
+    # потеря авторизации маскируется намеренной остановкой.
+    cards = [_card("931"), _card("932")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        if vacancy.vacancy_id == "932":
+            raise KeyboardInterrupt
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.UNAUTHENTICATED, "требуется авторизация"
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args()) is True
+    output = capsys.readouterr().out
+
+    assert "прерван пользователем" in output
+    assert "[FAIL] сессия истекла во время прогона" in output

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -775,3 +775,30 @@ def test_throttle_pause_precedes_every_scan_including_retry_after_limit(monkeypa
         assert any(events[index][0] == "sleep" for index in range(previous + 1, current)), (
             f"нет паузы между сканами {events[previous]} и {events[current]}"
         )
+
+
+def test_retry_pass_also_honours_the_limit(monkeypatch, capsys):
+    # cycle-review PR #450 round 3: слив retry не должен игнорировать лимит.
+    # Если перепроверка сама подтверждает анкеты, цикл обязан остановиться на
+    # N-й, иначе --limit-questionnaires 1 прокликает все накопленные retry и
+    # вернёт N анкет вместо одной.
+    cards = [_card("981"), _card("982"), _card("983")]
+    calls = []
+
+    def scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
+        calls.append((vacancy.vacancy_id, timeout_ms))
+        if timeout_ms == questionnaire.FAST_TIMEOUT_MS:
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+            )
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    probe.run_questionnaires(_bulk_args(limit_questionnaires=1))
+    output = capsys.readouterr().out
+
+    retries = [call for call in calls if call[1] != questionnaire.FAST_TIMEOUT_MS]
+    assert len(retries) == 1, f"retry продолжился после достижения лимита: {retries}"
+    assert "анкет 1" in output

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -743,3 +743,35 @@ def test_clean_interrupt_without_uncertainty_still_succeeds(monkeypatch, capsys)
     probe = _bulk_env(monkeypatch, cards, scan)
     assert probe.run_questionnaires(_bulk_args()) is False
     assert "[FAIL]" not in capsys.readouterr().out
+
+
+def test_throttle_pause_precedes_every_scan_including_retry_after_limit(monkeypatch, capsys):
+    # cycle-review PR #450 round 2 (Codex): выход по лимиту происходит ДО
+    # time.sleep(), а следом сразу стартует накопленный retry — два клика по
+    # hh.ru подряд без паузы. Базовый принцип CLAUDE.md: троттлинг между
+    # реальными действиями не ослабляется, в том числе на границе лимита.
+    cards = [_card("971"), _card("972")]
+    events = []
+
+    def scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
+        events.append(("scan", vacancy.vacancy_id, timeout_ms))
+        if vacancy.vacancy_id == "971":
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+            )
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    monkeypatch.setattr(
+        "hhru_bot.commands.probe.time.sleep", lambda seconds: events.append(("sleep", seconds))
+    )
+    probe.run_questionnaires(_bulk_args(limit_questionnaires=1))
+    capsys.readouterr()
+
+    scans = [index for index, event in enumerate(events) if event[0] == "scan"]
+    for previous, current in zip(scans, scans[1:], strict=False):
+        assert any(events[index][0] == "sleep" for index in range(previous + 1, current)), (
+            f"нет паузы между сканами {events[previous]} и {events[current]}"
+        )

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -673,3 +673,73 @@ def test_interrupt_does_not_mask_lost_authentication(monkeypatch, capsys):
 
     assert "прерван пользователем" in output
     assert "[FAIL] сессия истекла во время прогона" in output
+
+
+def test_limit_still_drains_pending_retries_before_stopping(monkeypatch, capsys):
+    # cycle-review PR #450: лимит — условие «не начинать новые вакансии», а не
+    # повод бросить уже накопленную неопределённость. Без слива retry_ids
+    # вакансия с транзиентным unknown навсегда репортится как unknown, хотя
+    # перепроверка подтвердила бы анкету (#448: unknown не выдавать за
+    # отсутствие анкеты).
+    cards = [_card("941"), _card("942")]
+    scanned = []
+
+    def scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
+        scanned.append((vacancy.vacancy_id, timeout_ms))
+        if vacancy.vacancy_id == "941":
+            if timeout_ms == questionnaire.FAST_TIMEOUT_MS:
+                return questionnaire.QuestionnaireScanResult(
+                    vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+                )
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+            )
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    probe.run_questionnaires(_bulk_args(limit_questionnaires=1))
+    output = capsys.readouterr().out
+
+    assert ("941", 90_000) in scanned, "накопленный retry не выполнен из-за лимита"
+    assert "unknown 0" in output
+
+
+def test_interrupt_after_unresolved_unknown_is_a_failure(monkeypatch, capsys):
+    # cycle-review PR #450 (Codex): прерывание не должно давать exit 0, если в
+    # обработанной части остались неразрешённые unknown — иначе неполный скан
+    # неотличим от полного. Fail-closed тот же, что и для потери авторизации.
+    cards = [_card("951"), _card("952")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        if vacancy.vacancy_id == "952":
+            raise KeyboardInterrupt
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args()) is True
+    output = capsys.readouterr().out
+
+    assert "прерван пользователем" in output
+    assert "[FAIL]" in output
+
+
+def test_clean_interrupt_without_uncertainty_still_succeeds(monkeypatch, capsys):
+    # Обратная сторона: намеренная остановка чистого частичного прогона — не
+    # провал (#448 требует корректного частичного итога), иначе Ctrl-C всегда
+    # был бы ошибкой.
+    cards = [_card("961"), _card("962")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        if vacancy.vacancy_id == "962":
+            raise KeyboardInterrupt
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args()) is False
+    assert "[FAIL]" not in capsys.readouterr().out


### PR DESCRIPTION
Closes #448

## Summary
- stream per-vacancy questionnaire progress and confirmed question text/link
- add status counters, retry visibility, partial Ctrl-C summary, and --limit-questionnaires
- preserve read-only behavior and grouped final report

## Tests
- ruff check src/hhru_bot/commands/probe.py
- pytest -q tests/test_questionnaire_bulk.py tests/test_cli_commands.py