### PR TITLE
refactor(commands): extract run_supervised_command helper (#462)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -386,6 +386,20 @@ def run_supervised_command(
     (e.g. under future orchestration) does not clobber an outer caller's
     handler.
 
+    That LIFO-safety covers only the *signal handler*. The durable ledger
+    itself is NOT re-entrant (cycle-review PR #468, code-reviewer-462):
+    ``History.start_command_run`` marks any still-``running`` row
+    ``orphaned`` before inserting a new one, so a nested call's
+    ``start_command_run`` orphans the outer call's row -- the outer call's
+    later ``finish_command_run`` then finds no matching ``running`` row,
+    raises, and (via the masking guard below) silently skips its own
+    ``[RUN]`` summary print. This is pre-existing ``History`` behaviour, not
+    introduced by this helper, and is harmless today because no caller nests
+    ``run_supervised_command`` (``commands/run.py`` calls ``apply_cmd.run()``
+    and ``bump_cmd.run()`` sequentially, each already-finished before the
+    next starts). A future command that wraps this helper *inside* another
+    active run would need one ledger row per process, not per nested call.
+
     SIGINT deliberately gets NO custom ``signal.signal`` handler here --
     only the default ``KeyboardInterrupt`` it already raises is caught
     below. Installing a custom SIGINT handler would change what type of

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -12,6 +12,8 @@ import json
 import logging
 import math
 import re
+import signal
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +24,7 @@ from ..apply.verify import verify_response_in_negotiations
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
 from ..config_sections.scoring import ScoringWeights
 from ..copy_resume import resolve_numeric_resume_ids
+from ..exit_codes import CommandExitCode
 from ..history import History
 from ..search import (
     _LLM_SHORTLIST_DEFAULT,
@@ -342,6 +345,135 @@ class ApplyProgress:
             f"failed={self.failed_count} uncertain={self.uncertain_count} "
             f"skipped={self.skipped_count}"
         )
+
+
+class SignalTermination(BaseException):
+    """Raised from the SIGTERM handler installed by ``run_supervised_command``.
+
+    ``BaseException`` (not ``Exception``, #462 advisor review): several
+    ``except BaseException`` guards in the apply pipeline (and the command's
+    own ``finally``-based ledger bookkeeping below) must see this the same
+    way they see ``KeyboardInterrupt`` -- a plain ``Exception`` subclass
+    would let it be silently absorbed by a broad ``except Exception`` layer
+    somewhere in the pipeline instead of propagating up to this supervisor.
+    """
+
+    def __init__(self, signum: int):
+        self.signum = signum
+
+
+def run_supervised_command(
+    *,
+    command: str,
+    history: History,
+    requested_limit: int | None,
+    body: Callable[[ApplyProgress], bool],
+    reconcile: Callable[[ApplyProgress, History, str], None] | None = None,
+) -> bool | CommandExitCode:
+    """Run ``body`` under a durable command_run ledger row + typed signal supervision.
+
+    Extracted from ``commands/apply.py`` (#462, second sub-issue of #459) so
+    other WRITE-hh.ru commands (bump/publish/... in later issues) can reuse
+    the same SIGINT/SIGTERM handling and machine-readable ``[RUN]`` summary
+    without reimplementing it. ``bump``/``publish`` are NOT wired to this
+    helper in this PR -- only ``apply`` is, per #462 scope.
+
+    ``body`` receives the freshly created :class:`ApplyProgress` (with
+    ``run_id`` already set) and returns ``failed`` the same way
+    ``commands/apply.py::_run`` did. SIGTERM is registered for the duration
+    of the call and restored (LIFO-safe, via the previous handler captured
+    before installing ours) on the way out, so a nested/re-entrant call
+    (e.g. under future orchestration) does not clobber an outer caller's
+    handler.
+
+    SIGINT deliberately gets NO custom ``signal.signal`` handler here --
+    only the default ``KeyboardInterrupt`` it already raises is caught
+    below. Installing a custom SIGINT handler would change what type of
+    exception propagates through Playwright/pipeline code and would change
+    ``detail`` from ``"SIGINT"`` to ``"signal=2"``; #462 requires apply's
+    behaviour and tests to stay identical, so SIGINT handling is
+    intentionally left exactly as it already worked before this extraction.
+
+    ``reconcile`` is an optional hook invoked inside the same protected
+    ``finally`` block, right before ``finish_command_run`` and the
+    ``[RUN]`` summary print, to let a caller reconcile ``progress`` against
+    its own action-log semantics (apply's ``command_run_action_counts``
+    query filters ``action='apply'`` -- that is apply-specific, not generic,
+    so it is injected rather than hardcoded here; a future bump/publish
+    caller would pass its own reconcile or none at all).
+    """
+    run_id = history.start_command_run(command=command, requested_limit=requested_limit)
+    progress = ApplyProgress(run_id=run_id)
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def _terminate(signum, _frame):  # noqa: ANN001
+        raise SignalTermination(signum)
+
+    signal.signal(signal.SIGTERM, _terminate)
+    final_status = "failed"
+    exit_code = 1
+    detail = None
+    result: bool | CommandExitCode = True
+    try:
+        failed = body(progress)
+        final_status = (
+            "partial"
+            if failed and progress.attempted_count
+            else "failed"
+            if failed
+            else "completed"
+        )
+        exit_code = 1 if failed else 0
+        result = bool(failed)
+    except KeyboardInterrupt:
+        final_status = "interrupted"
+        exit_code = CommandExitCode.SIGINT.value
+        detail = "SIGINT"
+        result = CommandExitCode.SIGINT
+    except SignalTermination as exc:
+        final_status = "interrupted"
+        exit_code = 128 + exc.signum
+        detail = f"signal={exc.signum}"
+        result = CommandExitCode.SIGTERM
+    except BaseException as exc:
+        detail = f"{type(exc).__name__}: {exc}"
+        raise
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+        # cycle-review PR #460 (round 3, Claude /review), preserved verbatim
+        # through this extraction: this bookkeeping can itself raise (e.g.
+        # history.finish_command_run's ValueError when the run row is no
+        # longer 'running') while a real exception from `body` is already
+        # propagating through the `except BaseException: raise` above -- an
+        # exception raised here would replace/mask it (standard Python
+        # finally semantics), silently swallowing the original crash.
+        # Log-and-continue instead: the ledger row staying 'running'/stale is
+        # benign (`orphaned` already exists as the recognized terminal status
+        # for exactly this kind of leftover, recovered on the next command
+        # run's start_command_run()).
+        try:
+            if reconcile is not None:
+                reconcile(progress, history, run_id)
+            history.finish_command_run(
+                run_id,
+                status=final_status,
+                exit_code=exit_code,
+                attempted=progress.attempted_count,
+                success=progress.applied_count,
+                failed=progress.failed_count,
+                uncertain=progress.uncertain_count,
+                skipped=progress.skipped_count,
+                detail=detail,
+            )
+            print(progress.summary(final_status))
+        except Exception:
+            logger.exception(
+                "%s: не удалось финализировать durable ledger run_id=%s "
+                "(поглощено, чтобы не заслонить исходное исключение)",
+                command,
+                run_id,
+            )
+    return result
 
 
 @dataclass(frozen=True)

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-import signal
+from typing import TYPE_CHECKING
 
 from ._common import (
     ApplyProgress,
@@ -16,7 +16,11 @@ from ._common import (
     apply_search_page_limit,
     resumes_from_args,
     run_apply_for_resume,
+    run_supervised_command,
 )
+
+if TYPE_CHECKING:
+    from ..exit_codes import CommandExitCode
 
 logger = logging.getLogger("hhru_bot.cli")
 
@@ -31,11 +35,6 @@ def register(subparsers) -> None:
     )
     p.add_argument("--permit", help="Одноразовый permit из `review approve`")
     p.set_defaults(func=run)
-
-
-class _SignalTermination(BaseException):
-    def __init__(self, signum: int):
-        self.signum = signum
 
 
 def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> bool:
@@ -191,10 +190,31 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
     return failed
 
 
-def run(args: argparse.Namespace) -> bool:
+def _reconcile_from_action_log(progress: ApplyProgress, history, run_id: str) -> None:
+    """Apply-specific reconcile hook for ``run_supervised_command`` (#462).
+
+    If interruption landed inside an attempted vacancy after its durable
+    reservation, account for the unresolved result in the run summary.
+    ``command_run_action_counts`` filters ``action='apply'`` -- apply-only
+    semantics, kept out of the generic helper and injected here instead.
+    """
+    action_counts = history.command_run_action_counts(run_id)
+    progress.applied_count = max(progress.applied_count, action_counts.get("success", 0))
+    progress.failed_count = max(progress.failed_count, action_counts.get("failed", 0))
+    progress.uncertain_count = max(progress.uncertain_count, action_counts.get("uncertain", 0))
+    completed = (
+        progress.applied_count
+        + progress.failed_count
+        + progress.uncertain_count
+        + progress.skipped_count
+    )
+    if progress.attempted_count > completed:
+        progress.failed_count += progress.attempted_count - completed
+
+
+def run(args: argparse.Namespace) -> bool | CommandExitCode:
     """Run apply under a durable ledger and typed signal supervision."""
     from ..config import load_config_or_exit
-    from ..exit_codes import CommandExitCode
     from ..history import History
 
     if getattr(args, "approved", None) is not None and args.dry_run:
@@ -203,90 +223,16 @@ def run(args: argparse.Namespace) -> bool:
 
     config = load_config_or_exit(args.config)
     history = History(args.history)
-    run_id = history.start_command_run(
+
+    def _body(progress: ApplyProgress) -> bool:
+        # Module-level lookup (not a captured default/partial), so tests that
+        # monkeypatch ``apply_command._run`` still take effect here.
+        return _run(args, config, history, progress)
+
+    return run_supervised_command(
         command=getattr(args, "command", "apply"),
+        history=history,
         requested_limit=getattr(args, "limit", None),
+        body=_body,
+        reconcile=_reconcile_from_action_log,
     )
-    progress = ApplyProgress(run_id=run_id)
-    previous_sigterm = signal.getsignal(signal.SIGTERM)
-
-    def _terminate(signum, _frame):  # noqa: ANN001
-        raise _SignalTermination(signum)
-
-    signal.signal(signal.SIGTERM, _terminate)
-    final_status = "failed"
-    exit_code = 1
-    detail = None
-    result: bool | CommandExitCode = True
-    try:
-        failed = _run(args, config, history, progress)
-        final_status = (
-            "partial"
-            if failed and progress.attempted_count
-            else "failed"
-            if failed
-            else "completed"
-        )
-        exit_code = 1 if failed else 0
-        result = bool(failed)
-    except KeyboardInterrupt:
-        final_status = "interrupted"
-        exit_code = CommandExitCode.SIGINT.value
-        detail = "SIGINT"
-        result = CommandExitCode.SIGINT
-    except _SignalTermination as exc:
-        final_status = "interrupted"
-        exit_code = 128 + exc.signum
-        detail = f"signal={exc.signum}"
-        result = CommandExitCode.SIGTERM
-    except BaseException as exc:
-        detail = f"{type(exc).__name__}: {exc}"
-        raise
-    finally:
-        signal.signal(signal.SIGTERM, previous_sigterm)
-        # cycle-review PR #460 (round 3, Claude /review): this bookkeeping can
-        # itself raise (e.g. history.finish_command_run's ValueError when the
-        # run row is no longer 'running') while a real exception from `_run`
-        # is already propagating through the `except BaseException: raise`
-        # above -- an exception raised here would replace/mask it (standard
-        # Python finally semantics), silently swallowing the original crash.
-        # Log-and-continue instead: the ledger row staying 'running'/stale is
-        # benign (`orphaned` already exists as the recognized terminal status
-        # for exactly this kind of leftover, recovered on the next apply run).
-        try:
-            # If interruption landed inside an attempted vacancy after its
-            # durable reservation, account for the unresolved result in the
-            # run summary.
-            action_counts = history.command_run_action_counts(run_id)
-            progress.applied_count = max(progress.applied_count, action_counts.get("success", 0))
-            progress.failed_count = max(progress.failed_count, action_counts.get("failed", 0))
-            progress.uncertain_count = max(
-                progress.uncertain_count, action_counts.get("uncertain", 0)
-            )
-            completed = (
-                progress.applied_count
-                + progress.failed_count
-                + progress.uncertain_count
-                + progress.skipped_count
-            )
-            if progress.attempted_count > completed:
-                progress.failed_count += progress.attempted_count - completed
-            history.finish_command_run(
-                run_id,
-                status=final_status,
-                exit_code=exit_code,
-                attempted=progress.attempted_count,
-                success=progress.applied_count,
-                failed=progress.failed_count,
-                uncertain=progress.uncertain_count,
-                skipped=progress.skipped_count,
-                detail=detail,
-            )
-            print(progress.summary(final_status))
-        except Exception:
-            logger.exception(
-                "apply: не удалось финализировать durable ledger run_id=%s "
-                "(поглощено, чтобы не заслонить исходное исключение)",
-                run_id,
-            )
-    return result

--- a/tests/test_common_run_context.py
+++ b/tests/test_common_run_context.py
@@ -1,0 +1,202 @@
+"""``commands/_common.run_supervised_command`` in isolation (#462).
+
+Extracted from ``commands/apply.py`` (#460/#461 had it apply-specific) so any
+future WRITE-hh.ru command can reuse the same SIGINT/SIGTERM handling and
+machine-readable ``[RUN]`` summary. ``apply.py``'s own behaviour/tests are
+covered separately in ``test_reliability_bundle.py``/``test_apply_limit.py``
+and must stay green unchanged -- this file exercises the helper without any
+apply-specific plumbing.
+"""
+
+from __future__ import annotations
+
+import signal
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.commands._common import ApplyProgress, SignalTermination, run_supervised_command
+from hhru_bot.exit_codes import CommandExitCode
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.integration
+
+
+def test_completed_run_persists_summary_and_returns_false(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+
+    def body(progress: ApplyProgress) -> bool:
+        progress.begin_attempt()
+        progress.applied_count += 1
+        return False
+
+    result = run_supervised_command(command="apply", history=history, requested_limit=1, body=body)
+
+    assert result is False
+    row = history.command_runs()[-1]
+    assert row["status"] == "completed"
+    assert row["exit_code"] == 0
+    assert row["attempted"] == 1
+    assert row["success"] == 1
+
+
+def test_failed_run_without_attempts_is_failed_not_partial(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+
+    result = run_supervised_command(
+        command="apply", history=history, requested_limit=None, body=lambda _progress: True
+    )
+
+    assert result is True
+    row = history.command_runs()[-1]
+    assert row["status"] == "failed"
+    assert row["exit_code"] == 1
+
+
+def test_failed_run_with_attempts_is_partial(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+
+    def body(progress: ApplyProgress) -> bool:
+        progress.begin_attempt()
+        return True
+
+    result = run_supervised_command(
+        command="apply", history=history, requested_limit=None, body=body
+    )
+
+    assert result is True
+    row = history.command_runs()[-1]
+    assert row["status"] == "partial"
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [(KeyboardInterrupt(), CommandExitCode.SIGINT), (signal.SIGTERM, CommandExitCode.SIGTERM)],
+)
+def test_typed_signal_exit_is_persisted(tmp_path: Path, failure, expected: CommandExitCode) -> None:
+    history = History(tmp_path / "history.db")
+
+    def body(progress: ApplyProgress) -> bool:
+        progress.begin_attempt()
+        if failure == signal.SIGTERM:
+            signal.raise_signal(signal.SIGTERM)
+        raise failure
+
+    result = run_supervised_command(
+        command="apply", history=history, requested_limit=None, body=body
+    )
+
+    assert result is expected
+    row = history.command_runs()[-1]
+    assert row["status"] == "interrupted"
+    assert row["exit_code"] == expected.value
+
+
+def test_sigterm_handler_is_restored_after_normal_return(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+    previous = signal.getsignal(signal.SIGTERM)
+
+    run_supervised_command(
+        command="apply", history=history, requested_limit=None, body=lambda _progress: False
+    )
+
+    assert signal.getsignal(signal.SIGTERM) is previous
+
+
+def test_sigterm_handler_is_restored_after_exception(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def body(_progress: ApplyProgress) -> bool:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_supervised_command(command="apply", history=history, requested_limit=None, body=body)
+
+    assert signal.getsignal(signal.SIGTERM) is previous
+
+
+def test_nested_call_restores_outer_handler_lifo(tmp_path: Path) -> None:
+    # #462 review risk called out in the issue body: re-entrancy. A nested
+    # call's own SIGTERM handler must not clobber the outer call's handler
+    # on the way out -- restoration is LIFO via the previous handler each
+    # call captured before installing its own.
+    history = History(tmp_path / "history.db")
+    previous = signal.getsignal(signal.SIGTERM)
+    outer_handler_during_inner = None
+
+    def inner_body(_progress: ApplyProgress) -> bool:
+        return False
+
+    def outer_body(_progress: ApplyProgress) -> bool:
+        nonlocal outer_handler_during_inner
+        run_supervised_command(
+            command="apply", history=history, requested_limit=None, body=inner_body
+        )
+        outer_handler_during_inner = signal.getsignal(signal.SIGTERM)
+        return False
+
+    run_supervised_command(command="apply", history=history, requested_limit=None, body=outer_body)
+
+    # After the inner call returns, the outer call's own handler (installed
+    # before outer_body ran) must still be in place, not the pre-outer one.
+    assert outer_handler_during_inner is not previous
+    assert signal.getsignal(signal.SIGTERM) is previous
+
+
+def test_ledger_failure_does_not_mask_the_original_exception(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+
+    def body(progress: ApplyProgress) -> bool:
+        # Force finish_command_run to fail inside the helper's `finally`:
+        # mark the run already finished before body's own exception starts
+        # propagating, simulating a lost race / already-finalized run.
+        history.finish_command_run(
+            progress.run_id,
+            status="completed",
+            exit_code=0,
+            attempted=0,
+            success=0,
+            failed=0,
+            uncertain=0,
+            skipped=0,
+        )
+        raise RuntimeError("boom: real pipeline crash")
+
+    with pytest.raises(RuntimeError, match="boom: real pipeline crash"):
+        run_supervised_command(command="apply", history=history, requested_limit=None, body=body)
+
+
+def test_reconcile_hook_runs_before_finish_and_summary(tmp_path: Path) -> None:
+    history = History(tmp_path / "history.db")
+    seen_run_id = None
+
+    def body(progress: ApplyProgress) -> bool:
+        progress.begin_attempt()
+        return False
+
+    def reconcile(progress: ApplyProgress, hist: History, run_id: str) -> None:
+        nonlocal seen_run_id
+        seen_run_id = run_id
+        assert hist is history
+        progress.applied_count = 42
+
+    run_supervised_command(
+        command="apply",
+        history=history,
+        requested_limit=None,
+        body=body,
+        reconcile=reconcile,
+    )
+
+    row = history.command_runs()[-1]
+    assert seen_run_id == row["run_id"]
+    assert row["success"] == 42
+
+
+def test_signal_termination_is_a_base_exception() -> None:
+    # Must stay BaseException (not Exception): pipeline code has broad
+    # `except Exception` layers that must not silently swallow a SIGTERM
+    # raised from inside the helper's handler.
+    assert issubclass(SignalTermination, BaseException)
+    assert not issubclass(SignalTermination, Exception)

--- a/tests/test_common_run_context.py
+++ b/tests/test_common_run_context.py
@@ -116,6 +116,26 @@ def test_sigterm_handler_is_restored_after_exception(tmp_path: Path) -> None:
     assert signal.getsignal(signal.SIGTERM) is previous
 
 
+def test_generic_exception_persists_failed_status_with_detail(tmp_path: Path) -> None:
+    # cycle-review PR #468 (code-reviewer-462): the `except BaseException as
+    # exc: detail = ...; raise` path had no direct test -- only its handler-
+    # restoration side effect and the (deliberately finish_command_run-
+    # breaking) masking-guard test covered it, and the latter never lets
+    # `detail` reach the ledger row. Assert the row directly.
+    history = History(tmp_path / "history.db")
+
+    def body(_progress: ApplyProgress) -> bool:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_supervised_command(command="apply", history=history, requested_limit=None, body=body)
+
+    row = history.command_runs()[-1]
+    assert row["status"] == "failed"
+    assert row["exit_code"] == 1
+    assert row["detail"] == "RuntimeError: boom"
+
+
 def test_nested_call_restores_outer_handler_lifo(tmp_path: Path) -> None:
     # #462 review risk called out in the issue body: re-entrancy. A nested
     # call's own SIGTERM handler must not clobber the outer call's handler


### PR DESCRIPTION
## Что сделано

Второй sub-issue эпика #459 (фундамент #461 уже смерджен). Извлекает
SIGINT/SIGTERM-обработку + durable command_run ledger + machine-readable
`[RUN]`-summary из `commands/apply.py::run()` в переиспользуемый
`commands/_common.py::run_supervised_command`, чтобы будущие
WRITE-hh.ru команды (bump/publish/...) не изобретали ту же
try/finally-бухгалтерию заново.

## Как

- `commands/_common.py`: новый `SignalTermination` (остался
  `BaseException`, не понижен до `Exception` — иначе поглощался бы
  широкими `except Exception` в pipeline) и
  `run_supervised_command(command, history, requested_limit, body,
  reconcile=None)`. SIGTERM получает реальный обработчик,
  устанавливаемый/восстанавливаемый LIFO-safe (проверено тестом на
  реентерабельность — вложенный вызов не затирает внешний обработчик).
  SIGINT намеренно НЕ получает свой `signal.signal`-хендлер — как и
  раньше, полагается на дефолтный `KeyboardInterrupt` (иначе изменился
  бы тип исключения и `detail` с `"SIGINT"` на `"signal=2"`, что нарушило
  бы «поведение apply не должно измениться» из ТЗ). `finish_command_run`
  + печать `[RUN]`-summary остаются в том же `try/finally`, что уже
  защищает от маскировки исходного исключения (инвариант из cycle-review
  PR #460 round 3, сохранён дословно).
- Apply-специфичная сверка по `command_run_action_counts` (SQL-фильтр
  `action='apply'`) НЕ зашита в helper — вынесена в опциональный колбэк
  `reconcile`, чтобы helper оставался общим (без этого следующая команда
  на нём получила бы тихий ноль/некорректную сверку).
- `commands/apply.py`: `run()` теперь делегирует в `run_supervised_command`,
  передавая свой `_reconcile_from_action_log`. `_run()` сохранил имя и
  сигнатуру на уровне модуля — существующие тесты, которые monkeypatch'ят
  `apply_command._run`, продолжают работать без изменений.
- `tests/test_common_run_context.py` (новый, `pytest.mark.integration`):
  изолированные тесты helper'а — маппинг статусов
  completed/failed/partial, персист SIGINT/SIGTERM, восстановление
  обработчика (в т.ч. LIFO при реентерабельном вызове), ledger-failure
  не маскирует исходное исключение, вызов `reconcile`-хука,
  `SignalTermination` остаётся `BaseException`.

Не подключает `bump`/`publish` к durable run_id — только готовит
переиспользуемый механизм и доказывает его на apply, как и указано в
скоупе #462.

## Тесты

- `pytest -q` — вся сюита зелёная (существующие `test_reliability_bundle.py`
  и `test_apply_limit.py` не изменены и проходят без правок).
- `ruff check` / `ruff format --check` по `src tests` — чисто.
- `scripts/gen_cli_docs.py --check` — синхронизирован (новых команд нет).
- `scripts/check_pytest_budget.py` — в пределах бюджета.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)