### PR TITLE
refactor(history): rename apply_runs → command_runs, generalize functions

### DIFF
--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -203,7 +203,7 @@ def run(args: argparse.Namespace) -> bool:
 
     config = load_config_or_exit(args.config)
     history = History(args.history)
-    run_id = history.start_apply_run(
+    run_id = history.start_command_run(
         command=getattr(args, "command", "apply"),
         requested_limit=getattr(args, "limit", None),
     )
@@ -245,7 +245,7 @@ def run(args: argparse.Namespace) -> bool:
     finally:
         signal.signal(signal.SIGTERM, previous_sigterm)
         # cycle-review PR #460 (round 3, Claude /review): this bookkeeping can
-        # itself raise (e.g. history.finish_apply_run's ValueError when the
+        # itself raise (e.g. history.finish_command_run's ValueError when the
         # run row is no longer 'running') while a real exception from `_run`
         # is already propagating through the `except BaseException: raise`
         # above -- an exception raised here would replace/mask it (standard
@@ -257,7 +257,7 @@ def run(args: argparse.Namespace) -> bool:
             # If interruption landed inside an attempted vacancy after its
             # durable reservation, account for the unresolved result in the
             # run summary.
-            action_counts = history.apply_run_action_counts(run_id)
+            action_counts = history.command_run_action_counts(run_id)
             progress.applied_count = max(progress.applied_count, action_counts.get("success", 0))
             progress.failed_count = max(progress.failed_count, action_counts.get("failed", 0))
             progress.uncertain_count = max(
@@ -271,7 +271,7 @@ def run(args: argparse.Namespace) -> bool:
             )
             if progress.attempted_count > completed:
                 progress.failed_count += progress.attempted_count - completed
-            history.finish_apply_run(
+            history.finish_command_run(
                 run_id,
                 status=final_status,
                 exit_code=exit_code,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -43,7 +43,13 @@ CREATE TABLE IF NOT EXISTS actions (
     created_at TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS apply_runs (
+-- #461: изначально apply_runs (PR #460, только apply); переименована в
+-- command_runs, так как ledger применим к любой durable-команде, не только
+-- apply. Миграция старых БД — идемпотентный ALTER TABLE RENAME в
+-- _rename_apply_runs_to_command_runs (_init_schema), CREATE TABLE IF NOT
+-- EXISTS здесь покрывает свежую БД без старой apply_runs. Второй таблицы и
+-- алиасов старых имён функций намеренно нет (один пользователь, одна БД).
+CREATE TABLE IF NOT EXISTS command_runs (
     run_id TEXT PRIMARY KEY,
     command TEXT NOT NULL,
     requested_limit INTEGER,
@@ -58,7 +64,7 @@ CREATE TABLE IF NOT EXISTS apply_runs (
     exit_code INTEGER,
     detail TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_apply_runs_status ON apply_runs(status, started_at);
+CREATE INDEX IF NOT EXISTS idx_command_runs_status ON command_runs(status, started_at);
 
 -- #177: 'uncertain' тоже дедуплицируется в has_applied() (клик мог реально
 -- уйти на hh.ru, статус неизвестен) — индекс обязан покрывать этот статус,
@@ -480,6 +486,11 @@ class History:
         не теряем историю откликов.
         """
         with self._connect() as conn:
+            # #461: миграция старого имени таблицы ДО executescript(SCHEMA) —
+            # CREATE TABLE IF NOT EXISTS command_runs внутри SCHEMA не должен
+            # успеть создать пустую command_runs раньше RENAME, иначе RENAME
+            # упадёт на "table command_runs already exists".
+            _rename_apply_runs_to_command_runs(conn)
             conn.executescript(SCHEMA)
             _ensure_column(conn, "actions", "letter_variant", "TEXT")
             _ensure_column(conn, "actions", "search_query", "TEXT")
@@ -699,26 +710,26 @@ class History:
                 (datetime.now().isoformat(), item_id),
             )
 
-    def start_apply_run(self, *, command: str, requested_limit: int | None) -> str:
-        """Recover abandoned apply runs and create a durable running row."""
+    def start_command_run(self, *, command: str, requested_limit: int | None) -> str:
+        """Recover abandoned command runs and create a durable running row."""
         now = datetime.now().isoformat()
         run_id = str(uuid.uuid4())
         with self._connect() as conn:
             conn.execute(
-                """UPDATE apply_runs SET status='orphaned', finished_at=?, exit_code=NULL,
-                          detail=COALESCE(detail, 'recovered by next apply run')
+                """UPDATE command_runs SET status='orphaned', finished_at=?, exit_code=NULL,
+                          detail=COALESCE(detail, 'recovered by next command run')
                    WHERE status='running'""",
                 (now,),
             )
             conn.execute(
-                """INSERT INTO apply_runs
+                """INSERT INTO command_runs
                    (run_id, command, requested_limit, status, started_at)
                    VALUES (?, ?, ?, 'running', ?)""",
                 (run_id, command, requested_limit, now),
             )
         return run_id
 
-    def finish_apply_run(
+    def finish_command_run(
         self,
         run_id: str,
         *,
@@ -733,10 +744,10 @@ class History:
     ) -> None:
         allowed = {"completed", "partial", "failed", "interrupted", "orphaned"}
         if status not in allowed:
-            raise ValueError(f"недопустимый статус apply run: {status}")
+            raise ValueError(f"недопустимый статус command run: {status}")
         with self._connect() as conn:
             cur = conn.execute(
-                """UPDATE apply_runs SET status=?, attempted=?, success=?, failed=?,
+                """UPDATE command_runs SET status=?, attempted=?, success=?, failed=?,
                           uncertain=?, skipped=?, finished_at=?, exit_code=?, detail=?
                    WHERE run_id=? AND status='running'""",
                 (
@@ -753,14 +764,14 @@ class History:
                 ),
             )
             if cur.rowcount != 1:
-                raise ValueError(f"running apply run не найден: {run_id}")
+                raise ValueError(f"running command run не найден: {run_id}")
 
-    def apply_runs(self) -> list[dict]:
+    def command_runs(self) -> list[dict]:
         with self._connect() as conn:
-            rows = conn.execute("SELECT * FROM apply_runs ORDER BY started_at")
+            rows = conn.execute("SELECT * FROM command_runs ORDER BY started_at")
             return [dict(row) for row in rows]
 
-    def apply_run_action_counts(self, run_id: str) -> dict[str, int]:
+    def command_run_action_counts(self, run_id: str) -> dict[str, int]:
         with self._connect() as conn:
             rows = conn.execute(
                 """SELECT status, COUNT(*) AS count FROM actions
@@ -2796,6 +2807,36 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl_type: 
     existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
     if column not in existing:
         conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl_type}")
+
+
+def _rename_apply_runs_to_command_runs(conn: sqlite3.Connection) -> None:
+    """Идемпотентно переименовывает apply_runs → command_runs (#461).
+
+    ALTER TABLE ... RENAME TO переносит и старый индекс idx_apply_runs_status
+    под старым именем — SQLite не переименовывает индексы автоматически при
+    RENAME TABLE, поэтому индекс пересоздаём отдельно под новым именем.
+    Без второй таблицы и без wrapper-алиасов старых имён: один пользователь,
+    одна БД, миграция выполняется один раз на старой установке и затем
+    становится no-op (apply_runs больше не существует).
+    """
+    exists_old = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='apply_runs'"
+    ).fetchone()
+    if not exists_old:
+        return
+    exists_new = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='command_runs'"
+    ).fetchone()
+    if exists_new:
+        # Обе таблицы существуют одновременно — не должно происходить при
+        # нормальной эксплуатации (RENAME атомарно устраняет apply_runs).
+        # Оставляем command_runs как источник истины и не трогаем данные.
+        return
+    conn.execute("ALTER TABLE apply_runs RENAME TO command_runs")
+    conn.execute("DROP INDEX IF EXISTS idx_apply_runs_status")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_command_runs_status ON command_runs(status, started_at)"
+    )
 
 
 _APPLY_INDEX_SQL = (

--- a/tests/test_reliability_bundle.py
+++ b/tests/test_reliability_bundle.py
@@ -23,7 +23,7 @@ def _card(vacancy_id: str = "123") -> VacancyCard:
     return VacancyCard(vacancy_id, "Python", "ACME", f"https://hh.ru/vacancy/{vacancy_id}")
 
 
-def test_old_database_gets_apply_run_and_action_correlation_columns(tmp_path: Path) -> None:
+def test_old_database_gets_command_run_and_action_correlation_columns(tmp_path: Path) -> None:
     db = tmp_path / "history.db"
     with sqlite3.connect(db) as conn:
         conn.execute(
@@ -45,14 +45,71 @@ def test_old_database_gets_apply_run_and_action_correlation_columns(tmp_path: Pa
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master")}
 
     assert {"run_id", "reason_code"} <= columns
-    assert "apply_runs" in tables
+    assert "command_runs" in tables
 
 
-def test_apply_run_recovers_orphan_and_persists_counters(tmp_path: Path) -> None:
+def test_apply_runs_table_migrates_to_command_runs(tmp_path: Path) -> None:
+    # #461: старая БД с apply_runs (PR #460) должна получить переименованную
+    # таблицу command_runs с сохранёнными данными и переименованным индексом,
+    # а не вторую параллельную таблицу.
+    db = tmp_path / "history.db"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """CREATE TABLE apply_runs (
+                run_id TEXT PRIMARY KEY,
+                command TEXT NOT NULL,
+                requested_limit INTEGER,
+                status TEXT NOT NULL,
+                attempted INTEGER NOT NULL DEFAULT 0,
+                success INTEGER NOT NULL DEFAULT 0,
+                failed INTEGER NOT NULL DEFAULT 0,
+                uncertain INTEGER NOT NULL DEFAULT 0,
+                skipped INTEGER NOT NULL DEFAULT 0,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                exit_code INTEGER,
+                detail TEXT
+            )"""
+        )
+        conn.execute("CREATE INDEX idx_apply_runs_status ON apply_runs(status, started_at)")
+        conn.execute(
+            """INSERT INTO apply_runs (run_id, command, status, started_at)
+               VALUES ('old-run', 'apply', 'completed', '2026-01-01T00:00:00')"""
+        )
+
+    history = History(db)
+    with history._connect() as conn:
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        indexes = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        }
+
+    assert "command_runs" in tables
+    assert "apply_runs" not in tables
+    assert "idx_command_runs_status" in indexes
+    assert "idx_apply_runs_status" not in indexes
+
+    rows = {row["run_id"]: row for row in history.command_runs()}
+    assert rows["old-run"]["status"] == "completed"
+
+    # Идемпотентность: повторное открытие той же (уже смигрированной) БД не
+    # должно падать и не должно создавать вторую таблицу.
+    History(db)
+    with sqlite3.connect(db) as conn:
+        tables_again = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert "apply_runs" not in tables_again
+    assert "command_runs" in tables_again
+
+
+def test_command_run_recovers_orphan_and_persists_counters(tmp_path: Path) -> None:
     history = History(tmp_path / "history.db")
-    first = history.start_apply_run(command="apply", requested_limit=3)
-    second = history.start_apply_run(command="apply", requested_limit=2)
-    history.finish_apply_run(
+    first = history.start_command_run(command="apply", requested_limit=3)
+    second = history.start_command_run(command="apply", requested_limit=2)
+    history.finish_command_run(
         second,
         status="completed",
         exit_code=0,
@@ -63,7 +120,7 @@ def test_apply_run_recovers_orphan_and_persists_counters(tmp_path: Path) -> None
         skipped=0,
     )
 
-    rows = {row["run_id"]: row for row in history.apply_runs()}
+    rows = {row["run_id"]: row for row in history.command_runs()}
     assert rows[first]["status"] == "orphaned"
     assert rows[first]["finished_at"]
     assert rows[second]["success"] == 2
@@ -178,7 +235,7 @@ def test_questionnaire_probe_is_a_local_write_command() -> None:
     ("failure", "expected"),
     [(KeyboardInterrupt(), CommandExitCode.SIGINT), (signal.SIGTERM, CommandExitCode.SIGTERM)],
 )
-def test_apply_run_persists_typed_signal_exit(
+def test_command_run_persists_typed_signal_exit(
     tmp_path: Path, monkeypatch, failure, expected: CommandExitCode
 ) -> None:
     from hhru_bot.commands import apply as apply_command
@@ -203,18 +260,18 @@ def test_apply_run_persists_typed_signal_exit(
     )
 
     assert apply_command.run(args) is expected
-    row = History(args.history).apply_runs()[-1]
+    row = History(args.history).command_runs()[-1]
     assert row["status"] == "interrupted"
     assert row["exit_code"] == expected.value
     assert row["attempted"] == 1
     assert row["failed"] == 1  # interruption happened before durable submit reservation
 
 
-def test_apply_run_ledger_failure_does_not_mask_the_original_exception(
+def test_command_run_ledger_failure_does_not_mask_the_original_exception(
     tmp_path: Path, monkeypatch
 ) -> None:
     # cycle-review PR #460 (round 3, Claude /review): the `finally` block's
-    # `history.finish_apply_run(...)` call can itself raise ValueError (e.g.
+    # `history.finish_command_run(...)` call can itself raise ValueError (e.g.
     # if the run row is no longer 'running') while a real exception from
     # `_run` is already propagating through `except BaseException: ...;
     # raise` -- an exception raised inside `finally` replaces/masks the one
@@ -228,10 +285,10 @@ def test_apply_run_ledger_failure_does_not_mask_the_original_exception(
 
     def crash(_args, _config, history, progress):
         progress.begin_attempt()
-        # Force finish_apply_run to fail inside `finally`: mark the run
+        # Force finish_command_run to fail inside `finally`: mark the run
         # already finished before _run's own exception even starts
         # propagating, simulating a lost race / already-finalized run.
-        history.finish_apply_run(
+        history.finish_command_run(
             progress.run_id,
             status="completed",
             exit_code=0,


### PR DESCRIPTION
## Что сделано

Sub-issue #461 (эпик #459): переименована таблица `apply_runs` → `command_runs`
в `history.py`, обобщены связанные функции — ledger применим к любой durable-команде,
не только к `apply`.

- Схема: `CREATE TABLE IF NOT EXISTS command_runs (...)` с тем же набором колонок,
  что был у `apply_runs` (PR #460 ввёл полный набор колонок ровно одним коммитом
  раньше — старой формы для `_ensure_column`-миграции колонок нет).
- Идемпотентная миграция `_rename_apply_runs_to_command_runs()`: если существует
  `apply_runs` и не существует `command_runs` — `ALTER TABLE apply_runs RENAME TO
  command_runs`, индекс `idx_apply_runs_status` дропается и пересоздаётся как
  `idx_command_runs_status` (SQLite не переименовывает индексы при RENAME TABLE).
  Выполняется в `_init_schema()` **до** `executescript(SCHEMA)`, чтобы свежий
  `CREATE TABLE IF NOT EXISTS command_runs` не успел создать пустую таблицу раньше
  RENAME. Если обе таблицы почему-то уже существуют одновременно — миграция не
  трогает данные и оставляет `command_runs` как источник истины, `apply_runs`
  остаётся нетронутой (не должно происходить при нормальной эксплуатации).
- Функции переименованы **без алиасов старых имён** (один пользователь, одна БД,
  дублирование не нужно): `start_apply_run`→`start_command_run`,
  `finish_apply_run`→`finish_command_run`, `apply_runs()`→`command_runs()`,
  `apply_run_action_counts`→`command_run_action_counts`.
- `commands/apply.py` обновлён в этом же коммите (атомарная замена, без
  промежуточного дублирования).
- `actions.run_id` не менялся — уже универсален по названию.

## Тесты

- Новый `test_apply_runs_table_migrates_to_command_runs`: миграция старой БД
  (данные сохраняются, индекс переименован) + идемпотентность повторного открытия.
- Существующие `test_apply_run_*` → `test_command_run_*`, вызовы обновлены на
  новые имена функций.
- Полный набор: `pytest -n 4 --dist worksteal` — зелёный (9.37s, budget 60s).
- `ruff check` / `ruff format --check` — чисто.
- `scripts/gen_cli_docs.py --check` — синхронизирован.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Co8Pj6hDRTwH7Rk2vFJNmE