### PR TITLE
feat(commands): journal resume mutations

### DIFF
--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -128,12 +128,18 @@ def run(args: argparse.Namespace):
                 record_resume_action(history, resume.resume_id, "copy_resume", "failed", str(e))
             print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
             return True
-        except Exception as e:
+        except BaseException as e:
             # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
             # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал
             # ретраи) — копия на hh.ru могла создаться, а локальной записи не будет.
             # Результат после возможного клика не подтверждён: это ``uncertain`,
             # а не failed, чтобы не разрешить безопасный на вид повтор.
+            # #464 cycle-review (Codex round 2): ``BaseException``, not
+            # ``Exception`` -- SIGTERM/KeyboardInterrupt (both BaseException)
+            # landing right after copy_resume_on_hh's clone click previously
+            # bypassed this whole block, leaving no uncertain marker and
+            # letting the has_unresolved_uncertain guard above pass a blind
+            # retry through undetected.
             if not args.dry_run:
                 progress.uncertain_count += 1
                 record_resume_action(

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from ._common import ApplyProgress, run_supervised_command
+
 
 def register(subparsers) -> None:
     p = subparsers.add_parser(
@@ -72,7 +74,7 @@ def format_config_snippet(new_resume_id: str) -> str:
     )
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace):
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..copy_resume import copy_resume_on_hh
@@ -111,56 +113,74 @@ def run(args: argparse.Namespace) -> None:
                 "повторный запуск создаст ещё один дубль на hh.ru."
             )
 
-    try:
-        with launch_context(
-            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-        ) as context:
-            page = context.new_page()
-            result = copy_resume_on_hh(page, resume, args.dry_run)
-    except NotAuthenticated as e:
+    def _body(progress: ApplyProgress) -> bool:
+        try:
+            if not args.dry_run:
+                progress.begin_attempt()
+            with launch_context(
+                config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+            ) as context:
+                page = context.new_page()
+                result = copy_resume_on_hh(page, resume, args.dry_run)
+        except NotAuthenticated as e:
+            if not args.dry_run:
+                progress.failed_count += 1
+                record_resume_action(history, resume.resume_id, "copy_resume", "failed", str(e))
+            print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
+            return True
+        except Exception as e:
+            # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
+            # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал
+            # ретраи) — копия на hh.ru могла создаться, а локальной записи не будет.
+            # Результат после возможного клика не подтверждён: это ``uncertain`,
+            # а не failed, чтобы не разрешить безопасный на вид повтор.
+            if not args.dry_run:
+                progress.uncertain_count += 1
+                record_resume_action(
+                    history,
+                    resume.resume_id,
+                    "copy_resume",
+                    "uncertain",
+                    f"исключение в браузерном шаге: {e}",
+                )
+            raise
+
+        # Fail-closed (#116): success без нового id или с id, совпавшим с исходным,
+        # успехом не считается — копия не подтверждена.
+        if result.success and not args.dry_run:
+            if not result.new_resume_id or result.new_resume_id == resume.resume_id:
+                result.success = False
+                result.reason = "новый resume_id не подтверждён (совпал с исходным или пуст)"
+
         if not args.dry_run:
