### PR TITLE
fix: count durable mutation attempts exactly once

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -25,7 +25,7 @@ from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_place
 from ..config_sections.scoring import ScoringWeights
 from ..copy_resume import resolve_numeric_resume_ids
 from ..exit_codes import CommandExitCode
-from ..history import History
+from ..history import CommandRunBusy, History
 from ..search import (
     _LLM_SHORTLIST_DEFAULT,
     VacancyCard,
@@ -321,6 +321,7 @@ class ApplyProgress:
     uncertain_count: int = 0
     skipped_count: int = 0
     run_id: str | None = None
+    _finished_attempts: int = field(default=0, init=False, repr=False, compare=False)
 
     def reached(self, limit: int | None) -> bool:
         return limit is not None and self.applied_count >= limit
@@ -328,15 +329,56 @@ class ApplyProgress:
     def begin_attempt(self) -> None:
         self.attempted_count += 1
 
-    def finish(self, result) -> None:  # noqa: ANN001 - ApplyResult avoids import cycle
-        if getattr(result, "skipped", False):
+    def finish(
+        self,
+        result,  # noqa: ANN001 - command result types intentionally share a protocol
+        *,
+        uncertain_exceptions: tuple[type[BaseException], ...] = (),
+    ) -> str | None:
+        """Classify and count the current attempt exactly once.
+
+        Single results use structural flags (``skipped``, ``uncertain`` or
+        ``acted``, then ``success``).  Batch results are first collapsed so a
+        definite failure cannot be hidden by an uncertain sibling.  Typed
+        post-click exceptions can be supplied through ``uncertain_exceptions``;
+        exception messages are deliberately never inspected.
+        """
+        if self._finished_attempts >= self.attempted_count:
+            return None
+        self._finished_attempts += 1
+
+        if isinstance(result, BaseException):
+            status = "uncertain" if isinstance(result, uncertain_exceptions) else "failed"
+        elif isinstance(result, (list, tuple)):
+            status = _classify_result_batch(result)
+        else:
+            skipped = bool(getattr(result, "skipped", False))
+            success = bool(
+                getattr(result, "success", result if isinstance(result, bool) else False)
+            )
+            uncertain = bool(
+                getattr(result, "uncertain", False)
+                or (getattr(result, "acted", False) and not success)
+            )
+            status = (
+                "skipped"
+                if skipped
+                else "uncertain"
+                if uncertain
+                else "success"
+                if success
+                else "failed"
+            )
+
+        if status == "skipped":
             self.skipped_count += 1
-        elif getattr(result, "uncertain", False):
+        elif status == "uncertain":
             self.uncertain_count += 1
-        elif result.success:
+        elif status == "success":
             self.applied_count += 1
         else:
             self.failed_count += 1
+        return status
 
     def summary(self, status: str) -> str:
         return (
@@ -344,6 +386,90 @@ class ApplyProgress:
             f"attempted={self.attempted_count} success={self.applied_count} "
             f"failed={self.failed_count} uncertain={self.uncertain_count} "
             f"skipped={self.skipped_count}"
+        )
+
+
+def _classify_result_batch(results: list | tuple) -> str:
+    """Collapse a batch into the single status consumed by ``finish``."""
+    if not results:
+        return "failed"
+    flags = []
+    for result in results:
+        success = bool(getattr(result, "success", False))
+        skipped = bool(getattr(result, "skipped", False))
+        uncertain = bool(
+            getattr(result, "uncertain", False)
+            or (getattr(result, "acted", False) and not success)
+        )
+        flags.append((skipped, uncertain, success))
+    hard_failed = any(
+        not skipped and not uncertain and not success
+        for skipped, uncertain, success in flags
+    )
+    if hard_failed:
+        return "failed"
+    if all(skipped for skipped, _uncertain, _success in flags):
+        return "skipped"
+    if any(uncertain for _skipped, uncertain, _success in flags):
+        return "uncertain"
+    if all(success for _skipped, _uncertain, success in flags):
+        return "success"
+    return "failed"
+
+
+@dataclass(frozen=True)
+class MutationOutcome:
+    """Minimal structural result for mutations that otherwise return no object."""
+
+    success: bool = False
+    uncertain: bool = False
+    skipped: bool = False
+
+
+@dataclass
+class DurableMutationAttempt:
+    """Reserve/finalize one resume mutation at its browser click boundary."""
+
+    history: History
+    progress: ApplyProgress
+    resume_id: str
+    action: str
+    action_id: int | None = None
+
+    def before_click(self) -> None:
+        if self.action_id is not None:
+            raise RuntimeError(f"{self.action}: durable intent уже зарезервирован")
+        self.action_id = self.history.begin_action(
+            self.resume_id,
+            self.resume_id,
+            self.action,
+            run_id=self.progress.run_id,
+        )
+        self.progress.begin_attempt()
+
+    def finish(self, result) -> None:  # noqa: ANN001 - shared structural result protocol
+        if self.action_id is None:
+            return
+        status = self.progress.finish(result)
+        if status is None:
+            raise RuntimeError(f"{self.action}: попытка уже финализирована")
+        self.history.finalize_action(
+            self.action_id,
+            status,
+            getattr(result, "reason", None),
+            reason_code=status,
+        )
+
+    def interrupt(self, exc: BaseException) -> None:
+        if self.action_id is None:
+            return
+        outcome = MutationOutcome(uncertain=True)
+        self.progress.finish(outcome)
+        self.history.finalize_action(
+            self.action_id,
+            "uncertain",
+            f"исключение после точки невозврата: {type(exc).__name__}: {exc}",
+            reason_code="uncertain",
         )
 
 
@@ -386,19 +512,11 @@ def run_supervised_command(
     (e.g. under future orchestration) does not clobber an outer caller's
     handler.
 
-    That LIFO-safety covers only the *signal handler*. The durable ledger
-    itself is NOT re-entrant (cycle-review PR #468, code-reviewer-462):
-    ``History.start_command_run`` marks any still-``running`` row
-    ``orphaned`` before inserting a new one, so a nested call's
-    ``start_command_run`` orphans the outer call's row -- the outer call's
-    later ``finish_command_run`` then finds no matching ``running`` row,
-    raises, and (via the masking guard below) silently skips its own
-    ``[RUN]`` summary print. This is pre-existing ``History`` behaviour, not
-    introduced by this helper, and is harmless today because no caller nests
-    ``run_supervised_command`` (``commands/run.py`` calls ``apply_cmd.run()``
-    and ``bump_cmd.run()`` sequentially, each already-finished before the
-    next starts). A future command that wraps this helper *inside* another
-    active run would need one ledger row per process, not per nested call.
+    The durable ledger is intentionally non-reentrant: one live owner PID
+    holds the SQLite-backed supervised-command lease. A concurrent or nested
+    start is rejected without touching the active row; only a row whose owner
+    PID is confirmed dead (or a legacy row without owner metadata) is recovered
+    as ``orphaned``.
 
     SIGINT deliberately gets NO custom ``signal.signal`` handler here --
     only the default ``KeyboardInterrupt`` it already raises is caught
@@ -416,7 +534,11 @@ def run_supervised_command(
     so it is injected rather than hardcoded here; a future bump/publish
     caller would pass its own reconcile or none at all).
     """
-    run_id = history.start_command_run(command=command, requested_limit=requested_limit)
+    try:
+        run_id = history.start_command_run(command=command, requested_limit=requested_limit)
+    except CommandRunBusy as exc:
+        print(f"[FAIL] {exc}")
+        return True
     progress = ApplyProgress(run_id=run_id)
     previous_sigterm = signal.getsignal(signal.SIGTERM)
 

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -398,13 +398,11 @@ def _classify_result_batch(results: list | tuple) -> str:
         success = bool(getattr(result, "success", False))
         skipped = bool(getattr(result, "skipped", False))
         uncertain = bool(
-            getattr(result, "uncertain", False)
-            or (getattr(result, "acted", False) and not success)
+            getattr(result, "uncertain", False) or (getattr(result, "acted", False) and not success)
         )
         flags.append((skipped, uncertain, success))
     hard_failed = any(
-        not skipped and not uncertain and not success
-        for skipped, uncertain, success in flags
+        not skipped and not uncertain and not success for skipped, uncertain, success in flags
     )
     if hard_failed:
         return "failed"

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from ._common import ApplyProgress, run_supervised_command
+from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 
 
 def register(subparsers) -> None:
@@ -80,7 +80,6 @@ def run(args: argparse.Namespace):
     from ..copy_resume import copy_resume_on_hh
     from ..history import History
     from ..responses import NotAuthenticated
-    from ._audit import action_status, record_resume_action
 
     config = load_config_or_exit(args.config)
     from ._common import resolve_resume
@@ -114,41 +113,28 @@ def run(args: argparse.Namespace):
             )
 
     def _body(progress: ApplyProgress) -> bool:
+        attempt = (
+            None
+            if args.dry_run
+            else DurableMutationAttempt(history, progress, resume.resume_id, "copy_resume")
+        )
         try:
-            if not args.dry_run:
-                progress.begin_attempt()
             with launch_context(
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
                 page = context.new_page()
-                result = copy_resume_on_hh(page, resume, args.dry_run)
+                result = copy_resume_on_hh(
+                    page,
+                    resume,
+                    args.dry_run,
+                    before_click=attempt.before_click if attempt is not None else None,
+                )
         except NotAuthenticated as e:
-            if not args.dry_run:
-                progress.failed_count += 1
-                record_resume_action(history, resume.resume_id, "copy_resume", "failed", str(e))
             print(f"[FAIL] {resume.id} — Сессия недействительна: {e}")
             return True
         except BaseException as e:
-            # Клик по «Дублировать» уже мог уйти на hh.ru (POST /applicant/resumes/clone)
-            # раньше, чем упало исключение (например, goto_hh при diff-fallback исчерпал
-            # ретраи) — копия на hh.ru могла создаться, а локальной записи не будет.
-            # Результат после возможного клика не подтверждён: это ``uncertain`,
-            # а не failed, чтобы не разрешить безопасный на вид повтор.
-            # #464 cycle-review (Codex round 2): ``BaseException``, not
-            # ``Exception`` -- SIGTERM/KeyboardInterrupt (both BaseException)
-            # landing right after copy_resume_on_hh's clone click previously
-            # bypassed this whole block, leaving no uncertain marker and
-            # letting the has_unresolved_uncertain guard above pass a blind
-            # retry through undetected.
-            if not args.dry_run:
-                progress.uncertain_count += 1
-                record_resume_action(
-                    history,
-                    resume.resume_id,
-                    "copy_resume",
-                    "uncertain",
-                    f"исключение в браузерном шаге: {e}",
-                )
+            if attempt is not None:
+                attempt.interrupt(e)
             raise
 
         # Fail-closed (#116): success без нового id или с id, совпавшим с исходным,
@@ -158,17 +144,10 @@ def run(args: argparse.Namespace):
                 result.success = False
                 result.reason = "новый resume_id не подтверждён (совпал с исходным или пуст)"
 
-        if not args.dry_run:
-            progress.finish(result)
-            status = action_status(
-                dry_run=False, success=result.success, uncertain=result.uncertain
-            )
-            reason = (
-                f"new_resume_id={result.new_resume_id}" if status == "success" else result.reason
-            )
-            # Для action='copy_resume' нет vacancy_id (операция над резюме, не отклик) —
-            # как у bump, заполняем sentinel'ом resume_id.
-            record_resume_action(history, resume.resume_id, "copy_resume", status, reason)
+        if attempt is not None:
+            if result.success:
+                result.reason = f"new_resume_id={result.new_resume_id}"
+            attempt.finish(result)
 
         if args.dry_run:
             if not result.success:

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from ._audit import action_status, record_resume_action
-from ._common import ApplyProgress, run_supervised_command
+from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 from .copy_resume import confirm_write, format_config_snippet
 
 
@@ -61,44 +60,28 @@ def run(args: argparse.Namespace):
         raise SystemExit(1)
 
     def _body(progress: ApplyProgress) -> bool:
+        attempt = (
+            None
+            if dry_run
+            else DurableMutationAttempt(history, progress, "account", "create_resume")
+        )
         try:
-            if not dry_run:
-                progress.begin_attempt()
             with launch_context(
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
                 result = create_resume_on_hh(
-                    context.new_page(), area=args.area, title=args.title, dry_run=dry_run
+                    context.new_page(),
+                    area=args.area,
+                    title=args.title,
+                    dry_run=dry_run,
+                    before_click=attempt.before_click if attempt is not None else None,
                 )
         except BaseException as exc:
-            # A dry-run never changes hh.ru and therefore must not create an
-            # action-history row, including for a local/browser failure.
-            # #464 cycle-review (Codex): ``BaseException``, not ``Exception`` --
-            # ``KeyboardInterrupt``/``SignalTermination`` (both BaseException,
-            # not Exception, #462's own rationale) can land at any point inside
-            # ``create_resume_on_hh``, including right after the browser click
-            # that already created the resume on hh.ru but before the function
-            # returns. A plain ``except Exception`` would let such a signal
-            # skip this whole block and leave no actions row at all, so a
-            # later blind retry could create a duplicate resume. There is no
-            # way to tell from here whether the click already fired, so a
-            # signal interrupt is recorded ``uncertain`` (fail-closed, blocks
-            # a retry via has_unresolved_uncertain above) while an ordinary
-            # exception (browser/network failure, never reaching the click)
-            # keeps the prior ``failed`` status.
-            if not dry_run:
-                progress.failed_count += 1
-                status = "failed" if isinstance(exc, Exception) else "uncertain"
-                record_resume_action(
-                    history, "account", "create_resume", status, f"исключение: {exc}"
-                )
+            if attempt is not None:
+                attempt.interrupt(exc)
             raise
-        if not dry_run:
-            progress.finish(result)
-            status = action_status(
-                dry_run=False, success=result.success, uncertain=result.uncertain
-            )
-            history.record_action("account", "account", "create_resume", status, result.reason)
+        if attempt is not None:
+            attempt.finish(result)
         if not result.success:
             prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
             print(f"{prefix} {result.reason}")

--- a/src/hhru_bot/commands/delete_resume.py
+++ b/src/hhru_bot/commands/delete_resume.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from ._audit import action_status, record_resume_action
-from ._common import ApplyProgress, run_supervised_command
+from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 from .copy_resume import confirm_write
 
 
@@ -70,44 +69,31 @@ def run(args: argparse.Namespace):
         raise SystemExit(1)
 
     def _body(progress: ApplyProgress) -> bool:
+        attempt = (
+            None
+            if dry_run
+            else DurableMutationAttempt(history, progress, resume.resume_id, "delete_resume")
+        )
         try:
-            if not dry_run:
-                progress.begin_attempt()
             with launch_context(
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
-                result = delete_resume_on_hh(context.new_page(), resume, dry_run)
+                result = delete_resume_on_hh(
+                    context.new_page(),
+                    resume,
+                    dry_run,
+                    before_click=attempt.before_click if attempt is not None else None,
+                )
         except NotAuthenticated as exc:
-            if not dry_run:
-                progress.failed_count += 1
-                record_resume_action(history, resume.resume_id, "delete_resume", "failed", str(exc))
             print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
             return True
         except BaseException as exc:
-            # #464 cycle-review (Codex round 2): ``BaseException``, not
-            # ``Exception`` -- delete_resume_on_hh's own destructive-click
-            # try/except (delete_resume.py library module) already treats a
-            # PlaywrightError after the confirm click as uncertain, but a
-            # SIGTERM/KeyboardInterrupt landing at that same point is a
-            # BaseException and previously bypassed this whole block, leaving
-            # no actions row and no has_unresolved_uncertain marker to block
-            # a retry. Fail-closed: a signal interrupt is recorded
-            # ``uncertain``; an ordinary pre-click exception keeps the prior
-            # ``failed`` status (unchanged behavior).
-            if not dry_run:
-                progress.failed_count += 1
-                status = "failed" if isinstance(exc, Exception) else "uncertain"
-                record_resume_action(
-                    history, resume.resume_id, "delete_resume", status, f"исключение: {exc}"
-                )
+            if attempt is not None:
+                attempt.interrupt(exc)
             raise
 
-        if not dry_run:
-            progress.finish(result)
-            status = action_status(
-                dry_run=False, success=result.success, uncertain=result.uncertain
-            )
-            record_resume_action(history, resume.resume_id, "delete_resume", status, result.reason)
+        if attempt is not None:
+            attempt.finish(result)
         if not result.success:
             prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
             print(f"{prefix} {resume.id} — {result.reason}")

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -228,19 +228,22 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # A single classification for the whole attempt (#477): status comes
         # from ApplyProgress.finish()'s priority (skipped > uncertain > success
         # > failed) over the *entire* results batch, not from each item
-        # separately re-deriving "uncertain or not success" — that would
-        # classify the same attempt in two places.
+        # separately re-deriving "uncertain or not success" -- that would
+        # classify the same attempt in two places. Always record one row
+        # (no per-item filter): has_unresolved_uncertain never reads
+        # "edit_education" as a retry gate, so this ledger is audit/stats
+        # only, and a hard-failed batch must not disagree with command_runs
+        # (which already counts it via progress.finish above).
         status = progress.finish(results)
         assert status is not None
-        if any(result.success or result.uncertain or result.saved for result in results):
-            history.record_action(
-                resume.resume_id,
-                resume.resume_id,
-                "edit_education",
-                status,
-                "; ".join(result.reason for result in results),
-                run_id=progress.run_id,
-            )
+        history.record_action(
+            resume.resume_id,
+            resume.resume_id,
+            "edit_education",
+            status,
+            "; ".join(result.reason for result in results),
+            run_id=progress.run_id,
+        )
 
     failed = any(not result.success for result in results)
     if failed:

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -215,33 +215,36 @@ def _run(args: argparse.Namespace, progress) -> bool:
         print(f"[FAIL] {resume.id} — {exc}")
         return True
 
-    if not args.dry_run:
-        from ..history import History
-
-        history = History(args.history)
-        for result in results:
-            if result.success or result.uncertain or result.saved:
-                history.record_action(
-                    resume.resume_id,
-                    resume.resume_id,
-                    "edit_education",
-                    "uncertain" if result.uncertain or not result.success else "success",
-                    result.reason,
-                    run_id=progress.run_id,
-                )
-
-    failed = [result for result in results if not result.success]
     for result in results:
         prefix = "[OK]" if result.success else "[FAIL]"
         if result.uncertain:
             prefix = "[FAIL] (uncertain)"
         print(f"{prefix} {result.kind}: {result.reason}")
-    if failed:
-        if not args.dry_run:
-            progress.finish(results)
-        return True
+
     if not args.dry_run:
-        progress.finish(results)
+        from ..history import History
+
+        history = History(args.history)
+        # A single classification for the whole attempt (#477): status comes
+        # from ApplyProgress.finish()'s priority (skipped > uncertain > success
+        # > failed) over the *entire* results batch, not from each item
+        # separately re-deriving "uncertain or not success" — that would
+        # classify the same attempt in two places.
+        status = progress.finish(results)
+        assert status is not None
+        if any(result.success or result.uncertain or result.saved for result in results):
+            history.record_action(
+                resume.resume_id,
+                resume.resume_id,
+                "edit_education",
+                status,
+                "; ".join(result.reason for result in results),
+                run_id=progress.run_id,
+            )
+
+    failed = any(not result.success for result in results)
+    if failed:
+        return True
     if args.dry_run:
         print("[DRY-RUN] Ничего не сохранено на hh.ru")
     else:

--- a/src/hhru_bot/commands/edit_education.py
+++ b/src/hhru_bot/commands/edit_education.py
@@ -200,7 +200,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
             )
     except NotAuthenticated as exc:
         if not args.dry_run and progress.attempted_count:
-            progress.failed_count += 1
+            progress.finish(exc)
         print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
         return True
     except BrowserLaunchError:
@@ -211,7 +211,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
         raise
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback
         if not args.dry_run and progress.attempted_count:
-            progress.failed_count += 1
+            progress.finish(exc)
         print(f"[FAIL] {resume.id} — {exc}")
         return True
 
@@ -231,13 +231,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 )
 
     failed = [result for result in results if not result.success]
-    # A hard failure (not success, not uncertain) must win over uncertain
-    # when both appear in the same --section both batch (#465 review, round
-    # 2): checking "any uncertain in the whole batch" masked a definite hard
-    # failure on one block as merely uncertain because another block in the
-    # same call happened to be uncertain.
-    hard_failed = [result for result in failed if not result.uncertain]
-    uncertain = [result for result in failed if result.uncertain]
     for result in results:
         prefix = "[OK]" if result.success else "[FAIL]"
         if result.uncertain:
@@ -245,13 +238,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
         print(f"{prefix} {result.kind}: {result.reason}")
     if failed:
         if not args.dry_run:
-            if hard_failed:
-                progress.failed_count += 1
-            elif uncertain:
-                progress.uncertain_count += 1
+            progress.finish(results)
         return True
     if not args.dry_run:
-        progress.applied_count += 1
+        progress.finish(results)
     if args.dry_run:
         print("[DRY-RUN] Ничего не сохранено на hh.ru")
     else:

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -205,41 +205,24 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # before begin_attempt() runs, which must not misreport attempted=0
         # as failed=1.
         if progress.attempted_count:
-            progress.failed_count += 1
+            progress.finish(exc)
         print(f"[FAIL] {resume.id} — {exc}")
         return True
-    success = bool(results) and all("сохранено" in item for item in results)
-    # A hard failure (neither "сохранено" nor "uncertain") must win over
-    # uncertain in the same batch (#465 review, round 3 — same batch-
-    # classification bug already fixed for edit_education.py in round 2,
-    # found still present here): "any uncertain in the whole batch" masked a
-    # definite hard failure on one entry as merely uncertain because another
-    # entry in the same --entry batch happened to be uncertain.
-    hard_failed_items = [
-        item for item in results if "сохранено" not in item and "uncertain" not in item
-    ]
-    uncertain_items = [item for item in results if "uncertain" in item]
-    uncertain = bool(uncertain_items) and not hard_failed_items
+    success = bool(results) and all(item.success for item in results)
+    status = progress.finish(results)
+    assert status is not None
     history.record_action(
         resume.resume_id,
         resume.resume_id,
         "edit_experience",
-        "uncertain" if uncertain else ("success" if success else "failed"),
-        "; ".join(results),
+        status,
+        "; ".join(item.reason for item in results),
         run_id=progress.run_id,
     )
     for item in results:
-        is_item_uncertain = "uncertain" in item
-        prefix = "[FAIL] (uncertain)" if is_item_uncertain else ("[OK]" if success else "[FAIL]")
-        print(f"{prefix} {resume.id} — {item}")
-    if not success:
-        if hard_failed_items:
-            progress.failed_count += 1
-        elif uncertain_items:
-            progress.uncertain_count += 1
-        return True
-    progress.applied_count += 1
-    return False
+        prefix = "[FAIL] (uncertain)" if item.uncertain else ("[OK]" if item.success else "[FAIL]")
+        print(f"{prefix} {resume.id} — {item.reason}")
+    return not success
 
 
 def run(args: argparse.Namespace):

--- a/src/hhru_bot/commands/edit_languages.py
+++ b/src/hhru_bot/commands/edit_languages.py
@@ -116,22 +116,18 @@ def _run(args: argparse.Namespace, progress) -> bool:
             raise
         except Exception as exc:  # browser/auth errors are a failed command, not a traceback
             if progress.attempted_count:
-                progress.failed_count += 1
+                progress.finish(exc)
             print(f"[FAIL] {resume.id} — {exc}")
             return True
         if not result.success:
             # acted=True and not success is the uncertain discriminator
             # (CLAUDE.md #163/#176, #465 review round 3): the write may
             # already have reached hh.ru, so this is not a definite failure.
-            uncertain = result.acted
-            if uncertain:
-                progress.uncertain_count += 1
-            else:
-                progress.failed_count += 1
-            prefix = "[FAIL] (uncertain)" if uncertain else "[FAIL]"
+            progress.finish(result)
+            prefix = "[FAIL] (uncertain)" if result.acted else "[FAIL]"
             print(f"{prefix} {resume.id} — {result.reason}")
             return True
-        progress.applied_count += 1
+        progress.finish(result)
         print(f"[OK] {resume.id}: языков предложено: {len(result.proposed)}")
         for language in result.proposed:
             level = language.level or "нуждается в подтверждении"

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -123,7 +123,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
         raise
     except Exception as exc:  # browser/auth errors are a failed command, not a traceback
         if not args.dry_run and progress.attempted_count:
-            progress.failed_count += 1
+            progress.finish(exc)
         print(f"[FAIL] {resume.id} — {exc}")
         return True
 
@@ -131,13 +131,9 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # acted=True and not success is the uncertain discriminator
         # (CLAUDE.md #163/#176, #465 review round 3): the click may already
         # have reached hh.ru, so this is not a definite failure.
-        uncertain = result.acted
         if not args.dry_run:
-            if uncertain:
-                progress.uncertain_count += 1
-            else:
-                progress.failed_count += 1
-        prefix = "[FAIL] (uncertain)" if uncertain else "[FAIL]"
+            progress.finish(result)
+        prefix = "[FAIL] (uncertain)" if result.acted else "[FAIL]"
         print(f"{prefix} {resume.id} — {result.reason}")
         return True
     prefix = "[DRY-RUN]" if args.dry_run else "[OK]"
@@ -148,7 +144,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
     if args.dry_run:
         print("[INFO] Ничего не сохранено на hh.ru.")
     else:
-        progress.applied_count += 1
+        progress.finish(result)
     return False
 
 

--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from ._audit import action_status, record_resume_action
-from ._common import ApplyProgress, run_supervised_command
+from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 
 
 def register(subparsers) -> None:
@@ -56,32 +55,35 @@ def run(args: argparse.Namespace):
         sys.exit(1)
 
     def _body(progress: ApplyProgress) -> bool:
+        attempt = (
+            None
+            if args.dry_run
+            else DurableMutationAttempt(history, progress, resume.resume_id, "publish_resume")
+        )
         try:
-            if not args.dry_run:
-                progress.begin_attempt()
             with launch_context(
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
-                result = publish_resume_on_hh(context.new_page(), resume, args.dry_run)
+                result = publish_resume_on_hh(
+                    context.new_page(),
+                    resume,
+                    args.dry_run,
+                    before_click=attempt.before_click if attempt is not None else None,
+                )
         except NotAuthenticated as exc:
-            if not args.dry_run:
-                progress.failed_count += 1
             print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
             return True
+        except BaseException as exc:
+            if attempt is not None:
+                attempt.interrupt(exc)
+            raise
 
         # actions — журнал взаимодействий с hh.ru, а не всех проверок команды.
         # До клика (identity/state/button guards) внешний эффект невозможен и не
         # должен выглядеть в истории как неудачная попытка публикации.  ``uncertain``
         # означает, что клик уже мог уйти, поэтому такую запись сохраняем.
-        if not args.dry_run:
-            progress.finish(result)
-            if result.success or result.uncertain:
-                status = action_status(
-                    dry_run=False, success=result.success, uncertain=result.uncertain
-                )
-                record_resume_action(
-                    history, resume.resume_id, "publish_resume", status, result.reason
-                )
+        if attempt is not None:
+            attempt.finish(result)
 
         if not result.success:
             prefix = "[FAIL]" if not result.uncertain else "[FAIL] (uncertain)"

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -97,7 +97,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
     )
 
     config = load_config_or_exit(args.config)
-    from ._common import resolve_resume
+    from ._common import MutationOutcome, resolve_resume
 
     # Ручной ввод (#326): любое готовое поле отключает LLM; facts-гварды и
     # fill/from-scratch не применяются — значения даёт вызывающий, как в
@@ -223,7 +223,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 raise _SaveConfirmationUncertain(
                     f"сохранение не подтверждено (uncertain) после клика: {exc}"
                 ) from exc
-            progress.applied_count += 1
+            progress.finish(MutationOutcome(success=True))
             print(f"[OK] Раздел желаемой работы резюме '{resume.id}' обновлён.")
             return False
     except _SaveConfirmationUncertain as exc:
@@ -233,8 +233,8 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # type (not a substring match on the message) is the discriminator,
         # per the code-reviewer's round-3 finding that acted/uncertain must
         # be a structural signal, never free-text matching.
-        if progress.attempted_count and not progress.applied_count:
-            progress.uncertain_count += 1
+        if progress.attempted_count:
+            progress.finish(exc, uncertain_exceptions=(_SaveConfirmationUncertain,))
         print(f"[FAIL] (uncertain) {exc}")
         return True
     except BrowserLaunchError:
@@ -243,14 +243,10 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # instead of the broad except Exception below swallowing it.
         raise
     except Exception as exc:
-        # #465 review: applied_count is only ever incremented right above,
-        # immediately before `return False` exits the `with` block. If
-        # context.__exit__ itself raises during that unwind, this handler
-        # would otherwise also add failed_count for the same attempt —
-        # progress.applied_count is the guard against double-counting one
-        # attempt as both a success and a failure.
-        if progress.attempted_count and not progress.applied_count:
-            progress.failed_count += 1
+        # If context.__exit__ raises after the success above, ApplyProgress's
+        # one-finish-per-attempt guard prevents counting the same attempt again.
+        if progress.attempted_count:
+            progress.finish(exc)
         print(f"[FAIL] {exc}")
         return True
 

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
 
@@ -620,7 +621,13 @@ def _wait_single_match_count(locator, *, timeout_ms: int) -> int:
     return match_count
 
 
-def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyResumeResult:
+def copy_resume_on_hh(
+    page: Page,
+    resume: ResumeConfig,
+    dry_run: bool,
+    *,
+    before_click: Callable[[], None] | None = None,
+) -> CopyResumeResult:
     observer = None
     absolute_deadline = _monotonic() + PROFILE_ABSOLUTE_TIMEOUT_SECONDS
     if not dry_run:
@@ -688,6 +695,8 @@ def copy_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> CopyRe
     before = _card_hashes(page)
 
     try:
+        if before_click is not None:
+            before_click()
         duplicate.click()
         logger.info("Клик по «Дублировать» — жду страницу нового резюме")
 

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from playwright.sync_api import Error as PlaywrightError
@@ -48,11 +49,19 @@ def _require(locator: Locator | None) -> Locator:
     return locator
 
 
-def _click_one(page: Page, selector: str, label: str) -> str:
+def _click_one(
+    page: Page,
+    selector: str,
+    label: str,
+    *,
+    before_click: Callable[[], None] | None = None,
+) -> str:
     """Resolve exactly one locator and click it; return a non-empty reason on failure."""
     locator, reason = _one(page, selector, label)
     if reason:
         return reason
+    if before_click is not None:
+        before_click()
     _require(locator).click()
     return ""
 
@@ -138,7 +147,14 @@ def _existing_resume_reason(page: Page, title: str) -> str:
     return _existing_title_reason(cards.count(), titles, title)
 
 
-def create_resume_on_hh(page: Page, *, area: str, title: str, dry_run: bool) -> CreateResumeResult:
+def create_resume_on_hh(
+    page: Page,
+    *,
+    area: str,
+    title: str,
+    dry_run: bool,
+    before_click: Callable[[], None] | None = None,
+) -> CreateResumeResult:
     """Create one draft; never uses a direct HTTP request.
 
     Dry-run only reads the list and wizard DOM.  In particular it never clicks
@@ -208,7 +224,12 @@ def create_resume_on_hh(page: Page, *, area: str, title: str, dry_run: bool) -> 
         if category_reason:
             return CreateResumeResult(False, reason=category_reason)
         page.locator(RESUME_CREATION_NEXT).first.wait_for(state="visible", timeout=15000)
-        reason = _click_one(page, RESUME_CREATION_NEXT, "кнопка продолжения после каталога")
+        reason = _click_one(
+            page,
+            RESUME_CREATION_NEXT,
+            "кнопка продолжения после каталога",
+            before_click=before_click,
+        )
         if reason:
             return CreateResumeResult(False, reason=reason)
         page.wait_for_url(_RESUME_ID_RE, wait_until="commit")

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -7,6 +7,7 @@ No endpoint is called directly: both destructive steps are UI clicks.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from playwright.sync_api import Error as PlaywrightError
@@ -49,7 +50,13 @@ def _wait_resume_list_ready(page: Page) -> None:
     )
 
 
-def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult:
+def delete_resume_on_hh(
+    page: Page,
+    resume,
+    dry_run: bool,
+    *,
+    before_click: Callable[[], None] | None = None,
+) -> DeleteResumeResult:
     """Delete exactly ``resume.resume_id`` after strict identity checks.
 
     A post-click exception is ``uncertain``: the click may have reached hh.ru.
@@ -137,6 +144,8 @@ def delete_resume_on_hh(page: Page, resume, dry_run: bool) -> DeleteResumeResult
             resume_id, False, "подтверждение удаления не подтверждено однозначно", False
         )
     try:
+        if before_click is not None:
+            before_click()
         confirm.first.click()
     except PlaywrightError as exc:
         return DeleteResumeResult(resume_id, False, f"ошибка destructive-клика: {exc}", True)

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -258,9 +258,7 @@ def edit_experience_on_hh(
             add = page.locator(EXPERIENCE_ADD_BUTTON)
             if add.count() != 1:
                 return results + [
-                    ExperienceResult(
-                        f"строка опыта {index}: add-триггер не подтверждён однозначно"
-                    )
+                    ExperienceResult(f"строка опыта {index}: add-триггер не подтверждён однозначно")
                 ]
             try:
                 add.click()

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -67,6 +67,15 @@ class ExperiencePlan:
     reason: str = ""
 
 
+@dataclass(frozen=True)
+class ExperienceResult:
+    """Structural outcome for one experience row."""
+
+    reason: str
+    success: bool = False
+    uncertain: bool = False
+
+
 def _entry(raw: Any) -> ExperienceEntry | None:
     if not isinstance(raw, dict):
         return None
@@ -231,13 +240,13 @@ def read_experience_on_hh(page: Page, resume_id: str) -> list[ExperienceEntry]:
 def edit_experience_on_hh(
     page: Page, resume_id: str, plan: ExperiencePlan, *, dry_run: bool, indexes=None
 ):
-    """Apply a plan to one or more rows; return a list of textual results."""
+    """Apply a plan to one or more rows; return structural row outcomes."""
     try:
         open_confirmed_resume(page, resume_id)
     except ValueError:
-        return ["identity резюме не подтверждён"]
+        return [ExperienceResult("identity резюме не подтверждён")]
     if plan.used_fallback and not plan.entries:
-        return [plan.reason or "LLM не предложил безопасных изменений"]
+        return [ExperienceResult(plan.reason or "LLM не предложил безопасных изменений")]
     selected = list(indexes if indexes is not None else range(len(plan.entries)))
     results = []
     for entry, index in zip(plan.entries, selected, strict=False):
@@ -248,15 +257,25 @@ def edit_experience_on_hh(
             # text or a broad CSS selector.
             add = page.locator(EXPERIENCE_ADD_BUTTON)
             if add.count() != 1:
-                return results + [f"строка опыта {index}: add-триггер не подтверждён однозначно"]
+                return results + [
+                    ExperienceResult(
+                        f"строка опыта {index}: add-триггер не подтверждён однозначно"
+                    )
+                ]
             try:
                 add.click()
                 trigger = page.locator(EXPERIENCE_EDIT_BUTTON.format(index=index))
                 trigger.first.wait_for(state="visible", timeout=SAVE_TIMEOUT_MS)
             except PlaywrightError as exc:
-                return results + [f"строка опыта {index}: не удалось открыть новую запись: {exc}"]
+                return results + [
+                    ExperienceResult(
+                        f"строка опыта {index}: не удалось открыть новую запись: {exc}"
+                    )
+                ]
         if trigger.count() != 1:
-            return results + [f"строка опыта {index}: триггер не найден однозначно"]
+            return results + [
+                ExperienceResult(f"строка опыта {index}: триггер не найден однозначно")
+            ]
         save_attempted = False
         try:
             trigger.click()
@@ -272,12 +291,14 @@ def edit_experience_on_hh(
             if entry.company_url and page.locator(EXPERIENCE_COMPANY_URL).count() == 1:
                 _fill(page.locator(EXPERIENCE_COMPANY_URL), entry.company_url)
             if dry_run:
-                results.append(f"строка {index}: предложено, save не нажат")
+                results.append(ExperienceResult(f"строка {index}: предложено, save не нажат", True))
                 page.locator(EXPERIENCE_CANCEL).click()
             else:
                 save = page.locator(EXPERIENCE_SAVE)
                 if save.count() != 1:
-                    return results + [f"строка {index}: save-кнопка не подтверждена"]
+                    return results + [
+                        ExperienceResult(f"строка {index}: save-кнопка не подтверждена")
+                    ]
                 save_attempted = True
                 save.click()
                 try:
@@ -288,14 +309,24 @@ def edit_experience_on_hh(
                     )
                 except PlaywrightError as exc:
                     return results + [
-                        f"строка {index}: сохранение не подтверждено (uncertain) после клика: {exc}"
+                        ExperienceResult(
+                            f"строка {index}: сохранение не подтверждено после клика: {exc}",
+                            uncertain=True,
+                        )
                     ]
                 if not resume_identity_matches(page, resume_id):
                     return results + [
-                        f"строка {index}: после save identity резюме не подтверждён (uncertain)"
+                        ExperienceResult(
+                            f"строка {index}: после save identity резюме не подтверждён",
+                            uncertain=True,
+                        )
                     ]
-                results.append(f"строка {index}: сохранено")
+                results.append(ExperienceResult(f"строка {index}: сохранено", True))
         except (PlaywrightError, ValueError) as exc:
-            suffix = " (uncertain: клик сохранения уже был выполнен)" if save_attempted else ""
-            return results + [f"строка {index}: {exc}{suffix}"]
+            return results + [
+                ExperienceResult(
+                    f"строка {index}: {exc}",
+                    uncertain=save_attempted,
+                )
+            ]
     return results

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -4,6 +4,7 @@ import difflib
 import hashlib
 import json
 import logging
+import os
 import re
 import secrets
 import sqlite3
@@ -62,7 +63,8 @@ CREATE TABLE IF NOT EXISTS command_runs (
     started_at TEXT NOT NULL,
     finished_at TEXT,
     exit_code INTEGER,
-    detail TEXT
+    detail TEXT,
+    owner_pid INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_command_runs_status ON command_runs(status, started_at);
 
@@ -456,6 +458,36 @@ SKIP_REASON_VALUES = (
 REPLY_STATUS_VALUES = ("success", "failed", "dry_run", "uncertain")
 
 
+class CommandRunBusy(RuntimeError):
+    """A live process already owns the supervised-command lease."""
+
+    def __init__(self, run_id: str, command: str, owner_pid: int | None):
+        self.run_id = run_id
+        self.command = command
+        self.owner_pid = owner_pid
+        super().__init__(
+            f"supervised-команда уже выполняется: command={command}, "
+            f"pid={owner_pid}, run_id={run_id}"
+        )
+
+
+def _pid_is_alive(pid: int | None) -> bool:
+    """Return whether a recorded local PID is confirmed alive.
+
+    Legacy rows have no owner PID and are recoverable. Permission errors mean
+    the process exists and therefore must be treated as alive (fail closed).
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 class History:
     # Feedback is deliberately bounded: it is prompt context, not an archive
     # of potentially sensitive letters.
@@ -502,6 +534,7 @@ class History:
             _ensure_column(conn, "actions", "search_query", "TEXT")
             _ensure_column(conn, "actions", "run_id", "TEXT")
             _ensure_column(conn, "actions", "reason_code", "TEXT")
+            _ensure_column(conn, "command_runs", "owner_pid", "INTEGER")
             # #473: questionnaire research snapshots predate the apply audit
             # fields.  CREATE TABLE IF NOT EXISTS leaves those old tables
             # untouched, so keep the migration explicitly idempotent.
@@ -726,21 +759,31 @@ class History:
             )
 
     def start_command_run(self, *, command: str, requested_limit: int | None) -> str:
-        """Recover abandoned command runs and create a durable running row."""
+        """Recover dead owners and acquire the single supervised-command lease."""
         now = datetime.now().isoformat()
         run_id = str(uuid.uuid4())
         with self._connect() as conn:
+            # Serialize the read/recover/insert sequence across processes.  A
+            # normal deferred SQLite transaction would let two starters both
+            # observe no owner before either INSERT commits.
+            conn.execute("BEGIN IMMEDIATE")
+            running = conn.execute(
+                "SELECT run_id, command, owner_pid FROM command_runs WHERE status='running'"
+            ).fetchall()
+            for row in running:
+                if _pid_is_alive(row["owner_pid"]):
+                    raise CommandRunBusy(row["run_id"], row["command"], row["owner_pid"])
             conn.execute(
                 """UPDATE command_runs SET status='orphaned', finished_at=?, exit_code=NULL,
-                          detail=COALESCE(detail, 'recovered by next command run')
+                          detail=COALESCE(detail, 'recovered after owner process exited')
                    WHERE status='running'""",
                 (now,),
             )
             conn.execute(
                 """INSERT INTO command_runs
-                   (run_id, command, requested_limit, status, started_at)
-                   VALUES (?, ?, ?, 'running', ?)""",
-                (run_id, command, requested_limit, now),
+                   (run_id, command, requested_limit, status, started_at, owner_pid)
+                   VALUES (?, ?, ?, 'running', ?, ?)""",
+                (run_id, command, requested_limit, now, os.getpid()),
             )
         return run_id
 

--- a/src/hhru_bot/publish_resume.py
+++ b/src/hhru_bot/publish_resume.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from playwright.sync_api import Error as PlaywrightError
@@ -123,7 +124,13 @@ def _visibility_text(page: Page) -> str:
     return ""
 
 
-def publish_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> PublishResumeResult:
+def publish_resume_on_hh(
+    page: Page,
+    resume: ResumeConfig,
+    dry_run: bool,
+    *,
+    before_click: Callable[[], None] | None = None,
+) -> PublishResumeResult:
     """Inspect one config resume and optionally click its publish button."""
     try:
         open_confirmed_resume(page, resume.resume_id)
@@ -200,6 +207,8 @@ def publish_resume_on_hh(page: Page, resume: ResumeConfig, dry_run: bool) -> Pub
         return PublishResumeResult(resume.id, True, reason, state.status, state.is_searchable)
 
     try:
+        if before_click is not None:
+            before_click()
         publish.first.click(timeout=PUBLISH_TIMEOUT_MS)
     except PlaywrightError as exc:
         # #219 (по аналогии с #176/#207): клик мог уйти на hh.ru раньше, чем

--- a/tests/test_apply_progress.py
+++ b/tests/test_apply_progress.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hhru_bot.commands._common import ApplyProgress
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("result", "column"),
+    [
+        (SimpleNamespace(skipped=True, uncertain=True, success=True), "skipped_count"),
+        (SimpleNamespace(skipped=False, uncertain=True, success=True), "uncertain_count"),
+        (SimpleNamespace(skipped=False, uncertain=False, success=True), "applied_count"),
+        (SimpleNamespace(skipped=False, uncertain=False, success=False), "failed_count"),
+        (SimpleNamespace(success=False, acted=True), "uncertain_count"),
+    ],
+)
+def test_finish_has_one_structural_classification_priority(result, column: str) -> None:
+    progress = ApplyProgress()
+    progress.begin_attempt()
+
+    progress.finish(result)
+
+    counts = {
+        "skipped_count": progress.skipped_count,
+        "uncertain_count": progress.uncertain_count,
+        "applied_count": progress.applied_count,
+        "failed_count": progress.failed_count,
+    }
+    assert counts[column] == 1
+    assert sum(counts.values()) == 1
+
+
+def test_finish_counts_one_attempt_only_once() -> None:
+    progress = ApplyProgress()
+    progress.begin_attempt()
+
+    progress.finish(SimpleNamespace(success=True))
+    progress.finish(RuntimeError("context cleanup failed"))
+
+    assert progress.applied_count == 1
+    assert progress.failed_count == 0
+
+
+def test_batch_hard_failure_wins_over_uncertain_sibling() -> None:
+    progress = ApplyProgress()
+    progress.begin_attempt()
+
+    progress.finish(
+        [
+            SimpleNamespace(success=False, uncertain=True),
+            SimpleNamespace(success=False, uncertain=False),
+        ]
+    )
+
+    assert progress.failed_count == 1
+    assert progress.uncertain_count == 0
+
+
+def test_typed_exception_is_uncertain_without_message_matching() -> None:
+    class PostClick(RuntimeError):
+        pass
+
+    progress = ApplyProgress()
+    progress.begin_attempt()
+
+    progress.finish(PostClick("arbitrary text"), uncertain_exceptions=(PostClick,))
+
+    assert progress.uncertain_count == 1
+    assert progress.failed_count == 0

--- a/tests/test_bump_command_runs.py
+++ b/tests/test_bump_command_runs.py
@@ -115,6 +115,7 @@ def test_next_bump_run_recovers_abandoned_bump_as_orphaned(tmp_path, monkeypatch
     _patch_runtime(monkeypatch, config)
     history = History(tmp_path / "history.db")
     abandoned = history.start_command_run(command="bump", requested_limit=None)
+    monkeypatch.setattr("hhru_bot.history._pid_is_alive", lambda _pid: False)
     monkeypatch.setattr(
         "hhru_bot.bump.bump_resume", lambda *_args: (_ for _ in ()).throw(KeyboardInterrupt())
     )

--- a/tests/test_common_run_context.py
+++ b/tests/test_common_run_context.py
@@ -17,7 +17,7 @@ import pytest
 
 from hhru_bot.commands._common import ApplyProgress, SignalTermination, run_supervised_command
 from hhru_bot.exit_codes import CommandExitCode
-from hhru_bot.history import History
+from hhru_bot.history import CommandRunBusy, History
 
 pytestmark = pytest.mark.integration
 
@@ -67,6 +67,21 @@ def test_failed_run_with_attempts_is_partial(tmp_path: Path) -> None:
     assert result is True
     row = history.command_runs()[-1]
     assert row["status"] == "partial"
+
+
+def test_live_supervised_owner_rejects_competing_command_without_orphaning(
+    tmp_path: Path,
+) -> None:
+    history = History(tmp_path / "history.db")
+    active = history.start_command_run(command="apply", requested_limit=1)
+
+    with pytest.raises(CommandRunBusy):
+        history.start_command_run(command="clear-negotiations", requested_limit=None)
+
+    rows = history.command_runs()
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == active
+    assert rows[0]["status"] == "running"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -100,8 +100,10 @@ def env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(hhru_bot.browser, "launch_context", fake_launch)
 
-    def fake_copy(page, resume, dry_run):
+    def fake_copy(page, resume, dry_run, *, before_click=None):
         state.calls.append((resume.id, dry_run))
+        if not dry_run and (state.result.success or state.result.uncertain):
+            before_click()
         return state.result
 
     monkeypatch.setattr(hhru_bot.copy_resume, "copy_resume_on_hh", fake_copy)
@@ -165,8 +167,9 @@ def test_run_browser_failure_exits_1(env, capsys, tmp_path):
             "SELECT status, reason FROM actions WHERE resume_id = ? AND action = 'copy_resume'",
             (OLD_ID,),
         ).fetchone()
-    assert row["status"] == "failed"
-    assert row["reason"] == reason
+    assert row is None
+    run = h.command_runs()[-1]
+    assert run["attempted"] == run["failed"] == run["uncertain"] == 0
 
 
 def test_run_same_resume_id_fails_closed(env, capsys, tmp_path):
@@ -197,8 +200,9 @@ def test_run_browser_exception_still_records_audit_then_reraises(env, tmp_path, 
     # (например, goto_hh при diff-fallback исчерпал ретраи) — не должны молчать
     # локально о попытке: пишем uncertain в actions ДО того, как исключение улетит
     # дальше (#132 review: без этого возможна копия на hh.ru без локальной записи).
-    def raising_copy(page, resume, dry_run):
+    def raising_copy(page, resume, dry_run, *, before_click):
         env.calls.append((resume.id, dry_run))
+        before_click()
         raise RuntimeError("goto_hh исчерпал ретраи")
 
     monkeypatch.setattr(hhru_bot.copy_resume, "copy_resume_on_hh", raising_copy)
@@ -214,7 +218,21 @@ def test_run_browser_exception_still_records_audit_then_reraises(env, tmp_path, 
             (OLD_ID,),
         ).fetchone()
     assert row["status"] == "uncertain"
-    assert "исключение в браузерном шаге" in row["reason"]
+    assert "исключение после точки невозврата" in row["reason"]
+
+
+def test_pre_click_launch_failure_leaves_no_uncertain_marker(env, tmp_path, monkeypatch):
+    def fail_launch(*_args, **_kwargs):
+        raise RuntimeError("transient launch failure")
+
+    monkeypatch.setattr(hhru_bot.browser, "launch_context", fail_launch)
+
+    with pytest.raises(RuntimeError, match="transient launch failure"):
+        cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "h.db")
+    assert not history.has_unresolved_uncertain(OLD_ID, "copy_resume")
+    assert history.command_runs()[-1]["attempted"] == 0
 
 
 def test_run_uncertain_blocks_subsequent_copy(env, tmp_path, monkeypatch, capsys):
@@ -245,8 +263,9 @@ def test_sigterm_after_clone_click_leaves_unresolved_uncertain_marker(env, tmp_p
     after the click already fired.
     """
 
-    def raising_copy(page, resume, dry_run):  # noqa: ANN001, ARG001
+    def raising_copy(page, resume, dry_run, *, before_click):  # noqa: ANN001, ARG001
         env.calls.append((resume.id, dry_run))
+        before_click()
         signal.raise_signal(signal.SIGTERM)
 
     monkeypatch.setattr(hhru_bot.copy_resume, "copy_resume_on_hh", raising_copy)

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -47,8 +47,10 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr(hhru_bot.browser, "launch_context", launch)
     state = SimpleNamespace(result=CreateResumeResult(True, NEW_ID, "черновик создан"), calls=[])
 
-    def create(page, *, area, title, dry_run):
+    def create(page, *, area, title, dry_run, before_click=None):
         state.calls.append((area, title, dry_run))
+        if not dry_run and (state.result.success or state.result.uncertain):
+            before_click()
         return state.result
 
     monkeypatch.setattr(hhru_bot.create_resume, "create_resume_on_hh", create)
@@ -105,9 +107,10 @@ def test_sigterm_after_creation_leaves_unresolved_uncertain_marker(env, tmp_path
     external creation -- this test pins that gap red until fixed.
     """
 
-    def create(page, *, area, title, dry_run):  # noqa: ANN001, ARG001
+    def create(page, *, area, title, dry_run, before_click):  # noqa: ANN001, ARG001
         # Simulate hh.ru having already created the resume, then the process
         # getting SIGTERM'd before the command can record anything.
+        before_click()
         signal.raise_signal(signal.SIGTERM)
         return CreateResumeResult(True, NEW_ID, "черновик создан")
 
@@ -121,6 +124,20 @@ def test_sigterm_after_creation_leaves_unresolved_uncertain_marker(env, tmp_path
         "unresolved uncertain actions marker, or a blind retry can create "
         "a duplicate resume"
     )
+
+
+def test_pre_click_launch_failure_leaves_no_uncertain_marker(env, tmp_path, monkeypatch):
+    def fail_launch(*_args, **_kwargs):
+        raise RuntimeError("transient launch failure")
+
+    monkeypatch.setattr(hhru_bot.browser, "launch_context", fail_launch)
+
+    with pytest.raises(RuntimeError, match="transient launch failure"):
+        cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "history.db")
+    assert not history.has_unresolved_uncertain("account", "create_resume")
+    assert history.command_runs()[-1]["attempted"] == 0
 
 
 def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):

--- a/tests/test_delete_resume_command.py
+++ b/tests/test_delete_resume_command.py
@@ -58,6 +58,7 @@ def env(monkeypatch, tmp_path):
         yield SimpleNamespace(new_page=lambda: object())
 
     monkeypatch.setattr(hhru_bot.browser, "launch_context", launch)
+
     def delete(page, resume, dry, *, before_click=None):  # noqa: ANN001, ARG001
         if not dry and (state.result.success or state.result.uncertain):
             before_click()

--- a/tests/test_delete_resume_command.py
+++ b/tests/test_delete_resume_command.py
@@ -58,9 +58,12 @@ def env(monkeypatch, tmp_path):
         yield SimpleNamespace(new_page=lambda: object())
 
     monkeypatch.setattr(hhru_bot.browser, "launch_context", launch)
-    monkeypatch.setattr(
-        hhru_bot.delete_resume, "delete_resume_on_hh", lambda page, resume, dry: state.result
-    )
+    def delete(page, resume, dry, *, before_click=None):  # noqa: ANN001, ARG001
+        if not dry and (state.result.success or state.result.uncertain):
+            before_click()
+        return state.result
+
+    monkeypatch.setattr(hhru_bot.delete_resume, "delete_resume_on_hh", delete)
     return state
 
 
@@ -114,7 +117,8 @@ def test_sigterm_after_destructive_click_leaves_unresolved_uncertain_marker(
     row is written when the interrupt lands after the click already fired.
     """
 
-    def raising_delete(page, resume, dry_run):  # noqa: ANN001, ARG001
+    def raising_delete(page, resume, dry_run, *, before_click):  # noqa: ANN001, ARG001
+        before_click()
         signal.raise_signal(signal.SIGTERM)
 
     monkeypatch.setattr(hhru_bot.delete_resume, "delete_resume_on_hh", raising_delete)
@@ -126,6 +130,20 @@ def test_sigterm_after_destructive_click_leaves_unresolved_uncertain_marker(
         "a SIGTERM after the destructive click must leave an unresolved "
         "uncertain actions marker, or a blind retry can re-attempt deletion"
     )
+
+
+def test_pre_click_launch_failure_leaves_no_uncertain_marker(env, tmp_path, monkeypatch):
+    def fail_launch(*_args, **_kwargs):
+        raise RuntimeError("transient launch failure")
+
+    monkeypatch.setattr(hhru_bot.browser, "launch_context", fail_launch)
+
+    with pytest.raises(RuntimeError, match="transient launch failure"):
+        cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "history.db")
+    assert not history.has_unresolved_uncertain(RESUME_ID, "delete_resume")
+    assert history.command_runs()[-1]["attempted"] == 0
 
 
 def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -152,7 +152,7 @@ def test_edit_experience_manual_entry_appends_after_existing_rows(tmp_path, caps
     experience must append a new row (index len(existing)), never reuse an
     existing index — reusing an index blanks any field the manual JSON omitted.
     """
-    from hhru_bot.experience import ExperienceEntry
+    from hhru_bot.experience import ExperienceEntry, ExperienceResult
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", _fake_launch_context)
     monkeypatch.setattr(
@@ -166,7 +166,7 @@ def test_edit_experience_manual_entry_appends_after_existing_rows(tmp_path, caps
     def fake_edit_experience_on_hh(page, resume_id, plan, *, dry_run, indexes=None):
         captured["indexes"] = indexes
         captured["plan"] = plan
-        return ["строка 1: сохранено"]
+        return [ExperienceResult("строка 1: сохранено", success=True)]
 
     monkeypatch.setattr("hhru_bot.experience.edit_experience_on_hh", fake_edit_experience_on_hh)
     edit_experience_cmd.run(

--- a/tests/test_publish_resume_command.py
+++ b/tests/test_publish_resume_command.py
@@ -70,9 +70,11 @@ def env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(hhru_bot.browser, "launch_context", fake_launch)
 
-    def fake_publish(page, resume, dry_run):
+    def fake_publish(page, resume, dry_run, *, before_click=None):
         if state.exc is not None:
             raise state.exc
+        if not dry_run and (state.result.success or state.result.uncertain):
+            before_click()
         return state.result
 
     monkeypatch.setattr(hhru_bot.publish_resume, "publish_resume_on_hh", fake_publish)
@@ -202,6 +204,20 @@ def test_run_not_authenticated_is_not_recorded_and_exits(env, capsys, tmp_path):
     # резюме, поэтому pre-click отказ не оставляет строку в actions.
     with History(tmp_path / "h.db")._connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0
+
+
+def test_pre_click_launch_failure_leaves_no_uncertain_marker(env, tmp_path, monkeypatch):
+    def fail_launch(*_args, **_kwargs):
+        raise RuntimeError("transient launch failure")
+
+    monkeypatch.setattr(hhru_bot.browser, "launch_context", fail_launch)
+
+    with pytest.raises(RuntimeError, match="transient launch failure"):
+        cmd.run(_args(tmp_path, force=True))
+
+    history = History(tmp_path / "h.db")
+    assert not history.has_unresolved_uncertain(RESUME_ID, "publish_resume")
+    assert history.command_runs()[-1]["attempted"] == 0
 
 
 def test_run_dry_run_writes_nothing_to_history(env, capsys, tmp_path):

--- a/tests/test_reliability_bundle.py
+++ b/tests/test_reliability_bundle.py
@@ -105,9 +105,7 @@ def test_apply_runs_table_migrates_to_command_runs(tmp_path: Path) -> None:
     assert "command_runs" in tables_again
 
 
-def test_command_run_recovers_orphan_and_persists_counters(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_command_run_recovers_orphan_and_persists_counters(tmp_path: Path, monkeypatch) -> None:
     history = History(tmp_path / "history.db")
     first = history.start_command_run(command="apply", requested_limit=3)
     monkeypatch.setattr("hhru_bot.history._pid_is_alive", lambda _pid: False)

--- a/tests/test_reliability_bundle.py
+++ b/tests/test_reliability_bundle.py
@@ -105,9 +105,12 @@ def test_apply_runs_table_migrates_to_command_runs(tmp_path: Path) -> None:
     assert "command_runs" in tables_again
 
 
-def test_command_run_recovers_orphan_and_persists_counters(tmp_path: Path) -> None:
+def test_command_run_recovers_orphan_and_persists_counters(
+    tmp_path: Path, monkeypatch
+) -> None:
     history = History(tmp_path / "history.db")
     first = history.start_command_run(command="apply", requested_limit=3)
+    monkeypatch.setattr("hhru_bot.history._pid_is_alive", lambda _pid: False)
     second = history.start_command_run(command="apply", requested_limit=2)
     history.finish_command_run(
         second,

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -207,6 +207,7 @@ def test_edit_experience_uncertain_outcome_is_not_counted_as_failed(
 ) -> None:
     """Same regression as above, for edit_experience._run (#465 review)."""
     import hhru_bot.commands.edit_experience as command
+    from hhru_bot.experience import ExperienceResult
 
     resume = SimpleNamespace(id="r1", resume_id="r1")
     config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
@@ -221,7 +222,7 @@ def test_edit_experience_uncertain_outcome_is_not_counted_as_failed(
     monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
     monkeypatch.setattr(
         "hhru_bot.experience.edit_experience_on_hh",
-        lambda *_a, **_kw: ["строка 1: uncertain, не подтверждено"],
+        lambda *_a, **_kw: [ExperienceResult("строка 1: не подтверждено", uncertain=True)],
     )
 
     history_path = tmp_path / "history.db"
@@ -545,6 +546,7 @@ def test_edit_experience_hard_failure_wins_over_uncertain_in_same_batch(
     item in the same batch.
     """
     import hhru_bot.commands.edit_experience as command
+    from hhru_bot.experience import ExperienceResult
 
     resume = SimpleNamespace(id="r1", resume_id="r1")
     config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
@@ -560,8 +562,8 @@ def test_edit_experience_hard_failure_wins_over_uncertain_in_same_batch(
     monkeypatch.setattr(
         "hhru_bot.experience.edit_experience_on_hh",
         lambda *_a, **_kw: [
-            "строка 1: отклонено, ошибка формы",
-            "строка 2: uncertain, не подтверждено",
+            ExperienceResult("строка 1: отклонено, ошибка формы"),
+            ExperienceResult("строка 2: не подтверждено", uncertain=True),
         ],
     )
 

--- a/tests/test_resume_id_addressing.py
+++ b/tests/test_resume_id_addressing.py
@@ -132,7 +132,7 @@ def _patch_publish(monkeypatch, captured: list):
     def fake_launch(*a, **kw):
         yield SimpleNamespace(new_page=lambda: SimpleNamespace())
 
-    def fake_publish(page, resume, dry_run):
+    def fake_publish(page, resume, dry_run, *, before_click=None):
         captured.append((resume.id, resume.resume_id, dry_run))
         return _PublishResult(
             success=True, uncertain=False, reason="Черновик готов к публикации", is_searchable=None


### PR DESCRIPTION
## Summary
- serialize supervised durable commands with an SQLite lease owned by a live PID; recover only rows whose owner is confirmed dead
- add `before_click` seams to publish/copy/create/delete resume browser flows and reserve/finalize one durable action row around the irreversible click
- centralize single and batch progress classification in `ApplyProgress.finish()` using structural flags and typed post-click exceptions
- replace textual experience outcome matching with `ExperienceResult`

## Tests
- `ruff check src/ tests/`
- `pytest -q`

## Risk
- lease liveness is local-PID based; legacy running rows without owner metadata are recovered once as orphaned
- browser seams were unit/integration tested with mocks; no live write was performed

Closes #475
Closes #476
Closes #477
