### PR TITLE
feat(commands): journal reply and withdrawal runs

### DIFF
--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -198,7 +198,7 @@ def _reconcile_from_action_log(progress: ApplyProgress, history, run_id: str) ->
     ``command_run_action_counts`` filters ``action='apply'`` -- apply-only
     semantics, kept out of the generic helper and injected here instead.
     """
-    action_counts = history.command_run_action_counts(run_id)
+    action_counts = history.command_run_action_counts(run_id, action="apply")
     progress.applied_count = max(progress.applied_count, action_counts.get("success", 0))
     progress.failed_count = max(progress.failed_count, action_counts.get("failed", 0))
     progress.uncertain_count = max(progress.uncertain_count, action_counts.get("uncertain", 0))

--- a/src/hhru_bot/commands/clear_negotiations.py
+++ b/src/hhru_bot/commands/clear_negotiations.py
@@ -24,6 +24,7 @@ from ..selector_groups.negotiations import (
     NEGOTIATION_WITHDRAW_SUCCESS,
 )
 from ._audit import action_status
+from ._common import ApplyProgress, run_supervised_command
 from .copy_resume import confirm_write
 
 ACCOUNT_SCOPE = "__account__"
@@ -219,6 +220,40 @@ def _withdraw_topic(page, topic: str) -> tuple[bool, str, bool]:
         return False, f"состояние отзыва topic={topic} не подтверждено: {exc}", acted
 
 
+def _reconcile(progress: ApplyProgress, history, run_id: str) -> None:
+    """Reconcile reserved destructive actions after an interruption."""
+    counts = history.command_run_action_counts(run_id, action="withdraw")
+    progress.applied_count = max(progress.applied_count, counts.get("success", 0))
+    progress.failed_count = max(progress.failed_count, counts.get("failed", 0))
+    progress.uncertain_count = max(progress.uncertain_count, counts.get("uncertain", 0))
+    completed = (
+        progress.applied_count
+        + progress.failed_count
+        + progress.uncertain_count
+        + progress.skipped_count
+    )
+    if progress.attempted_count > completed:
+        progress.failed_count += progress.attempted_count - completed
+
+
+def _run_topics_in_browser(
+    args, topics, config, history, throttle, progress: ApplyProgress
+) -> bool:
+    from ..browser import launch_context
+
+    with launch_context(
+        config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+    ) as context:
+        return _run_topics(
+            args,
+            topics,
+            page=context.new_page(),
+            history=history,
+            throttle=throttle,
+            progress=progress,
+        )
+
+
 def run(args: argparse.Namespace) -> bool:
     """Return True when the run failed (fail-closed contract, see cli.main)."""
     _validate(args)
@@ -236,7 +271,22 @@ def run(args: argparse.Namespace) -> bool:
         if args.dry_run:
             print(f"[DRY-RUN] Отзыв отклика topic={args.topic}")
             return False
-        return _run_topics(args, [args.topic])
+        from ..config import load_config_or_exit
+        from ..history import History
+        from ..throttle import Throttle
+
+        config = load_config_or_exit(args.config)
+        history = History(args.history)
+        throttle = Throttle(config.throttle, history)
+        return run_supervised_command(
+            command=getattr(args, "command", "clear-negotiations"),
+            history=history,
+            requested_limit=1,
+            body=lambda progress: _run_topics_in_browser(
+                args, [args.topic], config, history, throttle, progress
+            ),
+            reconcile=_reconcile,
+        )
 
     # Vacancy/resume are intentionally read-only plans. With no selector there
     # is no safe target, so do not open a browser or imply that anything ran.
@@ -306,17 +356,32 @@ def run(args: argparse.Namespace) -> bool:
 
         if skipped:
             print(f"[INFO] Пропущено без topic (нет чата/неоднозначный SSR): {skipped}")
+
         # A skipped card means the account-wide run did not attempt every
         # negotiation it found. Reporting success (False) here would silently
         # understate coverage on a destructive, irreversible operation (Codex
         # review round 2, PR #196) — fold it into the same failure signal as a
         # failed withdrawal so callers/CI see an incomplete run. Withdraw first
         # (short-circuiting on `skipped` would skip resolved topics entirely).
-        withdraw_failed = _run_topics(args, topics, page=page, history=history, throttle=throttle)
-        return withdraw_failed or bool(skipped)
+        def _body(progress: ApplyProgress) -> bool:
+            progress.skipped_count += skipped
+            withdraw_failed = _run_topics(
+                args, topics, page=page, history=history, throttle=throttle, progress=progress
+            )
+            return withdraw_failed or bool(skipped)
+
+        return run_supervised_command(
+            command=getattr(args, "command", "clear-negotiations"),
+            history=history,
+            requested_limit=len(topics),
+            body=_body,
+            reconcile=_reconcile,
+        )
 
 
-def _run_topics(args, topics, *, page=None, history=None, throttle=None) -> bool:
+def _run_topics(
+    args, topics, *, page=None, history=None, throttle=None, progress: ApplyProgress | None = None
+) -> bool:
     """Withdraw each topic; return True if any withdrawal failed."""
     if page is None:
         from ..browser import launch_context
@@ -331,7 +396,12 @@ def _run_topics(args, topics, *, page=None, history=None, throttle=None) -> bool
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
             return _run_topics(
-                args, topics, page=context.new_page(), history=history, throttle=throttle
+                args,
+                topics,
+                page=context.new_page(),
+                history=history,
+                throttle=throttle,
+                progress=progress,
             )
 
     failed = False
@@ -347,6 +417,8 @@ def _run_topics(args, topics, *, page=None, history=None, throttle=None) -> bool
                 failed = True
             else:
                 print(f"[INFO] Уже есть запись об отзыве topic={topic} — не кликаю")
+            if progress is not None:
+                progress.skipped_count += 1
             continue
         # #245-style durable barrier: reserve the row as `uncertain` BEFORE
         # entering the irreversible click. If the process dies between the
@@ -358,7 +430,11 @@ def _run_topics(args, topics, *, page=None, history=None, throttle=None) -> bool
         # history is only ever None on the empty-discovery path (no topics
         # means the loop never runs); with real topics the callers above
         # always supply it, so it cannot be None here.
-        action_id = history.begin_action(ACCOUNT_SCOPE, topic, "withdraw")
+        if progress is not None:
+            progress.begin_attempt()
+        action_id = history.begin_action(
+            ACCOUNT_SCOPE, topic, "withdraw", run_id=progress.run_id if progress else None
+        )
         acted = False
         try:
             success, reason, acted = _withdraw_topic(page, topic)
@@ -366,6 +442,13 @@ def _run_topics(args, topics, *, page=None, history=None, throttle=None) -> bool
             success, reason = False, str(exc)
         status = action_status(dry_run=False, success=success, uncertain=acted and not success)
         history.finalize_action(action_id, status, reason or None, reason_code=status)
+        if progress is not None:
+            if status == "success":
+                progress.applied_count += 1
+            elif status == "uncertain":
+                progress.uncertain_count += 1
+            else:
+                progress.failed_count += 1
         if success:
             print(f"[OK] Отозван отклик topic={topic}")
         else:

--- a/src/hhru_bot/commands/clear_negotiations.py
+++ b/src/hhru_bot/commands/clear_negotiations.py
@@ -295,7 +295,6 @@ def run(args: argparse.Namespace) -> bool:
         print(f"[INFO] Только план: фильтр {scope}; боевой отзыв по нему запрещён.")
         return False
 
-    from ..browser import launch_context
     from ..config import load_config_or_exit
     from ..history import History
     from ..throttle import Throttle
@@ -303,6 +302,18 @@ def run(args: argparse.Namespace) -> bool:
     config = load_config_or_exit(args.config)
     history = History(args.history)
     throttle = Throttle(config.throttle, history)
+    return run_supervised_command(
+        command=getattr(args, "command", "clear-negotiations"),
+        history=history,
+        requested_limit=None,
+        body=lambda progress: _run_account_wide(args, config, history, throttle, progress),
+        reconcile=_reconcile,
+    )
+
+
+def _run_account_wide(args, config, history, throttle, progress: ApplyProgress) -> bool:
+    from ..browser import launch_context
+
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
@@ -363,20 +374,11 @@ def run(args: argparse.Namespace) -> bool:
         # review round 2, PR #196) — fold it into the same failure signal as a
         # failed withdrawal so callers/CI see an incomplete run. Withdraw first
         # (short-circuiting on `skipped` would skip resolved topics entirely).
-        def _body(progress: ApplyProgress) -> bool:
-            progress.skipped_count += skipped
-            withdraw_failed = _run_topics(
-                args, topics, page=page, history=history, throttle=throttle, progress=progress
-            )
-            return withdraw_failed or bool(skipped)
-
-        return run_supervised_command(
-            command=getattr(args, "command", "clear-negotiations"),
-            history=history,
-            requested_limit=len(topics),
-            body=_body,
-            reconcile=_reconcile,
+        progress.skipped_count += skipped
+        withdraw_failed = _run_topics(
+            args, topics, page=page, history=history, throttle=throttle, progress=progress
         )
+        return withdraw_failed or bool(skipped)
 
 
 def _run_topics(

--- a/src/hhru_bot/commands/clear_negotiations.py
+++ b/src/hhru_bot/commands/clear_negotiations.py
@@ -417,10 +417,20 @@ def _run_topics(
                     f"topic={topic} — не кликаю"
                 )
                 failed = True
+                # /review (cycle-review PR #471): this branch sets the overall
+                # `failed` return without touching failed_count, so a run that
+                # hits only this path prints status=partial/failed with every
+                # counter at zero except skipped -- misleading, since nothing
+                # here was actually skipped as routine/expected the way the
+                # empty-topic account-wide skip (progress.skipped_count above
+                # _run_topics) is. Count it as failed, matching the [FAIL] this
+                # branch already prints.
+                if progress is not None:
+                    progress.failed_count += 1
             else:
                 print(f"[INFO] Уже есть запись об отзыве topic={topic} — не кликаю")
-            if progress is not None:
-                progress.skipped_count += 1
+                if progress is not None:
+                    progress.skipped_count += 1
             continue
         # #245-style durable barrier: reserve the row as `uncertain` BEFORE
         # entering the irreversible click. If the process dies between the

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -109,9 +109,24 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 continue
             decision = needs_reply(chat)
             if not decision.should_reply:
-                print(f"[FAIL] {label} — {decision.reason}")
-                progress.failed_count += 1
-                failed = True
+                # /code-review high: "last_message_from_us" is the routine
+                # state of an already-answered chat waiting on the employer,
+                # not an error -- it fires on nearly every normal account-wide
+                # sweep once some chats are answered. Before durable-run
+                # wiring, run() always returned None and this branch never
+                # affected the exit code at all (cli.py's fail-closed
+                # contract, #148, was never opt-in for reply-employers).
+                # Keeping it a routine skip preserves that behaviour; only
+                # genuine DOM-read uncertainty (empty_chat/inbound_marker_
+                # unknown/author_unknown) is a real failure worth failing the
+                # run and a nonzero exit code for.
+                if decision.reason == "last_message_from_us":
+                    print(f"[skip] {label} — {decision.reason}")
+                    progress.skipped_count += 1
+                else:
+                    print(f"[FAIL] {label} — {decision.reason}")
+                    progress.failed_count += 1
+                    failed = True
                 continue
             assert chat is not None
             if history.has_replied(topic, chat.inbound_marker or ""):
@@ -236,7 +251,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 # here leaves the action finalized without a replies row, which
                 # only affects the has_replied() idempotency check, not the
                 # fail-closed action audit trail this fix exists for.
-                history.finalize_action(action_id, status, reason)
+                history.finalize_action(action_id, status, reason, reason_code=status)
                 history.record_reply(
                     topic,
                     inbound_marker,

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -123,6 +123,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
             inbound_marker = chat.inbound_marker or ""
             status = "dry_run" if args.dry_run else "failed"
             reason = "dry-run" if args.dry_run else None
+            action_id = None
             if args.dry_run:
                 print(f"[DRY-RUN] -> {label}\n    Письмо:\n    {letter}")
             else:
@@ -164,6 +165,22 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 # старого marker'а оставило бы новое входящее выглядящим
                 # неотвеченным, и следующий запуск отправил бы дубликат.
                 inbound_marker = live_chat.inbound_marker or ""
+                # Codex adversarial review (cycle-review PR #471, round 1): the
+                # durable action row must exist BEFORE the send click, mirroring
+                # apply's before_submit / clear-negotiations' begin_action
+                # pre-click barrier. Without it, a SIGINT/SIGTERM landing between
+                # this click and the post-confirmation write below leaves no
+                # actions row at all -- reconcile() then folds the attempt into
+                # an ordinary 'failed' count instead of the fail-closed
+                # 'uncertain' that a possibly-delivered message requires (#176
+                # applies here exactly as it does to apply/withdraw).
+                action_id = history.begin_action(
+                    resume_by_topic.get(topic) or "",
+                    str(candidate["vacancy_id"]),
+                    "reply",
+                    search_query=None,
+                    run_id=progress.run_id,
+                )
                 try:
                     send_reply_current(page, letter)
                 except NoReplyForm as exc:
@@ -208,15 +225,36 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                     # Клик состоялся (успешно или uncertain) — реальное
                     # действие на hh.ru, пауза нужна (#163).
                     throttle.wait(f"после ответа в чате {topic}")
-            history.record_reply_and_action(
-                topic,
-                inbound_marker,
-                vacancy_id=str(candidate["vacancy_id"]),
-                resume_id=resume_by_topic.get(topic),
-                status=status,
-                reason=reason,
-                run_id=progress.run_id,
-            )
+            if action_id is not None:
+                # Pre-click reservation exists (begin_action above) -- finalize
+                # it in place instead of inserting a second actions row, and
+                # journal the reply separately. Two statements, not one
+                # transaction like record_reply_and_action: the durable actions
+                # row (the SIGINT-safety property) is already committed by
+                # begin_action before the click, so there is nothing left for
+                # atomicity to protect between these two -- worst case a crash
+                # here leaves the action finalized without a replies row, which
+                # only affects the has_replied() idempotency check, not the
+                # fail-closed action audit trail this fix exists for.
+                history.finalize_action(action_id, status, reason)
+                history.record_reply(
+                    topic,
+                    inbound_marker,
+                    vacancy_id=str(candidate["vacancy_id"]),
+                    resume_id=resume_by_topic.get(topic),
+                    status=status,
+                    note=reason,
+                )
+            else:
+                history.record_reply_and_action(
+                    topic,
+                    inbound_marker,
+                    vacancy_id=str(candidate["vacancy_id"]),
+                    resume_id=resume_by_topic.get(topic),
+                    status=status,
+                    reason=reason,
+                    run_id=progress.run_id,
+                )
             if status == "success":
                 progress.applied_count += 1
             elif status == "uncertain":

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+from ._common import ApplyProgress, run_supervised_command
 from .copy_resume import confirm_write
 
 
@@ -45,10 +46,8 @@ def _letter(template: str, candidate: dict) -> str:
     return render_cover_letter(template, card)
 
 
-def run(args: argparse.Namespace) -> None:
+def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> bool:
     from ..browser import launch_context
-    from ..config import load_config_or_exit
-    from ..history import History
     from ..negotiations_chat import (
         NoReplyForm,
         is_robot_questionnaire,
@@ -61,34 +60,17 @@ def run(args: argparse.Namespace) -> None:
     from ..responses import NotAuthenticated, ResponsesIndeterminate
     from ..throttle import LimitReached, Throttle
 
-    if args.limit < 0:
-        print("[FAIL] --limit не может быть отрицательным", file=sys.stderr)
-        sys.exit(1)
     max_pages = getattr(args, "max_pages", 5)
-    if max_pages < 1:
-        print(f"[FAIL] --max-pages должен быть >= 1 (получено {max_pages}).", file=sys.stderr)
-        sys.exit(1)
-    if not args.dry_run and not confirm_write(
-        args.force,
-        prompt="Ответить работодателям в выбранных чатах?",
-    ):
-        print(
-            "[FAIL] Боевой режим требует --force или интерактивного подтверждения. "
-            "Ничего не отправлено."
-        )
-        sys.exit(1)
-
-    config = load_config_or_exit(args.config)
-    history = History(args.history)
     throttle = Throttle(config.throttle, history)
     candidates = history.reply_candidates(args.limit or None)
     template = args.template if args.template is not None else config.cover_letter_default
     print("=== Ответы работодателям (account-wide) ===")
     if not candidates:
         print("[INFO] В локальной истории нет чатов для проверки.")
-        return
+        return False
 
     sent = 0
+    failed = False
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
@@ -103,7 +85,7 @@ def run(args: argparse.Namespace) -> None:
             topic_list = paginated_topic_refs(page, max_pages=max_pages)
         except (NotAuthenticated, ResponsesIndeterminate) as exc:
             print(f"[FAIL] не удалось прочитать SSR chat mapping: {exc}", file=sys.stderr)
-            sys.exit(1)
+            raise SystemExit(1) from exc
         refs = {ref.topic_id: ref.chat_id for ref in topic_list}
         # #200: SSR отдаёт resumeId для каждой переписки (проверено на живой
         # сессии 2026-08-16, 7/7). Отдельный словарь, а не расширение refs:
@@ -119,19 +101,25 @@ def run(args: argparse.Namespace) -> None:
                     topic, vacancy_id=str(candidate["vacancy_id"]), reason="robot_questionnaire"
                 )
                 print(f"[skip] {label} — robot-questionnaire (ручная очередь)")
+                progress.skipped_count += 1
                 continue
             if history.is_robot_questionnaire(topic):
                 print(f"[skip] {label} — robot-questionnaire (ручная очередь)")
+                progress.skipped_count += 1
                 continue
             decision = needs_reply(chat)
             if not decision.should_reply:
                 print(f"[FAIL] {label} — {decision.reason}")
+                progress.failed_count += 1
+                failed = True
                 continue
             assert chat is not None
             if history.has_replied(topic, chat.inbound_marker or ""):
                 print(f"[skip] {label} — уже отвечали на это сообщение")
+                progress.skipped_count += 1
                 continue
             letter = _letter(template, candidate)
+            progress.begin_attempt()
             inbound_marker = chat.inbound_marker or ""
             status = "dry_run" if args.dry_run else "failed"
             reason = "dry-run" if args.dry_run else None
@@ -142,6 +130,8 @@ def run(args: argparse.Namespace) -> None:
                     throttle.check_reply_limit(False)
                 except LimitReached as exc:
                     print(f"[FAIL] {label} — {exc}")
+                    progress.failed_count += 1
+                    failed = True
                     break
                 # Codex-ревью (#198): между планированием (needs_reply выше) и
                 # отправкой прошло время (рендер письма, проверка лимита) —
@@ -160,7 +150,10 @@ def run(args: argparse.Namespace) -> None:
                         resume_id=resume_by_topic.get(topic),
                         status="failed",
                         reason=reason,
+                        run_id=progress.run_id,
                     )
+                    progress.failed_count += 1
+                    failed = True
                     continue
                 assert live_chat is not None
                 # Codex-ревью round 2 (#198): дедуплицируем и журналируем по
@@ -222,6 +215,64 @@ def run(args: argparse.Namespace) -> None:
                 resume_id=resume_by_topic.get(topic),
                 status=status,
                 reason=reason,
+                run_id=progress.run_id,
             )
+            if status == "success":
+                progress.applied_count += 1
+            elif status == "uncertain":
+                progress.uncertain_count += 1
+                failed = True
+            elif status == "dry_run":
+                progress.skipped_count += 1
+            else:
+                progress.failed_count += 1
+                failed = True
 
     print(f"Итого отправлено: {sent} ({'dry-run' if args.dry_run else 'боевой режим'})")
+    return failed
+
+
+def _reconcile(progress: ApplyProgress, history, run_id: str) -> None:
+    counts = history.command_run_action_counts(run_id, action="reply")
+    progress.applied_count = max(progress.applied_count, counts.get("success", 0))
+    progress.failed_count = max(progress.failed_count, counts.get("failed", 0))
+    progress.uncertain_count = max(progress.uncertain_count, counts.get("uncertain", 0))
+    completed = (
+        progress.applied_count
+        + progress.failed_count
+        + progress.uncertain_count
+        + progress.skipped_count
+    )
+    if progress.attempted_count > completed:
+        progress.failed_count += progress.attempted_count - completed
+
+
+def run(args: argparse.Namespace):
+    """Reply under a durable command run without changing reply deduplication."""
+    from ..config import load_config_or_exit
+    from ..history import History
+
+    if args.limit < 0:
+        print("[FAIL] --limit не может быть отрицательным", file=sys.stderr)
+        sys.exit(1)
+    max_pages = getattr(args, "max_pages", 5)
+    if max_pages < 1:
+        print(f"[FAIL] --max-pages должен быть >= 1 (получено {max_pages}).", file=sys.stderr)
+        sys.exit(1)
+    if not args.dry_run and not confirm_write(
+        args.force, prompt="Ответить работодателям в выбранных чатах?"
+    ):
+        print(
+            "[FAIL] Боевой режим требует --force или интерактивного подтверждения. "
+            "Ничего не отправлено."
+        )
+        sys.exit(1)
+    config = load_config_or_exit(args.config)
+    history = History(args.history)
+    return run_supervised_command(
+        command=getattr(args, "command", "reply-employers"),
+        history=history,
+        requested_limit=args.limit or None,
+        body=lambda progress: _run(args, config, history, progress),
+        reconcile=_reconcile,
+    )

--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -241,24 +241,24 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                     # действие на hh.ru, пауза нужна (#163).
                     throttle.wait(f"после ответа в чате {topic}")
             if action_id is not None:
-                # Pre-click reservation exists (begin_action above) -- finalize
-                # it in place instead of inserting a second actions row, and
-                # journal the reply separately. Two statements, not one
-                # transaction like record_reply_and_action: the durable actions
-                # row (the SIGINT-safety property) is already committed by
-                # begin_action before the click, so there is nothing left for
-                # atomicity to protect between these two -- worst case a crash
-                # here leaves the action finalized without a replies row, which
-                # only affects the has_replied() idempotency check, not the
-                # fail-closed action audit trail this fix exists for.
-                history.finalize_action(action_id, status, reason, reason_code=status)
-                history.record_reply(
+                # Pre-click reservation exists (begin_action above). Codex
+                # adversarial review (cycle-review PR #471, round 3): finalizing
+                # the action and journaling the reply as two separate
+                # transactions left a crash window where a confirmed external
+                # reply's action row was finalized but its replies row never
+                # committed -- has_replied() (dedup barrier #12) reads only
+                # replies, so that crash silently reopened the duplicate-send
+                # guard. finalize_reply_action() commits both in one
+                # transaction, matching record_reply_and_action's atomicity for
+                # the non-reserved (dry-run/pre-click-failed) path below.
+                history.finalize_reply_action(
+                    action_id,
                     topic,
                     inbound_marker,
                     vacancy_id=str(candidate["vacancy_id"]),
                     resume_id=resume_by_topic.get(topic),
                     status=status,
-                    note=reason,
+                    reason=reason,
                 )
             else:
                 history.record_reply_and_action(

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -771,12 +771,13 @@ class History:
             rows = conn.execute("SELECT * FROM command_runs ORDER BY started_at")
             return [dict(row) for row in rows]
 
-    def command_run_action_counts(self, run_id: str) -> dict[str, int]:
+    def command_run_action_counts(self, run_id: str, *, action: str = "apply") -> dict[str, int]:
+        """Return durable outcome counts for one action type in a command run."""
         with self._connect() as conn:
             rows = conn.execute(
                 """SELECT status, COUNT(*) AS count FROM actions