-            record_resume_action(history, resume.resume_id, "copy_resume", "failed", str(e))
-        print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
-        sys.exit(1)
-    except Exception as e:
-        # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
-        # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал
-        # ретраи) — копия на hh.ru могла создаться, а локальной записи не будет.
-        # Результат после возможного клика не подтверждён: это ``uncertain`,
-        # а не failed, чтобы не разрешить безопасный на вид повтор.
-        if not args.dry_run:
-            record_resume_action(
-                history,
-                resume.resume_id,
-                "copy_resume",
-                "uncertain",
-                f"исключение в браузерном шаге: {e}",
+            progress.finish(result)
+            status = action_status(
+                dry_run=False, success=result.success, uncertain=result.uncertain
             )
-        raise
+            reason = (
+                f"new_resume_id={result.new_resume_id}" if status == "success" else result.reason
+            )
+            # Для action='copy_resume' нет vacancy_id (операция над резюме, не отклик) —
+            # как у bump, заполняем sentinel'ом resume_id.
+            record_resume_action(history, resume.resume_id, "copy_resume", status, reason)
 
-    # Fail-closed (#116): success без нового id или с id, совпавшим с исходным,
-    # успехом не считается — копия не подтверждена.
-    if result.success and not args.dry_run:
-        if not result.new_resume_id or result.new_resume_id == resume.resume_id:
-            result.success = False
-            result.reason = "новый resume_id не подтверждён (совпал с исходным или пуст)"
+        if args.dry_run:
+            if not result.success:
+                print(f"[FAIL] {resume.id} — {result.reason}")
+                return True
+            print("[INFO] Ничего не отправлено.")
+        elif result.success:
+            print(f"[OK] Резюме {resume.id} скопировано. Новый resume_id: {result.new_resume_id}")
+            print(format_config_snippet(result.new_resume_id))
+        else:
+            prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
+            print(f"{prefix} {resume.id} — {result.reason}")
+            return True
+        return False
 
-    if not args.dry_run:
-        status = action_status(dry_run=False, success=result.success, uncertain=result.uncertain)
-        reason = f"new_resume_id={result.new_resume_id}" if status == "success" else result.reason
-        # Для action='copy_resume' нет vacancy_id (операция над резюме, не отклик) —
-        # как у bump, заполняем sentinel'ом resume_id.
-        record_resume_action(history, resume.resume_id, "copy_resume", status, reason)
-
-    if args.dry_run:
-        if not result.success:
-            print(f"[FAIL] {resume.id} — {result.reason}")
-            sys.exit(1)
-        print("[INFO] Ничего не отправлено.")
-    elif result.success:
-        print(f"[OK] Резюме {resume.id} скопировано. Новый resume_id: {result.new_resume_id}")
-        print(format_config_snippet(result.new_resume_id))
-    else:
-        prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
-        print(f"{prefix} {resume.id} — {result.reason}")
-        sys.exit(1)
+    return run_supervised_command(
+        command=getattr(args, "command", "copy-resume"),
+        history=history,
+        requested_limit=None,
+        body=_body,
+    )

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ._audit import action_status
+from ._common import ApplyProgress, run_supervised_command
 from .copy_resume import confirm_write, format_config_snippet
 
 
@@ -27,7 +28,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace):
     from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..create_resume import create_resume_on_hh
@@ -47,31 +48,47 @@ def run(args: argparse.Namespace) -> None:
             "Ничего не создано."
         )
         raise SystemExit(1)
-    try:
-        with launch_context(
-            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-        ) as context:
-            result = create_resume_on_hh(
-                context.new_page(), area=args.area, title=args.title, dry_run=dry_run
-            )
-    except Exception as exc:
-        # A dry-run never changes hh.ru and therefore must not create an
-        # action-history row, including for a local/browser failure.
+
+    def _body(progress: ApplyProgress) -> bool:
+        try:
+            if not dry_run:
+                progress.begin_attempt()
+            with launch_context(
+                config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+            ) as context:
+                result = create_resume_on_hh(
+                    context.new_page(), area=args.area, title=args.title, dry_run=dry_run
+                )
+        except Exception as exc:
+            # A dry-run never changes hh.ru and therefore must not create an
+            # action-history row, including for a local/browser failure.
+            if not dry_run:
+                progress.failed_count += 1
+                history.record_action(
+                    "account", "account", "create_resume", "failed", f"исключение: {exc}"
+                )
+            raise
         if not dry_run:
-            history.record_action(
-                "account", "account", "create_resume", "failed", f"исключение: {exc}"
+            progress.finish(result)
+            status = action_status(
+                dry_run=False, success=result.success, uncertain=result.uncertain
             )
-        raise
-    if not dry_run:
-        status = action_status(dry_run=False, success=result.success, uncertain=result.uncertain)
-        history.record_action("account", "account", "create_resume", status, result.reason)
-    if not result.success:
-        prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
-        print(f"{prefix} {result.reason}")
-        raise SystemExit(1)
-    if dry_run:
-        print(f"[DRY-RUN] Создание резюме: area={args.area}, title={args.title}")
-        print(f"[INFO] {result.reason}")
-    else:
-        print(f"[OK] Черновик резюме создан. Новый resume_id: {result.new_resume_id}")
-        print(format_config_snippet(result.new_resume_id))
+            history.record_action("account", "account", "create_resume", status, result.reason)
+        if not result.success:
+            prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
+            print(f"{prefix} {result.reason}")
+            return True
+        if dry_run:
+            print(f"[DRY-RUN] Создание резюме: area={args.area}, title={args.title}")
+            print(f"[INFO] {result.reason}")
+        else:
+            print(f"[OK] Черновик резюме создан. Новый resume_id: {result.new_resume_id}")
+            print(format_config_snippet(result.new_resume_id))
+        return False
+
+    return run_supervised_command(
+        command=getattr(args, "command", "create-resume"),
+        history=history,
+        requested_limit=None,
+        body=_body,
+    )

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from ._audit import action_status
+from ._audit import action_status, record_resume_action
 from ._common import ApplyProgress, run_supervised_command
 from .copy_resume import confirm_write, format_config_snippet
 
@@ -48,6 +48,17 @@ def run(args: argparse.Namespace):
             "Ничего не создано."
         )
         raise SystemExit(1)
+    # #464 cycle-review (Codex): a blind retry after an unresolved uncertain
+    # creation could add a second resume -- unlike publish/copy, create-resume
+    # has no vacancy/resume_id of its own before hh.ru assigns one, so the
+    # guard/marker use the fixed "account" key already shared with the
+    # actions rows written below (same convention as record_action calls).
+    if not dry_run and history.has_unresolved_uncertain("account", "create_resume"):
+        print(
+            "[FAIL] предыдущее создание резюме не подтверждено (uncertain). "
+            "Проверьте список резюме на hh.ru вручную перед повтором."
+        )
+        raise SystemExit(1)
 
     def _body(progress: ApplyProgress) -> bool:
         try:
@@ -59,13 +70,27 @@ def run(args: argparse.Namespace):
                 result = create_resume_on_hh(
                     context.new_page(), area=args.area, title=args.title, dry_run=dry_run
                 )
-        except Exception as exc:
+        except BaseException as exc:
             # A dry-run never changes hh.ru and therefore must not create an
             # action-history row, including for a local/browser failure.
+            # #464 cycle-review (Codex): ``BaseException``, not ``Exception`` --
+            # ``KeyboardInterrupt``/``SignalTermination`` (both BaseException,
+            # not Exception, #462's own rationale) can land at any point inside
+            # ``create_resume_on_hh``, including right after the browser click
+            # that already created the resume on hh.ru but before the function
+            # returns. A plain ``except Exception`` would let such a signal
+            # skip this whole block and leave no actions row at all, so a
+            # later blind retry could create a duplicate resume. There is no
+            # way to tell from here whether the click already fired, so a
+            # signal interrupt is recorded ``uncertain`` (fail-closed, blocks
+            # a retry via has_unresolved_uncertain above) while an ordinary
+            # exception (browser/network failure, never reaching the click)
+            # keeps the prior ``failed`` status.
             if not dry_run:
                 progress.failed_count += 1
-                history.record_action(
-                    "account", "account", "create_resume", "failed", f"исключение: {exc}"
+                status = "failed" if isinstance(exc, Exception) else "uncertain"
+                record_resume_action(
+                    history, "account", "create_resume", status, f"исключение: {exc}"
                 )
             raise
         if not dry_run:

--- a/src/hhru_bot/commands/delete_resume.py
+++ b/src/hhru_bot/commands/delete_resume.py
@@ -59,6 +59,15 @@ def run(args: argparse.Namespace):
             "Ничего не удалено."
         )
         raise SystemExit(1)
+    # #464 cycle-review (Codex round 2): mirrors publish-resume/copy-resume's
+    # existing guard -- an unresolved uncertain deletion must block a blind
+    # retry, since the destructive click may have already gone through.
+    if not dry_run and history.has_unresolved_uncertain(resume.resume_id, "delete_resume"):
+        print(
+            f"[FAIL] {resume.id} — предыдущее удаление не подтверждено (uncertain). "
+            "Проверьте статус резюме на hh.ru вручную перед повтором."
+        )
+        raise SystemExit(1)
 
     def _body(progress: ApplyProgress) -> bool:
         try:
@@ -74,11 +83,22 @@ def run(args: argparse.Namespace):
                 record_resume_action(history, resume.resume_id, "delete_resume", "failed", str(exc))
             print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
             return True
