### PR TITLE
feat(scoring): resume<->vacancy keyword-match score (Этап 1, #492)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -804,6 +804,33 @@ def _load_apply_page(page, filters: SearchFilters, page_num: int) -> tuple[list[
     return cards, _has_next_page(page, page_num)
 
 
+def _log_resume_match_scores(candidates: list[VacancyCard], profile) -> None:
+    """Считает и логирует resume<->vacancy keyword-match score (Этап 1, #492).
+
+    Только логирование — НЕ фильтрует и не влияет на ranked/skipped. Цель issue
+    #492 Этапа 1: увидеть на реальных прогонах реальное распределение score,
+    прежде чем калибровать порог отсечения (Этап 2, отдельно). Сбой скоринга
+    одной карточки не должен ронять план откликов — как и остальные
+    провайдеры скоринга в проекте (см. LLMScoringProvider), поэтому ошибка
+    только логируется и вычисление продолжается на следующей карточке.
+    """
+    from ..scoring import score_resume_match
+
+    for card in candidates:
+        try:
+            outcome = score_resume_match(card, profile)
+        except Exception as e:  # noqa: BLE001 — логирование не должно ронять план
+            logger.warning("Resume-match scoring failed for '%s': %s", card.title, e)
+            continue
+        logger.info(
+            "Resume-match score для '%s' (%s): %.1f/100 (breakdown=%s)",
+            card.title,
+            card.vacancy_id,
+            outcome.score_0_100,
+            outcome.breakdown,
+        )
+
+
 def build_apply_plan(
     candidates: list[VacancyCard],
     filters: SearchFilters,
@@ -827,6 +854,8 @@ def build_apply_plan(
     """
     prefilter = getattr(getattr(resume, "scoring", None), "prefilter", None)
     filtered, skipped = filter_candidates(candidates, filters, resume.resume_id, history, prefilter)
+
+    _log_resume_match_scores(filtered, getattr(resume, "ai_profile", None))
 
     ranked = rank_candidates(
         filtered,

--- a/src/hhru_bot/scoring/__init__.py
+++ b/src/hhru_bot/scoring/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from .employer import TIER_BOOST, KnownCompanyTier, classify_employer
 from .prefilter import PREFILTER_SKIP_REASON, employer_passes_prefilter
+from .resume_match import ResumeMatchOutcome, score_resume_match
 from .types import EmployerInfo, ScoreOutcome, ScoringProvider
 from .vacancy import HeuristicScoringProvider, LLMScoringProvider, heuristic_score
 
@@ -27,9 +28,11 @@ __all__ = [
     "HeuristicScoringProvider",
     "KnownCompanyTier",
     "LLMScoringProvider",
+    "ResumeMatchOutcome",
     "ScoreOutcome",
     "ScoringProvider",
     "classify_employer",
     "employer_passes_prefilter",
     "heuristic_score",
+    "score_resume_match",
 ]

--- a/src/hhru_bot/scoring/resume_match.py
+++ b/src/hhru_bot/scoring/resume_match.py
@@ -1,0 +1,116 @@
+"""Скоринг соответствия профиля резюме тексту вакансии (Этап 1, #492).
+
+Чистая функция без ML: взвешенное пересечение токенов ``AIProfile``
+(``skills``/``desired_role``/``highlights``/``summary``) с ``VacancyCard.vacancy_text``.
+Источники текста подтверждены разведкой (#492): ``vacancy_text`` заполняется уже
+на search-шаге (``search.py``, ``card.inner_text()``), полный текст резюме бот
+нигде не парсит — скоринг работает по ``AIProfile``, не по резюме на hh.ru.
+
+Этап 1 (эта issue): только вычисление и логирование score — без фильтрации,
+без блокировки отправки (см. вызов в ``commands/_common.build_apply_plan``).
+Этап 2 (порог отсечения через существующий ``filter_candidates``) — отдельный
+шаг после наблюдения на реальных прогонах, здесь НЕ реализован.
+
+Шкала — 0-100 (переиспользует соглашение ``ScoreOutcome.score_0_100``, issue
+явно требует не заводить отдельную шкалу 0-1).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from ..search import _tokenize
+
+if TYPE_CHECKING:
+    from ..config_sections.ai_profile import AIProfile
+    from ..search import VacancyCard
+
+# Веса полей профиля при построении набора токенов "что кандидат ищет". skills
+# и desired_role — самый прямой сигнал намерения (конкретные технологии/роль),
+# summary — общий текст о себе (наименее специфичный, самый шумный источник
+# случайных пересечений, см. #490: тема слова ≠ намерение вопроса). highlights
+# — достижения, обычно тоже конкретные (проекты/стек), вес между skills и summary.
+_FIELD_WEIGHT_SKILLS = 3.0
+_FIELD_WEIGHT_DESIRED_ROLE = 3.0
+_FIELD_WEIGHT_HIGHLIGHTS = 2.0
+_FIELD_WEIGHT_SUMMARY = 1.0
+
+# Токены короче этого порога (предлоги, союзы, обрывки) отбрасываются из знаменателя
+# и из матчинга — иначе случайное совпадение однобуквенных/двухбуквенных токенов
+# ("в", "на", "по") давало бы ложный вклад в score, не связанный со смыслом
+# (тот же класс риска, что #490 - тема слова вместо намерения).
+_MIN_TOKEN_LEN = 3
+
+
+@dataclass(frozen=True)
+class ResumeMatchOutcome:
+    """Результат скоринга соответствия резюме вакансии (0-100 + breakdown).
+
+    score_0_100 — доля ВЗВЕШЕННОГО веса токенов профиля, найденных в тексте
+    вакансии (recall со стороны профиля, не Jaccard: вакансия почти всегда
+    длиннее и разнообразнее профиля, поэтому симметричное пересечение давало бы
+    равномерно маленькие числа и было бы бесполезно для калибровки порога
+    ~90/100, см. #492). breakdown — вклад по полям профиля (для логов/анализа
+    распределения на Этапе 1).
+    """
+
+    score_0_100: float
+    matched_tokens: tuple[str, ...] = ()
+    breakdown: dict[str, float] = field(default_factory=dict)
+
+
+def _weighted_profile_tokens(profile: AIProfile) -> dict[str, float]:
+    """Строит {токен: вес} из полей профиля, суммируя веса при повторах."""
+    weighted: dict[str, float] = {}
+
+    def _add(text: str, weight: float) -> None:
+        for token in _tokenize(text):
+            if len(token) < _MIN_TOKEN_LEN:
+                continue
+            weighted[token] = weighted.get(token, 0.0) + weight
+
+    _add(profile.summary, _FIELD_WEIGHT_SUMMARY)
+    for skill in profile.skills:
+        _add(skill, _FIELD_WEIGHT_SKILLS)
+    for highlight in profile.highlights:
+        _add(highlight, _FIELD_WEIGHT_HIGHLIGHTS)
+    _add(profile.desired_role, _FIELD_WEIGHT_DESIRED_ROLE)
+
+    return weighted
+
+
+def score_resume_match(card: VacancyCard, profile: AIProfile | None) -> ResumeMatchOutcome:
+    """Скорит соответствие профиля кандидата тексту вакансии (0-100).
+
+    Пустой профиль (``None`` или все поля пусты) и пустой ``vacancy_text``
+    (карточка ещё не несёт текста, см. #492 про источник) дают score 0.0 с
+    breakdown, объясняющим причину (``reason``) — иначе на Этапе 1 нельзя
+    отличить в логе «0 потому что нет пересечения» от «0 потому что нечем
+    было сравнивать», что делает калибровку порога Этапа 2 ненадёжной.
+    """
+    if profile is None:
+        return ResumeMatchOutcome(score_0_100=0.0, breakdown={"reason": -1.0})
+
+    weighted = _weighted_profile_tokens(profile)
+    if not weighted:
+        return ResumeMatchOutcome(score_0_100=0.0, breakdown={"reason": -1.0})
+
+    vacancy_text = card.vacancy_text or ""
+    vacancy_tokens = {t for t in _tokenize(vacancy_text) if len(t) >= _MIN_TOKEN_LEN}
+    if not vacancy_tokens:
+        return ResumeMatchOutcome(score_0_100=0.0, breakdown={"reason": -2.0})
+
+    total_weight = sum(weighted.values())
+    matched = [token for token in weighted if token in vacancy_tokens]
+    matched_weight = sum(weighted[token] for token in matched)
+
+    score = (matched_weight / total_weight) * 100.0
+    return ResumeMatchOutcome(
+        score_0_100=score,
+        matched_tokens=tuple(sorted(matched)),
+        breakdown={
+            "matched_weight": matched_weight,
+            "total_weight": total_weight,
+        },
+    )

--- a/tests/test_scoring_resume_match.py
+++ b/tests/test_scoring_resume_match.py
@@ -1,0 +1,117 @@
+"""Тесты resume<->vacancy keyword-match скоринга (issue #492, Этап 1).
+
+Чистая логика без браузера/LLM: score_resume_match взвешенно пересекает токены
+AIProfile (skills/desired_role/highlights/summary) с VacancyCard.vacancy_text.
+Покрывает: точное совпадение, частичное, полное несовпадение, пустой профиль,
+пустой vacancy_text, и regression-кейс класса #490 (тема слова, а не намерение
+— наивное пересечение не должно давать ложный высокий score на нерелевантной
+роли только из-за совпадения общеупотребимых существительных).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.config_sections.ai_profile import AIProfile
+from hhru_bot.scoring import score_resume_match
+from hhru_bot.search import VacancyCard
+
+pytestmark = pytest.mark.unit
+
+
+def _card(vacancy_text: str, title: str = "Vacancy") -> VacancyCard:
+    return VacancyCard(
+        vacancy_id="1",
+        title=title,
+        company="ООО Ромашка",
+        url="https://hh.ru/vacancy/1",
+        vacancy_text=vacancy_text,
+    )
+
+
+def test_exact_match_scores_high():
+    profile = AIProfile(
+        skills=["python", "django", "postgresql"],
+        desired_role="backend developer",
+    )
+    card = _card(
+        "Ищем Python-разработчика со знанием Django и PostgreSQL на позицию "
+        "backend developer в нашу команду."
+    )
+
+    outcome = score_resume_match(card, profile)
+
+    assert outcome.score_0_100 == pytest.approx(100.0)
+    assert set(outcome.matched_tokens) >= {"python", "django", "postgresql", "backend", "developer"}
+
+
+def test_partial_match_scores_between_bounds():
+    profile = AIProfile(skills=["python", "django", "kubernetes"])
+    card = _card("Ищем Python-разработчика, опыт с Django обязателен.")
+
+    outcome = score_resume_match(card, profile)
+
+    assert 0.0 < outcome.score_0_100 < 100.0
+
+
+def test_no_overlap_scores_zero():
+    profile = AIProfile(skills=["python", "django"], desired_role="backend developer")
+    card = _card("Требуется сварщик пятого разряда на производство металлоконструкций.")
+
+    outcome = score_resume_match(card, profile)
+
+    assert outcome.score_0_100 == 0.0
+    assert outcome.matched_tokens == ()
+
+
+def test_empty_profile_returns_zero_with_reason():
+    card = _card("Ищем Python-разработчика.")
+
+    outcome = score_resume_match(card, None)
+
+    assert outcome.score_0_100 == 0.0
+    assert outcome.breakdown.get("reason") is not None
+
+
+def test_blank_profile_fields_return_zero_with_reason():
+    profile = AIProfile()  # все поля пустые по умолчанию
+    card = _card("Ищем Python-разработчика.")
+
+    outcome = score_resume_match(card, profile)
+
+    assert outcome.score_0_100 == 0.0
+    assert outcome.breakdown.get("reason") is not None
+
+
+def test_empty_vacancy_text_returns_zero_with_reason():
+    profile = AIProfile(skills=["python"])
+    card = _card("")
+
+    outcome = score_resume_match(card, profile)
+
+    assert outcome.score_0_100 == 0.0
+    assert outcome.breakdown.get("reason") is not None
+
+
+def test_topic_word_without_intent_does_not_inflate_score():
+    """Regression для класса ошибки #490: совпадение общей темы (не намерения).
+
+    Профиль ищет роль HR-специалиста (тема "зарплата" как часть обязанностей).
+    Вакансия — программист, где "зарплата" встречается только в блоке
+    компенсации ("зарплата от..."). Наивное пересечение токенов ловит слово
+    "зарплата" в обоих текстах, но это не должно давать высокий score: остальные
+    специфичные токены профиля (hr, кадры, подбор) в вакансии отсутствуют, и
+    единственное совпадение — по общеупотребимому слову с разным намерением.
+    """
+    profile = AIProfile(
+        skills=["hr", "кадровое делопроизводство", "подбор персонала"],
+        desired_role="hr-специалист, расчет зарплаты сотрудников",
+    )
+    card = _card(
+        "Требуется Python-разработчик. Зарплата от 200000 руб. Обязанности: "
+        "разработка backend-сервисов на Django."
+    )
+
+    outcome = score_resume_match(card, profile)
+
+    assert outcome.score_0_100 < 30.0


### PR DESCRIPTION
## Summary

- Реализует Этап 1 из #492: чистая функция `score_resume_match` (`scoring/resume_match.py`) — взвешенное пересечение токенов `AIProfile` (`skills`/`desired_role` весомее `highlights`, `summary` наименее весом) с `VacancyCard.vacancy_text`, шкала 0-100 (переиспользует `ScoreOutcome.score_0_100`, без отдельной шкалы 0-1, как явно требует issue).
- Подключает вызов в `commands/_common.py::build_apply_plan` — только **вычисление и логирование** score для каждой отфильтрованной карточки, без фильтрации и без блокировки отправки (Этап 2 — отдельный шаг после наблюдения реального распределения на живых прогонах, сознательно не реализован).
- Пустой профиль / пустой `vacancy_text` дают `score_0_100 = 0.0` с явной причиной в `breakdown`, чтобы в логах можно было отличить "нет пересечения" от "нечем было сравнивать" — иначе калибровка порога Этапа 2 была бы ненадёжной.
- Regression-тест на класс ошибки из #490 (тема слова ≠ намерение): совпадение общеупотребимого слова между профилем и вакансией без совпадения специфичных токенов не должно давать высокий score.

## Test plan

- [x] `pytest tests/test_scoring_resume_match.py -q` — 7 тестов (точное совпадение, частичное, полное несовпадение, пустой профиль, пустые поля профиля, пустой vacancy_text, regression на #490).
- [x] `ruff check src tests` — чисто.
- [x] `ruff format --check src tests` — чисто.
- [x] Полная сюита `pytest -q -n 4 --dist worksteal` — зелёная, 9.6s (бюджет 60s).
- [x] Новых CLI-команд/флагов нет — `gen_cli_docs.py` перегенерация не требуется.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)