### PR TITLE
fix(probe): return 130 on questionnaire scan interrupt

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -182,6 +182,11 @@ def _execute(args: argparse.Namespace) -> None:
 
     try:
         failed = args.func(args)
+        # A command may return the conventional SIGINT status explicitly after
+        # rendering a partial report (rather than raising KeyboardInterrupt).
+        # Keep this separate from the bool-based fail-closed command contract.
+        if failed == 130 and not isinstance(failed, bool):
+            sys.exit(130)
         # Fail-closed contract (#148) is opt-in: only commands that report a
         # real bool success flag (search/apply/run) can trip sys.exit(1).
         # Commands returning other truthy values (e.g. clear-skipped's int

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -18,6 +18,7 @@ from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
 from .apply.antibot import AntiBotChallengeDetected
 from .browser import BrowserLaunchError
+from .exit_codes import CommandExitCode
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
 
@@ -185,8 +186,8 @@ def _execute(args: argparse.Namespace) -> None:
         # A command may return the conventional SIGINT status explicitly after
         # rendering a partial report (rather than raising KeyboardInterrupt).
         # Keep this separate from the bool-based fail-closed command contract.
-        if failed == 130 and not isinstance(failed, bool):
-            sys.exit(130)
+        if failed is CommandExitCode.SIGINT:
+            sys.exit(failed.value)
         # Fail-closed contract (#148) is opt-in: only commands that report a
         # real bool success flag (search/apply/run) can trip sys.exit(1).
         # Commands returning other truthy values (e.g. clear-skipped's int

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -748,6 +748,8 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
         # стоит ВЫШЕ interrupted: Ctrl-C после потери сессии — это тоже
         # неполный скан, прерывание не отменяет fail-closed инвариант.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
+        if interrupted and unknown:
+            print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
         if interrupted:
             return CommandExitCode.SIGINT
         return True

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -606,7 +606,7 @@ def _limit_reached(results, limit: int) -> bool:
     return bool(limit) and _questionnaire_counts(results)["questionnaire"] >= limit
 
 
-def run_questionnaires(args: argparse.Namespace) -> bool:
+def run_questionnaires(args: argparse.Namespace) -> bool | int:
     """Scan raw search cards in one context/page, without local history."""
     from ..apply.questionnaire import (
         FAST_FORM_TIMEOUT_MS,
@@ -747,6 +747,8 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
         # стоит ВЫШЕ interrupted: Ctrl-C после потери сессии — это тоже
         # неполный скан, прерывание не отменяет fail-closed инвариант.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
+        if interrupted:
+            return 130
         return True
     if interrupted and unknown:
         # cycle-review PR #450 (Codex): прерывание не отменяет fail-closed —
@@ -754,11 +756,11 @@ def run_questionnaires(args: argparse.Namespace) -> bool:
         # неотличимым от полного скана, если выйти с успехом. Retry этих
         # вакансий не состоялся именно из-за остановки.
         print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
-        return True
+        return 130
     if interrupted:
-        # Осознанное прерывание пользователем — не провал: частичный отчёт уже
-        # напечатан, а всё проверенное подтверждено (иначе сработал бы гейт выше).
-        return False
+        # Частичный отчёт уже напечатан, но Ctrl-C всегда сохраняет стандартный
+        # POSIX-код SIGINT, независимо от подтверждённости результатов.
+        return 130
     if all_results and unknown == len(all_results):
         # #433 cycle-review round 3 fix-up: единичный unknown по конкретной
         # вакансии (timeout, drift, частично распознанная анкета) — часть

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -443,7 +443,7 @@ def _vacancy_from_url(url: str):
     )
 
 
-def run(args: argparse.Namespace) -> bool | None:
+def run(args: argparse.Namespace) -> bool | CommandExitCode | None:
     if getattr(args, "healthcheck", False):
         return run_healthcheck(args)
     if getattr(args, "negotiations", False):