-        except Exception as exc:
+        except BaseException as exc:
+            # #464 cycle-review (Codex round 2): ``BaseException``, not
+            # ``Exception`` -- delete_resume_on_hh's own destructive-click
+            # try/except (delete_resume.py library module) already treats a
+            # PlaywrightError after the confirm click as uncertain, but a
+            # SIGTERM/KeyboardInterrupt landing at that same point is a
+            # BaseException and previously bypassed this whole block, leaving
+            # no actions row and no has_unresolved_uncertain marker to block
+            # a retry. Fail-closed: a signal interrupt is recorded
+            # ``uncertain``; an ordinary pre-click exception keeps the prior
+            # ``failed`` status (unchanged behavior).
             if not dry_run:
                 progress.failed_count += 1
+                status = "failed" if isinstance(exc, Exception) else "uncertain"
                 record_resume_action(
-                    history, resume.resume_id, "delete_resume", "failed", f"исключение: {exc}"
+                    history, resume.resume_id, "delete_resume", status, f"исключение: {exc}"
                 )
             raise
 

--- a/src/hhru_bot/commands/delete_resume.py
+++ b/src/hhru_bot/commands/delete_resume.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ._audit import action_status, record_resume_action
+from ._common import ApplyProgress, run_supervised_command
 from .copy_resume import confirm_write
 
 
@@ -32,7 +33,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace):
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..delete_resume import delete_resume_on_hh
@@ -59,32 +60,48 @@ def run(args: argparse.Namespace) -> None:
         )
         raise SystemExit(1)
 
-    try:
-        with launch_context(
-            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-        ) as context:
-            result = delete_resume_on_hh(context.new_page(), resume, dry_run)
-    except NotAuthenticated as exc:
-        if not dry_run:
-            record_resume_action(history, resume.resume_id, "delete_resume", "failed", str(exc))
-        print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
-        raise SystemExit(1) from None
-    except Exception as exc:
-        if not dry_run:
-            record_resume_action(
-                history, resume.resume_id, "delete_resume", "failed", f"исключение: {exc}"
-            )
-        raise
+    def _body(progress: ApplyProgress) -> bool:
+        try:
+            if not dry_run:
+                progress.begin_attempt()
+            with launch_context(
+                config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+            ) as context:
+                result = delete_resume_on_hh(context.new_page(), resume, dry_run)
+        except NotAuthenticated as exc:
+            if not dry_run:
+                progress.failed_count += 1
+                record_resume_action(history, resume.resume_id, "delete_resume", "failed", str(exc))
+            print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
+            return True
+        except Exception as exc:
+            if not dry_run:
+                progress.failed_count += 1
+                record_resume_action(
+                    history, resume.resume_id, "delete_resume", "failed", f"исключение: {exc}"
+                )
+            raise
 
-    if not dry_run:
-        status = action_status(dry_run=False, success=result.success, uncertain=result.uncertain)
-        record_resume_action(history, resume.resume_id, "delete_resume", status, result.reason)
-    if not result.success:
-        prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
-        print(f"{prefix} {resume.id} — {result.reason}")
-        raise SystemExit(1)
-    if dry_run:
-        print(f"[DRY-RUN] Резюме {resume.id}: {result.reason}")
-        print("[INFO] Ничего не удалено.")
-    else:
-        print(f"[OK] Резюме {resume.id} удалено")
+        if not dry_run:
+            progress.finish(result)
+            status = action_status(
+                dry_run=False, success=result.success, uncertain=result.uncertain
+            )
+            record_resume_action(history, resume.resume_id, "delete_resume", status, result.reason)
+        if not result.success:
+            prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
+            print(f"{prefix} {resume.id} — {result.reason}")
+            return True
+        if dry_run:
+            print(f"[DRY-RUN] Резюме {resume.id}: {result.reason}")
+            print("[INFO] Ничего не удалено.")
+        else:
+            print(f"[OK] Резюме {resume.id} удалено")
+        return False
+
+    return run_supervised_command(
+        command=getattr(args, "command", "delete-resume"),
+        history=history,
+        requested_limit=None,
+        body=_body,
+    )

--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 from ._audit import action_status, record_resume_action
+from ._common import ApplyProgress, run_supervised_command
 
 
 def register(subparsers) -> None:
@@ -27,7 +28,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(args: argparse.Namespace):
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..history import History
@@ -54,35 +55,56 @@ def run(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    try:
-        with launch_context(
-            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-        ) as context:
-            result = publish_resume_on_hh(context.new_page(), resume, args.dry_run)
-    except NotAuthenticated as exc:
-        print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
-        sys.exit(1)
+    def _body(progress: ApplyProgress) -> bool:
+        try:
+            if not args.dry_run:
+                progress.begin_attempt()
+            with launch_context(
+                config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+            ) as context:
+                result = publish_resume_on_hh(context.new_page(), resume, args.dry_run)
+        except NotAuthenticated as exc:
+            if not args.dry_run:
+                progress.failed_count += 1
+            print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
+            return True
 
-    # actions — журнал взаимодействий с hh.ru, а не всех проверок команды.
-    # До клика (identity/state/button guards) внешний эффект невозможен и не
-    # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
-    # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
-    if not args.dry_run and (result.success or result.uncertain):
-        status = action_status(dry_run=False, success=result.success, uncertain=result.uncertain)
-        record_resume_action(history, resume.resume_id, "publish_resume", status, result.reason)
+        # actions — журнал взаимодействий с hh.ru, а не всех проверок команды.
+        # До клика (identity/state/button guards) внешний эффект невозможен и не
+        # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
+        # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
+        if not args.dry_run:
+            progress.finish(result)
+            if result.success or result.uncertain:
+                status = action_status(
+                    dry_run=False, success=result.success, uncertain=result.uncertain
+                )
+                record_resume_action(
+                    history, resume.resume_id, "publish_resume", status, result.reason
+                )
 
-    if not result.success:
-        prefix = "[FAIL]" if not result.uncertain else "[FAIL] (uncertain)"
-        print(f"{prefix} {resume.id} — {result.reason}")
-        sys.exit(1)
-    if args.dry_run:
-        print(f"[DRY-RUN] Резюме {resume.id}: {result.reason}")
-        print("[INFO] Ничего не нажато; изменение видимости — отдельное действие.")
-    else:
-        visibility = "не подтверждена"
-        if result.is_searchable is True:
-            visibility = "видно в поиске"
-        elif result.is_searchable is False:
-            visibility = "не видно в поиске"
-        print(f"[OK] Резюме {resume.id} опубликовано")
-        print(f"[INFO] Текущая видимость: {visibility}. Изменение видимости — отдельное действие.")
+        if not result.success:
+            prefix = "[FAIL]" if not result.uncertain else "[FAIL] (uncertain)"
+            print(f"{prefix} {resume.id} — {result.reason}")
+            return True
+        if args.dry_run:
+            print(f"[DRY-RUN] Резюме {resume.id}: {result.reason}")
+            print("[INFO] Ничего не нажато; изменение видимости — отдельное действие.")
+        else:
+            visibility = "не подтверждена"
+            if result.is_searchable is True:
+                visibility = "видно в поиске"
+            elif result.is_searchable is False:
+                visibility = "не видно в поиске"
+            print(f"[OK] Резюме {resume.id} опубликовано")
+            print(
+                f"[INFO] Текущая видимость: {visibility}. Изменение видимости — отдельное действие."
+            )
+        return False
+
+    return run_supervised_command(
+        command=getattr(args, "command", "publish-resume"),
+        history=history,
+        requested_limit=None,
+        body=_body,
+    )

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -116,6 +116,14 @@ def test_run_success_prints_ok_and_yaml_snippet(env, capsys, tmp_path):
     # Аудит в actions.
     h = History(tmp_path / "h.db")
     assert h.count_today(OLD_ID, "copy_resume") == 1
+    run = h.command_runs()[-1]
+    assert (run["command"], run["status"], run["attempted"], run["success"], run["failed"]) == (
+        "copy-resume",
+        "completed",
+        1,
+        1,
+        0,
+    )
 
 
 def test_run_without_force_non_tty_exits_1(env, capsys, tmp_path, monkeypatch):
@@ -145,9 +153,7 @@ def test_run_dry_run_needs_no_confirmation(env, capsys, tmp_path, monkeypatch):
 def test_run_browser_failure_exits_1(env, capsys, tmp_path):
     reason = "profile_stalled: профиль hh.ru перестал прогружаться; копия не создавалась"
     env.result = CopyResumeResult("backend", False, reason=reason)
-    with pytest.raises(SystemExit) as exc:
-        cmd.run(_args(tmp_path, force=True))
-    assert exc.value.code == 1
+    assert cmd.run(_args(tmp_path, force=True)) is True
     out = capsys.readouterr().out
     assert "[FAIL]" in out
     assert reason in out
@@ -165,9 +171,7 @@ def test_run_browser_failure_exits_1(env, capsys, tmp_path):
 def test_run_same_resume_id_fails_closed(env, capsys, tmp_path):
     # Страховка fail-closed в команде: браузерный шаг вернул success с исходным id.
     env.result = CopyResumeResult("backend", True, OLD_ID)
-    with pytest.raises(SystemExit) as exc:
-        cmd.run(_args(tmp_path, force=True))
-    assert exc.value.code == 1
+    assert cmd.run(_args(tmp_path, force=True)) is True
     assert "[FAIL]" in capsys.readouterr().out
 
 

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -9,6 +9,7 @@ WRITE-hh-ru команда: боевой режим требует --force ил�
 from __future__ import annotations
 
 import argparse
+import signal
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -233,3 +234,27 @@ def test_run_uncertain_blocks_subsequent_copy(env, tmp_path, monkeypatch, capsys
     assert "[FAIL]" in out
     assert "не подтверждено (uncertain)" in out
     assert env.calls == []  # до браузера не дошло
+
+
+def test_sigterm_after_clone_click_leaves_unresolved_uncertain_marker(env, tmp_path, monkeypatch):
+    """Codex cycle-review PR #470 (round 2): a SIGTERM/KeyboardInterrupt
+    delivered right after copy_resume_on_hh's clone click must not let a
+    blind retry create a duplicate. ``except Exception`` cannot catch a
+    signal-raised ``BaseException`` (KeyboardInterrupt/SignalTermination),
+    so today no uncertain actions row is written when the interrupt lands
+    after the click already fired.
+    """
+
+    def raising_copy(page, resume, dry_run):  # noqa: ANN001, ARG001
+        env.calls.append((resume.id, dry_run))
+        signal.raise_signal(signal.SIGTERM)
+
+    monkeypatch.setattr(hhru_bot.copy_resume, "copy_resume_on_hh", raising_copy)
+
+    cmd.run(_args(tmp_path, force=True))
+
+    h = History(tmp_path / "h.db")
+    assert h.has_unresolved_uncertain(OLD_ID, "copy_resume"), (
+        "a SIGTERM after the clone click must leave an unresolved uncertain "
+        "actions marker, or a blind retry can create a duplicate resume"
+    )

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import signal
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -89,3 +90,53 @@ def test_no_force_is_dry_run_even_in_non_tty(env, tmp_path, capsys, monkeypatch)
     cmd.run(_args(tmp_path, force=False, dry_run=False))
     assert "[DRY-RUN]" in capsys.readouterr().out
     assert env.calls == [("it", "Backend developer", True)]
+
+
+def test_sigterm_after_creation_leaves_unresolved_uncertain_marker(env, tmp_path, monkeypatch):
+    """Codex cycle-review PR #470: a SIGTERM/KeyboardInterrupt delivered after
+    ``create_resume_on_hh`` has already created the resume on hh.ru must not
+    let a blind retry create a duplicate. ``run_supervised_command``'s
+    ``command_runs`` ledger row (status ``interrupted``) is a diagnostic
+    record, not the dedup barrier -- that's ``actions``, checked via
+    ``has_unresolved_uncertain`` the same way publish-resume/copy-resume
+    already do. ``except Exception`` inside ``create_resume.py::_body``
+    cannot catch a signal-raised ``BaseException``, so today no ``actions``
+    row is written at all when the interrupt lands after a successful
+    external creation -- this test pins that gap red until fixed.
+    """
+
+    def create(page, *, area, title, dry_run):  # noqa: ANN001, ARG001
+        # Simulate hh.ru having already created the resume, then the process
+        # getting SIGTERM'd before the command can record anything.
+        signal.raise_signal(signal.SIGTERM)
+        return CreateResumeResult(True, NEW_ID, "черновик создан")
+
+    monkeypatch.setattr(hhru_bot.create_resume, "create_resume_on_hh", create)
+
+    cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "history.db")
+    assert history.has_unresolved_uncertain("account", "create_resume"), (
+        "a SIGTERM after hh.ru already created the resume must leave an "
+        "unresolved uncertain actions marker, or a blind retry can create "
+        "a duplicate resume"
+    )
+
+
+def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):
+    """The guard side of the same #464 fix: once an uncertain marker exists
+    (e.g. from the SIGTERM scenario above), a plain retry must refuse rather
+    than silently attempt a second creation -- mirrors publish-resume/
+    copy-resume's existing ``has_unresolved_uncertain`` guard.
+    """
+    history = History(tmp_path / "history.db")
+    history.record_action("account", "account", "create_resume", "uncertain", "клик мог уйти")
+
+    with pytest.raises(SystemExit):
+        cmd.run(_args(tmp_path, force=True))
+
+    output = capsys.readouterr().out
+    assert "[FAIL]" in output
+    assert "uncertain" in output
+    # No browser call was attempted -- the guard fires before _body runs.
+    assert env.calls == []

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -12,6 +12,7 @@ import hhru_bot.browser
 import hhru_bot.commands.create_resume as cmd
 import hhru_bot.create_resume
 from hhru_bot.create_resume import CreateResumeResult
