### PR TITLE
fix(edit-skills): verify chips after save

### DIFF
--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -5,21 +5,27 @@ from __future__ import annotations
 import argparse
 from urllib.parse import urlsplit
 
+from ..skills import _skill_key
 from .copy_resume import confirm_write
 
 
 def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
     """Print counts that distinguish additions from skills already present."""
     prefix = "[DRY-RUN]" if dry_run else "[OK]"
-    added_keys = {name.casefold() for name in result.added}
+    # Match the pipeline's normalization (_skill_key): a chip rendered with a
+    # double internal space or nbsp must still classify against the single-spaced
+    # plan.  Bare casefold() here diverged from skills.py and reported an added
+    # chip as "уже были" / "сохранить" (#536 round 3).  The raw chip spelling is
+    # preserved in the report; _skill_key is only for the equality key.
+    added_keys = {_skill_key(name) for name in result.added}
     # Report the chip as it was read off the resume, not as the caller spelled
-    # it: matching is casefolded, and #528 exists so the output confirms what
+    # it: matching is normalized, and #528 exists so the output confirms what
     # is actually on hh.ru.  ``existing`` is the DOM-read source of truth.
-    existing_by_key = {name.casefold(): name for name in result.existing}
+    existing_by_key = {_skill_key(name): name for name in result.existing}
     already_present = tuple(
-        existing_by_key.get(skill.name.casefold(), skill.name)
+        existing_by_key.get(_skill_key(skill.name), skill.name)
         for skill in result.proposed
-        if skill.name.casefold() not in added_keys
+        if _skill_key(skill.name) not in added_keys
     )
     # A dry run cancels the form, so nothing was added: state the counts in the
     # future tense there.  The real run keeps the wording #528 asked for.
@@ -42,8 +48,8 @@ def _print_success(resume_id: str, result, *, dry_run: bool) -> None:
     if already_present:
         print(f"  уже были: {', '.join(already_present)}")
     for skill in result.proposed:
-        state = "добавить" if skill.name.casefold() in added_keys else "сохранить"
-        name = existing_by_key.get(skill.name.casefold(), skill.name)
+        state = "добавить" if _skill_key(skill.name) in added_keys else "сохранить"
+        name = existing_by_key.get(_skill_key(skill.name), skill.name)
         print(f"  - {name} [{skill.level}] — {state}")
     if dry_run:
         print("[INFO] Ничего не сохранено на hh.ru.")

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -130,6 +130,19 @@ def read_skills(page: Page) -> tuple[str, ...]:
     return tuple(values)
 
 
