### PR TITLE
fix: report added resume skills

### DIFF
--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -12,8 +12,14 @@ def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
     """Print counts that distinguish additions from skills already present."""
     prefix = "[DRY-RUN]" if dry_run else "[OK]"
     added_keys = {name.casefold() for name in result.added}
+    # Report the chip as it was read off the resume, not as the caller spelled
+    # it: matching is casefolded, and #528 exists so the output confirms what
+    # is actually on hh.ru.  ``existing`` is the DOM-read source of truth.
+    existing_by_key = {name.casefold(): name for name in result.existing}
     already_present = tuple(
-        skill.name for skill in result.proposed if skill.name.casefold() not in added_keys
+        existing_by_key.get(skill.name.casefold(), skill.name)
+        for skill in result.proposed
+        if skill.name.casefold() not in added_keys
     )
     print(
         f"{prefix} {resume_id}: навыков было {len(result.existing)}, "

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -43,7 +43,8 @@ def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
         print(f"  уже были: {', '.join(already_present)}")
     for skill in result.proposed:
         state = "добавить" if skill.name.casefold() in added_keys else "сохранить"
-        print(f"  - {skill.name} [{skill.level}] — {state}")
+        name = existing_by_key.get(skill.name.casefold(), skill.name)
+        print(f"  - {name} [{skill.level}] — {state}")
     if dry_run:
         print("[INFO] Ничего не сохранено на hh.ru.")
 

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -8,6 +8,28 @@ from urllib.parse import urlsplit
 from .copy_resume import confirm_write
 
 
+def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
+    """Print counts that distinguish additions from skills already present."""
+    prefix = "[DRY-RUN]" if dry_run else "[OK]"
+    added_keys = {name.casefold() for name in result.added}
+    already_present = tuple(
+        skill.name for skill in result.proposed if skill.name.casefold() not in added_keys
+    )
+    print(
+        f"{prefix} {resume_id}: навыков было {len(result.existing)}, "
+        f"добавлено {len(result.added)}, стало {len(result.existing) + len(result.added)}"
+    )
+    if result.added:
+        print(f"  добавлены: {', '.join(result.added)}")
+    if already_present:
+        print(f"  уже были: {', '.join(already_present)}")
+    for skill in result.proposed:
+        state = "добавить" if skill.name.casefold() in added_keys else "сохранить"
+        print(f"  - {skill.name} [{skill.level}] — {state}")
+    if dry_run:
+        print("[INFO] Ничего не сохранено на hh.ru.")
+
+
 def register(subparsers) -> None:
     parser = subparsers.add_parser(
         "edit-skills",
@@ -136,14 +158,8 @@ def _run(args: argparse.Namespace, progress) -> bool:
         prefix = "[FAIL] (uncertain)" if result.acted else "[FAIL]"
         print(f"{prefix} {resume.id} — {result.reason}")
         return True
-    prefix = "[DRY-RUN]" if args.dry_run else "[OK]"
-    print(f"{prefix} {resume.id}: существующие навыки сохранены: {len(result.existing)}")
-    for skill in result.proposed:
-        state = "добавить" if skill.name in result.added else "сохранить"
-        print(f"  - {skill.name} [{skill.level}] — {state}")
-    if args.dry_run:
-        print("[INFO] Ничего не сохранено на hh.ru.")
-    else:
+    _print_success(resume.id, result, dry_run=args.dry_run)
+    if not args.dry_run:
         progress.finish(result)
     return False
 

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -21,12 +21,24 @@ def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
         for skill in result.proposed
         if skill.name.casefold() not in added_keys
     )
-    print(
-        f"{prefix} {resume_id}: навыков было {len(result.existing)}, "
-        f"добавлено {len(result.added)}, стало {len(result.existing) + len(result.added)}"
-    )
+    # A dry run cancels the form, so nothing was added: state the counts in the
+    # future tense there.  The real run keeps the wording #528 asked for.
+    if dry_run:
+        counts = (
+            f"навыков сейчас {len(result.existing)}, "
+            f"будет добавлено {len(result.added)}, "
+            f"станет {len(result.existing) + len(result.added)}"
+        )
+    else:
+        counts = (
+            f"навыков было {len(result.existing)}, "
+            f"добавлено {len(result.added)}, "
+            f"стало {len(result.existing) + len(result.added)}"
+        )
+    print(f"{prefix} {resume_id}: {counts}")
     if result.added:
-        print(f"  добавлены: {', '.join(result.added)}")
+        label = "будут добавлены" if dry_run else "добавлены"
+        print(f"  {label}: {', '.join(result.added)}")
     if already_present:
         print(f"  уже были: {', '.join(already_present)}")
     for skill in result.proposed:

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -66,7 +66,10 @@ def test_success_output_names_skill_as_read_from_resume(capsys):
 
     output = capsys.readouterr().out
     assert "уже были: Python" in output
-    assert "уже были: PYTHON" not in output
+    # The itemized line must agree with the line above it: both name the chip
+    # as read off the resume, not as the caller spelled it.
+    assert "  - Python [advanced] — сохранить" in output
+    assert "PYTHON" not in output
 
 
 def test_dry_run_output_does_not_claim_skills_were_added(capsys):

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -9,12 +9,45 @@ from types import SimpleNamespace
 import pytest
 
 import hhru_bot.commands.edit_skills as command
+from hhru_bot.skills import Skill, SkillsResult
 
 pytestmark = pytest.mark.unit
 
 
 class _Page:
     url = "https://hh.ru/resume/wrong-resume"
+
+
+def test_success_output_reports_added_and_existing_skills(capsys):
+    result = SkillsResult(
+        success=True,
+        existing=("Python", "Git"),
+        proposed=(Skill("Python", "advanced"), Skill("Docker", "intermediate")),
+        added=("Docker",),
+    )
+
+    command._print_success("resume", result, dry_run=False)
+
+    output = capsys.readouterr().out
+    assert "навыков было 2, добавлено 1, стало 3" in output
+    assert "добавлены: Docker" in output
+    assert "уже были: Python" in output
+
+
+def test_success_output_reports_noop_append(capsys):
+    result = SkillsResult(
+        success=True,
+        existing=("Python",),
+        proposed=(Skill("python", "advanced"),),
+        added=(),
+    )
+
+    command._print_success("resume", result, dry_run=False)
+
+    output = capsys.readouterr().out
+    assert "навыков было 1, добавлено 0, стало 1" in output
+    assert "уже были: python" in output
+    assert "добавлены:" not in output
 
 
 @contextmanager

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -69,6 +69,24 @@ def test_success_output_names_skill_as_read_from_resume(capsys):
     assert "уже были: PYTHON" not in output
 
 
+def test_dry_run_output_does_not_claim_skills_were_added(capsys):
+    """A cancelled dry run must not report additions in the past tense (#528)."""
+    result = SkillsResult(
+        success=True,
+        existing=("Python",),
+        proposed=(Skill("Python", "advanced"), Skill("Docker", "basic")),
+        added=("Docker",),
+    )
+
+    command._print_success("resume", result, dry_run=True)
+
+    output = capsys.readouterr().out
+    assert "навыков сейчас 1, будет добавлено 1, станет 2" in output
+    assert "добавлено 1, стало 2" not in output
+    assert "будут добавлены: Docker" in output
+    assert "[INFO] Ничего не сохранено на hh.ru." in output
+
+
 @contextmanager
 def _launch_context(*_args, **_kwargs):
     yield SimpleNamespace(new_page=lambda: _Page())

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -37,7 +37,7 @@ def test_success_output_reports_added_and_existing_skills(capsys):
 def test_success_output_reports_noop_append(capsys):
     result = SkillsResult(
         success=True,
-        existing=("Python",),
+        existing=("Python", "Git"),
         proposed=(Skill("python", "advanced"),),
         added=(),
     )
@@ -45,9 +45,28 @@ def test_success_output_reports_noop_append(capsys):
     command._print_success("resume", result, dry_run=False)
 
     output = capsys.readouterr().out
-    assert "навыков было 1, добавлено 0, стало 1" in output
-    assert "уже были: python" in output
+    assert "навыков было 2, добавлено 0, стало 2" in output
+    # The resume holds "Python"; the caller typed "python".  The report must
+    # name the chip read from the page, not the caller's spelling (#528).
+    assert "уже были: Python" in output
+    assert "уже были: python" not in output
     assert "добавлены:" not in output
+
+
+def test_success_output_names_skill_as_read_from_resume(capsys):
+    """An uppercase --skill still reports the chip's own spelling (#528)."""
+    result = SkillsResult(
+        success=True,
+        existing=("Python",),
+        proposed=(Skill("PYTHON", "advanced"),),
+        added=(),
+    )
+
+    command._print_success("resume", result, dry_run=False)
+
+    output = capsys.readouterr().out
+    assert "уже были: Python" in output
+    assert "уже были: PYTHON" not in output
 
 
 @contextmanager


### PR DESCRIPTION
Closes #528

## Summary
- report existing, added, and resulting skill counts for `edit-skills`
- list newly added skills and distinguish already-present skills
- cover append/no-op output with focused tests

## Tests
- `pytest -q tests/test_edit_skills_command.py tests/test_skills.py`
- `git diff --check`
