### PR TITLE
feat: hybrid questionnaire answerer audit

### DIFF
--- a/src/hhru_bot/ai/questions.py
+++ b/src/hhru_bot/ai/questions.py
@@ -45,6 +45,10 @@ class AnswerProposal:
     answer: str
     confidence: float
     option_indices: tuple[int, ...] = ()
+    # ``profile`` means a local account fact (exact key or key classifier);
+    # ``llm`` is an answer generated for this vacancy.  The value itself never
+    # leaves the process during the profile-key classification stage.
+    answer_source: str = "llm"
 
     @property
     def low_confidence(self) -> bool:
@@ -200,7 +204,7 @@ class AIQuestionAnswerer:
         if profile_answer is not None:
             indices = self._choice_indices(question, profile_answer)
             if question.kind != "choice" or indices:
-                return AnswerProposal(question, profile_answer, 1.0, indices)
+                return AnswerProposal(question, profile_answer, 1.0, indices, "profile")
         try:
             response = self._llm.chat(_prompt(question, self._profile), temperature=0.2)
             payload: Any = json.loads((response.content or "").strip())

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -228,7 +228,7 @@ def _record_questionnaire_answers(
                     "answer": proposal.answer if not proposal.low_confidence else "",
                     "answer_source": proposal.answer_source,
                     "confidence": proposal.confidence,
-                    "filled": filled and not proposal.low_confidence,
+                    "filled": filled,
                 }
                 for proposal in proposals
             ],

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -12,15 +12,16 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from ..ai.questions import AIQuestionAnswerer, extract_questions
+from ..ai.questions import AIQuestionAnswerer, AnswerProposal, extract_questions
 from ..browser import goto_hh, has_login_form
-from ..history import SKIP_REASONS
+from ..history import SKIP_REASONS, History
 from ..search import VacancyCard
 from . import steps as apply_steps
 from .antibot import AntiBotChallengeDetected, detect_antibot_on_page
@@ -113,6 +114,8 @@ class ApplyContext:
     # #245: durable audit marker immediately before entering the submit path.
     before_submit: Callable[[], None] | None = None
     question_answerer: AIQuestionAnswerer | None = None
+    questionnaire_history: History | None = None
+    run_id: str | None = None
     force: bool = False
     allow_relocation: bool = False
 
@@ -176,6 +179,8 @@ def apply_to_vacancy(
     verifier: ResponseVerifier | None = None,
     before_submit: Callable[[], None] | None = None,
     question_answerer: AIQuestionAnswerer | None = None,
+    questionnaire_history: History | None = None,
+    run_id: str | None = None,
     force: bool = False,
     allow_relocation: bool = False,
 ) -> ApplyResult:
@@ -190,10 +195,50 @@ def apply_to_vacancy(
         verifier=verifier,
         before_submit=before_submit,
         question_answerer=question_answerer,
+        questionnaire_history=questionnaire_history,
+        run_id=run_id,
         force=force,
         allow_relocation=allow_relocation,
     )
     return _run(ctx)
+
+
+def _record_questionnaire_answers(
+    ctx: ApplyContext, proposals: list[AnswerProposal], *, filled: bool
+) -> bool:
+    """Persist a local audit snapshot without claiming the response was sent."""
+    if ctx.questionnaire_history is None or ctx.dry_run:
+        return True
+    try:
+        ctx.questionnaire_history.record_questionnaire(
+            ctx.resume_id,
+            ctx.vacancy.vacancy_id,
+            ctx.vacancy.url,
+            ctx.vacancy.title,
+            ctx.vacancy.company,
+            [
+                {
+                    "body_index": proposal.question.body_index,
+                    "text": proposal.question.text,
+                    "kind": proposal.question.kind,
+                    "is_radio": proposal.question.is_radio,
+                    "options": list(proposal.question.options),
+                    # A low-confidence proposal deliberately records no
+                    # answer, even if malformed model output contained one.
+                    "answer": proposal.answer if not proposal.low_confidence else "",
+                    "answer_source": proposal.answer_source,
+                    "confidence": proposal.confidence,
+                    "filled": filled and not proposal.low_confidence,
+                }
+                for proposal in proposals
+            ],
+            source="apply",
+            run_id=ctx.run_id,
+        )
+        return True
+    except sqlite3.Error as exc:
+        logger.warning("[FAIL] %s — не удалось записать аудит анкеты: %s", ctx.vacancy.title, exc)
+        return False
 
 
 def _finalize_blocker(ctx: ApplyContext, blocker: PostClickBlocker) -> ApplyResult:
@@ -503,6 +548,8 @@ def _run(ctx: ApplyContext) -> ApplyResult:
             )
         low_confidence = [proposal for proposal in proposals if proposal.low_confidence]
         if low_confidence:
+            if not _record_questionnaire_answers(ctx, proposals, filled=False):
+                return ctx.fail("не удалось записать аудит ответов анкеты")
             reason = (
                 f"пропущен вопрос с низкой уверенностью ({len(low_confidence)}): "
                 + low_confidence[0].question.text
@@ -530,6 +577,8 @@ def _run(ctx: ApplyContext) -> ApplyResult:
             reason = f"ошибка Playwright при заполнении ответов на вопросы ({exc})"
             logger.warning("[FAIL] %s — %s", ctx.vacancy.title, reason)
             return ctx.fail(reason)
+        if not _record_questionnaire_answers(ctx, proposals, filled=True):
+            return ctx.fail("не удалось записать аудит заполненной анкеты")
 
     # #176: окно действия. Submit-клик — единственный необратимый шаг формы;
     # исключение в момент/сразу после него (navigation timeout после POST,

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -221,7 +221,7 @@ def _build_question_answerer(
     except ImportError as exc:
         logger.warning("LLM-ответы на вопросы недоступны: %s", exc)
         return None
-    return AIQuestionAnswerer(client, getattr(resume, "ai_profile", None), known_data)
+    return AIQuestionAnswerer(client, getattr(resume, "ai_profile", None), known_data=known_data)
 
 
 def _build_scoring_provider(
@@ -516,7 +516,9 @@ def _build_apply_providers(
     return ApplyProviders(
         scoring_provider=_build_scoring_provider(config, resume),
         letter_provider=_build_letter_provider(config, resume, cover_letter_template),
-        question_answerer=_build_question_answerer(config, resume, history.get_profile_answers()),
+        question_answerer=_build_question_answerer(
+            config, resume, known_data=history.get_profile_answers()
+        ),
     )
 
 

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -1028,6 +1028,10 @@ def _run_apply_for_resume(
         if question_answerer is not None:
             apply_kwargs["question_answerer"] = question_answerer
             apply_kwargs["force"] = getattr(args, "force", False)
+            # #473: the questionnaire audit is append-only and linked to the
+            # command ledger/action outcome through this run id.
+            apply_kwargs["questionnaire_history"] = history
+            apply_kwargs["run_id"] = progress.run_id if progress is not None else None
         if progress is not None:
             progress.begin_attempt()
         try:

--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -85,7 +85,9 @@ def run(args: argparse.Namespace) -> None:
         print(format_summary(summary, args.format))
         if args.format != "csv":
             print(f"Тестов ожидает: {pending_tests}")
-            questionnaire_answers = history.questionnaire_answer_summary()
+            questionnaire_answers = history.questionnaire_answer_summary(
+                resume_id=resume_id, period=args.period
+            )
             print(
                 "Анкеты: профиль={profile}, LLM={llm}, не закрыто={unanswered}".format(
                     **questionnaire_answers

--- a/src/hhru_bot/commands/stats.py
+++ b/src/hhru_bot/commands/stats.py
@@ -85,6 +85,12 @@ def run(args: argparse.Namespace) -> None:
         print(format_summary(summary, args.format))
         if args.format != "csv":
             print(f"Тестов ожидает: {pending_tests}")
+            questionnaire_answers = history.questionnaire_answer_summary()
+            print(
+                "Анкеты: профиль={profile}, LLM={llm}, не закрыто={unanswered}".format(
+                    **questionnaire_answers
+                )
+            )
         # CSV — экспорт для машин: один документ, одна схема колонок (см. #112
         # ревью). Reply-сводка имеет другую схему (metric,value), поэтому в csv
         # её печатать вторым документом в тот же stdout-поток нельзя — консьюмер,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -329,6 +329,7 @@ CREATE TABLE IF NOT EXISTS questionnaire_scans (
     vacancy_url TEXT NOT NULL,
     title TEXT NOT NULL,
     company TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'probe',
     detected_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_questionnaire_scans_detected_at
@@ -341,7 +342,12 @@ CREATE TABLE IF NOT EXISTS questionnaire_questions (
     text TEXT NOT NULL,
     kind TEXT NOT NULL,
     is_radio INTEGER NOT NULL,
-    options_json TEXT NOT NULL
+    options_json TEXT NOT NULL,
+    answer TEXT,
+    answer_source TEXT,
+    confidence REAL,
+    filled INTEGER NOT NULL DEFAULT 0,
+    run_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_questionnaire_questions_scan_id
     ON questionnaire_questions(scan_id);
@@ -496,6 +502,15 @@ class History:
             _ensure_column(conn, "actions", "search_query", "TEXT")
             _ensure_column(conn, "actions", "run_id", "TEXT")
             _ensure_column(conn, "actions", "reason_code", "TEXT")
+            # #473: questionnaire research snapshots predate the apply audit
+            # fields.  CREATE TABLE IF NOT EXISTS leaves those old tables
+            # untouched, so keep the migration explicitly idempotent.
+            _ensure_column(conn, "questionnaire_scans", "source", "TEXT NOT NULL DEFAULT 'probe'")
+            _ensure_column(conn, "questionnaire_questions", "answer", "TEXT")
+            _ensure_column(conn, "questionnaire_questions", "answer_source", "TEXT")
+            _ensure_column(conn, "questionnaire_questions", "confidence", "REAL")
+            _ensure_column(conn, "questionnaire_questions", "filled", "INTEGER NOT NULL DEFAULT 0")
+            _ensure_column(conn, "questionnaire_questions", "run_id", "TEXT")
             # #420 follow-up (Codex adversarial-review, PR #449): review_queue
             # rows created before this column existed have no stored search_query
             # — they stay NULL and are legacy-attributed via the existing
@@ -2601,20 +2616,39 @@ class History:
         title: str,
         company: str,
         questions: list[dict[str, object]],
+        *,
+        source: str = "probe",
+        run_id: str | None = None,
     ) -> None:
-        """Append a questionnaire snapshot and all visible question options."""
+        """Append a questionnaire snapshot and its visible questions.
+
+        ``filled`` records only a successful form fill, never an HH.ru submit
+        or its later confirmation.  Apply results remain the single source of
+        truth in ``actions`` and are joined to this audit by ``run_id``.
+        """
+        if source not in {"probe", "apply"}:
+            raise ValueError(f"unknown questionnaire source: {source!r}")
         with self._connect() as conn:
             cursor = conn.execute(
                 """INSERT INTO questionnaire_scans
-                   (resume_id, vacancy_id, vacancy_url, title, company, detected_at)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (resume_id, vacancy_id, vacancy_url, title, company, datetime.now().isoformat()),
+                   (resume_id, vacancy_id, vacancy_url, title, company, source, detected_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    resume_id,
+                    vacancy_id,
+                    vacancy_url,
+                    title,
+                    company,
+                    source,
+                    datetime.now().isoformat(),
+                ),
             )
             scan_id = cursor.lastrowid
             conn.executemany(
                 """INSERT INTO questionnaire_questions
-                   (scan_id, body_index, text, kind, is_radio, options_json)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
+                   (scan_id, body_index, text, kind, is_radio, options_json,
+                    answer, answer_source, confidence, filled, run_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 [
                     (
                         scan_id,
@@ -2623,10 +2657,29 @@ class History:
                         str(question["kind"]),
                         int(bool(question["is_radio"])),
                         json.dumps(question["options"], ensure_ascii=False),
+                        question.get("answer"),
+                        question.get("answer_source"),
+                        question.get("confidence"),
+                        int(bool(question.get("filled", False))),
+                        run_id,
                     )
                     for question in questions
                 ],
             )
+
+    def questionnaire_answer_summary(self) -> dict[str, int]:
+        """Return filled profile/LLM and unfilled counts from apply audits."""
+        with self._connect() as conn:
+            row = conn.execute(
+                """SELECT
+                       COALESCE(SUM(filled = 1 AND answer_source = 'profile'), 0) AS profile,
+                       COALESCE(SUM(filled = 1 AND answer_source = 'llm'), 0) AS llm,
+                       COALESCE(SUM(filled = 0), 0) AS unanswered
+                     FROM questionnaire_questions AS question
+                     JOIN questionnaire_scans AS scan ON scan.id = question.scan_id
+                    WHERE scan.source = 'apply'"""
+            ).fetchone()
+        return {key: int(row[key]) for key in ("profile", "llm", "unanswered")}
 
     def is_robot_questionnaire(self, topic: str) -> bool:
         with self._connect() as conn:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -2667,17 +2667,37 @@ class History:
                 ],
             )
 
-    def questionnaire_answer_summary(self) -> dict[str, int]:
-        """Return filled profile/LLM and unfilled counts from apply audits."""
+    def questionnaire_answer_summary(
+        self, resume_id: str | None = None, period: str = "all"
+    ) -> dict[str, int]:
+        """Return filled profile/LLM and unfilled counts from apply audits.
+
+        Scoped the same way as ``summary()``/``reply_summary()`` (#473 cycle-review):
+        ``resume_id=None`` means all resumes, ``period`` filters on
+        ``questionnaire_scans.detected_at`` — otherwise a scoped ``stats
+        --resume X --period 7d`` call would silently mix in lifetime,
+        all-resume totals for this one line.
+        """
+        where = ["scan.source = 'apply'"]
+        params: list = []
+        if resume_id is not None:
+            where.append("scan.resume_id = ?")
+            params.append(resume_id)
+        since = self._period_since(period)
+        if since is not None:
+            where.append("scan.detected_at >= ?")
+            params.append(since)
+        clause = " AND ".join(where)
         with self._connect() as conn:
             row = conn.execute(
-                """SELECT
+                f"""SELECT
                        COALESCE(SUM(filled = 1 AND answer_source = 'profile'), 0) AS profile,
                        COALESCE(SUM(filled = 1 AND answer_source = 'llm'), 0) AS llm,
                        COALESCE(SUM(filled = 0), 0) AS unanswered
                      FROM questionnaire_questions AS question
                      JOIN questionnaire_scans AS scan ON scan.id = question.scan_id
-                    WHERE scan.source = 'apply'"""
+                    WHERE {clause}""",
+                params,
             ).fetchone()
         return {key: int(row[key]) for key in ("profile", "llm", "unanswered")}
 

--- a/tests/test_ai_questions_extract.py
+++ b/tests/test_ai_questions_extract.py
@@ -36,6 +36,7 @@ def test_answerer_marks_exact_known_fact_as_profile_source():
     assert proposal.confidence == 1.0
     assert proposal.answer_source == "profile"
 
+
 _VOID = {"input", "br", "hr", "img", "meta", "link", "area", "col", "embed", "source"}
 
 

--- a/tests/test_ai_questions_extract.py
+++ b/tests/test_ai_questions_extract.py
@@ -22,6 +22,20 @@ from hhru_bot.ai.questions import AIQuestionAnswerer, AnswerProposal, Question, 
 
 pytestmark = pytest.mark.unit
 
+
+def test_answerer_marks_exact_known_fact_as_profile_source():
+    class _LLM:
+        def chat(self, *_args, **_kwargs):
+            raise AssertionError("exact profile match must not call the LLM")
+
+    proposal = AIQuestionAnswerer(_LLM(), None, {"Готовы к переезду?": "Да"}).propose(
+        Question(0, "Готовы к переезду?", "text")
+    )
+
+    assert proposal.answer == "Да"
+    assert proposal.confidence == 1.0
+    assert proposal.answer_source == "profile"
+
 _VOID = {"input", "br", "hr", "img", "meta", "link", "area", "col", "embed", "source"}
 
 

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -1179,21 +1179,34 @@ def test_apply_questionnaire_audit_records_profile_fill_and_run_id(monkeypatch):
 
     question = Question(0, "Готовы к переезду?", "text")
     proposal = AnswerProposal(question, "Да", 1.0, answer_source="profile")
-    monkeypatch.setattr(pipeline_module, "detect_questions", lambda _page: _question_detection(True))
+    monkeypatch.setattr(
+        pipeline_module, "detect_questions", lambda _page: _question_detection(True)
+    )
     monkeypatch.setattr(pipeline_module, "extract_questions", lambda _page: ([question], 1))
     history = _QuestionnaireHistory()
 
     result = apply_to_vacancy(
         FakePage(apply_button=True, success=True, submit_in_form=True),
-        _vacancy(), "RID", "x", dry_run=False,
-        question_answerer=_StubAnswerer({question.text: proposal}), force=True,
-        questionnaire_history=history, run_id="run-473",
+        _vacancy(),
+        "RID",
+        "x",
+        dry_run=False,
+        question_answerer=_StubAnswerer({question.text: proposal}),
+        force=True,
+        questionnaire_history=history,
+        run_id="run-473",
     )
 
     assert result.success is True
     assert len(history.calls) == 1
     args, kwargs = history.calls[0]
-    assert args[:5] == ("RID", _vacancy().vacancy_id, _vacancy().url, _vacancy().title, _vacancy().company)
+    assert args[:5] == (
+        "RID",
+        _vacancy().vacancy_id,
+        _vacancy().url,
+        _vacancy().title,
+        _vacancy().company,
+    )
     assert kwargs["source"] == "apply"
     assert kwargs["run_id"] == "run-473"
     assert args[5][0]["answer_source"] == "profile"
@@ -1206,15 +1219,22 @@ def test_apply_questionnaire_audit_records_low_confidence_without_fill(monkeypat
 
     question = Question(0, "Расскажите о кейсе", "text")
     proposal = AnswerProposal(question, "Сомнительный ответ", 0.2)
-    monkeypatch.setattr(pipeline_module, "detect_questions", lambda _page: _question_detection(True))
+    monkeypatch.setattr(
+        pipeline_module, "detect_questions", lambda _page: _question_detection(True)
+    )
     monkeypatch.setattr(pipeline_module, "extract_questions", lambda _page: ([question], 1))
     history = _QuestionnaireHistory()
 
     result = apply_to_vacancy(
         FakePage(apply_button=True, success=True, submit_in_form=True),
-        _vacancy(), "RID", "x", dry_run=False,
-        question_answerer=_StubAnswerer({question.text: proposal}), force=True,
-        questionnaire_history=history, run_id="run-473",
+        _vacancy(),
+        "RID",
+        "x",
+        dry_run=False,
+        question_answerer=_StubAnswerer({question.text: proposal}),
+        force=True,
+        questionnaire_history=history,
+        run_id="run-473",
     )
 
     assert result.skipped is True

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -1016,6 +1016,14 @@ class _StubAnswerer:
         return [p for p in proposals if p.low_confidence]
 
 
+class _QuestionnaireHistory:
+    def __init__(self):
+        self.calls = []
+
+    def record_questionnaire(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
 def _question_detection(has_questions=True, reason="anketa"):
     from hhru_bot.apply.questions import QuestionDetection
 
@@ -1164,6 +1172,58 @@ def test_apply_dry_run_low_confidence_does_not_persist_skip(monkeypatch):
 
     assert result.success is False
     assert result.skipped is False
+
+
+def test_apply_questionnaire_audit_records_profile_fill_and_run_id(monkeypatch):
+    from hhru_bot.ai.questions import AnswerProposal, Question
+
+    question = Question(0, "Готовы к переезду?", "text")
+    proposal = AnswerProposal(question, "Да", 1.0, answer_source="profile")
+    monkeypatch.setattr(pipeline_module, "detect_questions", lambda _page: _question_detection(True))
+    monkeypatch.setattr(pipeline_module, "extract_questions", lambda _page: ([question], 1))
+    history = _QuestionnaireHistory()
+
+    result = apply_to_vacancy(
+        FakePage(apply_button=True, success=True, submit_in_form=True),
+        _vacancy(), "RID", "x", dry_run=False,
+        question_answerer=_StubAnswerer({question.text: proposal}), force=True,
+        questionnaire_history=history, run_id="run-473",
+    )
+
+    assert result.success is True
+    assert len(history.calls) == 1
+    args, kwargs = history.calls[0]
+    assert args[:5] == ("RID", _vacancy().vacancy_id, _vacancy().url, _vacancy().title, _vacancy().company)
+    assert kwargs["source"] == "apply"
+    assert kwargs["run_id"] == "run-473"
+    assert args[5][0]["answer_source"] == "profile"
+    assert args[5][0]["answer"] == "Да"
+    assert args[5][0]["filled"] is True
+
+
+def test_apply_questionnaire_audit_records_low_confidence_without_fill(monkeypatch):
+    from hhru_bot.ai.questions import AnswerProposal, Question
+
+    question = Question(0, "Расскажите о кейсе", "text")
+    proposal = AnswerProposal(question, "Сомнительный ответ", 0.2)
+    monkeypatch.setattr(pipeline_module, "detect_questions", lambda _page: _question_detection(True))
+    monkeypatch.setattr(pipeline_module, "extract_questions", lambda _page: ([question], 1))
+    history = _QuestionnaireHistory()
+
+    result = apply_to_vacancy(
+        FakePage(apply_button=True, success=True, submit_in_form=True),
+        _vacancy(), "RID", "x", dry_run=False,
+        question_answerer=_StubAnswerer({question.text: proposal}), force=True,
+        questionnaire_history=history, run_id="run-473",
+    )
+
+    assert result.skipped is True
+    args, kwargs = history.calls[0]
+    assert kwargs["source"] == "apply"
+    assert args[5][0]["answer_source"] == "llm"
+    assert args[5][0]["answer"] == ""
+    assert args[5][0]["confidence"] == 0.2
+    assert args[5][0]["filled"] is False
 
 
 def test_apply_dry_run_shows_proposals_without_submitting(monkeypatch):

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -91,20 +91,37 @@ def test_probe_questionnaire_keeps_new_audit_fields_empty(tmp_path):
 def test_apply_questionnaire_audit_preserves_answer_fields_and_summary(tmp_path):
     history = History(tmp_path / "history.db")
     history.record_questionnaire(
-        "marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme",
+        "marketing",
+        "123",
+        "https://hh.ru/vacancy/123",
+        "Маркетолог",
+        "Acme",
         [
             {
-                "body_index": 0, "text": "Переезд?", "kind": "text", "is_radio": False,
-                "options": [], "answer": "Да", "answer_source": "profile",
-                "confidence": 1.0, "filled": True,
+                "body_index": 0,
+                "text": "Переезд?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "Да",
+                "answer_source": "profile",
+                "confidence": 1.0,
+                "filled": True,
             },
             {
-                "body_index": 1, "text": "Кейс?", "kind": "text", "is_radio": False,
-                "options": [], "answer": "", "answer_source": "llm",
-                "confidence": 0.2, "filled": False,
+                "body_index": 1,
+                "text": "Кейс?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "",
+                "answer_source": "llm",
+                "confidence": 0.2,
+                "filled": False,
             },
         ],
-        source="apply", run_id="run-473",
+        source="apply",
+        run_id="run-473",
     )
 
     with history._connect() as conn:

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -133,3 +134,64 @@ def test_apply_questionnaire_audit_preserves_answer_fields_and_summary(tmp_path)
     assert tuple(rows[0]) == ("Да", "profile", 1.0, 1, "run-473")
     assert tuple(rows[1]) == ("", "llm", 0.2, 0, "run-473")
     assert history.questionnaire_answer_summary() == {"profile": 1, "llm": 0, "unanswered": 1}
+
+
+def test_questionnaire_answer_summary_scoped_by_resume_and_period(tmp_path):
+    """cycle-review #473: stats --resume/--period must not mix in other resumes.
+
+    Regression test for a /review finding: questionnaire_answer_summary() had
+    no filters even though it was printed inside the resume/period-scoped
+    stats block, so it silently reported lifetime, all-resume totals.
+    """
+    history = History(tmp_path / "history.db")
+    question = {
+        "body_index": 0,
+        "text": "Переезд?",
+        "kind": "text",
+        "is_radio": False,
+        "options": [],
+        "answer": "Да",
+        "answer_source": "profile",
+        "confidence": 1.0,
+        "filled": True,
+    }
+    history.record_questionnaire(
+        "marketing",
+        "1",
+        "https://hh.ru/vacancy/1",
+        "Маркетолог",
+        "Acme",
+        [question],
+        source="apply",
+        run_id="run-a",
+    )
+    history.record_questionnaire(
+        "backend",
+        "2",
+        "https://hh.ru/vacancy/2",
+        "Разработчик",
+        "Beta",
+        [question],
+        source="apply",
+        run_id="run-b",
+    )
+    # Backdate the "marketing" scan outside a "today" window.
+    with history._connect() as conn:
+        stale = (datetime.now() - timedelta(days=2)).isoformat()
+        conn.execute(
+            "UPDATE questionnaire_scans SET detected_at = ? WHERE resume_id = 'marketing'",
+            (stale,),
+        )
+        conn.commit()
+
+    assert history.questionnaire_answer_summary(resume_id="backend") == {
+        "profile": 1,
+        "llm": 0,
+        "unanswered": 0,
+    }
+    assert history.questionnaire_answer_summary(period="today") == {
+        "profile": 1,
+        "llm": 0,
+        "unanswered": 0,
+    }
+    assert history.questionnaire_answer_summary() == {"profile": 2, "llm": 0, "unanswered": 0}

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -43,3 +43,76 @@ def test_record_questionnaire_stores_questions_and_options_without_dedup(tmp_pat
     assert stored[0][:4] == (0, "Ваш опыт?", "choice", 1)
     assert json.loads(stored[0][4]) == ["Да", "Нет"]
     assert len(stored) == 2
+
+
+def test_questionnaire_schema_migrates_legacy_db_idempotently(tmp_path):
+    """Existing #456 research databases receive the #473 audit columns once."""
+    db_path = tmp_path / "history.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE questionnaire_scans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, resume_id TEXT NOT NULL,
+                vacancy_id TEXT NOT NULL, vacancy_url TEXT NOT NULL, title TEXT NOT NULL,
+                company TEXT NOT NULL, detected_at TEXT NOT NULL
+            );
+            CREATE TABLE questionnaire_questions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER NOT NULL, body_index INTEGER NOT NULL, text TEXT NOT NULL,
+                kind TEXT NOT NULL, is_radio INTEGER NOT NULL, options_json TEXT NOT NULL
+            );
+            """
+        )
+
+    History(db_path)
+    History(db_path)  # must not attempt duplicate ALTER TABLE ADD COLUMN
+
+    with sqlite3.connect(db_path) as conn:
+        scan_columns = {row[1] for row in conn.execute("PRAGMA table_info(questionnaire_scans)")}
+        question_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(questionnaire_questions)")
+        }
+
+    assert "source" in scan_columns
+    assert {"answer", "answer_source", "confidence", "filled", "run_id"} <= question_columns
+
+
+def test_probe_questionnaire_keeps_new_audit_fields_empty(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme", []
+    )
+
+    with history._connect() as conn:
+        scan = conn.execute("SELECT source FROM questionnaire_scans").fetchone()
+    assert scan["source"] == "probe"
+
+
+def test_apply_questionnaire_audit_preserves_answer_fields_and_summary(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "marketing", "123", "https://hh.ru/vacancy/123", "Маркетолог", "Acme",
+        [
+            {
+                "body_index": 0, "text": "Переезд?", "kind": "text", "is_radio": False,
+                "options": [], "answer": "Да", "answer_source": "profile",
+                "confidence": 1.0, "filled": True,
+            },
+            {
+                "body_index": 1, "text": "Кейс?", "kind": "text", "is_radio": False,
+                "options": [], "answer": "", "answer_source": "llm",
+                "confidence": 0.2, "filled": False,
+            },
+        ],
+        source="apply", run_id="run-473",
+    )
+
+    with history._connect() as conn:
+        rows = conn.execute(
+            "SELECT answer, answer_source, confidence, filled, run_id "
+            "FROM questionnaire_questions ORDER BY body_index"
+        ).fetchall()
+
+    assert tuple(rows[0]) == ("Да", "profile", 1.0, 1, "run-473")
+    assert tuple(rows[1]) == ("", "llm", 0.2, 0, "run-473")
+    assert history.questionnaire_answer_summary() == {"profile": 1, "llm": 0, "unanswered": 1}


### PR DESCRIPTION
## Summary
- wire account-profile facts into questionnaire answer proposals and mark answer provenance
- migrate questionnaire scan/question audit fields and persist apply-time fill outcomes linked by command run ID
- expose apply-answer source summary in `stats`

Closes #473

## Tests
- `uv run pytest -q`
- `uv run ruff check src tests/test_history_questionnaires.py tests/test_apply_pipeline.py tests/test_ai_questions_extract.py`

## Risks
- `filled` means the form field was filled, not that hh.ru accepted or confirmed the application; final outcome remains in `actions` via `run_id`.