+def _skill_key(name: str) -> str:
+    """Casefolded, whitespace-normalized key for comparing skill chips.
+
+    parse_skill_plan normalizes planned names via ``" ".join(name.split())``;
+    read_skills only strips. Without applying the same normalization to the
+    observed/existing chips, a chip rendered with a double space or nbsp would
+    falsely mismatch the Counter and report false uncertain, locking the resume
+    via has_unresolved_uncertain (#536 round 2). The raw chip spelling is still
+    preserved in the success report; this key is only for equality comparison.
+    """
+    return " ".join(name.split()).casefold()
+
+
 def edit_skills_on_hh(
     page: Page,
     resume: ResumeConfig,
@@ -159,8 +172,8 @@ def edit_skills_on_hh(
     except RuntimeError as exc:
         return SkillsResult(False, reason=str(exc))
     existing = read_skills(page)
-    existing_keys = {skill.casefold() for skill in existing}
-    additions = tuple(skill for skill in skills if skill.name.casefold() not in existing_keys)
+    existing_keys = {_skill_key(skill) for skill in existing}
+    additions = tuple(skill for skill in skills if _skill_key(skill.name) not in existing_keys)
     if mode == "fresh" and existing:
         return SkillsResult(False, existing, skills, reason="режим с нуля требует пустого раздела")
     if dry_run:
@@ -223,9 +236,9 @@ def edit_skills_on_hh(
     # the chips are the source of truth for what actually landed on the resume.
     # Compare multisets so a rejected, duplicated, or otherwise unexpected
     # chip cannot be reported as a successful addition.
-    existing_keys = [skill.casefold() for skill in existing]
-    expected_keys = existing_keys + [skill.name.casefold() for skill in additions]
-    observed_keys = [skill.casefold() for skill in observed]
+    existing_keys = [_skill_key(skill) for skill in existing]
+    expected_keys = existing_keys + [_skill_key(skill.name) for skill in additions]
+    observed_keys = [_skill_key(skill) for skill in observed]
     if Counter(observed_keys) != Counter(expected_keys):
         return SkillsResult(
             False,
@@ -244,7 +257,7 @@ def edit_skills_on_hh(
     remaining_existing = Counter(existing_keys)
     observed_added: list[str] = []
     for skill in observed:
-        key = skill.casefold()
+        key = _skill_key(skill)
         if remaining_existing[key]:
             remaining_existing[key] -= 1
         else:

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
@@ -193,4 +194,45 @@ def edit_skills_on_hh(
             reason=f"сохранение навыков не подтверждено: {exc}",
             acted=True,
         )
-    return SkillsResult(True, existing, skills, tuple(s.name for s in additions), acted=True)
+    try:
+        observed = read_skills(page)
+    except PlaywrightError as exc:
+        return SkillsResult(
+            False,
+            existing,
+            skills,
+            reason=f"сохранение навыков не подтверждено: чипы не прочитаны: {exc}",
+            acted=True,
+        )
+
+    # The editor closing only confirms that the UI accepted the interaction;
+    # the chips are the source of truth for what actually landed on the resume.
+    # Compare multisets so a rejected, duplicated, or otherwise unexpected
+    # chip cannot be reported as a successful addition.
+    existing_keys = [skill.casefold() for skill in existing]
+    expected_keys = existing_keys + [skill.name.casefold() for skill in additions]
+    observed_keys = [skill.casefold() for skill in observed]
+    if Counter(observed_keys) != Counter(expected_keys):
+        return SkillsResult(
+            False,
+            existing,
+            skills,
+            reason=(
+                "сохранение навыков не подтверждено: наблюдаемое состояние чипов "
+                f"не совпало с планом (ожидалось {len(expected_keys)}, "
+                f"наблюдалось {len(observed_keys)})"
+            ),
+            acted=True,
+        )
+
+    # Preserve the spelling observed on hh.ru in the success report while
+    # keeping ``existing`` as the pre-write snapshot used for the "было" count.
+    remaining_existing = Counter(existing_keys)
+    observed_added: list[str] = []
+    for skill in observed:
+        key = skill.casefold()
+        if remaining_existing[key]:
+            remaining_existing[key] -= 1
+        else:
+            observed_added.append(skill)
+    return SkillsResult(True, existing, skills, tuple(observed_added), acted=True)

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -194,6 +194,20 @@ def edit_skills_on_hh(
             reason=f"сохранение навыков не подтверждено: {exc}",
             acted=True,
         )
+    # editor.wait_for(state="hidden") only confirms the overlay closed, not that
+    # the underlying resume page has re-rendered the chip list (CLAUDE.md: "commit
+    # не значит отрисовано"). Give the chip count a short window to settle before
+    # the strict read below, matching the wait_for(state="visible") pattern used
+    # after other mutating clicks (resume_position.py, bump.py, etc.) — a mismatch
+    # is still fail-closed after the wait, this only avoids racing the re-render.
+    expected_chip_count = len(existing) + len(additions)
+    if expected_chip_count > 0:
+        try:
+            page.locator(resume_page.RESUME_SKILLS_CHIP).nth(expected_chip_count - 1).wait_for(
+                state="visible", timeout=5_000
+            )
+        except PlaywrightError:
+            pass
     try:
         observed = read_skills(page)
     except PlaywrightError as exc:

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -90,6 +90,56 @@ def test_dry_run_output_does_not_claim_skills_were_added(capsys):
     assert "[INFO] Ничего не сохранено на hh.ru." in output
 
 
+def test_success_output_normalizes_internal_whitespace_in_added_chip(capsys):
+    """An added chip rendered with double internal whitespace must still be
+    classified as added, not already-present (#536 round 3).
+
+    ``_print_success`` used bare ``casefold()`` while the pipeline normalizes via
+    ``_skill_key`` (``" ".join(split).casefold()``); a chip "Machine  Learning"
+    (double space) mismatched the single-spaced plan key and was reported as
+    "уже были" / "сохранить" instead of "добавлены" / "добавить".
+    """
+    result = SkillsResult(
+        success=True,
+        existing=("Python",),
+        proposed=(Skill("Machine Learning", "intermediate"),),
+        added=("Machine  Learning",),  # double space from hh.ru chip
+    )
+
+    command._print_success("resume", result, dry_run=False)
+
+    output = capsys.readouterr().out
+    # The chip spelling observed on hh.ru is preserved in the roll-up.
+    assert "добавлены: Machine  Learning" in output
+    # The proposed skill is classified as an addition despite the whitespace gap.
+    assert "добавить" in output
+    assert "сохранить" not in output
+    assert "уже были: Machine" not in output
+
+
+def test_success_output_normalizes_internal_whitespace_in_existing_chip(capsys):
+    """An existing chip with double internal whitespace must match a same-spelling
+    plan entry as already-present (#536 round 3).
+
+    Without normalizing the existing-chip key, "Python  Dev" (double space) would
+    not match the plan's "Python Dev" (single space); the skill would fall through
+    to the ``skill.name`` fallback and be reported as an addition.
+    """
+    result = SkillsResult(
+        success=True,
+        existing=("Python  Dev",),  # double space from hh.ru chip
+        proposed=(Skill("Python Dev", "advanced"),),  # single space from plan
+        added=(),
+    )
+
+    command._print_success("resume", result, dry_run=False)
+
+    output = capsys.readouterr().out
+    assert "уже были: Python  Dev" in output  # chip spelling preserved
+    assert "  - Python  Dev [advanced] — сохранить" in output
+    assert "добавлены:" not in output
+
+
 @contextmanager
 def _launch_context(*_args, **_kwargs):
     yield SimpleNamespace(new_page=lambda: _Page())

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -307,3 +307,90 @@ def test_edit_skills_post_save_wait_timeout_falls_through_to_strict_read(monkeyp
     assert result.success is False
     assert result.acted is True
     assert "не совпало с планом" in result.reason
+
+
+def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatch) -> None:
+    """A chip rendered with double internal whitespace must still match the plan.
+
+    parse_skill_plan normalizes planned names via " ".join(split); read_skills only
+    strips. Without applying the same normalization to observed/existing chips, a
+    chip carrying a double space (or nbsp) would falsely mismatch the Counter and
+    report false uncertain, locking the resume via has_unresolved_uncertain (#536
+    round 2). The raw spelling is still preserved in the success report.
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    # hh.ru rendered the added chip with a double internal space; the plan carries
+    # a single space (parse_skill_plan normalized it).
+    monkeypatch.setattr(
+        skills_module,
+        "read_skills",
+        MagicMock(side_effect=[("Python",), ("Python", "Machine  Learning")]),
+    )
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Machine Learning", "intermediate"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is True
+    assert result.acted is True
+    # Spelling observed on hh.ru is preserved in the success report.
+    assert result.added == ("Machine  Learning",)
+
+
+def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) -> None:
+    """An existing chip rendered with double internal whitespace must dedup the
+    same skill from the plan, not be treated as a new addition.
+
+    Without normalizing the existing-chip key (line 162), "Python  Dev" (double
+    space) would not match the plan's "Python Dev" (single space), the skill would
+    be re-added as a duplicate, the post-save Counter would mismatch, and the
+    resume would lock via has_unresolved_uncertain (#536 round 2).
+    """
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    # Existing chip already carries a double space; the plan re-offers the same
+    # skill with a single space — it must be deduped, not re-added.
+    monkeypatch.setattr(
+        skills_module,
+        "read_skills",
+        MagicMock(side_effect=[("Python  Dev",), ("Python  Dev",)]),
+    )
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python Dev", "advanced"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is True
+    assert result.acted is True
+    assert result.added == ()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -195,6 +195,13 @@ def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) ->
     assert editor.wait_for.call_count == 1
 
 
+def _mock_chip_locator() -> MagicMock:
+    """A RESUME_SKILLS_CHIP locator stub whose .nth().wait_for() no-ops."""
+    chip_locator = MagicMock()
+    chip_locator.nth.return_value.wait_for.return_value = None
+    return chip_locator
+
+
 def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None:
     """A closed editor is not enough: the saved chip set must match the plan."""
     resume = bare_resume("resume-id")
@@ -205,9 +212,11 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     input_.count.return_value = 1
     save = MagicMock()
     save.count.return_value = 1
+    chip_locator = _mock_chip_locator()
     page.locator.side_effect = lambda selector: {
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
@@ -224,6 +233,11 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     assert result.added == ("Docker",)
     assert result.acted is True
     assert read_skills.call_count == 2
+    # #536 round 1: the post-save read must wait for the chip container to
+    # settle instead of racing the React re-render right after the editor
+    # (a separate overlay) reports hidden.
+    chip_locator.nth.assert_called_once_with(1)
+    chip_locator.nth.return_value.wait_for.assert_called_once_with(state="visible", timeout=5_000)
 
 
 def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
@@ -239,6 +253,44 @@ def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
     page.locator.side_effect = lambda selector: {
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(
+        skills_module, "read_skills", MagicMock(side_effect=[("Python",), ("Python",)])
+    )
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is False
+    assert result.acted is True
+    assert "не совпало с планом" in result.reason
+
+
+def test_edit_skills_post_save_wait_timeout_falls_through_to_strict_read(monkeypatch) -> None:
+    """If the chip never settles in time, the strict multiset check still fires
+    (fail-closed) instead of the wait's PlaywrightError propagating uncaught."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    chip_locator = MagicMock()
+    chip_locator.nth.return_value.wait_for.side_effect = PlaywrightError("timeout")
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -193,3 +193,65 @@ def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) ->
     assert result.success is True
     assert trigger.click.call_count == 1
     assert editor.wait_for.call_count == 1
+
+
+def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None:
+    """A closed editor is not enough: the saved chip set must match the plan."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    read_skills = MagicMock(side_effect=[("Python",), ("Python", "Docker")])
+    monkeypatch.setattr(skills_module, "read_skills", read_skills)
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is True
+    assert result.added == ("Docker",)
+    assert result.acted is True
+    assert read_skills.call_count == 2
+
+
+def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
+    """A successful save click with a missing chip must not produce [OK]."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(
+        skills_module, "read_skills", MagicMock(side_effect=[("Python",), ("Python",)])
+    )
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is False
+    assert result.acted is True
+    assert "не совпало с планом" in result.reason


### PR DESCRIPTION
Closes #536

## Summary
- reread resume skill chips after the inline editor closes
- compare the observed chip multiset with the pre-write state plus requested additions
- report acted mismatches as uncertain instead of [OK]

## Tests
- `pytest -q tests/test_skills.py tests/test_edit_skills_command.py tests/test_resume_edit_command_runs.py`
- `ruff check src/hhru_bot/skills.py tests/test_skills.py`
- `ruff format --check src/hhru_bot/skills.py tests/test_skills.py`

## Risk
- no live hh.ru browser verification was performed; the existing chip selector is reused for the post-save read.