### PR TITLE
feat(commands): journal resume edit runs

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -490,6 +490,31 @@ def run_supervised_command(
     return result
 
 
+def run_single_mutation_command(
+    *,
+    command: str,
+    args: argparse.Namespace,
+    body: Callable[[argparse.Namespace, ApplyProgress], bool],
+) -> bool | CommandExitCode:
+    """Thin ``run(args)`` for the single-mutation resume-edit commands (#465).
+
+    Collapses the identical 8-line wrapper that ``edit_education.py``/
+    ``edit_experience.py``/``edit_skills.py``/``edit_languages.py``/
+    ``resume_position.py`` each duplicated verbatim (cycle-review PR #472,
+    /code-review finding): open one ``History`` against ``args.history``,
+    hand it to ``run_supervised_command`` with ``requested_limit=1`` (each of
+    these commands performs at most one mutation per invocation), and forward
+    ``progress`` into the command's own ``_run(args, progress)``.
+    """
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command=command,
+        history=history,
+        requested_limit=1,
+        body=lambda progress: body(args, progress),
+    )
+
+
 @dataclass(frozen=True)
 class ApplyResumeIdentity:
     verify_resume_id: str

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -81,7 +81,7 @@ def _parse_manual_records(flag: str, raw_entries) -> list:
 
 
 def _run(args: argparse.Namespace, progress) -> bool:
-    from ..browser import launch_context
+    from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..responses import NotAuthenticated
     from ..resume_education import _record, edit_education_on_hh
@@ -203,6 +203,12 @@ def _run(args: argparse.Namespace, progress) -> bool:
             progress.failed_count += 1
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         return True
+    except BrowserLaunchError:
+        # #465 review round 3: a broad `except Exception` here would swallow
+        # BrowserLaunchError before it reaches cli.py's dedicated handler
+        # (prints "[ENVIRONMENT] ..." and exits distinctly from an ordinary
+        # command failure) — re-raise so that classification is preserved.
+        raise
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback
         if not args.dry_run and progress.attempted_count:
             progress.failed_count += 1

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -81,7 +81,7 @@ def _parse_manual_records(flag: str, raw_entries) -> list:
     return records
 
 
-def run(args: argparse.Namespace) -> None:
+def _run(args: argparse.Namespace, progress) -> bool:
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..responses import NotAuthenticated
@@ -182,6 +182,8 @@ def run(args: argparse.Namespace) -> None:
     )
     if plan.used_fallback:
         print(f"[INFO] {plan.reason}")
+    if not args.dry_run:
+        progress.begin_attempt()
     try:
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -194,8 +196,10 @@ def run(args: argparse.Namespace) -> None:
                 dry_run=args.dry_run,
             )
     except NotAuthenticated as exc:
+        if not args.dry_run:
+            progress.failed_count += 1
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
-        sys.exit(1)
+        return True
 
     if not args.dry_run:
         from ..history import History
@@ -209,6 +213,7 @@ def run(args: argparse.Namespace) -> None:
                     "edit_education",
                     "uncertain" if result.uncertain or not result.success else "success",
                     result.reason,
+                    run_id=progress.run_id,
                 )
 
     failed = [result for result in results if not result.success]
@@ -218,8 +223,27 @@ def run(args: argparse.Namespace) -> None:
             prefix = "[FAIL] (uncertain)"
         print(f"{prefix} {result.kind}: {result.reason}")
     if failed:
-        sys.exit(1)
+        if not args.dry_run:
+            progress.failed_count += 1
+        return True
+    if not args.dry_run:
+        progress.applied_count += 1
     if args.dry_run:
         print("[DRY-RUN] Ничего не сохранено на hh.ru")
     else:
         print("[OK] Образование сохранено на hh.ru")
+    return False
+
+
+def run(args: argparse.Namespace):
+    """Execute one resume-edit command under the durable command-run ledger."""
+    from ..history import History
+    from ._common import run_supervised_command
+
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command="edit_education",
+        history=history,
+        requested_limit=1,
+        body=lambda progress: _run(args, progress),
+    )

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 
 from ..resume_education import EducationPlan, generate_education_plan
 from .copy_resume import confirm_write
@@ -101,7 +100,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
             "[FAIL] --source/--mode относятся к LLM-планированию и не сочетаются "
             "с ручными записями (#326)"
         )
-        sys.exit(1)
+        return True
 
     # needs='education': команда не имеет смысла без секции — точечная ошибка
     # вместо «резюме не найдено в конфиге» (#319). Ручной ввод (#326) полный,
@@ -110,7 +109,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
         resume = resolve_resume(config, args.resume, needs=() if manual else ("education",))
     except ConfigError as exc:
         print(f"[FAIL] {exc}")
-        sys.exit(1)
+        return True
 
     education = resume.education
 
@@ -121,7 +120,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
             "[FAIL] Боевой режим требует --force или интерактивного подтверждения. "
             "Ничего не сохранено."
         )
-        sys.exit(1)
+        return True
 
     try:
         primary_manual = _parse_manual_records("--primary-entry", args.primary_entry or [])
@@ -135,11 +134,11 @@ def _run(args: argparse.Namespace, progress) -> bool:
             )
             if not scalar_record.institution.strip():
                 print("[FAIL] Явные поля основного образования требуют непустой --institution")
-                sys.exit(1)
+                return True
             primary_manual.append(scalar_record)
     except ValueError as exc:
         print(f"[FAIL] {exc}")
-        sys.exit(1)
+        return True
 
     if manual:
         plan = EducationPlan(
@@ -182,12 +181,16 @@ def _run(args: argparse.Namespace, progress) -> bool:
     )
     if plan.used_fallback:
         print(f"[INFO] {plan.reason}")
-    if not args.dry_run:
-        progress.begin_attempt()
     try:
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
+            # begin_attempt() right before the real mutation, after the
+            # browser/context are already open (#465 review): counting the
+            # attempt before launch_context succeeded would misreport a
+            # browser-launch or auth failure as a real (but failed) attempt.
+            if not args.dry_run:
+                progress.begin_attempt()
             results = edit_education_on_hh(
                 context.new_page(),
                 resume.resume_url,
@@ -196,7 +199,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 dry_run=args.dry_run,
             )
     except NotAuthenticated as exc:
-        if not args.dry_run:
+        if not args.dry_run and progress.attempted_count:
             progress.failed_count += 1
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         return True
@@ -217,6 +220,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 )
 
     failed = [result for result in results if not result.success]
+    uncertain = [result for result in results if result.uncertain]
     for result in results:
         prefix = "[OK]" if result.success else "[FAIL]"
         if result.uncertain:
@@ -224,7 +228,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
         print(f"{prefix} {result.kind}: {result.reason}")
     if failed:
         if not args.dry_run:
-            progress.failed_count += 1
+            if uncertain:
+                progress.uncertain_count += 1
+            else:
+                progress.failed_count += 1
         return True
     if not args.dry_run:
         progress.applied_count += 1
@@ -237,13 +244,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
 
 def run(args: argparse.Namespace):
     """Execute one resume-edit command under the durable command-run ledger."""
-    from ..history import History
-    from ._common import run_supervised_command
+    from ._common import run_single_mutation_command
 
-    history = History(getattr(args, "history", "data/history.db"))
-    return run_supervised_command(
-        command="edit_education",
-        history=history,
-        requested_limit=1,
-        body=lambda progress: _run(args, progress),
-    )
+    return run_single_mutation_command(command="edit_education", args=args, body=_run)

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -203,6 +203,11 @@ def _run(args: argparse.Namespace, progress) -> bool:
             progress.failed_count += 1
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         return True
+    except Exception as exc:  # browser/auth errors are a failed command, not a traceback
+        if not args.dry_run and progress.attempted_count:
+            progress.failed_count += 1
+        print(f"[FAIL] {resume.id} — {exc}")
+        return True
 
     if not args.dry_run:
         from ..history import History
@@ -220,7 +225,13 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 )
 
     failed = [result for result in results if not result.success]
-    uncertain = [result for result in results if result.uncertain]
+    # A hard failure (not success, not uncertain) must win over uncertain
+    # when both appear in the same --section both batch (#465 review, round
+    # 2): checking "any uncertain in the whole batch" masked a definite hard
+    # failure on one block as merely uncertain because another block in the
+    # same call happened to be uncertain.
+    hard_failed = [result for result in failed if not result.uncertain]
+    uncertain = [result for result in failed if result.uncertain]
     for result in results:
         prefix = "[OK]" if result.success else "[FAIL]"
         if result.uncertain:
@@ -228,10 +239,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
         print(f"{prefix} {result.kind}: {result.reason}")
     if failed:
         if not args.dry_run:
-            if uncertain:
-                progress.uncertain_count += 1
-            else:
+            if hard_failed:
                 progress.failed_count += 1
+            elif uncertain:
+                progress.uncertain_count += 1
         return True
     if not args.dry_run:
         progress.applied_count += 1

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -106,22 +106,22 @@ def _run(args: argparse.Namespace, progress) -> bool:
     manual = bool(getattr(args, "entry", None))
     if manual and args.career:
         print("[FAIL] --career относится к LLM-планированию и не сочетается с --entry (#326)")
-        raise SystemExit(1)
+        return True
     if not manual and not args.career:
         print("[FAIL] Требуется --career (LLM) или --entry (готовый текст, #326)")
-        raise SystemExit(1)
+        return True
     if manual and args.mode != "fill":
         print("[FAIL] --mode относится к LLM-планированию и не сочетается с --entry (#326)")
-        raise SystemExit(1)
+        return True
 
     try:
         resume = resolve_resume(config, args.resume)
     except ConfigError as exc:
         print(f"[FAIL] {exc}")
-        raise SystemExit(1) from exc
+        return True
     if not manual and config.ai is None:
         print("[FAIL] AI выключен: добавьте пустую секцию 'ai' в config.yaml")
-        raise SystemExit(1)
+        return True
     if not args.dry_run and not confirm_write(
         args.force, prompt=f"Сохранить опыт работы резюме '{resume.id}' на hh.ru?"
     ):
@@ -129,13 +129,13 @@ def _run(args: argparse.Namespace, progress) -> bool:
             "[FAIL] Боевой режим требует --force или интерактивного подтверждения. "
             "Ничего не сохранено."
         )
-        raise SystemExit(1)
+        return True
     try:
         existing = _load_existing(args.existing)
         entries = _load_entries(getattr(args, "entry", None))
     except ValueError as exc:
         print(f"[FAIL] {exc}")
-        raise SystemExit(1) from exc
+        return True
 
     if manual:
         plan = ExperiencePlan(entries)
@@ -151,7 +151,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     existing = read_experience_on_hh(context.new_page(), resume.resume_id)
             except Exception as exc:  # noqa: BLE001 - command reports browser drift clearly
                 print(f"[FAIL] Не удалось прочитать существующий опыт: {exc}")
-                raise SystemExit(1) from exc
+                return True
 
         try:
             from ..ai.llm_client import LLMClient
@@ -161,21 +161,20 @@ def _run(args: argparse.Namespace, progress) -> bool:
             )
         except ImportError as exc:
             print(f"[FAIL] AI-пакет не установлен: {exc}")
-            raise SystemExit(1) from exc
+            return True
 
     if plan.used_fallback:
         print(f"[INFO] {plan.reason}; безопасный fallback: существующие записи без изменений")
     print(json.dumps([entry.__dict__ for entry in plan.entries], ensure_ascii=False, indent=2))
     if args.dry_run:
         print("[DRY-RUN] save не нажат; изменений на hh.ru нет")
-        return
+        return False
     if plan.used_fallback or not plan.entries:
         print("[FAIL] Нет безопасного LLM-плана; боевая запись запрещена.")
-        raise SystemExit(1)
+        return True
 
     history = History(args.history)
     try:
-        progress.begin_attempt()
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
@@ -187,11 +186,21 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 # JSON omitted. Always append after the live row count instead.
                 existing_count = len(read_experience_on_hh(page, resume.resume_id))
                 indexes = list(range(existing_count, existing_count + len(plan.entries)))
+            # begin_attempt() right before the real mutation, after the page/
+            # context are already open (#465 review): counting the attempt
+            # before launch_context succeeded would misreport a browser-launch
+            # or auth failure as a real (but failed) mutation attempt.
+            progress.begin_attempt()
             results = edit_experience_on_hh(
                 page, resume.resume_id, plan, dry_run=False, indexes=indexes
             )
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback contract
-        progress.failed_count += 1
+        # Only count a failure if the attempt was actually reserved (#465
+        # review): read_experience_on_hh (manual re-index path) can raise
+        # before begin_attempt() runs, which must not misreport attempted=0
+        # as failed=1.
+        if progress.attempted_count:
+            progress.failed_count += 1
         print(f"[FAIL] {resume.id} — {exc}")
         return True
     uncertain = any("uncertain" in item for item in results)
@@ -208,7 +217,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
         prefix = "[FAIL] (uncertain)" if uncertain else ("[OK]" if success else "[FAIL]")
         print(f"{prefix} {resume.id} — {item}")
     if not success:
-        progress.failed_count += 1
+        if uncertain:
+            progress.uncertain_count += 1
+        else:
+            progress.failed_count += 1
         return True
     progress.applied_count += 1
     return False
@@ -216,13 +228,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
 
 def run(args: argparse.Namespace):
     """Execute one resume-edit command under the durable command-run ledger."""
-    from ..history import History
-    from ._common import run_supervised_command
+    from ._common import run_single_mutation_command
 
-    history = History(getattr(args, "history", "data/history.db"))
-    return run_supervised_command(
-        command="edit_experience",
-        history=history,
-        requested_limit=1,
-        body=lambda progress: _run(args, progress),
-    )
+    return run_single_mutation_command(command="edit_experience", args=args, body=_run)

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -88,7 +88,7 @@ def _load_entries(raw_entries: list[str] | None):
     return entries
 
 
-def run(args: argparse.Namespace) -> None:
+def _run(args: argparse.Namespace, progress) -> bool:
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..experience import (
@@ -175,6 +175,7 @@ def run(args: argparse.Namespace) -> None:
 
     history = History(args.history)
     try:
+        progress.begin_attempt()
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
@@ -190,8 +191,9 @@ def run(args: argparse.Namespace) -> None:
                 page, resume.resume_id, plan, dry_run=False, indexes=indexes
             )
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback contract
+        progress.failed_count += 1
         print(f"[FAIL] {resume.id} — {exc}")
-        raise SystemExit(1) from exc
+        return True
     uncertain = any("uncertain" in item for item in results)
     success = bool(results) and all("сохранено" in item for item in results)
     history.record_action(
@@ -200,9 +202,27 @@ def run(args: argparse.Namespace) -> None:
         "edit_experience",
         "uncertain" if uncertain else ("success" if success else "failed"),
         "; ".join(results),
+        run_id=progress.run_id,
     )
     for item in results:
         prefix = "[FAIL] (uncertain)" if uncertain else ("[OK]" if success else "[FAIL]")
         print(f"{prefix} {resume.id} — {item}")
     if not success:
-        raise SystemExit(1)
+        progress.failed_count += 1
+        return True
+    progress.applied_count += 1
+    return False
+
+
+def run(args: argparse.Namespace):
+    """Execute one resume-edit command under the durable command-run ledger."""
+    from ..history import History
+    from ._common import run_supervised_command
+
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command="edit_experience",
+        history=history,
+        requested_limit=1,
+        body=lambda progress: _run(args, progress),
+    )

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -89,7 +89,7 @@ def _load_entries(raw_entries: list[str] | None):
 
 
 def _run(args: argparse.Namespace, progress) -> bool:
-    from ..browser import launch_context
+    from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..experience import (
         ExperiencePlan,
@@ -194,6 +194,11 @@ def _run(args: argparse.Namespace, progress) -> bool:
             results = edit_experience_on_hh(
                 page, resume.resume_id, plan, dry_run=False, indexes=indexes
             )
+    except BrowserLaunchError:
+        # #465 review round 3: re-raise so cli.py's dedicated handler
+        # (prints "[ENVIRONMENT] ..." and exits distinctly) still fires,
+        # instead of the broad except Exception below swallowing it.
+        raise
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback contract
         # Only count a failure if the attempt was actually reserved (#465
         # review): read_experience_on_hh (manual re-index path) can raise
@@ -203,8 +208,18 @@ def _run(args: argparse.Namespace, progress) -> bool:
             progress.failed_count += 1
         print(f"[FAIL] {resume.id} — {exc}")
         return True
-    uncertain = any("uncertain" in item for item in results)
     success = bool(results) and all("сохранено" in item for item in results)
+    # A hard failure (neither "сохранено" nor "uncertain") must win over
+    # uncertain in the same batch (#465 review, round 3 — same batch-
+    # classification bug already fixed for edit_education.py in round 2,
+    # found still present here): "any uncertain in the whole batch" masked a
+    # definite hard failure on one entry as merely uncertain because another
+    # entry in the same --entry batch happened to be uncertain.
+    hard_failed_items = [
+        item for item in results if "сохранено" not in item and "uncertain" not in item
+    ]
+    uncertain_items = [item for item in results if "uncertain" in item]
+    uncertain = bool(uncertain_items) and not hard_failed_items
     history.record_action(
         resume.resume_id,
         resume.resume_id,
@@ -214,13 +229,14 @@ def _run(args: argparse.Namespace, progress) -> bool:
         run_id=progress.run_id,
     )
     for item in results:
-        prefix = "[FAIL] (uncertain)" if uncertain else ("[OK]" if success else "[FAIL]")
+        is_item_uncertain = "uncertain" in item
+        prefix = "[FAIL] (uncertain)" if is_item_uncertain else ("[OK]" if success else "[FAIL]")
         print(f"{prefix} {resume.id} — {item}")
     if not success:
-        if uncertain:
-            progress.uncertain_count += 1
-        else:
+        if hard_failed_items:
             progress.failed_count += 1
+        elif uncertain_items:
+            progress.uncertain_count += 1
         return True
     progress.applied_count += 1
     return False

--- a/src/hhru_bot/commands/edit_languages.py
+++ b/src/hhru_bot/commands/edit_languages.py
@@ -52,7 +52,7 @@ def register(subparsers) -> None:
     parser.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def _run(args: argparse.Namespace, progress) -> bool:
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..languages import (
@@ -94,14 +94,19 @@ def run(args: argparse.Namespace) -> None:
         ):
             print("[FAIL] Требуется --force или интерактивное подтверждение. Ничего не сохранено.")
             sys.exit(1)
+        progress.begin_attempt()
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
             result = edit_languages_on_hh(
                 context.new_page(), resume, proposed, dry_run=False, mode=args.mode
             )
+        if not result.success:
+            progress.failed_count += 1
+        else:
+            progress.applied_count += 1
         _report(result, resume.id, False)
-        return
+        return not result.success
     else:
         if config.ai is None:
             print("[FAIL] Секция ai не включена; укажите --language NAME=CEFR или добавьте ai: {}")
@@ -194,3 +199,17 @@ def _report(result, resume_id: str, dry_run: bool) -> None:
         print(f"  - {language.name} [{level}]")
     if dry_run:
         print("[INFO] Ничего не сохранено на hh.ru.")
+
+
+def run(args: argparse.Namespace):
+    """Execute one resume-edit command under the durable command-run ledger."""
+    from ..history import History
+    from ._common import run_supervised_command
+
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command="edit_languages",
+        history=history,
+        requested_limit=1,
+        body=lambda progress: _run(args, progress),
+    )

--- a/src/hhru_bot/commands/edit_languages.py
+++ b/src/hhru_bot/commands/edit_languages.py
@@ -52,7 +52,7 @@ def register(subparsers) -> None:
 
 
 def _run(args: argparse.Namespace, progress) -> bool:
-    from ..browser import launch_context
+    from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..languages import (
         build_languages_prompt,
@@ -109,14 +109,27 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 result = edit_languages_on_hh(
                     context.new_page(), resume, proposed, dry_run=False, mode=args.mode
                 )
+        except BrowserLaunchError:
+            # #465 review round 3: re-raise so cli.py's dedicated handler
+            # (prints "[ENVIRONMENT] ..." and exits distinctly) still fires,
+            # instead of the broad except Exception below swallowing it.
+            raise
         except Exception as exc:  # browser/auth errors are a failed command, not a traceback
             if progress.attempted_count:
                 progress.failed_count += 1
             print(f"[FAIL] {resume.id} — {exc}")
             return True
         if not result.success:
-            progress.failed_count += 1
-            print(f"[FAIL] {resume.id} — {result.reason}")
+            # acted=True and not success is the uncertain discriminator
+            # (CLAUDE.md #163/#176, #465 review round 3): the write may
+            # already have reached hh.ru, so this is not a definite failure.
+            uncertain = result.acted
+            if uncertain:
+                progress.uncertain_count += 1
+            else:
+                progress.failed_count += 1
+            prefix = "[FAIL] (uncertain)" if uncertain else "[FAIL]"
+            print(f"{prefix} {resume.id} — {result.reason}")
             return True
         progress.applied_count += 1
         print(f"[OK] {resume.id}: языков предложено: {len(result.proposed)}")
@@ -173,7 +186,9 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 )
                 content = response.content if response and response.content else ""
                 proposed = parse_language_plan(content)
-            except (ImportError, ValueError, RuntimeError) as exc:
+            except (ImportError, ValueError, RuntimeError, PlaywrightError) as exc:
+                # #465 review round 3: page.locator("body").inner_text() can
+                # also raise PlaywrightError, same as the card read above.
                 print(f"[FAIL] Не удалось построить безопасный план языков: {exc}")
                 return True
             # #265 code-review round 3: the LLM branch is a planner only, not

--- a/src/hhru_bot/commands/edit_languages.py
+++ b/src/hhru_bot/commands/edit_languages.py
@@ -93,20 +93,32 @@ def _run(args: argparse.Namespace, progress) -> bool:
         ):
             print("[FAIL] Требуется --force или интерактивное подтверждение. Ничего не сохранено.")
             return True
-        progress.begin_attempt()
-        with launch_context(
-            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-        ) as context:
-            result = edit_languages_on_hh(
-                context.new_page(), resume, proposed, dry_run=False, mode=args.mode
-            )
+        try:
+            with launch_context(
+                config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+            ) as context:
+                # begin_attempt() right before the real mutation, after the
+                # browser/context are already open (#465 review, round 2):
+                # counting the attempt before launch_context succeeded would
+                # misreport a browser-launch failure as a real (but failed)
+                # attempt — this whole block previously had no try/except at
+                # all, so such a failure escaped run_supervised_command's
+                # bool-based classification entirely (raw traceback,
+                # attempted=1 with every outcome column at 0).
+                progress.begin_attempt()
+                result = edit_languages_on_hh(
+                    context.new_page(), resume, proposed, dry_run=False, mode=args.mode
+                )
+        except Exception as exc:  # browser/auth errors are a failed command, not a traceback
+            if progress.attempted_count:
+                progress.failed_count += 1
+            print(f"[FAIL] {resume.id} — {exc}")
+            return True
         if not result.success:
             progress.failed_count += 1
-        else:
-            progress.applied_count += 1
-        if not result.success:
             print(f"[FAIL] {resume.id} — {result.reason}")
             return True
+        progress.applied_count += 1
         print(f"[OK] {resume.id}: языков предложено: {len(result.proposed)}")
         for language in result.proposed:
             level = language.level or "нуждается в подтверждении"

--- a/src/hhru_bot/commands/edit_languages.py
+++ b/src/hhru_bot/commands/edit_languages.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
@@ -70,7 +69,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
         resume = resolve_resume(config, args.resume)
     except ConfigError as exc:
         print(f"[FAIL] {exc}")
-        sys.exit(1)
+        return True
 
     manual = bool(args.language)
     if manual:
@@ -80,11 +79,11 @@ def _run(args: argparse.Namespace, progress) -> bool:
             proposed = parse_manual_languages(args.language)
         except ValueError as exc:
             print(f"[FAIL] {exc}")
-            sys.exit(1)
+            return True
         _print_plan(proposed, args.dry_run)
         if args.dry_run:
             print("[INFO] Ничего не сохранено на hh.ru.")
-            return
+            return False
         if not confirm_write(
             args.force,
             prompt=(
@@ -93,7 +92,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
             ),
         ):
             print("[FAIL] Требуется --force или интерактивное подтверждение. Ничего не сохранено.")
-            sys.exit(1)
+            return True
         progress.begin_attempt()
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -105,12 +104,18 @@ def _run(args: argparse.Namespace, progress) -> bool:
             progress.failed_count += 1
         else:
             progress.applied_count += 1
-        _report(result, resume.id, False)
-        return not result.success
+        if not result.success:
+            print(f"[FAIL] {resume.id} — {result.reason}")
+            return True
+        print(f"[OK] {resume.id}: языков предложено: {len(result.proposed)}")
+        for language in result.proposed:
+            level = language.level or "нуждается в подтверждении"
+            print(f"  - {language.name} [{level}]")
+        return False
     else:
         if config.ai is None:
             print("[FAIL] Секция ai не включена; укажите --language NAME=CEFR или добавьте ai: {}")
