### PR TITLE
feat: persist questionnaire research data

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-r
 - `--max-pages MAX_PAGES` — Максимум страниц поиска (по умолчанию: 5)
 - `--vacancy-id` — ID целевой вакансии (число из URL https://hh.ru/vacancy/<id>)
 - `--vacancy-url` — URL целевой вакансии (альтернатива --vacancy-id)
+- `--start-page START_PAGE` — Начальная страница поиска (нумерация с 0)
 - `--healthcheck` — Read-only проверка ключевых селекторов hh.ru (OK/NOT_FOUND) без отклика (#88)
 - `--negotiations` — Read-only дамп списка переговоров или чата без отправки (#107)
 - `--topic` — ID topic из SSR-дампа negotiations для открытия чата (только чтение)

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -614,25 +614,39 @@ def _limit_reached(results, limit: int) -> bool:
     return bool(limit) and _questionnaire_counts(results)["questionnaire"] >= limit
 
 
-def _record_questionnaire_if_confirmed(history, resume_id: str, vacancy, result) -> None:
+def _record_questionnaire_if_confirmed(history, resume_id: str, vacancy, result) -> bool:
     """Persist a confirmed questionnaire snapshot; called after every scan pass.
+
+    Returns False only when persistence was attempted and failed — callers use
+    this to surface a run-level [FAIL], not to abort the scan (see below).
+    True covers both "nothing to persist" (no history configured, or the
+    result isn't a confirmed questionnaire) and "persisted successfully".
 
     cycle-review PR #456 (Codex): вызывается и после быстрого прохода, и после
     retry (731-743 в исходной нумерации) — иначе анкета, подтверждённая только
     на retry после transient UNKNOWN, остаётся в печатном отчёте, но не попадает
     в SQLite, и исследовательская база расходится с выводом команды.
 
-    cycle-review PR #456 (Claude /review): запись обёрнута в except sqlite3.Error,
-    в отличие от голого вызова раньше — падение записи (locked DB, диск полон) не
-    должно обрывать весь bulk-скан для всех оставшихся вакансий/резюме (команда
-    fail-tolerant: --start-page, retry, обработка KeyboardInterrupt рядом же).
-    Ловим именно sqlite3.Error, а не bare Exception — узкий except тут тот же
-    принцип проекта, что и в run_healthcheck (см. её докстринг).
+    cycle-review PR #456 round 1 (Claude /review): запись обёрнута в except
+    sqlite3.Error, в отличие от голого вызова раньше — падение записи (locked
+    DB, диск полон) не должно обрывать весь bulk-скан для всех оставшихся
+    вакансий/резюме (команда fail-tolerant: --start-page, retry, обработка
+    KeyboardInterrupt рядом же). Ловим именно sqlite3.Error, а не bare
+    Exception — узкий except тут тот же принцип проекта, что и в
+    run_healthcheck (см. её докстринг).
+
+    cycle-review PR #456 round 2 (Codex): проглатывание ошибки одним только
+    logger.warning превращало потерю подтверждённой анкеты в молчаливый
+    success — run_questionnaires мог напечатать обычный отчёт и вернуть False,
+    хотя исследовательские данные реально потеряны без единого
+    машинно-обнаружимого сигнала. Возврат False здесь и накопление в
+    history_write_failed (в run_questionnaires) переводят это в [FAIL] в конце
+    прогона, не отменяя уже принятого решения «не обрывать скан».
     """
     from ..apply.questionnaire import QUESTIONNAIRE
 
     if history is None or result.status != QUESTIONNAIRE:
-        return
+        return True
     try:
         history.record_questionnaire(
             resume_id,
@@ -651,17 +665,27 @@ def _record_questionnaire_if_confirmed(history, resume_id: str, vacancy, result)
                 for question in result.questions
             ],
         )
+        return True
     except sqlite3.Error:
         logger.warning(
             "questionnaires-only: не удалось сохранить анкету %s в историю",
             vacancy.vacancy_id,
             exc_info=True,
         )
+        return False
 
 
 def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
     """Scan raw search cards in one context/page; confirmed questionnaires are
-    persisted to SQLite when --history is configured (see _record_questionnaire_if_confirmed)."""
+    persisted to SQLite via ``args.history`` (see _record_questionnaire_if_confirmed).
+
+    cycle-review PR #456 round 2 (Claude /review): ``args.history`` is resolved
+    to a real default path (``data/history.db`` or the account's history) by
+    ``cli._resolve_paths`` before any command runs — through the real CLI this
+    is effectively unconditional, not gated behind an explicit ``--history``
+    flag. Only a direct unit-test call that bypasses the CLI layer (constructing
+    ``args`` without a ``history`` attribute) leaves it ``None``.
+    """
     from ..apply.questionnaire import (
         FAST_FORM_TIMEOUT_MS,
         FAST_TIMEOUT_MS,
@@ -694,6 +718,9 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
 
     all_results: list[QuestionnaireScanResult] = []
     interrupted = False
+    # cycle-review PR #456 round 2 (Codex): накапливает потери записи в
+    # историю, не прерывая скан — см. _record_questionnaire_if_confirmed.
+    history_write_failed = False
     print(
         "[INFO] questionnaires-only: read-only поиск анкет "
         "(вопросы сохраняются в SQLite; без откликов, AI и артефактов)"
@@ -727,7 +754,8 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results.append(result)
                     all_results.append(result)
-                    _record_questionnaire_if_confirmed(history, resume.id, vacancy, result)
+                    if not _record_questionnaire_if_confirmed(history, resume.id, vacancy, result):
+                        history_write_failed = True
                     result_positions[vacancy.vacancy_id] = len(all_results) - 1
                     _print_questionnaire_progress(result, len(resume_results), len(vacancies))
                     if result.status == UNKNOWN and result.retryable:
@@ -772,7 +800,8 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results[result_index] = result
                     all_results[result_positions[vacancy_id]] = result
-                    _record_questionnaire_if_confirmed(history, resume.id, vacancy, result)
+                    if not _record_questionnaire_if_confirmed(history, resume.id, vacancy, result):
+                        history_write_failed = True
                     # Позиция самой перепроверяемой вакансии, а не длина списка:
                     # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».
                     _print_questionnaire_progress(result, result_index + 1, len(vacancies))
@@ -807,6 +836,13 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
         f"unknown {unknown}, "
         f"требует авторизации {unauthenticated}"
     )
+    if history_write_failed:
+        # cycle-review PR #456 round 2 (Codex): запись в SQLite могла упасть
+        # (locked DB, диск полон) без обрыва скана (round 1: fail-tolerant,
+        # см. _record_questionnaire_if_confirmed) — но это не должно выглядеть
+        # как молчаливый success. Печатаем безусловно, до unauthenticated/
+        # interrupted веток, чтобы строка была видна при любом сочетании.
+        print("[FAIL] не удалось сохранить одну или несколько анкет в историю")
     if unauthenticated:
         # #433 cycle-review: потеря сессии посреди прогона не должна выглядеть
         # как успешный полный скан — часть вакансий не проверена. Проверка
@@ -841,7 +877,9 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
         # строке, а только когда обязательные селекторы не найдены системно.
         print("[FAIL] все вакансии вернули неподтверждённый результат — скан не состоялся")
         return True
-    return False
+    # history_write_failed уже напечатан выше ([FAIL] строка); здесь только
+    # решение о статусе — иначе потеря записи истории осталась бы success.
+    return history_write_failed
 
 
 def _resolve_vacancy_url(args: argparse.Namespace) -> str:

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -72,6 +72,12 @@ def register(subparsers) -> None:
         help="URL целевой вакансии (альтернатива --vacancy-id)",
     )
     p.add_argument(
+        "--start-page",
+        type=int,
+        default=0,
+        help="Начальная страница поиска (нумерация с 0)",
+    )
+    p.add_argument(
         "--healthcheck",
         action="store_true",
         help="Read-only проверка ключевых селекторов hh.ru (OK/NOT_FOUND) без отклика (#88)",
@@ -360,7 +366,6 @@ def run_healthcheck(args: argparse.Namespace) -> bool:
     """
     from ..browser import launch_context
     from ..config import load_config_or_exit
-
     config = load_config_or_exit(args.config)
     spec = _healthcheck_spec(config)
 
@@ -618,6 +623,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
     )
     from ..browser import GOTO_TIMEOUT_MS, launch_context
     from ..config import load_config_or_exit
+    from ..history import History
     from ..search import VacancySearchIndeterminate, search_vacancies
 
     if args.vacancy_id or args.vacancy_url:
@@ -628,6 +634,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
         return True
 
     config = load_config_or_exit(args.config)
+    history = History(args.history) if getattr(args, "history", None) else None
     resumes = resolve_resumes(config, [args.resume] if args.resume else None)
     if not resumes:
         print("Ошибка: не выбрано резюме для bulk probe.", file=sys.stderr)
@@ -639,14 +646,22 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
 
     all_results: list[QuestionnaireScanResult] = []
     interrupted = False
-    print("[INFO] questionnaires-only: read-only поиск анкет (без истории и артефактов)")
+    print(
+        "[INFO] questionnaires-only: read-only поиск анкет "
+        "(вопросы сохраняются в SQLite; без откликов, AI и артефактов)"
+    )
     try:
         with launch_context(config.storage_state_file, headless=args.headless) as context:
             page = context.new_page()
             for resume in resumes:
                 try:
                     vacancies = _dedupe_vacancies(
-                        search_vacancies(page, resume.search, max_pages=args.max_pages)
+                        search_vacancies(
+                            page,
+                            resume.search,
+                            max_pages=args.max_pages,
+                            start_page=getattr(args, "start_page", 0),
+                        )
                     )
                 except VacancySearchIndeterminate as exc:
                     print(f"[FAIL] выдача поиска не подтверждена для {resume.id}: {exc}")
@@ -664,6 +679,24 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results.append(result)
                     all_results.append(result)
+                    if history is not None and result.status == "questionnaire":
+                        history.record_questionnaire(
+                            resume.id,
+                            vacancy.vacancy_id,
+                            vacancy.url,
+                            vacancy.title,
+                            vacancy.company,
+                            [
+                                {
+                                    "body_index": question.body_index,
+                                    "text": question.text,
+                                    "kind": question.kind,
+                                    "is_radio": question.is_radio,
+                                    "options": list(question.options),
+                                }
+                                for question in result.questions
+                            ],
+                        )
                     result_positions[vacancy.vacancy_id] = len(all_results) - 1
                     _print_questionnaire_progress(result, len(resume_results), len(vacancies))
                     if result.status == UNKNOWN and result.retryable:

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -26,6 +26,7 @@ import json
 import logging
 import random
 import re
+import sqlite3
 import sys
 import time
 from dataclasses import dataclass, field
@@ -366,6 +367,7 @@ def run_healthcheck(args: argparse.Namespace) -> bool:
     """
     from ..browser import launch_context
     from ..config import load_config_or_exit
+
     config = load_config_or_exit(args.config)
     spec = _healthcheck_spec(config)
 
@@ -612,8 +614,54 @@ def _limit_reached(results, limit: int) -> bool:
     return bool(limit) and _questionnaire_counts(results)["questionnaire"] >= limit
 
 
+def _record_questionnaire_if_confirmed(history, resume_id: str, vacancy, result) -> None:
+    """Persist a confirmed questionnaire snapshot; called after every scan pass.
+
+    cycle-review PR #456 (Codex): вызывается и после быстрого прохода, и после
+    retry (731-743 в исходной нумерации) — иначе анкета, подтверждённая только
+    на retry после transient UNKNOWN, остаётся в печатном отчёте, но не попадает
+    в SQLite, и исследовательская база расходится с выводом команды.
+
+    cycle-review PR #456 (Claude /review): запись обёрнута в except sqlite3.Error,
+    в отличие от голого вызова раньше — падение записи (locked DB, диск полон) не
+    должно обрывать весь bulk-скан для всех оставшихся вакансий/резюме (команда
+    fail-tolerant: --start-page, retry, обработка KeyboardInterrupt рядом же).
+    Ловим именно sqlite3.Error, а не bare Exception — узкий except тут тот же
+    принцип проекта, что и в run_healthcheck (см. её докстринг).
+    """
+    from ..apply.questionnaire import QUESTIONNAIRE
+
+    if history is None or result.status != QUESTIONNAIRE:
+        return
+    try:
+        history.record_questionnaire(
+            resume_id,
+            vacancy.vacancy_id,
+            vacancy.url,
+            vacancy.title,
+            vacancy.company,
+            [
+                {
+                    "body_index": question.body_index,
+                    "text": question.text,
+                    "kind": question.kind,
+                    "is_radio": question.is_radio,
+                    "options": list(question.options),
+                }
+                for question in result.questions
+            ],
+        )
+    except sqlite3.Error:
+        logger.warning(
+            "questionnaires-only: не удалось сохранить анкету %s в историю",
+            vacancy.vacancy_id,
+            exc_info=True,
+        )
+
+
 def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
-    """Scan raw search cards in one context/page, without local history."""
+    """Scan raw search cards in one context/page; confirmed questionnaires are
+    persisted to SQLite when --history is configured (see _record_questionnaire_if_confirmed)."""
     from ..apply.questionnaire import (
         FAST_FORM_TIMEOUT_MS,
         FAST_TIMEOUT_MS,
@@ -679,24 +727,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results.append(result)
                     all_results.append(result)
-                    if history is not None and result.status == "questionnaire":
-                        history.record_questionnaire(
-                            resume.id,
-                            vacancy.vacancy_id,
-                            vacancy.url,
-                            vacancy.title,
-                            vacancy.company,
-                            [
-                                {
-                                    "body_index": question.body_index,
-                                    "text": question.text,
-                                    "kind": question.kind,
-                                    "is_radio": question.is_radio,
-                                    "options": list(question.options),
-                                }
-                                for question in result.questions
-                            ],
-                        )
+                    _record_questionnaire_if_confirmed(history, resume.id, vacancy, result)
                     result_positions[vacancy.vacancy_id] = len(all_results) - 1
                     _print_questionnaire_progress(result, len(resume_results), len(vacancies))
                     if result.status == UNKNOWN and result.retryable:
@@ -741,6 +772,7 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results[result_index] = result
                     all_results[result_positions[vacancy_id]] = result
+                    _record_questionnaire_if_confirmed(history, resume.id, vacancy, result)
                     # Позиция самой перепроверяемой вакансии, а не длина списка:
                     # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».
                     _print_questionnaire_progress(result, result_index + 1, len(vacancies))

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -295,6 +295,31 @@ CREATE TABLE IF NOT EXISTS robot_questionnaires (
 CREATE INDEX IF NOT EXISTS idx_robot_questionnaires_detected_at
     ON robot_questionnaires(detected_at);
 
+-- Research snapshots are append-only by design; deduplication is out of scope.
+CREATE TABLE IF NOT EXISTS questionnaire_scans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    resume_id TEXT NOT NULL,
+    vacancy_id TEXT NOT NULL,
+    vacancy_url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    detected_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_scans_detected_at
+    ON questionnaire_scans(detected_at);
+
+CREATE TABLE IF NOT EXISTS questionnaire_questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id INTEGER NOT NULL REFERENCES questionnaire_scans(id),
+    body_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    is_radio INTEGER NOT NULL,
+    options_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_questionnaire_questions_scan_id
+    ON questionnaire_questions(scan_id);
+
 -- test_assignments — факт назначения внешнего теста работодателем (#180).
 -- Отдельно от responses/actions: это событие чата, а не статус отклика и не
 -- наше действие. Запись append-only, чтобы сохранять текст сообщения и URL.
@@ -2414,6 +2439,41 @@ class History:
                 "INSERT OR IGNORE INTO robot_questionnaires "
                 "(topic, vacancy_id, reason, detected_at) VALUES (?, ?, ?, ?)",
                 (topic, vacancy_id, reason, datetime.now().isoformat()),
+            )
+
+    def record_questionnaire(
+        self,
+        resume_id: str,
+        vacancy_id: str,
+        vacancy_url: str,
+        title: str,
+        company: str,
+        questions: list[dict[str, object]],
+    ) -> None:
+        """Append a questionnaire snapshot and all visible question options."""
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """INSERT INTO questionnaire_scans
+                   (resume_id, vacancy_id, vacancy_url, title, company, detected_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (resume_id, vacancy_id, vacancy_url, title, company, datetime.now().isoformat()),
+            )
+            scan_id = cursor.lastrowid
+            conn.executemany(
+                """INSERT INTO questionnaire_questions
+                   (scan_id, body_index, text, kind, is_radio, options_json)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                [
+                    (
+                        scan_id,
+                        int(question["body_index"]),
+                        str(question["text"]),
+                        str(question["kind"]),
+                        int(bool(question["is_radio"])),
+                        json.dumps(question["options"], ensure_ascii=False),
+                    )
+                    for question in questions
+                ],
             )
 
     def is_robot_questionnaire(self, topic: str) -> bool:

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -25,9 +25,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hhru_bot.search")
 
-# JS-страница поиска может отдать DOMContentLoaded до списка карточек. Ждём
-# ограниченно: это снимает гонку, не превращая обход в бесконечное ожидание.
-RENDER_TIMEOUT_MS = 10_000
+# JS-страница поиска может отдать DOMContentLoaded до списка карточек. На
+# живой выдаче #455 карточки второй страницы появились примерно через 20 с,
+# поэтому прежние 10 с давали ложный ``VacancySearchIndeterminate``. Ждём
+# ограниченно: 30 с заметно меньше навигационного потолка в 90 с и не
+# превращает обход в бесконечное ожидание.
+RENDER_TIMEOUT_MS = 30_000
 
 
 class VacancySearchIndeterminate(RuntimeError):
@@ -320,16 +323,21 @@ def search_vacancies(
 
         cards = page.locator(sel.VACANCY_CARD)
         # ``count()`` читает DOM немедленно, а выдача hh.ru появляется после
-        # JS-рендера. Ждём карточку ИЛИ подтверждённый empty-state: только эти
-        # два исхода различают непустую и честно пустую выдачу. Timeout
-        # fail-closed (устаревший selector/интерстишл не должны стать «пусто»).
-        ready = page.locator(f"{sel.VACANCY_CARD}, {sel.VACANCY_SEARCH_EMPTY}")
+        # JS-рендера. Контейнер карточки может смонтироваться раньше её
+        # содержимого, поэтому признак готовности — уже отрендеренная ссылка с
+        # названием вакансии ИЛИ подтверждённый empty-state. ``wait_for`` не
+        # делает фиксированную паузу: он возвращает управление сразу после
+        # появления этого DOM-узла. Timeout остаётся только fail-closed
+        # предохранителем для интерстишла/зависшей страницы.
+        ready = page.locator(
+            f"{sel.VACANCY_CARD_TITLE_LINK}, {sel.VACANCY_SEARCH_EMPTY}"
+        )
         try:
             ready.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
         except PlaywrightError:
             raise VacancySearchIndeterminate(
                 f"выдача поиска на странице {page_num} не подтверждена: "
-                f"карточка или empty-state не появились за {RENDER_TIMEOUT_MS} мс"
+                f"ссылка вакансии или empty-state не появились за {RENDER_TIMEOUT_MS} мс"
             ) from None
 
         count = cards.count()

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -329,9 +329,7 @@ def search_vacancies(
         # делает фиксированную паузу: он возвращает управление сразу после
         # появления этого DOM-узла. Timeout остаётся только fail-closed
         # предохранителем для интерстишла/зависшей страницы.
-        ready = page.locator(
-            f"{sel.VACANCY_CARD_TITLE_LINK}, {sel.VACANCY_SEARCH_EMPTY}"
-        )
+        ready = page.locator(f"{sel.VACANCY_CARD_TITLE_LINK}, {sel.VACANCY_SEARCH_EMPTY}")
         try:
             ready.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
         except PlaywrightError:

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -25,8 +25,12 @@ def test_record_questionnaire_stores_questions_and_options_without_dedup(tmp_pat
         }
     ]
 
-    history.record_questionnaire("marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions)
-    history.record_questionnaire("marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions)
+    history.record_questionnaire(
+        "marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions
+    )
+    history.record_questionnaire(
+        "marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions
+    )
 
     with sqlite3.connect(db_path) as conn:
         scans = conn.execute("SELECT vacancy_id FROM questionnaire_scans").fetchall()

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -1,0 +1,41 @@
+"""Persistence tests for append-only questionnaire research snapshots."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.unit
+
+
+def test_record_questionnaire_stores_questions_and_options_without_dedup(tmp_path):
+    db_path = tmp_path / "history.db"
+    history = History(db_path)
+    questions = [
+        {
+            "body_index": 0,
+            "text": "Ваш опыт?",
+            "kind": "choice",
+            "is_radio": True,
+            "options": ["Да", "Нет"],
+        }
+    ]
+
+    history.record_questionnaire("marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions)
+    history.record_questionnaire("marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", questions)
+
+    with sqlite3.connect(db_path) as conn:
+        scans = conn.execute("SELECT vacancy_id FROM questionnaire_scans").fetchall()
+        stored = conn.execute(
+            "SELECT body_index, text, kind, is_radio, options_json "
+            "FROM questionnaire_questions ORDER BY id"
+        ).fetchall()
+
+    assert scans == [("123",), ("123",)]
+    assert stored[0][:4] == (0, "Ваш опыт?", "choice", 1)
+    assert json.loads(stored[0][4]) == ["Да", "Нет"]
+    assert len(stored) == 2

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -904,7 +904,10 @@ def test_history_write_failure_does_not_abort_the_rest_of_the_scan(monkeypatch, 
     # search_vacancies чуть выше — упавшая запись (locked DB, диск полон)
     # прервала бы весь bulk-скан для всех оставшихся вакансий/резюме, что
     # противоречит fail-tolerant дизайну команды (--start-page, retry, обработка
-    # прерывания).
+    # прерывания). cycle-review round 2 (Codex): проглатывание sqlite3.Error
+    # не должно превращаться в молчаливый success — иначе подтверждённая
+    # анкета тихо теряется без [FAIL]/ненулевого результата, и повторный
+    # запуск может уже не найти тот же transient questionnaire.
     import sqlite3
 
     card1 = _card("992")
@@ -925,8 +928,11 @@ def test_history_write_failure_does_not_abort_the_rest_of_the_scan(monkeypatch, 
     result = probe.run_questionnaires(_bulk_args(history="history.db"))
     output = capsys.readouterr().out
 
-    # Скан должен дойти до второй вакансии, а не оборваться на первой записи.
+    # Скан должен дойти до второй вакансии, а не оборваться на первой записи...
     assert "993" in output
-    assert result is not True, (
-        "падение записи в history не должно превращаться в необработанный traceback"
-    )
+    # ...но потеря подтверждённой анкеты должна быть видна как провал, а не
+    # молчаливый success (иначе исследовательская база расходится с отчётом
+    # без единого машинно-обнаружимого сигнала).
+    assert result is True, "падение записи в history должно давать [FAIL], а не молчаливый success"
+    assert "[FAIL]" in output
+    assert "history" in output.lower() or "истори" in output.lower()

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -181,7 +181,8 @@ def test_bulk_uses_one_page_dedupes_and_retries_without_history(monkeypatch, cap
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
     monkeypatch.setattr(
-        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card1, card1, card2]
+        "hhru_bot.search.search_vacancies",
+        lambda page, search, max_pages, **kwargs: [card1, card1, card2],
     )
 
     def fake_scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
@@ -240,7 +241,9 @@ def test_bulk_counts_unauthenticated_as_failure(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
+    monkeypatch.setattr(
+        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card]
+    )
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -281,7 +284,9 @@ def test_bulk_counts_unknown_as_failure(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
+    monkeypatch.setattr(
+        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card]
+    )
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -324,7 +329,9 @@ def test_bulk_already_responded_does_not_fail_the_scan(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
+    monkeypatch.setattr(
+        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card]
+    )
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -472,7 +479,9 @@ def _bulk_env(monkeypatch, cards, scan, *, events=None):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: cards)
+    monkeypatch.setattr(
+        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: cards
+    )
     monkeypatch.setattr("hhru_bot.apply.questionnaire.scan_questionnaire", scan)
     monkeypatch.setattr("hhru_bot.commands.probe.time.sleep", lambda seconds: None)
     if events is not None:
@@ -850,3 +859,74 @@ def test_retry_pass_also_honours_the_limit(monkeypatch, capsys):
     retries = [call for call in calls if call[1] != questionnaire.FAST_TIMEOUT_MS]
     assert len(retries) == 1, f"retry продолжился после достижения лимита: {retries}"
     assert "анкет 1" in output
+
+
+class _FakeHistory:
+    """Records record_questionnaire() calls without touching real SQLite."""
+
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    def record_questionnaire(self, resume_id, vacancy_id, vacancy_url, title, company, questions):
+        self.calls.append(vacancy_id)
+
+
+def test_retry_confirmed_questionnaire_is_persisted_to_history(monkeypatch, capsys):
+    # cycle-review PR #456 (Codex): вакансия с transient UNKNOWN на быстром
+    # проходе и подтверждённой анкетой на retry (731-743) должна попасть в
+    # SQLite так же, как подтверждённая на первом проходе (682-699) — иначе
+    # итоговый отчёт (печать) расходится с исследовательской базой.
+    card = _card("991")
+
+    def scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
+        if timeout_ms == questionnaire.FAST_TIMEOUT_MS:
+            return questionnaire.QuestionnaireScanResult(
+                vacancy, questionnaire.UNKNOWN, "timeout", retryable=True
+            )
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, [card], scan)
+    fake_history = _FakeHistory()
+    monkeypatch.setattr("hhru_bot.history.History", lambda path: fake_history)
+    probe.run_questionnaires(_bulk_args(history="history.db"))
+    capsys.readouterr()
+
+    assert fake_history.calls == ["991"], (
+        "подтверждённая на retry анкета не записана в history.record_questionnaire"
+    )
+
+
+def test_history_write_failure_does_not_abort_the_rest_of_the_scan(monkeypatch, capsys):
+    # cycle-review PR #456 (Claude /review): history.record_questionnaire()
+    # внутри цикла (682-699) не обёрнут в try/except, в отличие от
+    # search_vacancies чуть выше — упавшая запись (locked DB, диск полон)
+    # прервала бы весь bulk-скан для всех оставшихся вакансий/резюме, что
+    # противоречит fail-tolerant дизайну команды (--start-page, retry, обработка
+    # прерывания).
+    import sqlite3
+
+    card1 = _card("992")
+    card2 = _card("993")
+
+    def scan(page_arg, vacancy, **kwargs):
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, [card1, card2], scan)
+
+    class FailingHistory(_FakeHistory):
+        def record_questionnaire(self, *args, **kwargs):
+            raise sqlite3.Error("database is locked")
+
+    monkeypatch.setattr("hhru_bot.history.History", lambda path: FailingHistory())
+    result = probe.run_questionnaires(_bulk_args(history="history.db"))
+    output = capsys.readouterr().out
+
+    # Скан должен дойти до второй вакансии, а не оборваться на первой записи.
+    assert "993" in output
+    assert result is not True, (
+        "падение записи в history не должно превращаться в необработанный traceback"
+    )

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -181,7 +181,7 @@ def test_bulk_uses_one_page_dedupes_and_retries_without_history(monkeypatch, cap
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
     monkeypatch.setattr(
-        "hhru_bot.search.search_vacancies", lambda page, search, max_pages: [card1, card1, card2]
+        "hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card1, card1, card2]
     )
 
     def fake_scan(page_arg, vacancy, *, timeout_ms, form_timeout_ms):
@@ -204,6 +204,7 @@ def test_bulk_uses_one_page_dedupes_and_retries_without_history(monkeypatch, cap
         config="config.yaml",
         resume="python",
         max_pages=10,
+        start_page=0,
         headless=True,
         vacancy_id=None,
         vacancy_url=None,
@@ -239,7 +240,7 @@ def test_bulk_counts_unauthenticated_as_failure(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages: [card])
+    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -280,7 +281,7 @@ def test_bulk_counts_unknown_as_failure(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages: [card])
+    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -323,7 +324,7 @@ def test_bulk_already_responded_does_not_fail_the_scan(monkeypatch, capsys):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages: [card])
+    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: [card])
     monkeypatch.setattr(
         "hhru_bot.apply.questionnaire.scan_questionnaire",
         lambda page_arg, vacancy, **kwargs: questionnaire.QuestionnaireScanResult(
@@ -471,7 +472,7 @@ def _bulk_env(monkeypatch, cards, scan, *, events=None):
 
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
     monkeypatch.setattr("hhru_bot.browser.launch_context", context_manager)
-    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages: cards)
+    monkeypatch.setattr("hhru_bot.search.search_vacancies", lambda page, search, max_pages, **kwargs: cards)
     monkeypatch.setattr("hhru_bot.apply.questionnaire.scan_questionnaire", scan)
     monkeypatch.setattr("hhru_bot.commands.probe.time.sleep", lambda seconds: None)
     if events is not None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -94,19 +94,26 @@ class _SearchPage:
     ):
         self.cards_locator = _DelayedCardsLocator(cards, delayed_cards)
         self.empty_locator = _DelayedCardsLocator([object()] if empty else [])
+        self.ready_selector: str | None = None
 
     def locator(self, selector: str):
         if selector == search.sel.VACANCY_CARD:
             return self.cards_locator
         if selector == search.sel.VACANCY_SEARCH_EMPTY:
             return self.empty_locator
-        if selector == f"{search.sel.VACANCY_CARD}, {search.sel.VACANCY_SEARCH_EMPTY}":
+        if selector == f"{search.sel.VACANCY_CARD_TITLE_LINK}, {search.sel.VACANCY_SEARCH_EMPTY}":
+            self.ready_selector = selector
             return self.empty_locator if self.empty_locator.count() else self.cards_locator
         raise AssertionError(f"unexpected selector: {selector}")
 
 
 def _search_filters():
     return SearchFilters(text="python")
+
+
+def test_search_render_timeout_allows_current_hh_js_render_lag():
+    """#455: 10 с недостаточно, хотя выдача появляется примерно за 20 с."""
+    assert search.RENDER_TIMEOUT_MS == 30_000
 
 
 def test_search_waits_for_delayed_cards_before_declaring_empty(monkeypatch):
@@ -121,6 +128,9 @@ def test_search_waits_for_delayed_cards_before_declaring_empty(monkeypatch):
 
     assert [card.vacancy_id for card in cards] == ["42"]
     assert page.cards_locator.wait_calls == [("attached", search.RENDER_TIMEOUT_MS)]
+    assert page.ready_selector == (
+        f"{search.sel.VACANCY_CARD_TITLE_LINK}, {search.sel.VACANCY_SEARCH_EMPTY}"
+    )
 
 
 def test_search_timeout_is_indeterminate_not_empty_result(monkeypatch):


### PR DESCRIPTION
Что изменено:
- сохраняет подтвержденные анкеты и все вопросы и варианты в SQLite questionnaire_scans и questionnaire_questions;
- запись append-only, дедупликация вне scope;
- добавлен probe --start-page для backfill без повторного обхода первых страниц;
- исправлено ожидание фактического DOM списка вакансий.

Проверки:
- python3 -m pytest -q
- python3 -m ruff check .

Отклики и заполнение форм этим изменением не выполняются.