### PR TITLE
feat(questionnaires): команда questionnaire audit — чтение аудита ответов (#488)

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -515,12 +515,13 @@
 
 #### `questionnaire` — обучаемые шаблоны ответов на анкеты (#482)
 
-- **Природа:** READ (`pending`, `templates`) и WRITE-local (`set`, `unset`, `learn`);
-  браузер не открывается, на hh.ru ничего не отправляется.
+- **Природа:** READ (`pending`, `templates`, `audit`) и WRITE-local (`set`, `unset`,
+  `learn`); браузер не открывается, на hh.ru ничего не отправляется.
 - **Сигнатуры:**
   ```
   hhru questionnaire pending   [--resume ID] [--limit N]
   hhru questionnaire templates [--resume ID]
+  hhru questionnaire audit     [--resume ID] [--last N] [--template T] [--low-confidence]
   hhru questionnaire learn     [--resume ID] [--limit N]
   hhru questionnaire set TEMPLATE --mode static     --answer VALUE     [--resume ID] [--cluster C]
   hhru questionnaire set TEMPLATE --mode contextual --instruction TEXT [--example TEXT ...] [--resume ID] [--cluster C]
@@ -554,6 +555,16 @@
   идущего `apply`.
 - `learn` интерактивен: в неинтерактивном режиме печатает `[INFO]` и ничего не меняет;
   Ctrl-C печатает частичный итог и возвращает 130.
+- **`audit`** (#488) — read-only снимок того, что уже записал живой `apply`
+  (`questionnaire_questions` со `scan.source = 'apply'`): ответ, источник
+  (`profile`/`llm`), уверенность, сопоставленный шаблон/кластер. Новый LLM-вызов не
+  делается — оценку правильности ставит человек или Claude Code, читая вывод.
+  `--last N` — сколько последних строк показать (новые сверху), `--template` —
+  фильтр по сопоставленному шаблону, `--low-confidence` — только строки с
+  уверенностью ниже `ai.questions.CONFIDENCE_THRESHOLD` (0.70); строки с
+  неизвестной (`NULL`) уверенностью в выборку не попадают. Низкоуверенные
+  предложения намеренно пишутся с `answer=""` (`apply/pipeline.py`), поэтому
+  «что бот хотел ответить, но не стал» этот аудит не показывает.
 - **Вывод:** ASCII-таблицы через `report._ascii_table`, префиксы `[OK]`/`[INFO]`/`[FAIL]`.
 
 ---

--- a/src/hhru_bot/commands/questionnaire.py
+++ b/src/hhru_bot/commands/questionnaire.py
@@ -45,6 +45,21 @@ def register(subparsers) -> None:
     templates.add_argument("--resume", help="Slug резюме или resume_id")
     templates.set_defaults(func=run_templates)
 
+    audit = commands.add_parser(
+        "audit",
+        help="Показать сохранённый аудит ответов на анкеты (READ)",
+        description="Что боевой apply реально ответил на вопросы анкет (#488).",
+    )
+    audit.add_argument("--resume", help="Slug резюме или resume_id (по умолчанию — все)")
+    audit.add_argument("--last", type=int, default=50, help="Сколько последних строк вывести")
+    audit.add_argument("--template", help="Только строки, сопоставленные этому шаблону")
+    audit.add_argument(
+        "--low-confidence",
+        action="store_true",
+        help="Только строки с уверенностью ниже 0.70 (ai.questions.CONFIDENCE_THRESHOLD)",
+    )
+    audit.set_defaults(func=run_audit)
+
     learn = commands.add_parser(
         "learn",
         help="Разобрать очередь и задать ответы (WRITE-local)",
@@ -86,16 +101,16 @@ def register(subparsers) -> None:
     unset_parser.set_defaults(func=run_unset)
 
 
-def _limit(args: argparse.Namespace) -> int:
-    """Проверенный ``--limit``. Отрицательное значение — явная ошибка.
+def _limit(args: argparse.Namespace, attr: str = "limit") -> int:
+    """Проверенный ``--limit``/``--last``. Отрицательное значение — явная ошибка.
 
     В SQLite ``LIMIT -1`` означает «без ограничения», то есть опечатка вроде
     ``--limit -5`` давала бы поведение, прямо противоположное намерению, и
     молча: команда напечатала бы ВСЮ очередь.
     """
-    limit = getattr(args, "limit", 0) or 0
+    limit = getattr(args, attr, 0) or 0
     if limit < 1:
-        print("[FAIL] --limit должен быть >= 1", file=sys.stderr)
+        print(f"[FAIL] --{attr.replace('_', '-')} должен быть >= 1", file=sys.stderr)
         sys.exit(1)
     return limit
 
@@ -188,6 +203,55 @@ def run_templates(args: argparse.Namespace) -> None:
             ],
         )
     )
+
+
+def _truncate(text: str, limit: int = 60) -> str:
+    """Обрезает длинную ячейку таблицы, чтобы одна строка не растягивала всю
+    таблицу до ширины реального вопроса анкеты (те бывают по 150-300 символов).
+    """
+    text = text.replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def run_audit(args: argparse.Namespace) -> None:
+    """Аудит сохранённых ответов на анкеты (#488).
+
+    Только чтение — новый LLM-вызов не делается, команда показывает то, что
+    ``apply`` уже записал через ``_record_questionnaire_answers``. Оценку
+    правильности ставит человек или Claude Code по выводу.
+    """
+    from ..history import History
+    from ..report import _ascii_table
+
+    limit = _limit(args, "last")
+    rows = History(args.history).list_questionnaire_audit(
+        _scope(args),
+        template=args.template,
+        low_confidence=args.low_confidence,
+        limit=limit,
+    )
+    if not rows:
+        print("[INFO] Аудит ответов на анкеты пуст.")
+        return
+    print(
+        _ascii_table(
+            ["vacancy", "conf", "source", "template", "question", "answer"],
+            [
+                [
+                    row["vacancy_id"],
+                    f"{row['confidence']:.2f}" if row["confidence"] is not None else "-",
+                    row["answer_source"] or "-",
+                    row["template"] or "-",
+                    _truncate(row["text"]),
+                    _truncate((row["answer"] or "") if row["filled"] else "[не заполнено]"),
+                ]
+                for row in rows
+            ],
+        )
+    )
+    print(f"[INFO] Показано строк: {len(rows)}.")
 
 
 def run_set(args: argparse.Namespace) -> None:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -3115,6 +3115,61 @@ class History:
                 ).rowcount
             )
 
+    def list_questionnaire_audit(
+        self,
+        resume_id: str | None = None,
+        *,
+        template: str | None = None,
+        low_confidence: bool = False,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """Аудит ответов на анкеты, записанных живым ``apply`` (#488).
+
+        Источник — ``questionnaire_questions``/``questionnaire_scans`` с
+        ``scan.source = 'apply'``: только реальные боевые сканы, не разведка
+        ``probe --questionnaires-only`` (та пишет ``source='probe'`` и вопросов
+        без ответа не имеет смысла показывать как «аудит ответов»).
+        Без фильтров/лимита — новые сверху (``question.id DESC``), чтобы
+        ``--last N`` показывал именно последние N ответов, а не первые N по
+        времени создания таблицы.
+        """
+        where = ["scan.source = 'apply'"]
+        params: list = []
+        if resume_id is not None:
+            where.append("scan.resume_id = ?")
+            params.append(resume_id)
+        if template is not None:
+            where.append("question.template = ?")
+            params.append(template)
+        if low_confidence:
+            # Ленивый импорт: используется только в этой ветке, а
+            # ai.questions тянет playwright.sync_api на уровне модуля —
+            # history.py в остальном не завязан на браузерный стек, и
+            # незачем тащить его в каждый импорт history для одного порога.
+            from .ai.questions import CONFIDENCE_THRESHOLD
+
+            # NULL confidence (обычный AIQuestionAnswerer без шаблонов) не
+            # входит в выборку: "низкая уверенность" осмысленна только когда
+            # уверенность вообще известна.
+            where.append("question.confidence IS NOT NULL AND question.confidence < ?")
+            params.append(CONFIDENCE_THRESHOLD)
+        clause = " AND ".join(where)
+        sql = f"""
+            SELECT question.id, scan.resume_id, scan.vacancy_id, question.text,
+                   question.answer, question.answer_source, question.confidence,
+                   question.filled, question.template, question.cluster,
+                   question.resolver_source
+            FROM questionnaire_questions AS question
+            JOIN questionnaire_scans AS scan ON scan.id = question.scan_id
+            WHERE {clause}
+            ORDER BY question.id DESC
+        """
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        with self._connect() as conn:
+            return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
     def list_scanned_questions(self, resume_id: str | None = None) -> list[dict]:
         """Вопросы анкет из ранее собранных сканов (#482).
 

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -195,3 +195,175 @@ def test_questionnaire_answer_summary_scoped_by_resume_and_period(tmp_path):
         "unanswered": 0,
     }
     assert history.questionnaire_answer_summary() == {"profile": 2, "llm": 0, "unanswered": 0}
+
+
+def test_list_questionnaire_audit_returns_apply_rows_newest_first(tmp_path):
+    """#488: чтение аудита ответов, записанных живым apply."""
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "marketing",
+        "1",
+        "https://hh.ru/vacancy/1",
+        "Маркетолог",
+        "Acme",
+        [
+            {
+                "body_index": 0,
+                "text": "Настоящим подтверждаю...",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "Да",
+                "answer_source": "profile",
+                "confidence": 1.0,
+                "filled": True,
+                "template": "data_accuracy",
+                "cluster": "compliance",
+                "resolver_source": "static",
+            }
+        ],
+        source="apply",
+        run_id="run-1",
+    )
+    history.record_questionnaire(
+        "marketing",
+        "2",
+        "https://hh.ru/vacancy/2",
+        "Маркетолог",
+        "Beta",
+        [
+            {
+                "body_index": 0,
+                "text": "Какие редакторы вы используете?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "",
+                "answer_source": None,
+                "confidence": 0.0,
+                "filled": False,
+                "template": None,
+                "cluster": None,
+                "resolver_source": None,
+            }
+        ],
+        source="apply",
+        run_id="run-2",
+    )
+    # probe-скан не должен попасть в аудит ответов.
+    history.record_questionnaire(
+        "marketing",
+        "3",
+        "https://hh.ru/vacancy/3",
+        "Маркетолог",
+        "Gamma",
+        [
+            {
+                "body_index": 0,
+                "text": "Вопрос из разведки?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+            }
+        ],
+        source="probe",
+    )
+
+    rows = history.list_questionnaire_audit()
+
+    assert [row["vacancy_id"] for row in rows] == ["2", "1"]
+    first = rows[0]
+    assert first["text"] == "Какие редакторы вы используете?"
+    assert first["filled"] == 0
+    assert first["template"] is None
+    second = rows[1]
+    assert second["answer"] == "Да"
+    assert second["answer_source"] == "profile"
+    assert second["confidence"] == 1.0
+    assert second["template"] == "data_accuracy"
+    assert second["cluster"] == "compliance"
+    assert second["resolver_source"] == "static"
+
+
+def test_list_questionnaire_audit_filters_by_resume_template_and_confidence(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "marketing",
+        "1",
+        "https://hh.ru/vacancy/1",
+        "Маркетолог",
+        "Acme",
+        [
+            {
+                "body_index": 0,
+                "text": "Зарплата?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "от 200000",
+                "answer_source": "profile",
+                "confidence": 0.9,
+                "filled": True,
+                "template": "salary",
+            }
+        ],
+        source="apply",
+    )
+    history.record_questionnaire(
+        "backend",
+        "2",
+        "https://hh.ru/vacancy/2",
+        "Разработчик",
+        "Beta",
+        [
+            {
+                "body_index": 0,
+                "text": "Готовы к переезду?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "",
+                "answer_source": "llm",
+                "confidence": 0.3,
+                "filled": False,
+                "template": "relocation",
+            }
+        ],
+        source="apply",
+    )
+
+    assert [row["vacancy_id"] for row in history.list_questionnaire_audit("backend")] == ["2"]
+    assert [row["vacancy_id"] for row in history.list_questionnaire_audit(template="salary")] == [
+        "1"
+    ]
+    low_conf = history.list_questionnaire_audit(low_confidence=True)
+    assert [row["vacancy_id"] for row in low_conf] == ["2"]
+    assert history.list_questionnaire_audit(limit=1) == history.list_questionnaire_audit()[:1]
+
+
+def test_list_questionnaire_audit_low_confidence_excludes_null_confidence(tmp_path):
+    """NULL confidence (обычный AIQuestionAnswerer) не считается низкой уверенностью."""
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "marketing",
+        "1",
+        "https://hh.ru/vacancy/1",
+        "Маркетолог",
+        "Acme",
+        [
+            {
+                "body_index": 0,
+                "text": "Вопрос без оценки уверенности?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+                "answer": "ответ",
+                "answer_source": "llm",
+                "confidence": None,
+                "filled": True,
+            }
+        ],
+        source="apply",
+    )
+
+    assert history.list_questionnaire_audit(low_confidence=True) == []

--- a/tests/test_questionnaire_cli.py
+++ b/tests/test_questionnaire_cli.py
@@ -25,6 +25,8 @@ def _args(tmp_path, **overrides) -> argparse.Namespace:
         "instruction": None,
         "example": [],
         "cluster": None,
+        "last": 50,
+        "low_confidence": False,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -220,6 +222,122 @@ def test_output_has_no_emoji(capsys, tmp_path):
     assert all(ord(char) < 0x2190 for char in out), "вывод CLI должен быть текст/ASCII-таблицы"
 
 
+# --- audit --------------------------------------------------------------
+
+
+def _record_apply_answer(tmp_path, **overrides):
+    question = {
+        "body_index": 0,
+        "text": "Настоящим подтверждаю...",
+        "kind": "text",
+        "is_radio": False,
+        "options": [],
+        "answer": "Да",
+        "answer_source": "profile",
+        "confidence": 1.0,
+        "filled": True,
+        "template": "data_accuracy",
+        "cluster": "compliance",
+        "resolver_source": "static",
+    }
+    question.update(overrides)
+    History(tmp_path / "h.db").record_questionnaire(
+        "marketing",
+        "132855712",
+        "https://hh.ru/vacancy/132855712",
+        "Маркетолог",
+        "Acme",
+        [question],
+        source="apply",
+    )
+
+
+def test_audit_prints_an_ascii_table(capsys, tmp_path):
+    _record_apply_answer(tmp_path)
+
+    cmd.run_audit(_args(tmp_path, template=None))
+
+    out = capsys.readouterr().out
+    assert "132855712" in out
+    assert "data_accuracy" in out
+    assert "Настоящим подтверждаю" in out
+    assert "Да" in out
+    assert "Показано строк: 1" in out
+
+
+def test_audit_truncates_long_question_and_answer_text(capsys, tmp_path):
+    """Реальные вопросы анкет — по 150-300 символов; без обрезки одна такая
+    строка растягивает всю ASCII-таблицу до нечитаемой ширины."""
+    long_question = "Расскажите подробно о своём опыте работы с CRM-системами. " * 5
+    long_answer = "У меня большой опыт работы с несколькими CRM-системами. " * 5
+    _record_apply_answer(tmp_path, text=long_question, answer=long_answer)
+
+    cmd.run_audit(_args(tmp_path, template=None))
+
+    out = capsys.readouterr().out
+    assert long_question not in out
+    assert long_answer not in out
+    assert "..." in out
+    assert max(len(line) for line in out.splitlines()) < len(long_question)
+
+
+def test_audit_shows_not_filled_marker_for_unanswered_questions(capsys, tmp_path):
+    _record_apply_answer(
+        tmp_path,
+        text="Какие редакторы вы используете?",
+        answer="",
+        answer_source=None,
+        confidence=0.0,
+        filled=False,
+        template=None,
+        cluster=None,
+        resolver_source=None,
+    )
+
+    cmd.run_audit(_args(tmp_path, template=None))
+
+    out = capsys.readouterr().out
+    assert "[не заполнено]" in out
+
+
+def test_audit_empty_prints_info(capsys, tmp_path):
+    cmd.run_audit(_args(tmp_path, template=None))
+
+    assert "[INFO]" in capsys.readouterr().out
+
+
+def test_audit_filters_by_resume(capsys, tmp_path):
+    _record_apply_answer(tmp_path)
+
+    cmd.run_audit(_args(tmp_path, template=None, resume="backend"))
+
+    assert "[INFO]" in capsys.readouterr().out
+
+
+def test_audit_filters_by_template(capsys, tmp_path):
+    _record_apply_answer(tmp_path)
+
+    cmd.run_audit(_args(tmp_path, template="other_template"))
+
+    assert "[INFO]" in capsys.readouterr().out
+
+
+def test_audit_filters_by_low_confidence(capsys, tmp_path):
+    _record_apply_answer(tmp_path)  # confidence=1.0 — не должен попасть
+
+    cmd.run_audit(_args(tmp_path, template=None, low_confidence=True))
+
+    assert "[INFO]" in capsys.readouterr().out
+
+
+def test_audit_rejects_non_positive_last(capsys, tmp_path):
+    with pytest.raises(SystemExit) as exc:
+        cmd.run_audit(_args(tmp_path, template=None, last=0))
+
+    assert exc.value.code == 1
+    assert "[FAIL]" in capsys.readouterr().err
+
+
 # --- learn ------------------------------------------------------------------
 
 
@@ -296,7 +414,7 @@ def test_mutating_subcommands_take_the_write_lock(subcommand):
     assert _is_write_command(args) is True
 
 
-@pytest.mark.parametrize("subcommand", ["pending", "templates"])
+@pytest.mark.parametrize("subcommand", ["pending", "templates", "audit"])
 def test_read_subcommands_do_not_take_the_write_lock(subcommand):
     args = argparse.Namespace(command="questionnaire", questionnaire_command=subcommand)
 
@@ -331,7 +449,7 @@ def test_parser_registers_every_subcommand():
         if isinstance(action, argparse._SubParsersAction)
     )
 
-    assert set(nested.choices) == {"pending", "templates", "learn", "set", "unset"}
+    assert set(nested.choices) == {"pending", "templates", "audit", "learn", "set", "unset"}
 
 
 def test_set_requires_a_mode():


### PR DESCRIPTION
## Проблема

Аудит ответов на анкеты уже пишется (`apply/pipeline.py::_record_questionnaire_answers`
в колонки `answer`, `answer_source`, `confidence`, `filled`, `template`, `cluster`,
`resolver_source`), но прочитать его было нечем — только прямым SQL по `data/history.db`.

## Решение

- `History.list_questionnaire_audit()` (`history.py`) — фильтр `scan.source = 'apply'`,
  флаги `resume_id`/`template`/`low_confidence`/`limit`, новые сверху.
- `questionnaire audit` — новая READ-подкоманда в `commands/questionnaire.py`
  (`--last`, `--resume`, `--template`, `--low-confidence`), вывод ASCII-таблицей
  через `report._ascii_table`; длинные вопросы/ответы (реальные формулировки анкет
  бывают по 150–300 символов) усекаются, чтобы не ломать ширину таблицы.
- `docs/cli-spec.md` — сигнатура и описание `audit` дописаны в существующую секцию.

## Проверка

- Юнит-тесты `History.list_questionnaire_audit` на фикстурной БД (дедуп источников
  probe/apply, фильтры resume/template/low_confidence, NULL-confidence не считается
  низкой уверенностью).
- CLI-тесты `run_audit`: пустой аудит, `[не заполнено]`-маркер, усечение длинного
  текста, write-lock классификация (READ, не блокирует idущий `apply`).
- Живой прогон на реальной `data/history.db` (основной чекаут) — подтвердил
  существующую строку с `filled=1`:
  ```
  $ hhru questionnaire audit --last 20
  +-----------+------+---------+---------------+----------------------...--+--------+
  | vacancy   | conf | source  | template      | question                  | answer |
  +-----------+------+---------+---------------+----------------------...--+--------+
  | 132855712 | 1.00 | profile | data_accuracy | Настоящим подтверждаю...  | Да     |
  +-----------+------+---------+---------------+----------------------...--+--------+
  ```
  Фильтры `--low-confidence`, `--template`, `--resume` проверены отдельно на той же БД.
- `pytest -q -n 4 --dist worksteal` — весь набор зелёный.
- `ruff check` / `ruff format --check` — чисто.
- `scripts/gen_cli_docs.py --check` — README синхронизирован (генератор не
  разворачивает вложенные подкоманды, поведение не изменилось).

## Известное ограничение

Низкоуверенные строки пишут `answer=""` намеренно (`pipeline.py`), поэтому «что бот
хотел ответить, но не стал» этот аудит не покажет — как и заявлено в issue.

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)