### PR TITLE
fix(questionnaires): resume_id-ключевание probe-сканов и --example для static (#486)

### DIFF
--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -722,10 +722,14 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
     # #486: старые запуски этой команды ключевали questionnaire_scans слагом
     # резюме (resume.id) вместо реального resume_id — накопленные строки были
     # недостижимы через --resume в questionnaire learn/pending. Нормализация
-    # идемпотентна и затрагивает только резюме из текущего конфига.
+    # идемпотентна; маппинг строится из ВСЕХ резюме конфига (не только
+    # запрошенного --resume), иначе сканы прочих резюме остаются осиротевшими
+    # под своим slug (тот же приём в questionnaire._rekey_scanned_slugs,
+    # которая и есть основная точка вызова для уже накопленных до этого фикса
+    # данных — эта команда мутирует БД только при собственном запуске).
     if history is not None:
         rekeyed = history.rekey_questionnaire_scans(
-            {resume.id: resume.resume_id for resume in resumes}
+            {resume.id: resume.resume_id for resume in config.resumes}
         )
         if rekeyed:
             print(

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -719,6 +719,20 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
         print("Ошибка: --limit-questionnaires не может быть отрицательным.", file=sys.stderr)
         return True
 
+    # #486: старые запуски этой команды ключевали questionnaire_scans слагом
+    # резюме (resume.id) вместо реального resume_id — накопленные строки были
+    # недостижимы через --resume в questionnaire learn/pending. Нормализация
+    # идемпотентна и затрагивает только резюме из текущего конфига.
+    if history is not None:
+        rekeyed = history.rekey_questionnaire_scans(
+            {resume.id: resume.resume_id for resume in resumes}
+        )
+        if rekeyed:
+            print(
+                f"[INFO] questionnaires-only: перепривязано {rekeyed} старых "
+                "записей questionnaire_scans со slug на resume_id (#486)"
+            )
+
     all_results: list[QuestionnaireScanResult] = []
     interrupted = False
     # cycle-review PR #456 round 2 (Codex): накапливает потери записи в
@@ -763,7 +777,13 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results.append(result)
                     all_results.append(result)
-                    if not _record_questionnaire_if_confirmed(history, resume.id, vacancy, result):
+                    # #486: resume.resume_id (хвост resume_url), а НЕ resume.id
+                    # (слаг конфига) — questionnaire._scope() и apply-путь
+                    # ключуют историю анкет реальным resume_id, слаг делал
+                    # накопленные сканы недостижимыми через --resume.
+                    if not _record_questionnaire_if_confirmed(
+                        history, resume.resume_id, vacancy, result
+                    ):
                         history_write_failed = True
                     result_positions[vacancy.vacancy_id] = len(all_results) - 1
                     _print_questionnaire_progress(result, len(resume_results), len(vacancies))
@@ -809,7 +829,9 @@ def run_questionnaires(args: argparse.Namespace) -> bool | CommandExitCode:
                     )
                     resume_results[result_index] = result
                     all_results[result_positions[vacancy_id]] = result
-                    if not _record_questionnaire_if_confirmed(history, resume.id, vacancy, result):
+                    if not _record_questionnaire_if_confirmed(
+                        history, resume.resume_id, vacancy, result
+                    ):
                         history_write_failed = True
                     # Позиция самой перепроверяемой вакансии, а не длина списка:
                     # retry вакансии 3 из 10 иначе печатал бы «проверено 10/10».

--- a/src/hhru_bot/commands/questionnaire.py
+++ b/src/hhru_bot/commands/questionnaire.py
@@ -124,6 +124,38 @@ def _scope(args: argparse.Namespace) -> str | None:
         return args.resume
 
 
+def _rekey_scanned_slugs(args: argparse.Namespace, history) -> None:
+    """Перенести накопленные questionnaire_scans со slug на resume_id (#486).
+
+    До фикса ``probe --questionnaires-only`` ключевал сканы ``resume.id``
+    (slug из config.yaml), а не реальным ``resume_id`` — той же историей
+    пользуется и ``_scope()`` выше. Вызывается здесь (WRITE-путь ``learn``,
+    держит write-lock), а не только из ``probe``: пользователь, у которого уже
+    накопились slug-строки старым бинарником, может никогда больше не
+    запустить ``probe`` заново — без вызова здесь его накопленные сканы
+    остались бы недостижимы через ``--resume`` навсегда.
+
+    Маппинг строится из ВСЕХ резюме конфига, а не только из запрошенного
+    ``--resume``: иначе (а) сканы других резюме остаются осиротевшими под
+    своим slug, и (б) ``list_scanned_questions()`` без ``--resume`` группирует
+    вопросы по ``(resume_id, текст)`` — один и тот же вопрос, лежащий и под
+    slug, и под resume_id одного резюме, до полной нормализации считается
+    дважды.
+
+    Молча пропускается, если конфиг недоступен (та же деградация, что у
+    ``_scope()``) — работа с уже начатой очередью не должна падать из-за
+    отсутствующего config.yaml.
+    """
+    from ..config import ConfigError, load_config
+
+    try:
+        config = load_config(args.config)
+    except (ConfigError, SystemExit, OSError):
+        return
+    mapping = {resume.id: resume.resume_id for resume in config.resumes}
+    history.rekey_questionnaire_scans(mapping)
+
+
 def run_pending(args: argparse.Namespace) -> None:
     from ..history import History
     from ..report import _ascii_table
@@ -278,6 +310,7 @@ def run_learn(args: argparse.Namespace):
 
     scope = _scope(args)
     history = History(args.history)
+    _rekey_scanned_slugs(args, history)
     if seeded := _seed_queue_from_scans(history, scope):
         print(f"[INFO] Добавлено в очередь из ранее собранных анкет: {seeded}.")
     rows = history.list_questionnaire_pending(scope, limit=_limit(args))

--- a/src/hhru_bot/commands/questionnaire.py
+++ b/src/hhru_bot/commands/questionnaire.py
@@ -214,9 +214,6 @@ def run_set(args: argparse.Namespace) -> None:
         # понятная строка [FAIL] и код возврата 1, а не argparse-usage.
         print(f"[FAIL] {exc}", file=sys.stderr)
         sys.exit(1)
-    if args.example and args.mode != "contextual":
-        print("[FAIL] --example имеет смысл только для --mode contextual", file=sys.stderr)
-        sys.exit(1)
     from ..questionnaires.templates import is_strict
 
     if is_strict(cluster) and args.mode != "static":

--- a/src/hhru_bot/commands/questionnaire.py
+++ b/src/hhru_bot/commands/questionnaire.py
@@ -125,15 +125,17 @@ def _scope(args: argparse.Namespace) -> str | None:
 
 
 def _rekey_scanned_slugs(args: argparse.Namespace, history) -> None:
-    """Перенести накопленные questionnaire_scans со slug на resume_id (#486).
+    """Перенести накопленные questionnaire_scans/pending со slug на resume_id (#486).
 
     До фикса ``probe --questionnaires-only`` ключевал сканы ``resume.id``
     (slug из config.yaml), а не реальным ``resume_id`` — той же историей
-    пользуется и ``_scope()`` выше. Вызывается здесь (WRITE-путь ``learn``,
+    пользуется и ``_scope()`` выше; ``_seed_queue_from_scans`` дальше
+    переносит эту ошибку в ``questionnaire_pending`` (сеет очередь под
+    тем же ключом, что был у скана). Вызывается здесь (WRITE-путь ``learn``,
     держит write-lock), а не только из ``probe``: пользователь, у которого уже
     накопились slug-строки старым бинарником, может никогда больше не
-    запустить ``probe`` заново — без вызова здесь его накопленные сканы
-    остались бы недостижимы через ``--resume`` навсегда.
+    запустить ``probe`` заново — без вызова здесь его накопленные сканы и
+    незакрытая очередь остались бы недостижимы через ``--resume`` навсегда.
 
     Маппинг строится из ВСЕХ резюме конфига, а не только из запрошенного
     ``--resume``: иначе (а) сканы других резюме остаются осиротевшими под
@@ -154,6 +156,7 @@ def _rekey_scanned_slugs(args: argparse.Namespace, history) -> None:
         return
     mapping = {resume.id: resume.resume_id for resume in config.resumes}
     history.rekey_questionnaire_scans(mapping)
+    history.rekey_questionnaire_pending(mapping)
 
 
 def run_pending(args: argparse.Namespace) -> None:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -3186,6 +3186,44 @@ class History:
                 total += cursor.rowcount
         return total
 
+    def rekey_questionnaire_pending(self, slug_to_resume_id: dict[str, str]) -> int:
+        """Перевести накопленные ``questionnaire_pending`` со slug на resume_id (#486).
+
+        Тот же дефект, что у ``rekey_questionnaire_scans``, но здесь нельзя
+        сделать голый ``UPDATE``: ``UNIQUE(resume_id, question_key)`` — если тот
+        же вопрос уже стоит в очереди и под slug, и под resume_id (после того,
+        как ``questionnaire learn`` без ``--resume`` уже пересеял его из
+        мигрированных сканов), прямой ``UPDATE`` упал бы на конфликте. Строка
+        под resume_id в этом случае новее (создана уже после фикса) и остаётся
+        как есть; осиротевшая slug-строка удаляется, а не апдейтится — иначе
+        она осталась бы висеть в очереди с обоими ключами навсегда,
+        недостижимая для ``resolve_pending_for_templates``/``clear_pending_skips``,
+        которые фильтруют по единственному переданному ``resume_id``.
+        """
+        if not slug_to_resume_id:
+            return 0
+        total = 0
+        with self._connect() as conn:
+            for slug, resume_id in slug_to_resume_id.items():
+                if not slug or not resume_id or slug == resume_id:
+                    continue
+                cursor = conn.execute(
+                    """
+                    DELETE FROM questionnaire_pending
+                    WHERE resume_id = ? AND question_key IN (
+                        SELECT question_key FROM questionnaire_pending WHERE resume_id = ?
+                    )
+                    """,
+                    (slug, resume_id),
+                )
+                total += cursor.rowcount
+                cursor = conn.execute(
+                    "UPDATE questionnaire_pending SET resume_id = ? WHERE resume_id = ?",
+                    (resume_id, slug),
+                )
+                total += cursor.rowcount
+        return total
+
     def resolve_pending_for_templates(
         self, templates: set[str], *, resume_id: str | None = None
     ) -> int:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -3151,6 +3151,41 @@ class History:
             ).fetchall()
         return [dict(row) for row in rows]
 
+    def rekey_questionnaire_scans(self, slug_to_resume_id: dict[str, str]) -> int:
+        """Перевести накопленные ``questionnaire_scans`` со slug на resume_id (#486).
+
+        `probe --questionnaires-only` до этого фикса ключевал сканы `resume.id`
+        (slug из config.yaml), тогда как apply-путь и `questionnaire._scope()`
+        используют реальный `resume_id` (хвост `resume_url`) — см. probe.py.
+        Одна и та же history.db поэтому могла держать вперемешку оба вида
+        ключей: `list_scanned_questions`/`questionnaire learn --resume <slug>`
+        фильтрует по `scan.resume_id`, и старые slug-строки для этого resume
+        были структурно недостижимы через `--resume`.
+
+        Идемпотентная нормализация данных, а не миграция схемы (в проекте
+        миграций нет намеренно, см. CLAUDE.md «Схема SQLite»): `UPDATE` по
+        известным парам slug→resume_id из текущего конфига. Строки, чей
+        `resume_id` не совпал ни с одним slug (уже resume_id, или slug из
+        резюме, отсутствующего в текущем конфиге), не трогаются — есть чем
+        сопоставить, только когда slug известен здесь и сейчас.
+        `questionnaire_scans` без UNIQUE-индекса на `resume_id` (append-only
+        research snapshot), поэтому переезд строки на уже занятый resume_id не
+        может конфликтовать.
+        """
+        if not slug_to_resume_id:
+            return 0
+        total = 0
+        with self._connect() as conn:
+            for slug, resume_id in slug_to_resume_id.items():
+                if not slug or not resume_id or slug == resume_id:
+                    continue
+                cursor = conn.execute(
+                    "UPDATE questionnaire_scans SET resume_id = ? WHERE resume_id = ?",
+                    (resume_id, slug),
+                )
+                total += cursor.rowcount
+        return total
+
     def resolve_pending_for_templates(
         self, templates: set[str], *, resume_id: str | None = None
     ) -> int:

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -195,3 +195,81 @@ def test_questionnaire_answer_summary_scoped_by_resume_and_period(tmp_path):
         "unanswered": 0,
     }
     assert history.questionnaire_answer_summary() == {"profile": 2, "llm": 0, "unanswered": 0}
+
+
+def test_rekey_questionnaire_scans_migrates_slug_rows_to_resume_id(tmp_path):
+    """#486: старые запуски probe --questionnaires-only ключевали
+    questionnaire_scans слагом резюме из config.yaml вместо реального
+    resume_id — list_scanned_questions()/questionnaire._scope() фильтруют по
+    resume_id, поэтому такие строки были недостижимы через --resume."""
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire(
+        "python",
+        "111",
+        "https://hh.ru/vacancy/111",
+        "Backend",
+        "Acme",
+        [
+            {
+                "body_index": 0,
+                "text": "Готовы к переезду?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+            }
+        ],
+    )
+    history.record_questionnaire(
+        "b3236ebbff10f60ff30039ed1f6d5876645331",
+        "222",
+        "https://hh.ru/vacancy/222",
+        "Backend",
+        "Beta",
+        [
+            {
+                "body_index": 0,
+                "text": "Ваш опыт с Django?",
+                "kind": "text",
+                "is_radio": False,
+                "options": [],
+            }
+        ],
+    )
+
+    rekeyed = history.rekey_questionnaire_scans(
+        {"python": "b3236ebbff10f60ff30039ed1f6d5876645331", "unrelated_slug": "deadbeef"}
+    )
+
+    assert rekeyed == 1
+    scoped = history.list_scanned_questions("b3236ebbff10f60ff30039ed1f6d5876645331")
+    assert {row["vacancy_id"] for row in scoped} == {"111", "222"}
+    assert history.list_scanned_questions("python") == []
+
+
+def test_rekey_questionnaire_scans_is_idempotent(tmp_path):
+    history = History(tmp_path / "history.db")
+    questions = [
+        {
+            "body_index": 0,
+            "text": "Готовы к переезду?",
+            "kind": "text",
+            "is_radio": False,
+            "options": [],
+        }
+    ]
+    history.record_questionnaire(
+        "python", "111", "https://hh.ru/vacancy/111", "Backend", "Acme", questions
+    )
+    mapping = {"python": "hex123"}
+
+    first = history.rekey_questionnaire_scans(mapping)
+    second = history.rekey_questionnaire_scans(mapping)
+
+    assert first == 1
+    assert second == 0
+    assert history.list_scanned_questions("hex123")[0]["vacancy_id"] == "111"
+
+
+def test_rekey_questionnaire_scans_ignores_empty_mapping(tmp_path):
+    history = History(tmp_path / "history.db")
+    assert history.rekey_questionnaire_scans({}) == 0

--- a/tests/test_history_questionnaires.py
+++ b/tests/test_history_questionnaires.py
@@ -273,3 +273,43 @@ def test_rekey_questionnaire_scans_is_idempotent(tmp_path):
 def test_rekey_questionnaire_scans_ignores_empty_mapping(tmp_path):
     history = History(tmp_path / "history.db")
     assert history.rekey_questionnaire_scans({}) == 0
+
+
+def test_rekey_questionnaire_pending_migrates_slug_rows(tmp_path):
+    """#486: очередь наследует слаг-ключ от скана, из которого её засеяли —
+    та же миграция, что и у questionnaire_scans, но по своей таблице."""
+    history = History(tmp_path / "history.db")
+    history.record_questionnaire_pending(
+        "python", [{"text": "Готовы к переезду?", "kind": "text", "reason": "нет шаблона"}]
+    )
+
+    rekeyed = history.rekey_questionnaire_pending({"python": "hex123"})
+
+    assert rekeyed == 1
+    assert len(history.list_questionnaire_pending("hex123")) == 1
+    assert history.list_questionnaire_pending("python") == []
+
+
+def test_rekey_questionnaire_pending_deletes_the_slug_row_on_conflict(tmp_path):
+    """Один и тот же вопрос уже стоит в очереди под ОБОИМИ ключами — это
+    происходит, если questionnaire learn без --resume уже пересеял вопрос под
+    resume_id (после миграции scans), пока slug-строка ещё не убрана.
+    UNIQUE(resume_id, question_key) не позволяет их слить UPDATE'ом; строка
+    под resume_id новее и остаётся, осиротевшая slug-строка удаляется, а не
+    висит недостижимой навсегда."""
+    history = History(tmp_path / "history.db")
+    question = [{"text": "Готовы к переезду?", "kind": "text", "reason": "нет шаблона"}]
+    history.record_questionnaire_pending("python", question)
+    history.record_questionnaire_pending("hex123", question)
+
+    rekeyed = history.rekey_questionnaire_pending({"python": "hex123"})
+
+    assert rekeyed == 1
+    rows = history.list_questionnaire_pending("hex123")
+    assert len(rows) == 1
+    assert history.list_questionnaire_pending("python") == []
+
+
+def test_rekey_questionnaire_pending_ignores_empty_mapping(tmp_path):
+    history = History(tmp_path / "history.db")
+    assert history.rekey_questionnaire_pending({}) == 0

--- a/tests/test_questionnaire_bulk.py
+++ b/tests/test_questionnaire_bulk.py
@@ -163,7 +163,7 @@ def _config(resumes):
 def test_bulk_uses_one_page_dedupes_and_retries_without_history(monkeypatch, capsys):
     card1 = _card("201")
     card2 = _card("202")
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     page = object()
     pages = []
@@ -227,7 +227,7 @@ def test_bulk_uses_one_page_dedupes_and_retries_without_history(monkeypatch, cap
 
 def test_bulk_counts_unauthenticated_as_failure(monkeypatch, capsys):
     card = _card("301")
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     page = object()
 
@@ -270,7 +270,7 @@ def test_bulk_counts_unauthenticated_as_failure(monkeypatch, capsys):
 
 def test_bulk_counts_unknown_as_failure(monkeypatch, capsys):
     card = _card("401")
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     page = object()
 
@@ -315,7 +315,7 @@ def test_bulk_counts_unknown_as_failure(monkeypatch, capsys):
 
 def test_bulk_already_responded_does_not_fail_the_scan(monkeypatch, capsys):
     card = _card("501")
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     page = object()
 
@@ -465,7 +465,7 @@ def _bulk_args(**overrides):
 
 def _bulk_env(monkeypatch, cards, scan, *, events=None):
     """Wire run_questionnaires to fakes; optionally record a print/scan event log."""
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     page = object()
 
@@ -628,7 +628,7 @@ def test_limit_zero_scans_every_vacancy(monkeypatch, capsys):
 
 
 def test_negative_limit_is_rejected_before_launching_a_browser(monkeypatch, capsys):
-    resume = SimpleNamespace(id="python", search=object())
+    resume = SimpleNamespace(id="python", resume_id="python_hex", search=object())
     config = _config([resume])
     monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda path: config)
 
@@ -866,9 +866,37 @@ class _FakeHistory:
 
     def __init__(self, *args, **kwargs):
         self.calls = []
+        self.resume_ids = []
+        self.rekey_calls = []
 
     def record_questionnaire(self, resume_id, vacancy_id, vacancy_url, title, company, questions):
         self.calls.append(vacancy_id)
+        self.resume_ids.append(resume_id)
+
+    def rekey_questionnaire_scans(self, slug_to_resume_id):
+        self.rekey_calls.append(slug_to_resume_id)
+        return 0
+
+
+def test_scan_is_recorded_under_resume_id_not_slug(monkeypatch, capsys):
+    """#486: history ключуется реальным resume_id (хвост resume_url), а не
+    resume.id (slug из config.yaml) — apply-путь и questionnaire._scope()
+    резолвят --resume тоже в resume_id, слаг делал сканы недостижимыми."""
+    card = _card("999")
+
+    def scan(page_arg, vacancy, **kwargs):
+        return questionnaire.QuestionnaireScanResult(
+            vacancy, questionnaire.QUESTIONNAIRE, "task-body", (), 0
+        )
+
+    probe = _bulk_env(monkeypatch, [card], scan)
+    fake_history = _FakeHistory()
+    monkeypatch.setattr("hhru_bot.history.History", lambda path: fake_history)
+    probe.run_questionnaires(_bulk_args(history="history.db"))
+    capsys.readouterr()
+
+    assert fake_history.resume_ids == ["python_hex"]
+    assert fake_history.rekey_calls == [{"python": "python_hex"}]
 
 
 def test_retry_confirmed_questionnaire_is_persisted_to_history(monkeypatch, capsys):

--- a/tests/test_questionnaire_cli.py
+++ b/tests/test_questionnaire_cli.py
@@ -85,6 +85,44 @@ def test_example_is_accepted_for_static_mode(tmp_path):
     assert history.get_confirmed_phrases()["доход?"] == "salary"
 
 
+def test_example_unblocks_a_compliance_template_end_to_end(tmp_path):
+    """#486 воспроизведение из живого прогона: questionnaire set --mode static
+    --cluster compliance --answer ... --example "<нестандартная формулировка>"
+    должен не только сохраниться, но и реально резолвить вопрос с этой
+    формулировкой через TemplateQuestionAnswerer — а не остаться недостижимым
+    из-за того, что gate не давал сохранить пример вместе с шаблоном."""
+    from hhru_bot.config_sections.questionnaires import QuestionnairesConfig
+    from hhru_bot.questionnaires.answerer import TemplateQuestionAnswerer
+
+    cmd.run_set(
+        _args(
+            tmp_path,
+            template="data_accuracy",
+            mode="static",
+            cluster="compliance",
+            answer="Да",
+            example=["Подтверждаете достоверность предоставленных данных?"],
+        )
+    )
+
+    history = History(tmp_path / "h.db")
+    answerer = TemplateQuestionAnswerer(
+        history,
+        "r1",
+        settings=QuestionnairesConfig(enabled=True),
+        confirm_fn=lambda **_: False,
+    )
+    from hhru_bot.ai.questions import Question
+
+    proposal = answerer.propose(
+        Question(0, "Подтверждаете достоверность предоставленных данных?", "text")
+    )
+
+    assert proposal.answer == "Да"
+    assert not proposal.low_confidence
+    assert answerer.pending == []
+
+
 def test_set_uses_the_seed_cluster_by_default(tmp_path):
     cmd.run_set(_args(tmp_path, answer="от 250000"))
 
@@ -452,6 +490,42 @@ def test_seeding_is_scoped_to_the_requested_resume(tmp_path, monkeypatch):
 
     assert len(history.list_questionnaire_pending("RID1")) == 1
     assert history.list_questionnaire_pending("RID2") == []
+
+
+def test_learn_rekeys_scans_stored_under_the_config_slug(tmp_path, monkeypatch):
+    """#486: до фикса probe --questionnaires-only ключевал questionnaire_scans
+    слагом резюме (resume.id), а не resume_id — questionnaire learn --resume
+    <slug> резолвит --resume в resume_id и находил почти ничего. learn обязан
+    сам мигрировать такие накопленные строки, а не только probe, потому что
+    пользователь мог никогда больше не перезапустить probe после апгрейда."""
+    import textwrap
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            account:
+              storage_state_file: data/storage_state/hh_session.json
+            resumes:
+              - id: python
+                resume_url: "https://hh.ru/resume/b3236ebbff10f60ff30039ed1f6d5876645331"
+                search:
+                  text: "python developer"
+            """
+        ),
+        encoding="utf-8",
+    )
+    history = History(tmp_path / "h.db")
+    # Записано под slug'ом — как это делал probe до фикса #486.
+    _scan(history, "python", "v1", "Опишите самый сложный проект")
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+    cmd.run_learn(_args(tmp_path, resume="python", limit=20))
+
+    real_resume_id = "b3236ebbff10f60ff30039ed1f6d5876645331"
+    assert len(history.list_questionnaire_pending(real_resume_id)) == 1
+    assert history.list_scanned_questions("python") == []
 
 
 # --- валидация аргументов ---------------------------------------------------

--- a/tests/test_questionnaire_cli.py
+++ b/tests/test_questionnaire_cli.py
@@ -73,11 +73,16 @@ def test_set_contextual_stores_instruction_and_examples(tmp_path):
     assert len(history.get_confirmed_phrases()) == 2
 
 
-def test_example_is_rejected_for_static_mode(capsys, tmp_path):
-    with pytest.raises(SystemExit):
-        cmd.run_set(_args(tmp_path, answer="от 250000", example=["Доход?"]))
+def test_example_is_accepted_for_static_mode(tmp_path):
+    """#486: match_phrase (confirm_questionnaire_example) не зависит от mode —
+    static-шаблон с формулировкой, не совпадающей ни с одним seed-шаблоном,
+    иначе недостижим неинтерактивно (критично для strict-кластеров compliance,
+    где ответ разрешён только явным static-значением)."""
+    cmd.run_set(_args(tmp_path, answer="от 250000", example=["Доход?"]))
 
-    assert "--example" in capsys.readouterr().err
+    history = History(tmp_path / "h.db")
+    assert history.get_questionnaire_templates()["salary"]["answer"] == "от 250000"
+    assert history.get_confirmed_phrases()["доход?"] == "salary"
 
 
 def test_set_uses_the_seed_cluster_by_default(tmp_path):


### PR DESCRIPTION
## Что исправлено

Follow-up к #482 (PR #484) — issue #486 описывает несколько дефектов, найденных первым живым прогоном заполнителя анкет. Этот PR закрывает два реальных бага (п.1, п.2 issue); п.3 и п.4 — не код, см. ниже.

**1. `probe --questionnaires-only` ключевал сканы слагом резюме, а не `resume_id`.**

`probe.py` писал `questionnaire_scans.resume_id = resume.id` (slug из config.yaml), тогда как apply-путь и `questionnaire._scope()` резолвят `--resume` в реальный `resume_id` (хвост `resume_url`). Одна `history.db` держала оба вида ключей одновременно — `questionnaire learn --resume python` находил 1 вопрос вместо 93.

Исправлено:
- `probe.py` теперь пишет `resume.resume_id`.
- `History.rekey_questionnaire_scans()` / `History.rekey_questionnaire_pending()` — идемпотентная нормализация накопленных slug-строк (не миграция схемы, см. CLAUDE.md «Схема SQLite»). Вызывается из **обоих** путей: `probe --questionnaires-only` (write-путь, который порождал баг) и `questionnaire learn` (read-к-данным / write-местный путь, которым реально пользуется пользователь при разборе очереди — из issue: «обходится запуском `learn` без `--resume`»). Маппинг строится из **всех** резюме конфига, не только запрошенного, иначе часть сканов остаётся осиротевшей, а `list_scanned_questions()` без `--resume` дважды считает один и тот же вопрос под двумя ключами.
- `questionnaire_pending` мигрируется отдельным методом: там есть `UNIQUE(resume_id, question_key)`, и голый `UPDATE` мог бы конфликтовать, если тот же вопрос уже засеян под обоими ключами (после промежуточного `learn` без `--resume`) — в этом случае осиротевшая slug-строка удаляется, а не апдейтится.

**2. `questionnaire set --example` был запрещён для `--mode static`.**

Механизм подтверждения формулировки (`confirm_questionnaire_example` → `match_phrase`) не зависит от режима шаблона — но CLI отказывал в `--example` для static, из-за чего static-шаблон с нестандартной формулировкой был недостижим неинтерактивно. Это в первую очередь бьёт по `compliance`-кластеру (документы, гражданство, судимость), где ответ разрешён **только** явным static-значением — путь без интерактива был закрыт полностью.

Гейт снят. `compliance_gate` уже отличает подтверждённую человеком формулировку (`PHRASE`) от догадки (`KEYWORD`/`LLM` — `_GUESSED_SOURCES`), так что инвариант «комплаенс только по явному значению» не ослаблен. Проверено сквозным тестом через `TemplateQuestionAnswerer`, а не только тем, что CLI перестал ругаться.

## Не входит в этот PR (issue #486, п.3–4 — не код)

- **П.3, LLM-ступень не проверена вживую** — `.[ai]` в разведке сознательно не ставили; нужен отдельный живой прогон с AI-зависимостью, а не правка кода.
- **П.4, покрытие 18% без LLM** — наблюдение о ценности LLM/ML-слота, не дефект.

## Известные ограничения фикса

- `questionnaire pending --resume <slug>` продолжит недосчитывать неразобранные вопросы, пока пользователь один раз не выполнит `questionnaire learn` — `pending` классифицирована READ-командой и не имеет права писать (`_unqueued_scanned` документирует это явно, есть тест-страж на write-lock классификацию).
- Миграция покрывает только резюме, присутствующие в текущем `config.yaml`; slug резюме, впоследствии удалённого из конфига, остаётся немигрированным. Оба rekey-хелпера тихо деградируют, если конфиг не загрузился — тот же fallback, что у `_scope()`.

## Тесты

- `tests/test_history_questionnaires.py` — `rekey_questionnaire_scans`/`rekey_questionnaire_pending`: миграция, идемпотентность, конфликт по `UNIQUE`, пустой маппинг.
- `tests/test_questionnaire_cli.py` — end-to-end: `learn --resume <slug>` мигрирует накопленные сканы; `set --mode static --example` сохраняет и реально резолвит вопрос через `TemplateQuestionAnswerer` в `compliance`-кластере.
- `tests/test_questionnaire_bulk.py` — `probe` пишет `resume.resume_id`, а не slug.

Полный прогон (`pytest -n 4 --dist worksteal`), `ruff check`/`ruff format --check` по `src tests`, `scripts/gen_cli_docs.py --check` — зелёные.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