@@ -745,8 +745,10 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
     if unauthenticated:
         # #433 cycle-review: потеря сессии посреди прогона не должна выглядеть
         # как успешный полный скан — часть вакансий не проверена. Проверка
-        # стоит ВЫШЕ interrupted: Ctrl-C после потери сессии — это тоже
-        # неполный скан, прерывание не отменяет fail-closed инвариант.
+        # стоит ВЫШЕ interrupted, чтобы строка [FAIL] о потере сессии
+        # печаталась и при Ctrl-C. #452: сам exit-код это не меняет —
+        # прерывание пользователем всегда старше по приоритету и возвращает
+        # SIGINT, даже если до него уже обнаружена потеря сессии.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
         if interrupted and unknown:
             print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
@@ -754,10 +756,10 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
             return CommandExitCode.SIGINT
         return True
     if interrupted and unknown:
-        # cycle-review PR #450 (Codex): прерывание не отменяет fail-closed —
-        # неразрешённый unknown в частичном прогоне делает результат
-        # неотличимым от полного скана, если выйти с успехом. Retry этих
-        # вакансий не состоялся именно из-за остановки.
+        # cycle-review PR #450 (Codex): неразрешённый unknown в частичном
+        # прогоне делает результат неотличимым от полного скана, если выйти
+        # с успехом — печатаем [FAIL]. #452: exit-код всё равно SIGINT —
+        # Ctrl-C имеет приоритет над fail-closed причиной остановки.
         print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
         return CommandExitCode.SIGINT
     if interrupted:

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -360,6 +360,7 @@ def run_healthcheck(args: argparse.Namespace) -> bool:
     """
     from ..browser import launch_context
     from ..config import load_config_or_exit
+
     config = load_config_or_exit(args.config)
     spec = _healthcheck_spec(config)
 

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -35,6 +35,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from ..browser import PAGE_STATE, goto_hh, has_login_form
 from ..config import is_resume_url_placeholder
+from ..exit_codes import CommandExitCode
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -359,7 +360,6 @@ def run_healthcheck(args: argparse.Namespace) -> bool:
     """
     from ..browser import launch_context
     from ..config import load_config_or_exit
-
     config = load_config_or_exit(args.config)
     spec = _healthcheck_spec(config)
 
@@ -606,7 +606,7 @@ def _limit_reached(results, limit: int) -> bool:
     return bool(limit) and _questionnaire_counts(results)["questionnaire"] >= limit
 
 