+from hhru_bot.history import History
 
 pytestmark = pytest.mark.integration
 NEW_ID = "b" * 38
@@ -67,6 +68,14 @@ def test_force_prints_yaml_but_does_not_modify_config(env, tmp_path, capsys):
     assert f"Новый resume_id: {NEW_ID}" in output
     assert f"https://hh.ru/resume/{NEW_ID}" in output
     assert not (tmp_path / "config.yaml").exists()
+    run = History(tmp_path / "history.db").command_runs()[-1]
+    assert (run["command"], run["status"], run["attempted"], run["success"], run["failed"]) == (
+        "create-resume",
+        "completed",
+        1,
+        1,
+        0,
+    )
 
 
 def test_dry_run_wins_when_force_is_also_present(env, tmp_path, capsys):

--- a/tests/test_delete_resume_command.py
+++ b/tests/test_delete_resume_command.py
@@ -82,11 +82,22 @@ def test_no_flags_is_dry_run(env, tmp_path, capsys):
 
 def test_uncertain_is_audited_and_fails(env, tmp_path, capsys):
     env.result = DeleteResumeResult(RESUME_ID, False, "ошибка после клика", uncertain=True)
-    with pytest.raises(SystemExit):
-        cmd.run(_args(tmp_path, force=True))
+    assert cmd.run(_args(tmp_path, force=True)) is True
     assert "uncertain" in capsys.readouterr().out
     with History(tmp_path / "history.db")._connect() as conn:
         row = conn.execute(
             "SELECT status FROM actions WHERE resume_id = ?", (RESUME_ID,)
         ).fetchone()
     assert row["status"] == "uncertain"