-                   WHERE run_id=? AND action='apply' GROUP BY status""",
-                (run_id,),
+                   WHERE run_id=? AND action=? GROUP BY status""",
+                (run_id, action),
             ).fetchall()
         return {row["status"]: row["count"] for row in rows}
 
@@ -2658,6 +2659,7 @@ class History:
         status: str,
         reason: str | None = None,
         letter_variant: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         """Write the reply journal and action audit in one SQLite transaction.
 
@@ -2691,9 +2693,10 @@ class History:
             # только когда SSR не отдал resumeId (см. докстринг).
             conn.execute(
                 """INSERT INTO actions
-                   (resume_id, vacancy_id, action, status, reason, letter_variant, created_at)
-                   VALUES (?, ?, 'reply', ?, ?, ?, ?)""",
-                (resume_id or "", vacancy_id, status, reason, letter_variant, now),
+                   (resume_id, vacancy_id, action, status, reason, letter_variant,
+                    run_id, created_at)
+                   VALUES (?, ?, 'reply', ?, ?, ?, ?, ?)""",
+                (resume_id or "", vacancy_id, status, reason, letter_variant, run_id, now),
             )
 
     def replies_since(self, since: datetime) -> list[dict]:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -2699,6 +2699,64 @@ class History:
                 (resume_id or "", vacancy_id, status, reason, letter_variant, run_id, now),
             )
 
