### PR TITLE
feat(commands): persist durable bump runs

### DIFF
--- a/src/hhru_bot/commands/_audit.py
+++ b/src/hhru_bot/commands/_audit.py
@@ -20,7 +20,13 @@ def action_status(*, dry_run: bool, success: bool, uncertain: bool = False) -> s
 
 
 def record_resume_action(
-    history: History, resume_id: str, action: str, status: str, reason: str
+    history: History,
+    resume_id: str,
+    action: str,
+    status: str,
+    reason: str,
+    *,
+    run_id: str | None = None,
 ) -> None:
     """Record a real or uncertain action for exactly one configured resume.
 
@@ -29,4 +35,4 @@ def record_resume_action(
     """
     if status == "dry_run":
         return
-    history.record_action(resume_id, resume_id, action, status, reason)
+    history.record_action(resume_id, resume_id, action, status, reason, run_id=run_id)

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -373,10 +373,10 @@ def run_supervised_command(
     """Run ``body`` under a durable command_run ledger row + typed signal supervision.
 
     Extracted from ``commands/apply.py`` (#462, second sub-issue of #459) so
-    other WRITE-hh.ru commands (bump/publish/... in later issues) can reuse
-    the same SIGINT/SIGTERM handling and machine-readable ``[RUN]`` summary
-    without reimplementing it. ``bump``/``publish`` are NOT wired to this
-    helper in this PR -- only ``apply`` is, per #462 scope.
+    other WRITE-hh.ru commands can reuse the same SIGINT/SIGTERM handling and
+    machine-readable ``[RUN]`` summary without reimplementing it.  ``apply``
+    and ``bump`` currently use it; a command supplies a reconcile hook only
+    when its own action semantics require one.
 
     ``body`` receives the freshly created :class:`ApplyProgress` (with
     ``run_id`` already set) and returns ``failed`` the same way

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -230,7 +230,9 @@ def run(args: argparse.Namespace) -> bool | CommandExitCode:
         return _run(args, config, history, progress)
 
     return run_supervised_command(
-        command=getattr(args, "command", "apply"),
+        # `commands/run.py` reuses this Namespace, whose CLI command is
+        # "run".  This durable row nevertheless represents the apply stage.
+        command="apply",
         history=history,
         requested_limit=getattr(args, "limit", None),
         body=_body,

--- a/src/hhru_bot/commands/bump.py
+++ b/src/hhru_bot/commands/bump.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ._audit import action_status, record_resume_action
-from ._common import add_common_args, resumes_from_args
+from ._common import ApplyProgress, add_common_args, resumes_from_args, run_supervised_command
 
 
 def register(subparsers) -> None:
@@ -14,17 +14,27 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def _reconcile_bump_progress(progress: ApplyProgress, _history, _run_id: str) -> None:
+    """Classify an interrupted in-flight bump as failed for bump's summary.
+
+    Bump has no ``uncertain`` *run* counter: its single remote operation is
+    either successful or failed from the command's perspective.  The action
+    audit still retains ``uncertain`` when a click may have reached hh.ru, so
+    the cooldown and daily limit remain fail-closed.
+    """
+    completed = progress.applied_count + progress.failed_count
+    if progress.attempted_count > completed:
+        progress.failed_count += progress.attempted_count - completed
+
+
+def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> bool:
     from ..browser import launch_context
     from ..bump import bump_resume
-    from ..config import load_config_or_exit
-    from ..history import History
     from ..throttle import LimitReached, Throttle
 
-    config = load_config_or_exit(args.config)
-    history = History(args.history)
     resumes = resumes_from_args(config, args)
     throttle = Throttle(config.throttle, history)
+    failed = False
 
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -44,6 +54,7 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Пропуск: рано поднимать, подождите ещё {wait_left}")
                 continue
 
+            progress.begin_attempt()
             result = bump_resume(page, resume, args.dry_run)
 
             # #163: actions — журнал реальных взаимодействий с hh.ru. Dry-run
@@ -61,11 +72,21 @@ def run(args: argparse.Namespace) -> None:
                 # не отклик). actions.vacancy_id NOT NULL — заполняем resume.resume_id
                 # как sentinel; UNIQUE-индекс idx_resume_vacancy_apply существует
                 # только WHERE action='apply', так что коллизий нет.
-                record_resume_action(history, resume.resume_id, "bump", status, result.reason)
+                record_resume_action(
+                    history,
+                    resume.resume_id,
+                    "bump",
+                    status,
+                    result.reason,
+                    run_id=progress.run_id,
+                )
 
             if result.success:
+                progress.applied_count += 1
                 print(f"  [OK] {resume.id} поднято")
             else:
+                progress.failed_count += 1
+                failed = True
                 print(f"  [FAIL] {resume.id} — {result.reason}")
 
             # #163: анти-бан-пауза — только после реального действия на hh.ru
@@ -74,3 +95,24 @@ def run(args: argparse.Namespace) -> None:
             # троттлинг обязателен (CLAUDE.md: «не убирай троттлинг/лимиты»).
             if result.acted:
                 throttle.wait(f"после поднятия резюме '{resume.id}'")
+    return failed
+
+
+def run(args: argparse.Namespace):
+    """Run bump under its own durable command ledger entry."""
+    from ..config import load_config_or_exit
+    from ..history import History
+
+    config = load_config_or_exit(args.config)
+    history = History(args.history)
+
+    def _body(progress: ApplyProgress) -> bool:
+        return _run(args, config, history, progress)
+
+    return run_supervised_command(
+        command="bump",
+        history=history,
+        requested_limit=None,
+        body=_body,
+        reconcile=_reconcile_bump_progress,
+    )

--- a/tests/test_bump_command_runs.py
+++ b/tests/test_bump_command_runs.py
@@ -1,0 +1,150 @@
+"""Durable command-run coverage for bump and the combined run command (#463)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.bump import BumpResult
+from hhru_bot.commands import bump as bump_command
+from hhru_bot.config import AppConfig, ResumeConfig, SearchFilters, ThrottleConfig
+from hhru_bot.exit_codes import CommandExitCode
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.integration
+
+
+class _LaunchContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):  # noqa: ANN001
+        return False
+
+    def new_page(self):
+        return object()
+
+
+def _config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        storage_state_file=tmp_path / "state.json",
+        throttle=ThrottleConfig(),
+        cover_letter_default="letter",
+        resumes=[
+            ResumeConfig(
+                id="resume",
+                resume_url="https://hh.ru/resume/abc123",
+                search=SearchFilters(text="python", area=1),
+            )
+        ],
+    )
+
+
+def _args(tmp_path: Path, *, command: str = "bump") -> argparse.Namespace:
+    return argparse.Namespace(
+        command=command,
+        config=None,
+        history=str(tmp_path / "history.db"),
+        dry_run=False,
+        headless=True,
+        resume=None,
+        max_pages=5,
+        limit=1,
+        approved=None,
+    )
+
+
+def _patch_runtime(monkeypatch, config: AppConfig) -> None:
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *_a, **_kw: _LaunchContext())
+    monkeypatch.setattr("hhru_bot.throttle.Throttle.wait", lambda *_a, **_kw: None)
+
+
+def test_bump_persists_success_and_correlates_action_to_run(tmp_path, monkeypatch, capsys) -> None:
+    config = _config(tmp_path)
+    _patch_runtime(monkeypatch, config)
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda _page, resume, _dry_run: BumpResult(resume.id, True, "ok", acted=True),
+    )
+
+    assert bump_command.run(_args(tmp_path)) is False
+
+    history = History(tmp_path / "history.db")
+    row = history.command_runs()[-1]
+    assert row["command"] == "bump"
+    assert (row["status"], row["attempted"], row["success"], row["failed"], row["uncertain"]) == (
+        "completed",
+        1,
+        1,
+        0,
+        0,
+    )
+    with history._connect() as conn:
+        action = conn.execute("SELECT run_id FROM actions WHERE action='bump'").fetchone()
+    assert action["run_id"] == row["run_id"]
+    assert "[RUN]" in capsys.readouterr().out
+
+
+def test_bump_exception_still_finishes_run_and_prints_summary(tmp_path, monkeypatch, capsys) -> None:
+    config = _config(tmp_path)
+    _patch_runtime(monkeypatch, config)
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume", lambda *_args: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        bump_command.run(_args(tmp_path))
+
+    row = History(tmp_path / "history.db").command_runs()[-1]
+    assert (row["status"], row["attempted"], row["failed"], row["detail"]) == (
+        "failed",
+        1,
+        1,
+        "RuntimeError: boom",
+    )
+    assert "[RUN]" in capsys.readouterr().out
+
+
+def test_next_bump_run_recovers_abandoned_bump_as_orphaned(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _patch_runtime(monkeypatch, config)
+    history = History(tmp_path / "history.db")
+    abandoned = history.start_command_run(command="bump", requested_limit=None)
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume", lambda *_args: (_ for _ in ()).throw(KeyboardInterrupt())
+    )
+
+    assert bump_command.run(_args(tmp_path)) is CommandExitCode.SIGINT
+
+    rows = {row["run_id"]: row for row in History(tmp_path / "history.db").command_runs()}
+    assert rows[abandoned]["status"] == "orphaned"
+    interrupted = next(row for row in rows.values() if row["run_id"] != abandoned)
+    assert interrupted["status"] == "interrupted"
+
+
+def test_combined_run_creates_distinct_apply_and_bump_rows(tmp_path, monkeypatch) -> None:
+    from hhru_bot.commands import apply as apply_command
+    from hhru_bot.commands import run as run_command
+
+    config = _config(tmp_path)
+    _patch_runtime(monkeypatch, config)
+
+    def apply_body(_args, _config, _history, progress):
+        progress.begin_attempt()
+        progress.applied_count += 1
+        return False
+
+    monkeypatch.setattr(apply_command, "_run", apply_body)
+    monkeypatch.setattr(
+        "hhru_bot.bump.bump_resume",
+        lambda _page, resume, _dry_run: BumpResult(resume.id, True, "ok", acted=True),
+    )
+
+    assert run_command.run(_args(tmp_path, command="run")) is False
+
+    rows = History(tmp_path / "history.db").command_runs()
+    assert [row["command"] for row in rows] == ["apply", "bump"]
+    assert rows[0]["run_id"] != rows[1]["run_id"]