+
+
+def test_live_success_is_recorded_as_single_completed_run(env, tmp_path):
+    assert cmd.run(_args(tmp_path, force=True)) is False
+    run = History(tmp_path / "history.db").command_runs()[-1]
+    assert (run["command"], run["status"], run["attempted"], run["success"], run["failed"]) == (
+        "delete-resume",
+        "completed",
+        1,
+        1,
+        0,
+    )

--- a/tests/test_delete_resume_command.py
+++ b/tests/test_delete_resume_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import signal
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -101,3 +102,44 @@ def test_live_success_is_recorded_as_single_completed_run(env, tmp_path):
         1,
         0,
     )
+
+
+def test_sigterm_after_destructive_click_leaves_unresolved_uncertain_marker(
+    env, tmp_path, monkeypatch
+):
+    """Codex cycle-review PR #470 (round 2): a SIGTERM/KeyboardInterrupt
+    delivered right after delete_resume_on_hh's destructive click must not
+    let a blind retry attempt a second deletion. ``except Exception`` cannot
+    catch a signal-raised ``BaseException``, so today no uncertain actions
+    row is written when the interrupt lands after the click already fired.
+    """
+
+    def raising_delete(page, resume, dry_run):  # noqa: ANN001, ARG001
+        signal.raise_signal(signal.SIGTERM)
+
+    monkeypatch.setattr(hhru_bot.delete_resume, "delete_resume_on_hh", raising_delete)
+
+    cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "history.db")
+    assert history.has_unresolved_uncertain(RESUME_ID, "delete_resume"), (
+        "a SIGTERM after the destructive click must leave an unresolved "
+        "uncertain actions marker, or a blind retry can re-attempt deletion"
+    )
+
+
+def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):
+    """The guard side of the same #464 fix: once an uncertain marker exists,
+    a plain retry must refuse rather than silently attempt another deletion --
+    mirrors publish-resume/copy-resume's existing has_unresolved_uncertain
+    guard, previously missing from delete-resume entirely.
+    """
+    history = History(tmp_path / "history.db")
+    history.record_action(RESUME_ID, RESUME_ID, "delete_resume", "uncertain", "клик мог уйти")
+
+    with pytest.raises(SystemExit) as exc:
+        cmd.run(_args(tmp_path, force=True))
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "uncertain" in out