+    def finalize_reply_action(
+        self,
+        action_id: int,
+        topic: str,
+        inbound_marker: str,
+        *,
+        vacancy_id: str,
+        resume_id: str | None = None,
+        status: str,
+        reason: str | None = None,
+        letter_variant: str | None = None,
+    ) -> None:
+        """Finalize a pre-click reply reservation and journal the reply atomically.
+
+        Codex adversarial review (cycle-review PR #471, round 3): the pre-click
+        durable barrier for reply-employers (``begin_action`` before the send
+        click, mirroring apply/withdraw) previously called
+        ``finalize_action`` and ``record_reply`` as two separate
+        ``self._connect()`` transactions. A crash between them left a
+        finalized ``actions`` row with no matching ``replies`` row -- the
+        action audit trail survived, but ``has_replied()`` (which reads only
+        ``replies``) would return False on the next run, silently reopening
+        the duplicate-send guard #12 exists to close. This method commits
+        both writes in one transaction, matching ``record_reply_and_action``'s
+        atomicity guarantee for the non-reserved (dry-run/pre-click-failed)
+        path this pre-click barrier does not cover.
+        """
+        if status not in REPLY_STATUS_VALUES:
+            raise ValueError(f"недопустимый status={status!r} для replies")
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE actions
+                   SET status = ?, reason = ?, letter_variant = ?, reason_code = ?
+                 WHERE id = ?
+                """,
+                (status, reason, letter_variant, status, action_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError(f"Действие истории не найдено: id={action_id}")
+            conn.execute(
+                """INSERT OR IGNORE INTO replies
+                   (topic, inbound_marker, vacancy_id, resume_id, status,
+                    letter_variant, note, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    topic,
+                    inbound_marker,
+                    vacancy_id,
+                    resume_id,
+                    status,
+                    letter_variant,
+                    reason,
+                    now,
+                ),
+            )
+
     def replies_since(self, since: datetime) -> list[dict]:
         """Наши ответы, записанные после ``since`` — для аналитики и отчётов.
 

--- a/tests/test_clear_negotiations_command.py
+++ b/tests/test_clear_negotiations_command.py
@@ -595,3 +595,53 @@ def test_sigint_mid_withdrawal_persists_partial_run_summary(tmp_path, monkeypatc
             "SELECT vacancy_id, status FROM actions WHERE action='withdraw' ORDER BY id"
         ).fetchall()
     assert [tuple(status) for status in statuses] == [("first", "success"), ("second", "uncertain")]
+
+
+def test_uncertain_retry_barrier_counts_as_failed_not_only_skipped(tmp_path, monkeypatch, capsys):
+    """/review (cycle-review PR #471): a pre-existing unresolved `uncertain`
+    withdrawal must refuse to re-click (retry barrier) *and* the durable
+    [RUN] summary must show it as a failure, matching the printed [FAIL].
+
+    Before this fix the retry-skip branch only incremented skipped_count,
+    so a run hitting exactly this path printed a misleading
+    'status=failed ... failed=0 ... skipped=1' -- the summary counters gave
+    no indication anything had actually failed.
+    """
+    history = History(tmp_path / "history.db")
+    # Seed a prior unresolved attempt exactly as begin_action would have
+    # left it: reserved 'uncertain', never finalized (simulated crash).
+    history.begin_action(command.ACCOUNT_SCOPE, "77", "withdraw")
+
+    page = _Page()
+
+    class Context:
+        def new_page(self):
+            return page
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(command, "confirm_write", lambda *args, **kwargs: True)
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *args, **kwargs: Context())
+    monkeypatch.setattr(
+        "hhru_bot.config.load_config_or_exit",
+        lambda *args, **kwargs: type(
+            "Cfg", (), {"storage_state_file": "unused", "user_agent": None, "throttle": None}
+        )(),
+    )
+    monkeypatch.setattr("hhru_bot.history.History", lambda *args, **kwargs: history)
+    monkeypatch.setattr("hhru_bot.throttle.Throttle", lambda *args, **kwargs: _Throttle())
+
+    result = command.run(_args(topic="77", force=True))
+    assert result is True
+
+    out = capsys.readouterr().out
+    assert "[FAIL] (uncertain)" in out
+    run = history.command_runs()[-1]
+    assert run["status"] in ("failed", "partial")
+    assert run["failed"] == 1
+    assert run["success"] == 0
+    assert run["uncertain"] == 0

--- a/tests/test_clear_negotiations_command.py
+++ b/tests/test_clear_negotiations_command.py
@@ -545,3 +545,53 @@ def test_account_wide_skips_cards_without_topic(tmp_path, monkeypatch):
     with history._connect() as conn:
         rows = conn.execute("SELECT vacancy_id FROM actions").fetchall()
     assert [r[0] for r in rows] == ["tp1"]
+
+
+def test_sigint_mid_withdrawal_persists_partial_run_summary(tmp_path, monkeypatch, capsys):
+    """A Ctrl-C after one irreversible withdrawal must not hide that withdrawal.
+
+    The second topic interrupts before its browser action returns.  Its pre-click
+    reservation is linked to the command run, so the supervisor reconciles both
+    the confirmed first withdrawal and the unresolved second one into the final
+    durable summary.
+    """
+    history = History(tmp_path / "history.db")
+    page = _Page()
+    calls = []
+
+    def _withdraw(_page, topic):
+        calls.append(topic)
+        if topic == "second":
+            raise KeyboardInterrupt
+        return True, "", True
+
+    monkeypatch.setattr(command, "_withdraw_topic", _withdraw)
+
+    from hhru_bot.commands._common import run_supervised_command
+    from hhru_bot.exit_codes import CommandExitCode
+
+    result = run_supervised_command(
+        command="clear-negotiations",
+        history=history,
+        requested_limit=2,
+        body=lambda progress: command._run_topics(
+            _args(force=True),
+            ["first", "second"],
+            page=page,
+            history=history,
+            throttle=_Throttle(),
+            progress=progress,
+        ),
+        reconcile=command._reconcile,
+    )
+
+    assert result is CommandExitCode.SIGINT
+    row = history.command_runs()[-1]
+    assert row["status"] == "interrupted"
+    assert (row["attempted"], row["success"], row["uncertain"]) == (2, 1, 1)
+    assert "status=interrupted attempted=2 success=1" in capsys.readouterr().out
+    with history._connect() as conn:
+        statuses = conn.execute(
+            "SELECT vacancy_id, status FROM actions WHERE action='withdraw' ORDER BY id"
+        ).fetchall()
+    assert [tuple(status) for status in statuses] == [("first", "success"), ("second", "uncertain")]

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -241,8 +241,14 @@ def test_last_message_from_us_is_skipped_not_sent(tmp_path, monkeypatch, capsys)
         send=_boom_send,
     )
 
-    command.run(_args(force=True))
-    assert "[FAIL]" in capsys.readouterr().out
+    result = command.run(_args(force=True))
+    # /code-review high: "already answered, waiting on the employer" is the
+    # routine state of most chats in a normal sweep, not a failure -- it must
+    # not flip the command's exit code (reply-employers was never part of the
+    # #148 fail-closed opt-in list before durable-run wiring changed run()'s
+    # return type from None to bool).
+    assert "[skip]" in capsys.readouterr().out
+    assert result is False
     with history._connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM replies").fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0
@@ -681,11 +687,74 @@ def test_sigint_after_send_click_persists_uncertain_action(tmp_path, monkeypatch
 
     with history._connect() as conn:
         rows = conn.execute(
-            "SELECT vacancy_id, status FROM actions WHERE action='reply'"
+            "SELECT vacancy_id, status, reason_code FROM actions WHERE action='reply'"
         ).fetchall()
-    assert [tuple(row) for row in rows] == [("1", "uncertain")]
+    # reason_code stays at begin_action's 'started' placeholder here -- the
+    # interrupt fires before finalize_action ever runs, so there is no real
+    # outcome to record it as (unlike the successful-finalize path covered by
+    # test_successful_reply_finalizes_reason_code_not_frozen_at_started).
+    assert [tuple(row) for row in rows] == [("1", "uncertain", "started")]
     # The action audit trail is fail-closed even though the reply journal
     # (replies table) never got a chance to be written -- has_replied() being
     # False here is expected (see the module docstring boundary note) and is
     # exactly why the actions-table barrier is the one that must not be lost.
     assert history.has_replied("tp1", "m1") is False
+
+
+def test_successful_reply_finalizes_reason_code_not_frozen_at_started(tmp_path, monkeypatch):
+    """/code-review high: finalize_action's ``reason_code`` must reflect the
+    real outcome, not stay frozen at begin_action's 'started' placeholder.
+
+    finalize_action's own docstring documents COALESCE(?, reason_code) --
+    omitting reason_code on the finalize call silently keeps 'started'
+    forever, exactly the bug already fixed once for a different caller in
+    PR #460 and reintroduced here for the new pre-click reply barrier.
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    refs = [TopicRef("tp1", "c1", "r1", "96223331")]
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=refs,
+        reader=lambda page, topic, refs: chat,
+        send=lambda page, text: None,
+    )
+
+    command.run(_args(force=True))
+
+    with history._connect() as conn:
+        row = conn.execute(
+            "SELECT status, reason_code FROM actions WHERE action='reply'"
+        ).fetchone()
+    assert tuple(row) == ("success", "success")
+
+
+def test_routine_already_answered_sweep_does_not_fail_the_run(tmp_path, monkeypatch):
+    """/code-review high: durable-run wiring changed run()'s return type from
+    None to bool -- cli.py now trips sys.exit(1) on any truthy return
+    (cli.py's own comment: fail-closed is opt-in, reply-employers was never
+    on that list before this PR). A sweep where every candidate chat is
+    already answered ("last_message_from_us") is the routine, expected state
+    of most account-wide runs, not an error -- it must return a falsy result
+    so cron/CI callers checking $? don't break on a run where nothing failed.
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    _seed_response(history, vacancy_id="2", topic="tp2")
+    refs = [TopicRef("tp1", "c1", None, "r1"), TopicRef("tp2", "c2", None, "r2")]
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=refs,
+        reader=lambda page, topic, refs: ChatMessage(author="me", inbound_marker="m1"),
+        send=lambda page, text: (_ for _ in ()).throw(
+            AssertionError("must not send when every chat is already answered")
+        ),
+    )
+
+    result = command.run(_args(force=True))
+    assert result is False

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -605,3 +605,36 @@ def test_successful_send_journals_the_live_marker_not_the_planning_one(
     # live one that was actually answered.
     assert history.has_replied("tp1", "m1") is False
     assert history.has_replied("tp1", "m2") is True
+
+
+def test_multiple_replies_are_linked_to_one_durable_run(tmp_path, monkeypatch):
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    _seed_response(history, vacancy_id="2", topic="tp2")
+    refs = [TopicRef("tp1", "c1", None, "r1"), TopicRef("tp2", "c2", None, "r2")]
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=refs,
+        reader=lambda _page, topic, _refs: ChatMessage(
+            author="employer", inbound_marker=f"m-{topic}"
+        ),
+        send=lambda _page, _text: None,
+    )
+
+    assert command.run(_args(force=True)) is False
+    run = history.command_runs()[-1]
+    assert run["command"] == "reply-employers"
+    assert (run["attempted"], run["success"], run["failed"], run["uncertain"], run["skipped"]) == (
+        2,
+        2,
+        0,
+        0,
+        0,
+    )
+    with history._connect() as conn:
+        run_ids = conn.execute(
+            "SELECT DISTINCT run_id FROM actions WHERE action='reply'"
+        ).fetchall()
+    assert [row[0] for row in run_ids] == [run["run_id"]]

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -638,3 +638,54 @@ def test_multiple_replies_are_linked_to_one_durable_run(tmp_path, monkeypatch):
             "SELECT DISTINCT run_id FROM actions WHERE action='reply'"
         ).fetchall()
     assert [row[0] for row in run_ids] == [run["run_id"]]
+
+
+# --- SIGINT mid-send must not lose the durable action audit trail (#466) ---
+
+
+def test_sigint_after_send_click_persists_uncertain_action(tmp_path, monkeypatch, capsys):
+    """A Ctrl-C right after the send click must not vanish from the ledger.
+
+    Mirrors the clear-negotiations SIGINT test: the message may have already
+    reached hh.ru by the time the process dies, so the pre-click durable
+    reservation (begin_action, mirroring apply's before_submit / withdraw's
+    begin_action) must survive the interruption and be visible as 'uncertain'
+    in both the actions table and the [RUN] summary -- not silently dropped
+    or misreported as an ordinary 'failed' attempt with no audit trail.
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    refs = [TopicRef("tp1", "c1", "r1", "96223331")]
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _send(page, text):
+        raise KeyboardInterrupt
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=refs,
+        reader=lambda page, topic, refs: chat,
+        send=_send,
+    )
+
+    from hhru_bot.exit_codes import CommandExitCode
+
+    result = command.run(_args(force=True))
+    assert result is CommandExitCode.SIGINT
+
+    run = history.command_runs()[-1]
+    assert run["status"] == "interrupted"
+    assert (run["attempted"], run["success"], run["uncertain"]) == (1, 0, 1)
+    assert "status=interrupted attempted=1 success=0" in capsys.readouterr().out
+
+    with history._connect() as conn:
+        rows = conn.execute(
+            "SELECT vacancy_id, status FROM actions WHERE action='reply'"
+        ).fetchall()
+    assert [tuple(row) for row in rows] == [("1", "uncertain")]
+    # The action audit trail is fail-closed even though the reply journal
+    # (replies table) never got a chance to be written -- has_replied() being
+    # False here is expected (see the module docstring boundary note) and is
+    # exactly why the actions-table barrier is the one that must not be lost.
+    assert history.has_replied("tp1", "m1") is False


### PR DESCRIPTION
## Summary
- add command-run summaries and action linkage for reply-employers
- journal destructive clear-negotiations withdrawals with reconciliation after signals
- cover multi-reply ledger and mid-withdrawal SIGINT outcomes

## Tests
- `ruff check src/hhru_bot/commands/reply_employers.py src/hhru_bot/commands/clear_negotiations.py src/hhru_bot/history.py tests/test_reply_employers_command.py tests/test_clear_negotiations_command.py`
- `pytest -q tests/test_reply_employers_command.py tests/test_clear_negotiations_command.py tests/test_common_run_context.py`
- `pytest -q`

Closes #466