-def run_questionnaires(args: argparse.Namespace) -> bool | int:
+def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
     """Scan raw search cards in one context/page, without local history."""
     from ..apply.questionnaire import (
         FAST_FORM_TIMEOUT_MS,
@@ -748,7 +748,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool | int:
         # неполный скан, прерывание не отменяет fail-closed инвариант.
         print("[FAIL] сессия истекла во время прогона — скан неполный")
         if interrupted:
-            return 130
+            return CommandExitCode.SIGINT
         return True
     if interrupted and unknown:
         # cycle-review PR #450 (Codex): прерывание не отменяет fail-closed —
@@ -756,11 +756,11 @@ def run_questionnaires(args: argparse.Namespace) -> bool | int:
         # неотличимым от полного скана, если выйти с успехом. Retry этих
         # вакансий не состоялся именно из-за остановки.
         print("[FAIL] скан прерван с неподтверждёнными вакансиями — результат неполный")
-        return 130
+        return CommandExitCode.SIGINT
     if interrupted:
         # Частичный отчёт уже напечатан, но Ctrl-C всегда сохраняет стандартный
         # POSIX-код SIGINT, независимо от подтверждённости результатов.
-        return 130
+        return CommandExitCode.SIGINT
     if all_results and unknown == len(all_results):
         # #433 cycle-review round 3 fix-up: единичный unknown по конкретной
         # вакансии (timeout, drift, частично распознанная анкета) — часть

--- a/src/hhru_bot/exit_codes.py
+++ b/src/hhru_bot/exit_codes.py
@@ -1,0 +1,9 @@
+"""Typed exit statuses returned by commands to the CLI dispatcher."""
+
+from enum import Enum
+
+
+class CommandExitCode(Enum):
+    """A command-level status that must be handled by :mod:`hhru_bot.cli`."""
+
+    SIGINT = 130

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -418,6 +418,17 @@ def test_clear_skipped_success_does_not_exit_nonzero(tmp_path):
         pytest.fail(f"main() exited with {e.code} on a successful deletion")
 
 
+def test_questionnaire_interrupt_propagates_sigint_exit_code():
+    from hhru_bot.cli import _execute
+
+    args = argparse.Namespace(command="log", func=lambda _args: 130)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _execute(args)
+
+    assert exc_info.value.code == 130
+
+
 def test_unhandled_exception_from_command_is_logged_to_file(monkeypatch, capsys):
     """#179: необработанное исключение из args.func (напр. непойманный внутри
     apply-пайплайна Playwright TimeoutError) раньше уходило только в stderr

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -420,8 +420,9 @@ def test_clear_skipped_success_does_not_exit_nonzero(tmp_path):
 
 def test_questionnaire_interrupt_propagates_sigint_exit_code():
     from hhru_bot.cli import _execute
+    from hhru_bot.exit_codes import CommandExitCode
 
-    args = argparse.Namespace(command="log", func=lambda _args: 130)
+    args = argparse.Namespace(command="log", func=lambda _args: CommandExitCode.SIGINT)
 
     with pytest.raises(SystemExit) as exc_info:
         _execute(args)

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -752,6 +752,46 @@ def test_clean_interrupt_without_uncertainty_returns_sigint_code(monkeypatch, ca
     assert "[FAIL]" not in capsys.readouterr().out
 
 
+def test_interrupt_with_lost_auth_and_unknown_prints_both_fail_lines(monkeypatch, capsys):
+    # Обе причины неполноты независимы: потерянная сессия не объясняет
+    # unresolved unknown у другой вакансии. Обе строки [FAIL] должны печататься.
+    cards = [_card("991"), _card("992"), _card("993")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        if vacancy.vacancy_id == "992":
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+            )
+        if vacancy.vacancy_id == "993":
+            raise KeyboardInterrupt
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.UNAUTHENTICATED, "требуется авторизация"
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    from hhru_bot.exit_codes import CommandExitCode
+
+    assert probe.run_questionnaires(_bulk_args()) is CommandExitCode.SIGINT
+    output = capsys.readouterr().out
+
+    assert "[FAIL] сессия истекла во время прогона" in output
+    assert "[FAIL] скан прерван с неподтверждёнными вакансиями" in output
+
+
+def test_limit_reached_exits_cleanly_without_interrupt(monkeypatch, capsys):
+    # --limit-questionnaires останавливает скан штатно, не через SIGINT.
+    cards = [_card("981"), _card("982")]
+
+    def scan(page_arg, vacancy, **kwargs):
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, cards, scan)
+    assert probe.run_questionnaires(_bulk_args(limit_questionnaires=1)) is False
+    assert "прерван пользователем" not in capsys.readouterr().out
+
+
 def test_throttle_pause_precedes_every_scan_including_retry_after_limit(monkeypatch, capsys):
     # cycle-review PR #450 round 2 (Codex): выход по лимиту происходит ДО
     # time.sleep(), а следом сразу стартует накопленный retry — два клика по

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -646,7 +646,9 @@ def test_keyboard_interrupt_prints_partial_report_without_traceback(monkeypatch,
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) == 130
+    from hhru_bot.exit_codes import CommandExitCode
+
+    assert probe.run_questionnaires(_bulk_args()) is CommandExitCode.SIGINT
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
@@ -655,9 +657,9 @@ def test_keyboard_interrupt_prints_partial_report_without_traceback(monkeypatch,
 
 
 def test_interrupt_does_not_mask_lost_authentication(monkeypatch, capsys):
-    # Fail-closed (CLAUDE.md, #433): Ctrl-C после потери сессии — тоже неполный
-    # скан. Прерывание не должно превращать [FAIL] в успешный выход, иначе
-    # потеря авторизации маскируется намеренной остановкой.
+    # Ctrl-C имеет приоритет над fail-closed причиной: владелец #452 закрепил
+    # единый exit 130 для любого пользовательского прерывания, даже если до
+    # него уже обнаружена потеря сессии. [FAIL] и частичный отчёт сохраняются.
     cards = [_card("931"), _card("932")]
 
     def scan(page_arg, vacancy, **kwargs):
@@ -668,7 +670,9 @@ def test_interrupt_does_not_mask_lost_authentication(monkeypatch, capsys):
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) == 130
+    from hhru_bot.exit_codes import CommandExitCode
+
+    assert probe.run_questionnaires(_bulk_args()) is CommandExitCode.SIGINT
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
@@ -720,7 +724,9 @@ def test_interrupt_after_unresolved_unknown_is_a_failure(monkeypatch, capsys):
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) == 130
+    from hhru_bot.exit_codes import CommandExitCode
+
+    assert probe.run_questionnaires(_bulk_args()) is CommandExitCode.SIGINT
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
@@ -740,7 +746,9 @@ def test_clean_interrupt_without_uncertainty_returns_sigint_code(monkeypatch, ca
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) == 130
+    from hhru_bot.exit_codes import CommandExitCode
+
+    assert probe.run_questionnaires(_bulk_args()) is CommandExitCode.SIGINT
     assert "[FAIL]" not in capsys.readouterr().out
 
 

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -646,7 +646,7 @@ def test_keyboard_interrupt_prints_partial_report_without_traceback(monkeypatch,
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) is False
+    assert probe.run_questionnaires(_bulk_args()) == 130
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
@@ -668,7 +668,7 @@ def test_interrupt_does_not_mask_lost_authentication(monkeypatch, capsys):
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) is True
+    assert probe.run_questionnaires(_bulk_args()) == 130
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
@@ -720,17 +720,16 @@ def test_interrupt_after_unresolved_unknown_is_a_failure(monkeypatch, capsys):
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) is True
+    assert probe.run_questionnaires(_bulk_args()) == 130
     output = capsys.readouterr().out
 
     assert "прерван пользователем" in output
     assert "[FAIL]" in output
 
 
-def test_clean_interrupt_without_uncertainty_still_succeeds(monkeypatch, capsys):
-    # Обратная сторона: намеренная остановка чистого частичного прогона — не
-    # провал (#448 требует корректного частичного итога), иначе Ctrl-C всегда
-    # был бы ошибкой.
+def test_clean_interrupt_without_uncertainty_returns_sigint_code(monkeypatch, capsys):
+    # Даже чистая намеренная остановка возвращает стандартный POSIX-код SIGINT;
+    # частичный отчёт при этом по-прежнему печатается без traceback.
     cards = [_card("961"), _card("962")]
 
     def scan(page_arg, vacancy, **kwargs):
@@ -741,7 +740,7 @@ def test_clean_interrupt_without_uncertainty_still_succeeds(monkeypatch, capsys)
         )
 
     probe = _bulk_env(monkeypatch, cards, scan)
-    assert probe.run_questionnaires(_bulk_args()) is False
+    assert probe.run_questionnaires(_bulk_args()) == 130
     assert "[FAIL]" not in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Summary
- return POSIX SIGINT exit code 130 for every Ctrl-C path in `probe --questionnaires-only`
- preserve partial report and existing fail-closed diagnostics
- propagate explicit command status through the CLI executor

## Tests
- `pytest -q`
- `ruff check src tests`
- `git diff --check`

Closes #452