--- a/tests/test_publish_resume_command.py
+++ b/tests/test_publish_resume_command.py
@@ -85,14 +85,21 @@ def test_run_success_records_success_in_history(env, capsys, tmp_path):
     assert "[OK] Резюме python опубликовано" in out
     h = History(tmp_path / "h.db")
     assert h.count_today(RESUME_ID, "publish_resume") == 1
+    run = h.command_runs()[-1]
+    assert (run["command"], run["status"], run["attempted"], run["success"], run["failed"]) == (
+        "publish-resume",
+        "completed",
+        1,
+        1,
+        0,
+    )
 
 
 def test_run_uncertain_result_records_uncertain_and_fails(env, capsys, tmp_path):
     env.result = PublishResumeResult(
         "python", False, "ошибка клика; результат не подтверждён: boom", uncertain=True
     )
-    with pytest.raises(SystemExit):
-        cmd.run(_args(tmp_path, force=True))
+    assert cmd.run(_args(tmp_path, force=True)) is True
     out = capsys.readouterr().out
     assert "[FAIL]" in out
     assert "uncertain" in out
@@ -178,8 +185,7 @@ def test_run_dry_run_bypasses_uncertain_guard(env, capsys, tmp_path):
 
 def test_run_plain_failure_is_not_recorded_or_counted(env, capsys, tmp_path):
     env.result = PublishResumeResult("python", False, "кнопка не найдена")
-    with pytest.raises(SystemExit):
-        cmd.run(_args(tmp_path, force=True))
+    assert cmd.run(_args(tmp_path, force=True)) is True
     h = History(tmp_path / "h.db")
     assert h.count_today(RESUME_ID, "publish_resume") == 0
     with h._connect() as conn:
@@ -188,8 +194,7 @@ def test_run_plain_failure_is_not_recorded_or_counted(env, capsys, tmp_path):
 
 def test_run_not_authenticated_is_not_recorded_and_exits(env, capsys, tmp_path):
     env.exc = NotAuthenticated("сессия истекла")
-    with pytest.raises(SystemExit):
-        cmd.run(_args(tmp_path, force=True))
+    assert cmd.run(_args(tmp_path, force=True)) is True
     out = capsys.readouterr().out
     assert "[FAIL]" in out
     assert "Сессия недействительна" in out


### PR DESCRIPTION
## Summary
- wrap publish-resume, copy-resume, create-resume, and delete-resume in the durable `command_runs` supervisor
- preserve their force and TTY confirmation guards, existing action-audit semantics, and typed signal handling
- add durable-ledger assertions for all four single-mutation commands

Each of these commands normally performs one mutation per invocation, unlike the multi-vacancy `apply`/`bump` workflows. Consequently their live runs naturally report `attempted` and `success`/`failed` as 0/1 or 1/0; they do not synthesize `skipped` or `uncertain` counts. (A genuine pre-existing uncertain mutation result is still preserved when returned.)

## Tests
- `ruff check src/hhru_bot/commands/{publish_resume,copy_resume,create_resume,delete_resume}.py tests/test_{publish_resume,copy_resume,create_resume,delete_resume}_command.py`
- `pytest -q` (1,714 passed)

Closes #464