### PR TITLE
fix: migration-safe lease grace + documented uncertain-marker reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,60 @@ python3 -m playwright install chromium
    а флаговые результаты (`questions.indeterminate`, `probe.unreachable`) используют
    тот же словарь состояний `browser.PAGE_STATE`.
 
+6. **Попытка засчитывается ровно один раз, в ровно одном месте, по структурному
+   сигналу** (эпик #459, `history.py`, `commands/_common.py`):
+   - **Lease на supervised-команды.** `history.start_command_run` сериализует
+     write-команды через SQLite lease с owner PID (`owner_pid` в
+     `command_runs`, `_pid_is_alive`): конкурентный запуск другой durable-команды
+     не осиротняет активный `running`-run, а получает `CommandRunBusy` (#475).
+     `owner_pid IS NULL` — legacy-строка без записанного PID (колонка добавлена
+     `_ensure_column`, задним числом PID не бэкфиллится); `_row_is_live` даёт ей
+     `LEGACY_LEASE_GRACE` (6 часов) как живой, прежде чем считать мёртвой —
+     иначе живая строка от старого бинарника, ещё выполняющего команду ровно в
+     момент `git pull` + переустановки между двумя терминальными сессиями,
+     была бы ошибочно осиротнена, разрешив второй одновременный supervised-запуск
+     (#479). Строка старше порога по-прежнему осиротняется безусловно — это
+     тот же trade-off, что был до #478 в более широком виде, просто сужен, а не
+     закрыт полностью (не строим unbounded-lease машинерию под гипотетическую
+     сверхстарую живую строку).
+   - **`before_click`/`DurableMutationAttempt` seam** (#476) — для
+     `publish-resume`/`copy-resume`/`create-resume`/`delete-resume`: узкое окно
+     между «клик по мутирующей кнопке ушёл» и «результат записан» резервирует
+     `uncertain`-маркер в actions только начиная с реального клика, а не с любой
+     pre-click ошибки (launch_context, форма не найдена и т.п. остаются обычным
+     `failed`/retry, не блокируют повторный запуск).
+   - **`ApplyProgress.finish()`** (#477) — единая точка классификации
+     skipped→uncertain→success→failed для целого batch-результата команды;
+     хендлеры команд (`edit_experience`/`edit_education`/`edit_skills`/
+     `edit_languages`, `resume_position`) не пересчитывают этот приоритет
+     каждый по-своему.
+   - **`has_unresolved_uncertain`** блокирует повтор той же mutation-команды для
+     `resume_id`, пока не появится более поздняя `success`-строка. Для
+     `delete-resume` это структурно недостижимо, если клик реально сработал:
+     резюме удалено → повтор всегда получит «резюме не найдено», никогда
+     `success` → команда для этого `resume_id` заблокирована навсегда без
+     ручного вмешательства (#480). **Осознанно нет отдельной `--reconcile`
+     команды** — новая read-машинерия на 4 разных сценария (delete/publish/
+     copy/create) ради узкого, редкого окна была бы преждевременной
+     инфраструктурой (принцип «максимальная простота», см. выше «Схема SQLite»).
+     Вместо этого — ручная reconciliation через прямой доступ к `history.db`
+     (проект и так не имеет системы миграций/admin UI, тот же принцип):
+     1. Подтвердить фактическое состояние на hh.ru вручную (для `delete-resume`
+        — резюме отсутствует в `list-resumes`; для остальных — соответствующий
+        наблюдаемый статус/список).
+     2. Только после подтверждения — вставить резолюцию: явную `success`-строку
+        (`created_at` позже существующей `uncertain`) в таблицу `actions`, тем
+        же action-именем (`delete_resume`/`publish_resume`/`copy_resume`/
+        `create_resume`):
+        ```sql
+        INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at)
+        VALUES ('<resume_id>', '<resume_id>', 'delete_resume', 'success',
+                'manual reconciliation: confirmed via hh.ru UI', datetime('now'));
+        ```
+     Писать `success` вручную можно **только** после подтверждения на hh.ru —
+     тот же fail-closed принцип, что и у самого `uncertain`: ложный `success`
+     хуже постоянной блокировки.
+
 ### Селекторы — статус проверки (критично)
 
 Канонический источник селекторов — пакет `selector_groups/` (по страницам);

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -488,6 +488,33 @@ def _pid_is_alive(pid: int | None) -> bool:
     return True
 
 
+#: #479 (Codex adversarial-review of PR #478): ``owner_pid`` is a column added
+#: by ``_ensure_column`` -- an idempotent ``ALTER TABLE`` that does not
+#: backfill PIDs onto rows written by an older binary. A genuinely stale
+#: legacy ``running`` row (created before this column existed, process long
+#: gone) and a *live* one from an older binary still executing a supervised
+#: command exactly across a ``git pull`` + reinstall between two terminal
+#: sessions are both indistinguishable by ``owner_pid IS NULL`` alone. This
+#: grace window trades a still-narrow reclaim delay for closing that overlap:
+#: a NULL-owner row younger than the grace period is treated as live (blocks
+#: a competing start, same as a confirmed-alive PID); older than it, it is
+#: still reclaimed unconditionally -- a NULL-owner row from months ago is not
+#: given an unbounded lease just because no PID was ever recorded. The window
+#: is sized well above any single supervised command's realistic duration
+#: (``apply``/``run`` under daily limits can run for a while), not "a couple
+#: of minutes" -- comparable in order of magnitude to ``throttle.BUMP_COOLDOWN``.
+LEGACY_LEASE_GRACE = timedelta(hours=6)
+
+
+def _row_is_live(row: sqlite3.Row, *, now: datetime) -> bool:
+    """Whether a ``running`` command_runs row still holds the lease (#479)."""
+    owner_pid = row["owner_pid"]
+    if owner_pid is not None:
+        return _pid_is_alive(owner_pid)
+    started_at = datetime.fromisoformat(row["started_at"])
+    return started_at > now - LEGACY_LEASE_GRACE
+
+
 class History:
     # Feedback is deliberately bounded: it is prompt context, not an archive
     # of potentially sensitive letters.
@@ -768,10 +795,11 @@ class History:
             # observe no owner before either INSERT commits.
             conn.execute("BEGIN IMMEDIATE")
             running = conn.execute(
-                "SELECT run_id, command, owner_pid FROM command_runs WHERE status='running'"
+                "SELECT run_id, command, owner_pid, started_at FROM command_runs "
+                "WHERE status='running'"
             ).fetchall()
             for row in running:
-                if _pid_is_alive(row["owner_pid"]):
+                if _row_is_live(row, now=datetime.now()):
                     raise CommandRunBusy(row["run_id"], row["command"], row["owner_pid"])
             conn.execute(
                 """UPDATE command_runs SET status='orphaned', finished_at=?, exit_code=NULL,

--- a/tests/test_common_run_context.py
+++ b/tests/test_common_run_context.py
@@ -11,13 +11,15 @@ apply-specific plumbing.
 from __future__ import annotations
 
 import signal
+import uuid
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
 
 from hhru_bot.commands._common import ApplyProgress, SignalTermination, run_supervised_command
 from hhru_bot.exit_codes import CommandExitCode
-from hhru_bot.history import CommandRunBusy, History
+from hhru_bot.history import LEGACY_LEASE_GRACE, CommandRunBusy, History
 
 pytestmark = pytest.mark.integration
 
@@ -82,6 +84,66 @@ def test_live_supervised_owner_rejects_competing_command_without_orphaning(
     assert len(rows) == 1
     assert rows[0]["run_id"] == active
     assert rows[0]["status"] == "running"
+
+
+def _insert_running_row(history: History, *, owner_pid: int | None, started_at: datetime) -> str:
+    """Insert a ``running`` command_runs row directly, bypassing the lease.
+
+    Simulates a row written by an older binary predating the ``owner_pid``
+    column (#479): ``_ensure_column``'s ``ALTER TABLE`` backfills existing
+    rows with NULL, it never retrofits a live PID onto them.
+    """
+    run_id = str(uuid.uuid4())
+    with history._connect() as conn:
+        conn.execute(
+            """INSERT INTO command_runs
+               (run_id, command, requested_limit, status, started_at, owner_pid)
+               VALUES (?, 'apply', NULL, 'running', ?, ?)""",
+            (run_id, started_at.isoformat(), owner_pid),
+        )
+    return run_id
+
+
+def test_recent_null_owner_row_blocks_competing_command_without_orphaning(
+    tmp_path: Path,
+) -> None:
+    """A NULL-owner row younger than the grace window is treated as live (#479).
+
+    Covers the migration-window race: an older binary, predating the
+    ``owner_pid`` column, is still executing a supervised command when a
+    freshly reinstalled binary starts and reads the same database. Without
+    the grace window, the old binary's live row (owner_pid=NULL, just
+    started) would be reclaimed unconditionally and a second supervised
+    command would run concurrently against the same account.
+    """
+    history = History(tmp_path / "history.db")
+    stale_run_id = _insert_running_row(history, owner_pid=None, started_at=datetime.now())
+
+    with pytest.raises(CommandRunBusy):
+        history.start_command_run(command="clear-negotiations", requested_limit=None)
+
+    rows = history.command_runs()
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == stale_run_id
+    assert rows[0]["status"] == "running"
+
+
+def test_old_null_owner_row_is_still_reclaimed(tmp_path: Path) -> None:
+    """A NULL-owner row older than the grace window is reclaimed as before.
+
+    Preserves pre-#479 behaviour for genuinely stale legacy rows: an
+    unbounded lease was never the intent, only closing the narrow
+    rolling-upgrade overlap.
+    """
+    history = History(tmp_path / "history.db")
+    old_started_at = datetime.now() - LEGACY_LEASE_GRACE - timedelta(minutes=1)
+    stale_run_id = _insert_running_row(history, owner_pid=None, started_at=old_started_at)
+
+    new_run_id = history.start_command_run(command="apply", requested_limit=1)
+
+    rows = {row["run_id"]: row for row in history.command_runs()}
+    assert rows[stale_run_id]["status"] == "orphaned"
+    assert rows[new_run_id]["status"] == "running"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two hardening follow-ups from Codex adversarial-review of #478 (attempt-accounting: #475/#476/#477), both explicitly non-blocking for that merge and deferred here.

## #479 — migration-safe lease handoff

`history.py::start_command_run`'s lease (#475) treated any `owner_pid IS NULL` running row as dead. `owner_pid` is a column added by #478 via an idempotent `_ensure_column` `ALTER TABLE` that does not backfill PIDs onto rows written by an older binary — so a row from an older binary still actively executing a supervised command, exactly during a `git pull` + reinstall between two terminal sessions, also has `owner_pid=NULL` and was reclaimed unconditionally, letting a second supervised command run concurrently against the same account.

`_row_is_live` now grants a `NULL`-owner row a `LEGACY_LEASE_GRACE` (6h) window based on `started_at` before treating it as reclaimable — sized well above any single supervised command's realistic duration, comparable in order of magnitude to `throttle.BUMP_COOLDOWN`. A row older than the window is still reclaimed unconditionally, same trade-off as before #478 (a genuinely stale legacy row must not hold an unbounded lease).

Tests: `test_recent_null_owner_row_blocks_competing_command_without_orphaning` (live pre-migration row within the grace window blocks a competing start) and `test_old_null_owner_row_is_still_reclaimed` (existing reclaim behaviour preserved past the window).

## #480 — reconciliation for a permanently-stuck uncertain marker

`has_unresolved_uncertain` blocks retry for `publish-resume`/`copy-resume`/`create-resume`/`delete-resume` until a later matching `success` row appears for the same `resume_id`/action. For `delete-resume` this is structurally unreachable if the click actually succeeded: the resume is gone, so any retry reports "resume not found", never `success` — the command stays permanently blocked for that `resume_id`.

No new `--reconcile` CLI command was added: that would be new read-path machinery for four different per-command scenarios to close a narrow, low-probability window the linked issue itself flags as deferrable — premature infrastructure ahead of a real incident, against this project's "maximum simplicity" principle (the project already has no migration system or admin UI for the same reason). Instead, `CLAUDE.md` §6 now documents the manual reconciliation recipe: confirm the real hh.ru state by hand, then insert an explicit resolving `success` row directly into `history.db`.

## Verification

- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean
- `pytest -q -n 4 --dist worksteal` — full suite green
- `scripts/gen_cli_docs.py --check` — in sync (no new CLI surface)

Closes #479
Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)