--- a/tests/test_bump_command_runs.py
+++ b/tests/test_bump_command_runs.py
@@ -88,7 +88,9 @@ def test_bump_persists_success_and_correlates_action_to_run(tmp_path, monkeypatc
     assert "[RUN]" in capsys.readouterr().out
 
 
-def test_bump_exception_still_finishes_run_and_prints_summary(tmp_path, monkeypatch, capsys) -> None:
+def test_bump_exception_still_finishes_run_and_prints_summary(
+    tmp_path, monkeypatch, capsys
+) -> None:
     config = _config(tmp_path)
     _patch_runtime(monkeypatch, config)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- wrap `bump` in the durable command-run supervisor and emit one final `[RUN]` summary
- correlate real bump action audit rows to their bump run; `run` now records distinct `apply` and `bump` stages
- preserve the existing four-hour cooldown and daily limits unchanged

`uncertain` remains an action-audit state for fail-closed cooldown/limit enforcement, but is intentionally not a bump run-summary outcome: bump summaries use attempted/success/failed and persist `uncertain=0`.

Closes #463

## Tests
- `pytest -q`
- `ruff check src/hhru_bot/commands/bump.py src/hhru_bot/commands/apply.py src/hhru_bot/commands/_audit.py tests/test_bump_command_runs.py`

## Risks / follow-up
- None known.