-            sys.exit(1)
+            return True
         from ..ai.llm_client import LLMClient
 
         with launch_context(
@@ -126,10 +131,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
             goto_hh(page, f"{HH_BASE_URL}/applicant/profile/me")
             if not has_auth_cookie(page) or has_login_form(page):
                 print("[FAIL] Сессия hh.ru не подтверждена")
-                sys.exit(1)
+                return True
             if urlsplit(page.url).path != "/applicant/profile/me":
                 print("[FAIL] Страница профиля не подтверждена")
-                sys.exit(1)
+                return True
             # #265 code-review round 1: fail closed on an indeterminate card
             # instead of silently feeding the LLM a false "no existing
             # languages" premise (PageStateIndeterminate invariant, CLAUDE.md).
@@ -144,11 +149,11 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 card = wait_for_language_card(page)
                 if card is None:
                     print("[FAIL] Карточка языков не найдена однозначно")
-                    sys.exit(1)
+                    return True
                 existing = read_existing_languages(card)
             except PlaywrightError as exc:
                 print(f"[FAIL] Карточка языков не подтверждена: {exc}")
-                sys.exit(1)
+                return True
             try:
                 response = LLMClient(config.ai).chat(
                     build_languages_prompt(page.locator("body").inner_text(), existing, args.mode),
@@ -158,7 +163,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 proposed = parse_language_plan(content)
             except (ImportError, ValueError, RuntimeError) as exc:
                 print(f"[FAIL] Не удалось построить безопасный план языков: {exc}")
-                sys.exit(1)
+                return True
             # #265 code-review round 3: the LLM branch is a planner only, not
             # a writer. parse_language_plan guarantees every LLM-sourced
             # Language.level is None (round 1 fix), so every genuinely new
@@ -177,7 +182,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 "[INFO] Для сохранения новых языков повторите с "
                 "--language NAME=CEFR для каждого языка."
             )
-            return
+            return False
 
 
 def _print_plan(proposed, dry_run: bool) -> None:
@@ -188,28 +193,8 @@ def _print_plan(proposed, dry_run: bool) -> None:
         print(f"  - {language.name} [{level}]")
 
 
-def _report(result, resume_id: str, dry_run: bool) -> None:
-    if not result.success:
-        print(f"[FAIL] {resume_id} — {result.reason}")
-        sys.exit(1)
-    prefix = "[DRY-RUN]" if dry_run else "[OK]"
-    print(f"{prefix} {resume_id}: языков предложено: {len(result.proposed)}")
-    for language in result.proposed:
-        level = language.level or "нуждается в подтверждении"
-        print(f"  - {language.name} [{level}]")
-    if dry_run:
-        print("[INFO] Ничего не сохранено на hh.ru.")
-
-
 def run(args: argparse.Namespace):
     """Execute one resume-edit command under the durable command-run ledger."""
-    from ..history import History
-    from ._common import run_supervised_command
+    from ._common import run_single_mutation_command
 
-    history = History(getattr(args, "history", "data/history.db"))
-    return run_supervised_command(
-        command="edit_languages",
-        history=history,
-        requested_limit=1,
-        body=lambda progress: _run(args, progress),
-    )
+    return run_single_mutation_command(command="edit_languages", args=args, body=_run)

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -41,7 +41,7 @@ def register(subparsers) -> None:
     parser.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def _run(args: argparse.Namespace, progress) -> bool:
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..skills import (
@@ -111,11 +111,15 @@ def run(args: argparse.Namespace) -> None:
                 print(f"[FAIL] Не удалось построить безопасный план навыков: {exc}")
                 sys.exit(1)
 
+        if not args.dry_run:
+            progress.begin_attempt()
         result = edit_skills_on_hh(page, resume, proposed, dry_run=args.dry_run, mode=args.mode)
 
     if not result.success:
+        if not args.dry_run:
+            progress.failed_count += 1
         print(f"[FAIL] {resume.id} — {result.reason}")
-        sys.exit(1)
+        return True
     prefix = "[DRY-RUN]" if args.dry_run else "[OK]"
     print(f"{prefix} {resume.id}: существующие навыки сохранены: {len(result.existing)}")
     for skill in result.proposed:
@@ -123,3 +127,20 @@ def run(args: argparse.Namespace) -> None:
         print(f"  - {skill.name} [{skill.level}] — {state}")
     if args.dry_run:
         print("[INFO] Ничего не сохранено на hh.ru.")
+    else:
+        progress.applied_count += 1
+    return False
+
+
+def run(args: argparse.Namespace):
+    """Execute one resume-edit command under the durable command-run ledger."""
+    from ..history import History
+    from ._common import run_supervised_command
+
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command="edit_skills",
+        history=history,
+        requested_limit=1,
+        body=lambda progress: _run(args, progress),
+    )

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from urllib.parse import urlsplit
 
 from .copy_resume import confirm_write
@@ -58,20 +57,20 @@ def _run(args: argparse.Namespace, progress) -> bool:
         resume = resolve_resume(config, args.resume)
     except ConfigError as exc:
         print(f"[FAIL] {exc}")
-        sys.exit(1)
+        return True
 
     if not args.dry_run and not confirm_write(
         args.force,
         prompt=f"Сохранить ключевые навыки резюме '{resume.id}' на hh.ru?",
     ):
         print("[FAIL] Требуется --force или интерактивное подтверждение. Ничего не сохранено.")
-        sys.exit(1)
+        return True
 
     try:
         manual = parse_manual_skills(args.skill)
     except ValueError as exc:
         print(f"[FAIL] {exc}")
-        sys.exit(1)
+        return True
 
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -86,7 +85,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 print(
                     "[FAIL] Секция ai не включена; укажите --skill NAME=LEVEL или добавьте ai: {}"
                 )
-                sys.exit(1)
+                return True
             from ..ai.llm_client import LLMClient
             from ..skills import read_skills
 
@@ -109,7 +108,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 proposed = parse_skill_plan(response.content)
             except (ImportError, ValueError, RuntimeError) as exc:
                 print(f"[FAIL] Не удалось построить безопасный план навыков: {exc}")
-                sys.exit(1)
+                return True
 
         if not args.dry_run:
             progress.begin_attempt()
@@ -134,13 +133,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
 
 def run(args: argparse.Namespace):
     """Execute one resume-edit command under the durable command-run ledger."""
-    from ..history import History
-    from ._common import run_supervised_command
+    from ._common import run_single_mutation_command
 
-    history = History(getattr(args, "history", "data/history.db"))
-    return run_supervised_command(
-        command="edit_skills",
-        history=history,
-        requested_limit=1,
-        body=lambda progress: _run(args, progress),
-    )
+    return run_single_mutation_command(command="edit_skills", args=args, body=_run)

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -112,7 +112,13 @@ def _run(args: argparse.Namespace, progress) -> bool:
 
         if not args.dry_run:
             progress.begin_attempt()
-        result = edit_skills_on_hh(page, resume, proposed, dry_run=args.dry_run, mode=args.mode)
+        try:
+            result = edit_skills_on_hh(page, resume, proposed, dry_run=args.dry_run, mode=args.mode)
+        except Exception as exc:  # browser/auth errors are a failed command, not a traceback
+            if not args.dry_run:
+                progress.failed_count += 1
+            print(f"[FAIL] {resume.id} — {exc}")
+            return True
 
     if not result.success:
         if not args.dry_run:

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -41,7 +41,7 @@ def register(subparsers) -> None:
 
 
 def _run(args: argparse.Namespace, progress) -> bool:
-    from ..browser import launch_context
+    from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..skills import (
         build_skills_prompt,
@@ -72,58 +72,73 @@ def _run(args: argparse.Namespace, progress) -> bool:
         print(f"[FAIL] {exc}")
         return True
 
-    with launch_context(
-        config.storage_state_file, headless=args.headless, user_agent=config.user_agent
-    ) as context:
-        page = context.new_page()
-        # Manual values intentionally avoid an LLM call. Otherwise use the same
-        # LLMClient transport and fail closed on every malformed/empty response.
-        if manual:
-            proposed = manual
-        else:
-            if config.ai is None:
-                print(
-                    "[FAIL] Секция ai не включена; укажите --skill NAME=LEVEL или добавьте ai: {}"
-                )
-                return True
-            from ..ai.llm_client import LLMClient
-            from ..skills import read_skills
+    try:
+        with launch_context(
+            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+        ) as context:
+            page = context.new_page()
+            # Manual values intentionally avoid an LLM call. Otherwise use the
+            # same LLMClient transport and fail closed on every malformed/empty
+            # response.
+            if manual:
+                proposed = manual
+            else:
+                if config.ai is None:
+                    print(
+                        "[FAIL] Секция ai не включена; "
+                        "укажите --skill NAME=LEVEL или добавьте ai: {}"
+                    )
+                    return True
+                from ..ai.llm_client import LLMClient
+                from ..skills import read_skills
 
-            try:
-                goto = f"https://hh.ru/resume/{resume.resume_id}"
-                from ..browser import goto_hh, has_auth_cookie, has_login_form
+                try:
+                    goto = f"https://hh.ru/resume/{resume.resume_id}"
+                    from ..browser import goto_hh, has_auth_cookie, has_login_form
 
-                goto_hh(page, goto)
-                if not has_auth_cookie(page) or has_login_form(page):
-                    raise RuntimeError("сессия hh.ru не подтверждена")
-                if urlsplit(page.url).path != f"/resume/{resume.resume_id}":
-                    raise RuntimeError("страница нужного резюме не подтверждена")
-                existing = read_skills(page)
-                response = LLMClient(config.ai).chat(
-                    build_skills_prompt(page.locator("body").inner_text(), existing, args.mode),
-                    temperature=0,
-                )
-                if not response or not response.content:
-                    raise ValueError("LLM вернул пустой ответ")
-                proposed = parse_skill_plan(response.content)
-            except (ImportError, ValueError, RuntimeError) as exc:
-                print(f"[FAIL] Не удалось построить безопасный план навыков: {exc}")
-                return True
+                    goto_hh(page, goto)
+                    if not has_auth_cookie(page) or has_login_form(page):
+                        raise RuntimeError("сессия hh.ru не подтверждена")
+                    if urlsplit(page.url).path != f"/resume/{resume.resume_id}":
+                        raise RuntimeError("страница нужного резюме не подтверждена")
+                    existing = read_skills(page)
+                    response = LLMClient(config.ai).chat(
+                        build_skills_prompt(page.locator("body").inner_text(), existing, args.mode),
+                        temperature=0,
+                    )
+                    if not response or not response.content:
+                        raise ValueError("LLM вернул пустой ответ")
+                    proposed = parse_skill_plan(response.content)
+                except (ImportError, ValueError, RuntimeError) as exc:
+                    print(f"[FAIL] Не удалось построить безопасный план навыков: {exc}")
+                    return True
 
-        if not args.dry_run:
-            progress.begin_attempt()
-        try:
-            result = edit_skills_on_hh(page, resume, proposed, dry_run=args.dry_run, mode=args.mode)
-        except Exception as exc:  # browser/auth errors are a failed command, not a traceback
             if not args.dry_run:
-                progress.failed_count += 1
-            print(f"[FAIL] {resume.id} — {exc}")
-            return True
+                progress.begin_attempt()
+            result = edit_skills_on_hh(page, resume, proposed, dry_run=args.dry_run, mode=args.mode)
+    except BrowserLaunchError:
+        # #465 review round 3: re-raise so cli.py's dedicated handler
+        # (prints "[ENVIRONMENT] ..." and exits distinctly) still fires,
+        # instead of the broad except Exception below swallowing it.
+        raise
+    except Exception as exc:  # browser/auth errors are a failed command, not a traceback
+        if not args.dry_run and progress.attempted_count:
+            progress.failed_count += 1
+        print(f"[FAIL] {resume.id} — {exc}")
+        return True
 
     if not result.success:
+        # acted=True and not success is the uncertain discriminator
+        # (CLAUDE.md #163/#176, #465 review round 3): the click may already
+        # have reached hh.ru, so this is not a definite failure.
+        uncertain = result.acted
         if not args.dry_run:
-            progress.failed_count += 1
-        print(f"[FAIL] {resume.id} — {result.reason}")
+            if uncertain:
+                progress.uncertain_count += 1
+            else:
+                progress.failed_count += 1
+        prefix = "[FAIL] (uncertain)" if uncertain else "[FAIL]"
+        print(f"{prefix} {resume.id} — {result.reason}")
         return True
     prefix = "[DRY-RUN]" if args.dry_run else "[OK]"
     print(f"{prefix} {resume.id}: существующие навыки сохранены: {len(result.existing)}")

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -216,22 +216,23 @@ def _run(args: argparse.Namespace, progress) -> bool:
             print(f"[OK] Раздел желаемой работы резюме '{resume.id}' обновлён.")
             return False
     except Exception as exc:
-        prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
-        if progress.attempted_count:
+        # #465 review: applied_count is only ever incremented right above,
+        # immediately before `return False` exits the `with` block. If
+        # context.__exit__ itself raises during that unwind, this handler
+        # would otherwise also add failed_count for the same attempt —
+        # progress.applied_count is the guard against double-counting one
+        # attempt as both a success and a failure.
+        if progress.attempted_count and not progress.applied_count:
+            prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
             progress.failed_count += 1
+        else:
+            prefix = "[FAIL]"
         print(f"{prefix} {exc}")
         return True
 
 
 def run(args: argparse.Namespace):
     """Execute one resume-edit command under the durable command-run ledger."""
-    from ..history import History
-    from ._common import run_supervised_command
+    from ._common import run_single_mutation_command
 
-    history = History(getattr(args, "history", "data/history.db"))
-    return run_supervised_command(
-        command="resume_position",
-        history=history,
-        requested_limit=1,
-        body=lambda progress: _run(args, progress),
-    )
+    return run_single_mutation_command(command="resume_position", args=args, body=_run)

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -7,6 +7,17 @@ import argparse
 from .copy_resume import confirm_write
 
 
+class _SaveConfirmationUncertain(RuntimeError):
+    """Post-click grey-zone failure marker (#465 review, round 3).
+
+    Raised only when the SAVE click already landed and confirmation
+    couldn't be verified (CLAUDE.md #207 grey-zone). A dedicated type, not a
+    substring match on the exception message, is the discriminator between
+    'uncertain' and 'failed' — text matching is fragile and was the exact
+    class of bug found in edit_skills.py/edit_languages.py in this round.
+    """
+
+
 def register(subparsers) -> None:
     p = subparsers.add_parser(
         "resume-position",
@@ -72,7 +83,7 @@ def _print_plan(plan) -> None:
 
 def _run(args: argparse.Namespace, progress) -> bool:
     from ..ai.llm_client import LLMClient
-    from ..browser import launch_context
+    from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..resume_position import (
         CANCEL,
@@ -209,12 +220,28 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     state="hidden", timeout=10_000
                 )
             except Exception as exc:  # click already landed; result is uncertain
-                raise RuntimeError(
+                raise _SaveConfirmationUncertain(
                     f"сохранение не подтверждено (uncertain) после клика: {exc}"
                 ) from exc
             progress.applied_count += 1
             print(f"[OK] Раздел желаемой работы резюме '{resume.id}' обновлён.")
             return False
+    except _SaveConfirmationUncertain as exc:
+        # #465 review round 3: the grey-zone post-click failure (CLAUDE.md
+        # #207) must be recorded as uncertain, not failed — the save click
+        # already landed and may have taken effect. A dedicated exception
+        # type (not a substring match on the message) is the discriminator,
+        # per the code-reviewer's round-3 finding that acted/uncertain must
+        # be a structural signal, never free-text matching.
+        if progress.attempted_count and not progress.applied_count:
+            progress.uncertain_count += 1
+        print(f"[FAIL] (uncertain) {exc}")
+        return True
+    except BrowserLaunchError:
+        # #465 review round 3: re-raise so cli.py's dedicated handler
+        # (prints "[ENVIRONMENT] ..." and exits distinctly) still fires,
+        # instead of the broad except Exception below swallowing it.
+        raise
     except Exception as exc:
         # #465 review: applied_count is only ever incremented right above,
         # immediately before `return False` exits the `with` block. If
@@ -223,11 +250,8 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # progress.applied_count is the guard against double-counting one
         # attempt as both a success and a failure.
         if progress.attempted_count and not progress.applied_count:
-            prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
             progress.failed_count += 1
-        else:
-            prefix = "[FAIL]"
-        print(f"{prefix} {exc}")
+        print(f"[FAIL] {exc}")
         return True
 
 

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -70,7 +70,7 @@ def _print_plan(plan) -> None:
         print(f"  {key}: {value}")
 
 
-def run(args: argparse.Namespace) -> bool:
+def _run(args: argparse.Namespace, progress) -> bool:
     from ..ai.llm_client import LLMClient
     from ..browser import launch_context
     from ..config import ConfigError, load_config_or_exit
@@ -199,6 +199,7 @@ def run(args: argparse.Namespace) -> bool:
                 page.locator(CANCEL).click()
                 print("[FAIL] Нужен --force или интерактивное подтверждение. Ничего не записано.")
                 return True
+            progress.begin_attempt()
             apply_position(page, plan)
             if page.locator(SAVE).count() != 1:
                 raise RuntimeError("кнопка сохранения формы не подтверждена")
@@ -211,9 +212,26 @@ def run(args: argparse.Namespace) -> bool:
                 raise RuntimeError(
                     f"сохранение не подтверждено (uncertain) после клика: {exc}"
                 ) from exc
+            progress.applied_count += 1
             print(f"[OK] Раздел желаемой работы резюме '{resume.id}' обновлён.")
             return False
     except Exception as exc:
         prefix = "[FAIL] (uncertain)" if "uncertain" in str(exc) else "[FAIL]"
+        if progress.attempted_count:
+            progress.failed_count += 1
         print(f"{prefix} {exc}")
         return True
+
+
+def run(args: argparse.Namespace):
+    """Execute one resume-edit command under the durable command-run ledger."""
+    from ..history import History
+    from ._common import run_supervised_command
+
+    history = History(getattr(args, "history", "data/history.db"))
+    return run_supervised_command(
+        command="resume_position",
+        history=history,
+        requested_limit=1,
+        body=lambda progress: _run(args, progress),
+    )

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -22,7 +22,7 @@ def _launch_context(*_args, **_kwargs):
     yield SimpleNamespace(new_page=lambda: _Page())
 
 
-def test_ai_planning_rejects_wrong_resume_route_before_read_or_llm(monkeypatch, capsys):
+def test_ai_planning_rejects_wrong_resume_route_before_read_or_llm(monkeypatch, capsys, tmp_path):
     resume = SimpleNamespace(id="requested", resume_id="requested")
     config = SimpleNamespace(ai=object(), storage_state_file="session.json", user_agent=None)
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
@@ -48,9 +48,10 @@ def test_ai_planning_rejects_wrong_resume_route_before_read_or_llm(monkeypatch, 
         skill=[],
         dry_run=True,
         force=False,
+        history=str(tmp_path / "history.db"),
     )
-    with pytest.raises(SystemExit) as exc:
-        command.run(args)
-
-    assert exc.value.code == 1
+    # #465: run() now returns `failed` (bool/CommandExitCode) under the
+    # durable command_run ledger instead of raising SystemExit — the
+    # validation error itself is unchanged, only how the command reports it.
+    assert command.run(args) is True
     assert "страница нужного резюме не подтверждена" in capsys.readouterr().out

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -107,38 +107,41 @@ def test_edit_experience_manual_entry_dry_run_without_ai(tmp_path, capsys, monke
 
 
 def test_edit_experience_manual_entry_invalid_json_fails_closed(tmp_path, capsys):
-    with pytest.raises(SystemExit) as exc:
+    # #465: run() reports a validation failure by returning `True` under the
+    # durable command_run ledger instead of raising SystemExit.
+    assert (
         edit_experience_cmd.run(
             _args(tmp_path, mode="fill", career=None, existing=None, entry=["{"])
         )
-    assert exc.value.code == 1
+        is True
+    )
     assert "валидный JSON" in capsys.readouterr().out
 
 
 def test_edit_experience_manual_entry_requires_company_and_position(tmp_path, capsys):
-    with pytest.raises(SystemExit) as exc:
+    assert (
         edit_experience_cmd.run(
             _args(tmp_path, mode="fill", career=None, existing=None, entry=['{"duties": "x"}'])
         )
-    assert exc.value.code == 1
+        is True
+    )
     assert "company и position" in capsys.readouterr().out
 
 
 def test_edit_experience_entry_conflicts_with_career(tmp_path, capsys):
-    with pytest.raises(SystemExit) as exc:
+    assert (
         edit_experience_cmd.run(
             _args(
                 tmp_path, career="факты", existing=None, entry=['{"company": "a", "position": "b"}']
             )
         )
-    assert exc.value.code == 1
+        is True
+    )
     assert "LLM-планированию" in capsys.readouterr().out
 
 
 def test_edit_experience_requires_career_or_entry(tmp_path, capsys):
-    with pytest.raises(SystemExit) as exc:
-        edit_experience_cmd.run(_args(tmp_path, mode="fill", career=None, existing=None))
-    assert exc.value.code == 1
+    assert edit_experience_cmd.run(_args(tmp_path, mode="fill", career=None, existing=None)) is True
     assert "--career" in capsys.readouterr().out
 
 
@@ -253,6 +256,54 @@ def test_resume_position_manual_allows_explicit_fill_mode(tmp_path, capsys, monk
     assert "新职位" in capsys.readouterr().out
 
 
+def test_resume_position_write_success_does_not_double_count_on_exit_error(
+    tmp_path, capsys, monkeypatch
+):
+    """A successful write must not also be counted as failed (#465 review).
+
+    Regression guard for the cycle-review PR #472 finding: applied_count was
+    incremented, then `return False` unwinds the `with launch_context(...)`
+    block — if `context.__exit__` itself raises during that unwind, the outer
+    `except Exception` handler must not ALSO add failed_count for the same
+    attempt (attempted=1 success=1 failed=1 would be a lie: the write did
+    land, per the applied_count already recorded).
+    """
+    from hhru_bot.history import History
+    from hhru_bot.resume_position import PositionValues
+
+    @contextmanager
+    def _exploding_launch_context(*_args, **_kwargs):
+        yield _FakePage()
+        raise RuntimeError("browser close failed")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", _exploding_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.open_position_form",
+        lambda page, resume: PositionValues(title="старая"),
+    )
+    monkeypatch.setattr("hhru_bot.resume_position.apply_position", lambda page, plan: None)
+
+    history_path = tmp_path / "h.db"
+    result = resume_position_cmd.run(
+        _args(
+            tmp_path,
+            title="新职位",
+            mode=None,
+            dry_run=False,
+            force=True,
+            history=str(history_path),
+        )
+    )
+    assert result is True  # the command still reports failure (exit unwind raised)
+
+    row = History(history_path).command_runs()[-1]
+    assert row["attempted"] == 1
+    assert row["success"] == 1
+    # The write itself landed (success=1); the __exit__ failure must not also
+    # be double-counted as a failure for the same single attempt.
+    assert row["failed"] == 0
+
+
 # --- edit-education ручные записи -------------------------------------------
 
 
@@ -275,11 +326,12 @@ def test_edit_education_parse_manual_records_requires_institution():
 
 
 def test_edit_education_manual_conflicts_with_source(tmp_path, capsys):
-    with pytest.raises(SystemExit) as exc:
+    assert (
         edit_education_cmd.run(
             _args(tmp_path, section="both", source="факты", mode=None, institution="МГУ")
         )
-    assert exc.value.code == 1
+        is True
+    )
     assert "LLM-планированию" in capsys.readouterr().out
 
 

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -140,34 +140,328 @@ def test_edit_languages_manual_write_failure_records_partial_not_failed(
     assert row["success"] == row["uncertain"] == row["skipped"] == 0
 
 
-@pytest.mark.parametrize(
-    ("module_name", "command_name"),
-    [
-        ("edit_education", "edit_education"),
-        ("edit_experience", "edit_experience"),
-    ],
-)
-def test_uncertain_outcome_is_not_counted_as_failed(
-    tmp_path: Path, monkeypatch, module_name: str, command_name: str
+def test_edit_education_uncertain_outcome_is_not_counted_as_failed(
+    tmp_path: Path, monkeypatch, capsys
 ) -> None:
     """An 'uncertain' mutation outcome must land in progress.uncertain_count,
     not failed_count (#465 review): CLAUDE.md/#176 treat 'uncertain' as
     'may have landed', which a ledger reading failed=1 uncertain=0 hides from
     the operator exactly the way this project fails closed against.
+
+    Drives the real edit_education._run body (not a stub of _run itself) by
+    mocking only edit_education_on_hh, per the code-reviewer agent's finding
+    that a monkeypatched _run never exercises the fix.
     """
-    command = importlib.import_module(f"hhru_bot.commands.{module_name}")
+    import hhru_bot.commands.edit_education as command
+    from hhru_bot.resume_education import EducationResult
 
-    def mutation(_args, progress):
-        progress.begin_attempt()
-        progress.uncertain_count += 1
-        return True
+    resume = SimpleNamespace(
+        id="r1", resume_id="r1", resume_url="https://hh.ru/resume/r1", education=None
+    )
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
 
-    monkeypatch.setattr(command, "_run", mutation)
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_education.edit_education_on_hh",
+        lambda *_a, **_kw: [
+            EducationResult(kind="primary", success=False, reason="не подтверждено", uncertain=True)
+        ],
+    )
+
     history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        section="both",
+        source=None,
+        mode=None,
+        institution="МГУ",
+        faculty=None,
+        specialty=None,
+        year=None,
+        primary_entry=None,
+        additional_entry=None,
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
 
-    assert command.run(argparse.Namespace(history=str(history_path))) is True
+    assert command.run(args) is True
+    assert "(uncertain)" in capsys.readouterr().out
 
     row = History(history_path).command_runs()[-1]
-    assert row["command"] == command_name
+    assert row["command"] == "edit_education"
     assert row["attempted"] == row["uncertain"] == 1
     assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_experience_uncertain_outcome_is_not_counted_as_failed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Same regression as above, for edit_experience._run (#465 review)."""
+    import hhru_bot.commands.edit_experience as command
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
+    monkeypatch.setattr(
+        "hhru_bot.experience.edit_experience_on_hh",
+        lambda *_a, **_kw: ["строка 1: uncertain, не подтверждено"],
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="fill",
+        career=None,
+        existing=None,
+        entry=['{"company": "a", "position": "b"}'],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "(uncertain)" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_experience"
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_languages_launch_failure_before_attempt_does_not_count_as_attempted(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for BLOCKING A found in cycle-review round 2 of PR #472:
+    the manual-write block had no try/except at all, so a launch_context
+    failure escaped run_supervised_command's bool-based classification
+    entirely (raw traceback, attempted=1 with every outcome column at 0).
+    A launch failure before begin_attempt() must not be counted as attempted.
+    """
+    import hhru_bot.commands.edit_languages as command
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    def exploding_launch_context(*_args, **_kwargs):
+        raise RuntimeError("browser launch failed")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", exploding_launch_context)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="append",
+        language=["English=B1"],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "browser launch failed" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_languages"
+    assert row["status"] == "failed"
+    assert row["attempted"] == 0
+    assert row["failed"] == row["success"] == row["uncertain"] == row["skipped"] == 0
+
+
+def test_edit_skills_mutation_exception_after_attempt_is_recorded_as_failed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a second BLOCKING finding in cycle-review round 2
+    of PR #472: edit_skills_on_hh() was called with no try/except after
+    begin_attempt(), so any exception it raised escaped run_supervised_command's
+    bool-based classification (attempted=1 with every outcome column at 0,
+    plus a raw traceback to the user).
+    """
+    import hhru_bot.commands.edit_skills as command
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    def exploding_edit_skills_on_hh(*_a, **_kw):
+        raise RuntimeError("skills form drifted")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.skills.edit_skills_on_hh", exploding_edit_skills_on_hh)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="append",
+        skill=["Python=advanced"],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "skills form drifted" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_skills"
+    assert row["status"] == "partial"
+    assert row["attempted"] == row["failed"] == 1
+    assert row["success"] == row["uncertain"] == row["skipped"] == 0
+
+
+def test_edit_education_hard_failure_wins_over_uncertain_in_same_batch(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a third finding in cycle-review round 2 of PR #472:
+    with --section both, a definite hard failure on one block was reported as
+    merely 'uncertain' whenever any OTHER block in the same batch happened to
+    be uncertain, because the old check was "any uncertain in the whole
+    batch" rather than "is THIS failure uncertain".
+    """
+    import hhru_bot.commands.edit_education as command
+    from hhru_bot.resume_education import EducationResult
+
+    resume = SimpleNamespace(
+        id="r1", resume_id="r1", resume_url="https://hh.ru/resume/r1", education=None
+    )
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_education.edit_education_on_hh",
+        lambda *_a, **_kw: [
+            EducationResult(
+                kind="primary",
+                success=False,
+                reason="строка образования отсутствует",
+                uncertain=False,
+            ),
+            EducationResult(
+                kind="additional",
+                success=False,
+                reason="сохранение не подтверждено",
+                uncertain=True,
+            ),
+        ],
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        section="both",
+        source=None,
+        mode=None,
+        institution="МГУ",
+        faculty=None,
+        specialty=None,
+        year=None,
+        primary_entry=None,
+        additional_entry=None,
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_education"
+    # The definite hard failure (primary) must dominate the ledger status,
+    # not the co-occurring uncertain result (additional).
+    assert row["attempted"] == row["failed"] == 1
+    assert row["uncertain"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_education_mutation_exception_after_attempt_is_recorded_as_failed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a fourth finding in cycle-review round 2 of PR
+    #472: only `except NotAuthenticated` guarded edit_education_on_hh() after
+    begin_attempt(), so any OTHER exception (e.g. a selector-drift
+    TimeoutError) escaped uncaught instead of being recorded as failed.
+    """
+    import hhru_bot.commands.edit_education as command
+
+    resume = SimpleNamespace(
+        id="r1", resume_id="r1", resume_url="https://hh.ru/resume/r1", education=None
+    )
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    def exploding_edit_education_on_hh(*_a, **_kw):
+        raise RuntimeError("education form drifted")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_education.edit_education_on_hh", exploding_edit_education_on_hh
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        section="both",
+        source=None,
+        mode=None,
+        institution="МГУ",
+        faculty=None,
+        specialty=None,
+        year=None,
+        primary_entry=None,
+        additional_entry=None,
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "education form drifted" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_education"
+    assert row["status"] == "partial"
+    assert row["attempted"] == row["failed"] == 1
+    assert row["success"] == row["uncertain"] == row["skipped"] == 0

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -465,3 +465,305 @@ def test_edit_education_mutation_exception_after_attempt_is_recorded_as_failed(
     assert row["status"] == "partial"
     assert row["attempted"] == row["failed"] == 1
     assert row["success"] == row["uncertain"] == row["skipped"] == 0
+
+
+def test_resume_position_grey_zone_post_click_failure_is_uncertain_not_failed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a BLOCKING finding in cycle-review round 3 of PR
+    #472: the CLAUDE.md #207 grey-zone post-click failure (save click landed,
+    confirmation timed out) was recorded as failed_count instead of
+    uncertain_count, losing the "may have landed" fail-closed semantic.
+    """
+    import hhru_bot.commands.resume_position as command
+    from hhru_bot.resume_position import PositionValues
+
+    resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=object())
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=object())
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    class _FailingLocator:
+        def count(self):
+            return 1
+
+        def click(self):
+            return None
+
+        def wait_for(self, *, state=None, timeout=None):
+            raise TimeoutError("form did not hide")
+
+    class _Page:
+        def locator(self, _selector):
+            return _FailingLocator()
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: _Page())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.open_position_form",
+        lambda page, resume: PositionValues(title="старая"),
+    )
+    monkeypatch.setattr("hhru_bot.resume_position.apply_position", lambda page, plan: None)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        title="новая",
+        specialization=None,
+        salary=None,
+        currency=None,
+        employment=None,
+        work_format=None,
+        commute=None,
+        business_trips=None,
+        mode=None,
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "(uncertain)" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "resume_position"
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_experience_hard_failure_wins_over_uncertain_in_same_batch(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for the same batch-classification bug (round 2 fixed
+    it in edit_education.py; round 3 found it still present here): a hard
+    failure on one --entry item must win over an uncertain result on another
+    item in the same batch.
+    """
+    import hhru_bot.commands.edit_experience as command
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
+    monkeypatch.setattr(
+        "hhru_bot.experience.edit_experience_on_hh",
+        lambda *_a, **_kw: [
+            "строка 1: отклонено, ошибка формы",
+            "строка 2: uncertain, не подтверждено",
+        ],
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="fill",
+        career=None,
+        existing=None,
+        entry=[
+            '{"company": "a", "position": "b"}',
+            '{"company": "c", "position": "d"}',
+        ],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_experience"
+    assert row["attempted"] == row["failed"] == 1
+    assert row["uncertain"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_skills_acted_failure_is_recorded_as_uncertain(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a BLOCKING finding in cycle-review round 3 of PR
+    #472: edit_skills.py had no uncertain lane at all — SkillsResult(
+    success=False, acted=True) was always counted as failed, even though
+    ``acted`` documents that the click may already have reached hh.ru.
+    """
+    import hhru_bot.commands.edit_skills as command
+    from hhru_bot.skills import SkillsResult
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.skills.edit_skills_on_hh",
+        lambda *_a, **_kw: SkillsResult(
+            success=False, acted=True, reason="сохранение навыков не подтверждено"
+        ),
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="append",
+        skill=["Python=advanced"],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "(uncertain)" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_skills"
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
+def test_edit_languages_acted_failure_is_recorded_as_uncertain(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for a BLOCKING finding in cycle-review round 3 of PR
+    #472: edit_languages.py had no uncertain lane at all — LanguagesResult(
+    success=False, acted=True) was always counted as failed.
+    """
+    import hhru_bot.commands.edit_languages as command
+    from hhru_bot.languages import Language, LanguagesResult
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.languages.edit_languages_on_hh",
+        lambda *_a, **_kw: LanguagesResult(
+            success=False,
+            acted=True,
+            proposed=(Language("English", "B1"),),
+            reason="сохранение не подтверждено",
+        ),
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="append",
+        language=["English=B1"],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "(uncertain)" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_languages"
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["edit_education", "edit_experience", "edit_skills", "edit_languages", "resume_position"],
+)
+def test_browser_launch_error_propagates_to_cli_environment_handler(
+    tmp_path: Path, monkeypatch, module_name: str
+) -> None:
+    """Regression test for a finding in cycle-review round 3 of PR #472: a
+    broad ``except Exception`` added around launch_context in each command
+    must not swallow BrowserLaunchError before it reaches cli.py's dedicated
+    handler (prints "[ENVIRONMENT] ..." and exits distinctly from an
+    ordinary command failure).
+    """
+    from hhru_bot.browser import BrowserLaunchError
+
+    command = importlib.import_module(f"hhru_bot.commands.{module_name}")
+    resume = SimpleNamespace(
+        id="r1",
+        resume_id="r1",
+        resume_url="https://hh.ru/resume/r1",
+        education=None,
+        ai_profile=object(),
+    )
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=object())
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    def exploding_launch_context(*_args, **_kwargs):
+        raise BrowserLaunchError("CODEX_SANDBOX_BROWSER_FAILURE: sandboxed")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", exploding_launch_context)
+
+    history_path = tmp_path / "history.db"
+    base_args = {
+        "config": "config.yaml",
+        "headless": True,
+        "resume": "r1",
+        "dry_run": False,
+        "force": True,
+        "history": str(history_path),
+    }
+    per_command_args = {
+        "edit_education": {
+            "section": "both",
+            "source": None,
+            "mode": None,
+            "institution": "МГУ",
+            "faculty": None,
+            "specialty": None,
+            "year": None,
+            "primary_entry": None,
+            "additional_entry": None,
+        },
+        "edit_experience": {
+            "mode": "fill",
+            "career": None,
+            "existing": None,
+            "entry": ['{"company": "a", "position": "b"}'],
+        },
+        "edit_skills": {"mode": "append", "skill": ["Python=advanced"]},
+        "edit_languages": {"mode": "append", "language": ["English=B1"]},
+        "resume_position": {
+            "title": "новая",
+            "specialization": None,
+            "salary": None,
+            "currency": None,
+            "employment": None,
+            "work_format": None,
+            "commute": None,
+            "business_trips": None,
+            "mode": None,
+        },
+    }
+    args = argparse.Namespace(**base_args, **per_command_args[module_name])
+
+    with pytest.raises(BrowserLaunchError):
+        command.run(args)

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import importlib
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -44,3 +46,128 @@ def test_successful_resume_edit_persists_one_complete_command_run(
     assert row["attempted"] == row["success"] == 1
     assert row["failed"] == row["uncertain"] == row["skipped"] == 0
     assert "attempted=1 success=1 failed=0 uncertain=0 skipped=0" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("module_name", "command_name"),
+    [
+        ("edit_experience", "edit_experience"),
+        ("edit_education", "edit_education"),
+        ("edit_skills", "edit_skills"),
+        ("edit_languages", "edit_languages"),
+        ("resume_position", "resume_position"),
+    ],
+)
+def test_failed_mutation_after_attempt_persists_partial_status(
+    tmp_path: Path, monkeypatch, module_name: str, command_name: str
+) -> None:
+    """A failure AFTER begin_attempt() must record status='partial' (#465 review).
+
+    Regression guard for the edit_languages.py bug found in cycle-review of
+    PR #472: a body that still called sys.exit()/raised SystemExit past the
+    attempt-reservation point escaped run_supervised_command's normal
+    bool-based classification (the generic ``except BaseException`` branch
+    never computes final_status), recording status='failed' instead of the
+    'partial' every other command produces for the identical one-attempt-
+    failed outcome.
+    """
+    command = importlib.import_module(f"hhru_bot.commands.{module_name}")
+
+    def mutation(_args, progress):
+        progress.begin_attempt()
+        progress.failed_count += 1
+        return True
+
+    monkeypatch.setattr(command, "_run", mutation)
+    history_path = tmp_path / "history.db"
+
+    assert command.run(argparse.Namespace(history=str(history_path))) is True
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == command_name
+    assert row["status"] == "partial"
+    assert row["attempted"] == row["failed"] == 1
+    assert row["success"] == row["uncertain"] == row["skipped"] == 0
+
+
+def test_edit_languages_manual_write_failure_records_partial_not_failed(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Regression test for the dead-code/status bug found in cycle-review of
+    PR #472: a failed manual ``--language`` write must return True (not raise
+    SystemExit via a leftover ``_report()`` call) and the ledger must show
+    ``status='partial'`` like every sibling command, not ``'failed'``.
+    """
+    import hhru_bot.commands.edit_languages as command
+    from hhru_bot.languages import Language, LanguagesResult
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.languages.edit_languages_on_hh",
+        lambda *_a, **_kw: LanguagesResult(
+            success=False, proposed=(Language("English", "B1"),), reason="запись не подтверждена"
+        ),
+    )
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="append",
+        language=["English=B1"],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "запись не подтверждена" in capsys.readouterr().out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "edit_languages"
+    assert row["status"] == "partial"
+    assert row["attempted"] == row["failed"] == 1
+    assert row["success"] == row["uncertain"] == row["skipped"] == 0
+
+
+@pytest.mark.parametrize(
+    ("module_name", "command_name"),
+    [
+        ("edit_education", "edit_education"),
+        ("edit_experience", "edit_experience"),
+    ],
+)
+def test_uncertain_outcome_is_not_counted_as_failed(
+    tmp_path: Path, monkeypatch, module_name: str, command_name: str
+) -> None:
+    """An 'uncertain' mutation outcome must land in progress.uncertain_count,
+    not failed_count (#465 review): CLAUDE.md/#176 treat 'uncertain' as
+    'may have landed', which a ledger reading failed=1 uncertain=0 hides from
+    the operator exactly the way this project fails closed against.
+    """
+    command = importlib.import_module(f"hhru_bot.commands.{module_name}")
+
+    def mutation(_args, progress):
+        progress.begin_attempt()
+        progress.uncertain_count += 1
+        return True
+
+    monkeypatch.setattr(command, "_run", mutation)
+    history_path = tmp_path / "history.db"
+
+    assert command.run(argparse.Namespace(history=str(history_path))) is True
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == command_name
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -1,0 +1,46 @@
+"""Durable-ledger wiring for the single-mutation resume edit commands (#465)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("module_name", "command_name"),
+    [
+        ("edit_experience", "edit_experience"),
+        ("edit_education", "edit_education"),
+        ("edit_skills", "edit_skills"),
+        ("edit_languages", "edit_languages"),
+        ("resume_position", "resume_position"),
+    ],
+)
+def test_successful_resume_edit_persists_one_complete_command_run(
+    tmp_path: Path, monkeypatch, capsys, module_name: str, command_name: str
+) -> None:
+    command = importlib.import_module(f"hhru_bot.commands.{module_name}")
+
+    def mutation(_args, progress):
+        progress.begin_attempt()
+        progress.applied_count += 1
+        return False
+
+    monkeypatch.setattr(command, "_run", mutation)
+    history_path = tmp_path / "history.db"
+
+    assert command.run(argparse.Namespace(history=str(history_path))) is False
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == command_name
+    assert row["status"] == "completed"
+    assert row["attempted"] == row["success"] == 1
+    assert row["failed"] == row["uncertain"] == row["skipped"] == 0
+    assert "attempted=1 success=1 failed=0 uncertain=0 skipped=0" in capsys.readouterr().out

--- a/tests/test_resume_id_addressing.py
+++ b/tests/test_resume_id_addressing.py
@@ -203,20 +203,19 @@ def test_edit_education_remote_hash_requires_education_section(capsys, tmp_path)
     from hhru_bot.commands import edit_education as edit_cmd
 
     config = _write_config(tmp_path, _config_body())
-    with pytest.raises(SystemExit) as exc:
-        edit_cmd.run(
-            _args(
-                config,
-                tmp_path / "h.db",
-                resume=REMOTE_ONLY_HASH,
-                section="both",
-                source=None,
-                mode=None,
-                dry_run=True,
-                force=False,
-            )
+    result = edit_cmd.run(
+        _args(
+            config,
+            tmp_path / "h.db",
+            resume=REMOTE_ONLY_HASH,
+            section="both",
+            source=None,
+            mode=None,
+            dry_run=True,
+            force=False,
         )
-    assert exc.value.code == 1
+    )
+    assert result is True
     out = capsys.readouterr().out
     assert "[FAIL]" in out
     assert "требуется настройка 'education'" in out


### PR DESCRIPTION
## Summary
- wire durable `command_runs` supervision into all five remaining resume-edit WRITE commands
- count one real mutation per command execution and correlate existing education/experience actions to the run
- cover successful ledger rows for every command

## Tests
- `pytest -q`
- `ruff check src/hhru_bot/commands/edit_{experience,education,skills,languages}.py src/hhru_bot/commands/resume_position.py tests/test_resume_edit_command_runs.py`

Closes #465