### PR TITLE
Fix copy-resume config write lock location

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -171,7 +171,8 @@ def _is_write_command(args: argparse.Namespace) -> bool:
 
 def _write_lock_path(args: argparse.Namespace) -> Path:
     """Return the lock location for the state mutated by a write command."""
-    lock_root = Path(args.config if args.command == "config" else args.history)
+    writes_config = args.command == "config" or getattr(args, "write_config", False)
+    lock_root = Path(args.config if writes_config else args.history)
     return lock_root.expanduser().resolve().parent / ".hhru.lock"
 
 

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -92,9 +92,7 @@ def test_config_write_lock_uses_config_directory(tmp_path):
 
 
 @pytest.mark.parametrize("write_config", [False, True])
-def test_copy_resume_write_config_lock_uses_mutated_state_directory(
-    tmp_path, write_config
-):
+def test_copy_resume_write_config_lock_uses_mutated_state_directory(tmp_path, write_config):
     parser = cli.build_parser()
     argv = [
         "--config",

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -91,6 +91,30 @@ def test_config_write_lock_uses_config_directory(tmp_path):
     assert _write_lock_path(args) == (tmp_path / "settings" / ".hhru.lock").resolve()
 
 
+@pytest.mark.parametrize("write_config", [False, True])
+def test_copy_resume_write_config_lock_uses_mutated_state_directory(
+    tmp_path, write_config
+):
+    parser = cli.build_parser()
+    argv = [
+        "--config",
+        str(tmp_path / "settings" / "config.yaml"),
+        "--history",
+        str(tmp_path / "other" / "history.db"),
+        "copy-resume",
+        "--resume",
+        "backend",
+    ]
+    if write_config:
+        argv.append("--write-config")
+
+    args = parser.parse_args(argv)
+    cli._resolve_paths(args)
+
+    expected_root = tmp_path / ("settings" if write_config else "other")
+    assert _write_lock_path(args) == (expected_root / ".hhru.lock").resolve()
+
+
 def test_account_list_is_read_only_and_bypasses_lock_and_logging(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- lock `copy-resume --write-config` beside the config it mutates
- keep regular copy-resume writes locked beside history
- add regression coverage for divergent `--config` and `--history` paths

Fixes #534

## Tests
- `pytest -q tests/test_write_lock.py tests/test_copy_resume_command.py`
- `ruff check src/hhru_bot/cli.py tests/test_write_lock.py`

## Risk
Low: only lock-path selection changes for commands carrying `--write-config`.