### PR TITLE
feat(scoring): add resume-vacancy keyword match

### DIFF
--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -144,7 +144,9 @@ def run(args: argparse.Namespace) -> bool:
             )
             for c, score, breakdown in ranked:
                 factors = ", ".join(
-                    f"{name}={value:+.2f}" for name, value in breakdown.items() if value
+                    f"{name}={value:+.2f}"
+                    for name, value in breakdown.items()
+                    if value or name == "resume_match"
                 )
                 detail = f" | {factors}" if factors else ""
                 print(f"  [candidate] score={score:+.2f} {_format_card_line(c)}{detail}")

--- a/src/hhru_bot/scoring/__init__.py
+++ b/src/hhru_bot/scoring/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from .employer import TIER_BOOST, KnownCompanyTier, classify_employer
 from .prefilter import PREFILTER_SKIP_REASON, employer_passes_prefilter
+from .resume_match import score_resume_match
 from .types import EmployerInfo, ScoreOutcome, ScoringProvider
 from .vacancy import HeuristicScoringProvider, LLMScoringProvider, heuristic_score
 
@@ -32,4 +33,5 @@ __all__ = [
     "classify_employer",
     "employer_passes_prefilter",
     "heuristic_score",
+    "score_resume_match",
 ]

--- a/src/hhru_bot/scoring/resume_match.py
+++ b/src/hhru_bot/scoring/resume_match.py
@@ -1,0 +1,146 @@
+"""Cheap keyword match between an ``AIProfile`` and vacancy text (#492).
+
+Stage 1 is deliberately observational: this module computes a 0--100 metric,
+but does not decide whether a vacancy may be applied to.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from .types import ScoreOutcome
+
+if TYPE_CHECKING:
+    from ..config_sections.ai_profile import AIProfile
+    from ..search import VacancyCard
+
+
+_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
+
+# Function words add overlap without saying anything about candidate fit.  Keep
+# this intentionally small and language-local rather than growing a linguistic
+# dependency for the tier-0 metric.
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "for",
+    "in",
+    "of",
+    "on",
+    "the",
+    "to",
+    "with",
+    "ваш",
+    "ваша",
+    "ваше",
+    "ваши",
+    "для",
+    "его",
+    "или",
+    "как",
+    "мы",
+    "на",
+    "наш",
+    "не",
+    "но",
+    "от",
+    "по",
+    "с",
+    "со",
+    "у",
+    "что",
+    "это",
+}
+
+# Lightweight Russian inflection folding.  It intentionally handles endings,
+# not semantics: ``зарплату`` and ``зарплатные`` share a topic, while the other
+# words in their phrases still keep intentually different texts far apart.
+_RU_SUFFIXES = (
+    "иями",
+    "ями",
+    "ами",
+    "ого",
+    "ему",
+    "ому",
+    "ные",
+    "ная",
+    "ный",
+    "ную",
+    "ов",
+    "ев",
+    "ам",
+    "ям",
+    "ах",
+    "ях",
+    "ы",
+    "и",
+    "а",
+    "я",
+    "у",
+    "ю",
+    "е",
+    "о",
+)
+
+_SECTION_WEIGHTS = {
+    "desired_role": 35.0,
+    "skills": 45.0,
+    "summary": 10.0,
+    "highlights": 10.0,
+}
+
+
+def _fold_token(token: str) -> str:
+    token = token.casefold().replace("ё", "е")
+    if not any("а" <= char <= "я" for char in token):
+        return token
+    for suffix in _RU_SUFFIXES:
+        if token.endswith(suffix) and len(token) - len(suffix) >= 4:
+            return token[: -len(suffix)]
+    return token
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        folded
+        for raw in _TOKEN_RE.findall(text)
+        if raw.casefold().replace("ё", "е") not in _STOPWORDS
+        if len(folded := _fold_token(raw)) >= 2
+    }
+
+
+def score_resume_match(profile: AIProfile | None, card: VacancyCard) -> ScoreOutcome:
+    """Return profile-token coverage by ``card.vacancy_text`` on a 0--100 scale.
+
+    Each populated profile section contributes its configured weight; weights
+    are normalized over populated sections so a complete match is always 100.
+    Coverage is measured against profile tokens (extra vacancy prose is not a
+    penalty).  Multi-word evidence is important: sharing only a broad topic,
+    for example ``зарплата``, cannot make a differently-intended phrase a high
+    match by itself.
+    """
+    vacancy_tokens = _tokens(card.vacancy_text or "")
+    if profile is None:
+        return ScoreOutcome(score_0_100=0.0, mode="resume_match")
+
+    sections = {
+        "desired_role": _tokens(profile.desired_role),
+        "skills": _tokens(" ".join(profile.skills)),
+        "summary": _tokens(profile.summary),
+        "highlights": _tokens(" ".join(profile.highlights)),
+    }
+    active = {name: tokens for name, tokens in sections.items() if tokens}
+    active_weight = sum(_SECTION_WEIGHTS[name] for name in active)
+    if not active or not vacancy_tokens:
+        return ScoreOutcome(score_0_100=0.0, mode="resume_match")
+
+    breakdown: dict[str, float] = {}
+    for name, profile_tokens in active.items():
+        coverage = len(profile_tokens & vacancy_tokens) / len(profile_tokens)
+        breakdown[name] = 100.0 * _SECTION_WEIGHTS[name] / active_weight * coverage
+
+    score = min(100.0, sum(breakdown.values()))
+    return ScoreOutcome(score_0_100=score, mode="resume_match", breakdown=breakdown)

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -922,6 +922,7 @@ def rank_candidates(
             breakdown = outcome.breakdown
         else:
             score, breakdown = _score_card(card, filters, weights)
+        breakdown = _add_resume_match(card, profile, breakdown)
         scored.append((card, score, breakdown))
 
     # Стабильно: сортировка только по score; равные score сохраняют входной
@@ -929,6 +930,19 @@ def rank_candidates(
     # он переупорядочивал бы legacy candidates[:limit] при перемешанных id.
     scored.sort(key=lambda item: -item[1])
     return scored
+
+
+def _add_resume_match(card, profile, breakdown: dict[str, float]) -> dict[str, float]:
+    """Attach and log the observational stage-1 metric without changing rank."""
+    from .scoring import score_resume_match
+
+    outcome = score_resume_match(profile, card)
+    logger.info(
+        "vacancy %s resume_match score=%.2f",
+        card.vacancy_id,
+        outcome.score_0_100,
+    )
+    return {**breakdown, "resume_match": outcome.score_0_100}
 
 
 # Максимальный размер shortlist для LLM-скоринга по умолчанию (Codex #74 F3).
@@ -969,9 +983,11 @@ def _rank_with_llm_shortlist(
     for card, heur_score, heur_breakdown in heur:
         if card.vacancy_id in shortlist_ids:
             outcome = scoring_provider.score(card, profile)
-            scored.append((card, outcome.score_0_100, outcome.breakdown))
+            breakdown = _add_resume_match(card, profile, outcome.breakdown)
+            scored.append((card, outcome.score_0_100, breakdown))
         else:
-            scored.append((card, heur_score, heur_breakdown))
+            breakdown = _add_resume_match(card, profile, heur_breakdown)
+            scored.append((card, heur_score, breakdown))
 
     # Шаг 4: финальная стабильная сортировка по итоговому score.
     scored.sort(key=lambda item: -item[1])

--- a/tests/test_resume_match.py
+++ b/tests/test_resume_match.py
@@ -1,0 +1,90 @@
+"""Keyword matching between an AIProfile and vacancy card text (#492)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hhru_bot.config import ResumeConfig, SearchFilters
+from hhru_bot.config_sections.ai_profile import AIProfile
+from hhru_bot.scoring import score_resume_match
+from hhru_bot.search import VacancyCard, rank_candidates
+
+pytestmark = pytest.mark.unit
+
+
+def card(text: str) -> VacancyCard:
+    return VacancyCard(
+        vacancy_id="1",
+        title="Backend developer",
+        company="Example",
+        url="https://hh.ru/vacancy/1",
+        vacancy_text=text,
+    )
+
+
+def test_resume_match_exact_keywords_score_100():
+    profile = AIProfile(desired_role="Python developer", skills=["Django", "PostgreSQL"])
+
+    outcome = score_resume_match(
+        profile,
+        card("Python developer. Stack: Django and PostgreSQL."),
+    )
+
+    assert outcome.score_0_100 == pytest.approx(100.0)
+    assert sum(outcome.breakdown.values()) == pytest.approx(100.0)
+
+
+def test_resume_match_partial_keywords():
+    profile = AIProfile(skills=["Python", "Django", "PostgreSQL", "Docker"])
+
+    outcome = score_resume_match(profile, card("We use Python and PostgreSQL."))
+
+    assert outcome.score_0_100 == pytest.approx(50.0)
+
+
+def test_resume_match_no_overlap():
+    profile = AIProfile(desired_role="Data analyst", skills=["SQL"])
+
+    assert score_resume_match(profile, card("Java mobile developer")).score_0_100 == 0.0
+
+
+def test_resume_match_empty_profile():
+    assert score_resume_match(AIProfile(), card("Python Django developer")).score_0_100 == 0.0
+
+
+def test_resume_match_empty_vacancy_text():
+    profile = AIProfile(desired_role="Python developer", skills=["Django"])
+
+    assert score_resume_match(profile, card("")).score_0_100 == 0.0
+
+
+def test_resume_match_topic_does_not_imply_same_intent():
+    """#490 regression: a shared salary topic is not a full intent match."""
+    profile = AIProfile(highlights=["Рассчитывал зарплату сотрудников"])
+
+    outcome = score_resume_match(profile, card("Укажите ваши зарплатные ожидания"))
+
+    assert 0.0 < outcome.score_0_100 < 50.0
+
+
+def test_rank_candidates_logs_match_and_keeps_it_out_of_ranking(caplog):
+    profile = AIProfile(skills=["Python"])
+    resume = ResumeConfig(
+        id="r1",
+        resume_url="https://hh.ru/resume/AAA111",
+        search=SearchFilters(text="developer"),
+        ai_profile=profile,
+    )
+    matching = card("Python developer")
+    unrelated = VacancyCard("2", "Developer", "Example", "u", vacancy_text="Java developer")
+
+    with caplog.at_level(logging.INFO, logger="hhru_bot.search"):
+        ranked = rank_candidates([unrelated, matching], resume.search, resume)
+
+    # Stage 1 only observes the metric: legacy zero-score order is unchanged.
+    assert [item[0].vacancy_id for item in ranked] == ["2", "1"]
+    assert [item[2]["resume_match"] for item in ranked] == [0.0, 100.0]
+    assert "resume_match score=100.00" in caplog.text
+    assert "resume_match score=0.00" in caplog.text

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -500,7 +500,7 @@ def test_rank_candidates_with_provider_uses_provider_score():
     # Provider вызван на каждую карточку; сортировка по его score (desc).
     assert spy.called == ["1", "2"]
     assert [c.vacancy_id for c, _s, _b in ranked] == ["1", "2"]
-    assert ranked[0][2] == {"llm": 90.0}
+    assert ranked[0][2] == {"llm": 90.0, "resume_match": 0.0}
 
 
 # --- rank_candidates: shortlist-кэп LLM-запросов (#74 F3, анти-фрод) ---------


### PR DESCRIPTION
## Summary
- add a dependency-free `score_resume_match` metric on the shared 0–100 `ScoreOutcome` scale
- weight coverage across `desired_role`, `skills`, `summary`, and `highlights`, with lightweight Russian ending folding and stop-word removal
- attach and log `resume_match` for every ranked card without changing filtering or ranking in stage 1
- keep zero scores visible in search output so real-run distributions can be calibrated

## Tests
- `ruff check .`
- `ruff format --check .`
- `pytest` (2018 passed, 3 deselected)

## Risks / follow-up
- This is intentionally a tier-0 lexical metric; it does not attempt semantic equivalence. Stage 2 thresholding remains disabled pending real-data calibration.

Closes #492
