### PR TITLE
fix(history): preserve vacancy data on selector misses

### DIFF
--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -111,7 +111,17 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
         # An empty company means that this scrape did not produce a usable
         # observation. Do not turn it into ``unknown`` and overwrite a
         # previously classified employer during selector drift (#532).
-        tier = classify_employer(company, getattr(card, "employer_info", None)) if company else None
+        employer_info = getattr(card, "employer_info", None) if company else None
+        tier = classify_employer(company, employer_info) if company else None
+        # Review-финдинг (#532): classify_employer("unknown") не отличает
+        # «компания реально неизвестна» от «rating/reviews-селектор не дал
+        # сигнала на этом scrape» — оба случая раньше схлопывались в строку
+        # "unknown", которая проходит COALESCE(NULLIF(...)) как непустая и
+        # затирает ранее подтверждённый tier (например "mid" из прошлого
+        # scrape). top_tech/big_corp матчатся по имени и не зависят от
+        # employer_info, поэтому им это не грозит — гейтим только unknown.
+        if tier == "unknown" and employer_info is None:
+            tier = None
         try:
             history.upsert_vacancy_seen(
                 vacancy_id=card.vacancy_id,

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -114,13 +114,20 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
         employer_info = getattr(card, "employer_info", None) if company else None
         tier = classify_employer(company, employer_info) if company else None
         # Review-финдинг (#532): classify_employer("unknown") не отличает
-        # «компания реально неизвестна» от «rating/reviews-селектор не дал
-        # сигнала на этом scrape» — оба случая раньше схлопывались в строку
-        # "unknown", которая проходит COALESCE(NULLIF(...)) как непустая и
-        # затирает ранее подтверждённый tier (например "mid" из прошлого
-        # scrape). top_tech/big_corp матчатся по имени и не зависят от
-        # employer_info, поэтому им это не грозит — гейтим только unknown.
-        if tier == "unknown" and employer_info is None:
+        # «компания реально неизвестна» от «reviews-селектор не дал сигнала на
+        # этом scrape» — оба случая раньше схлопывались в строку "unknown",
+        # которая проходит COALESCE(NULLIF(...)) как непустая и затирала ранее
+        # подтверждённый tier (например "mid" из прошлого scrape). top_tech/
+        # big_corp матчатся по имени и не зависят от employer_info, поэтому им
+        # это не грозит — гейтим только unknown. Гейт широкий: «unknown»
+        # достоверен лишь когда reviews_count РЕАЛЬНО прочитан (и оказался ниже
+        # порога). Если reviews_count не прочитан — либо весь блок
+        # employer_info=None (селектор-промах), либо partial-failure (rating/
+        # trusted выжили, но reviews_count-селектор дрейфнул) — оба случая
+        # неоднозначны, подавляем в None, оставляя COALESCE прежнее значение.
+        # reviews_count прочитан, но мал (вкл. 0) → настоящий «небольшой
+        # работодатель», unknown не подавляется.
+        if tier == "unknown" and (employer_info is None or employer_info.reviews_count is None):
             tier = None
         try:
             history.upsert_vacancy_seen(

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -100,24 +100,29 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
 
     address/is_remote/experience/snippet_requirement/snippet_responsibility
     (#517) — доп. признаки карточки для статистики/ML, прокидываются как есть
-    из VacancyCard (пустая строка/False, если hh.ru не отдал блок).
+    из VacancyCard (пустая строка/None, если hh.ru не отдал блок).
     """
     from ..scoring import classify_employer
 
     for card in cards:
         salary = card.salary
-        tier = classify_employer(card.company, getattr(card, "employer_info", None))
+        title = card.title.strip() or None
+        company = card.company.strip() or None
+        # An empty company means that this scrape did not produce a usable
+        # observation. Do not turn it into ``unknown`` and overwrite a
+        # previously classified employer during selector drift (#532).
+        tier = classify_employer(company, getattr(card, "employer_info", None)) if company else None
         try:
             history.upsert_vacancy_seen(
                 vacancy_id=card.vacancy_id,
                 search_query=search_query,
-                title=card.title,
-                company=card.company,
+                title=title,
+                company=company,
                 salary_from=salary.salary_from if salary else None,
                 salary_to=salary.salary_to if salary else None,
                 salary_currency=salary.currency if salary else None,
                 employer_tier=tier,
-                vacancy_text=card.vacancy_text,
+                vacancy_text=card.vacancy_text or None,
                 published_at=card.published_at.isoformat() if card.published_at else None,
                 address=card.address or None,
                 is_remote=card.is_remote,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -1867,6 +1867,8 @@ class History:
         находится и за сколько). При повторном scrape та же пара обновляет
         title/company/salary (hh.ru мог поменять вилку) и двигает
         ``last_seen_at``; ``first_seen_at`` хранит ПЕРВОЕ появление и не трогается.
+        Пустое значение не затирает ранее подтверждённое: это позволяет
+        пережить дрейф/временный сбой селектора без потери истории.
 
         Зарплата приходит из ``SalaryInfo`` (#34): ``salary_from``/``salary_to``
         оба NULL = «з/п не указана» (``parse_salary`` вернул None) — такая
@@ -1895,20 +1897,14 @@ class History:
         значение перезаписывает старое, а пропуск при повторном scrape НЕ
         затирает ранее собранные данные NULL'ом.
 
-        ``is_remote`` — исключение из этого правила: у него нет
-        промежуточного «не удалось прочитать» состояния при РАБОТАЮЩЕМ
-        селекторе — ``count()`` либо 0, либо >0, всегда однозначно. Поэтому
-        пишется безусловно (``excluded.is_remote``, не COALESCE): `False` —
-        валидное наблюдение "метки не было", а не признак сбоя.
+        ``is_remote`` — тристейтный сигнал: ``True`` и ``False`` — наблюдения,
+        ``None`` — селектор не дал наблюдения. Поэтому ``None`` не затирает
+        сохранённое значение, а явный ``False`` всё ещё может обновить
+        ``True``.
 
-        Это рассуждение перестаёт быть верным при ДРЕЙФЕ/переименовании
-        самого селектора (``VACANCY_CARD_REMOTE_LABEL``) — тогда ``count()``
-        молча вернёт 0 для всех карточек, и `is_remote` окажется неотличим
-        от массового "метки действительно не было". Тот же класс риска
-        (безусловная перезапись при дрейфе селектора) существует и для
-        ``title``/``company``/``salary_*``/``employer_tier`` выше — не
-        специфичен для `is_remote` и не устраняется точечным патчем одного
-        поля; разбор — issue #532.
+        Для всех полей действует консервативная политика «best known»: NULL и
+        пустые строки из нового scrape не удаляют подтверждённые данные. Это
+        предотвращает массовую потерю истории при дрейфе селектора (#532).
         """
         now = datetime.now().isoformat()
         with self._connect() as conn:
@@ -1926,22 +1922,46 @@ class History:
                      snippet_responsibility)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(vacancy_id, search_query) DO UPDATE SET
-                    title = excluded.title,
-                    company = excluded.company,
-                    salary_from = excluded.salary_from,
-                    salary_to = excluded.salary_to,
-                    salary_currency = excluded.salary_currency,
-                    employer_tier = excluded.employer_tier,
-                    vacancy_text = excluded.vacancy_text,
-                    published_at = COALESCE(excluded.published_at, published_at),
-                    address = COALESCE(excluded.address, address),
-                    is_remote = excluded.is_remote,
-                    experience = COALESCE(excluded.experience, experience),
+                    title = COALESCE(NULLIF(excluded.title, ''), title),
+                    company = COALESCE(NULLIF(excluded.company, ''), company),
+                    salary_from = CASE
+                        WHEN excluded.salary_from IS NOT NULL
+                          OR excluded.salary_to IS NOT NULL
+                          OR NULLIF(excluded.salary_currency, '') IS NOT NULL
+                        THEN excluded.salary_from
+                        ELSE salary_from
+                    END,
+                    salary_to = CASE
+                        WHEN excluded.salary_from IS NOT NULL
+                          OR excluded.salary_to IS NOT NULL
+                          OR NULLIF(excluded.salary_currency, '') IS NOT NULL
+                        THEN excluded.salary_to
+                        ELSE salary_to
+                    END,
+                    salary_currency = CASE
+                        WHEN excluded.salary_from IS NOT NULL
+                          OR excluded.salary_to IS NOT NULL
+                          OR NULLIF(excluded.salary_currency, '') IS NOT NULL
+                        THEN excluded.salary_currency
+                        ELSE salary_currency
+                    END,
+                    employer_tier = COALESCE(
+                        NULLIF(excluded.employer_tier, ''), employer_tier
+                    ),
+                    vacancy_text = COALESCE(
+                        NULLIF(excluded.vacancy_text, ''), vacancy_text
+                    ),
+                    published_at = COALESCE(
+                        NULLIF(excluded.published_at, ''), published_at
+                    ),
+                    address = COALESCE(NULLIF(excluded.address, ''), address),
+                    is_remote = COALESCE(excluded.is_remote, is_remote),
+                    experience = COALESCE(NULLIF(excluded.experience, ''), experience),
                     snippet_requirement = COALESCE(
-                        excluded.snippet_requirement, snippet_requirement
+                        NULLIF(excluded.snippet_requirement, ''), snippet_requirement
                     ),
                     snippet_responsibility = COALESCE(
-                        excluded.snippet_responsibility, snippet_responsibility
+                        NULLIF(excluded.snippet_responsibility, ''), snippet_responsibility
                     ),
                     last_seen_at = excluded.last_seen_at
                 """,

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -516,8 +516,13 @@ def search_vacancies(
             # Доп. признаки карточки для статистики/ML (issue #517). Все блоки
             # опциональны — мягкий парсинг, отсутствие не роняет сбор карточки.
             address = _optional_text(card, sel.VACANCY_CARD_ADDRESS) or ""
+            # Карточка уже гарантированно распарсилась (card_text/title выше не
+            # упали) — отсутствие лейбла здесь не «дрейф селектора», а законное
+            # наблюдение «вакансия не удалённая» (#532 review-финдинг: тристейт
+            # был декоративен, т.к. search.py никогда не эмитил явный False, и
+            # ранее сохранённый True было невозможно скорректировать обратно).
             remote_label = card.locator(sel.VACANCY_CARD_REMOTE_LABEL).first
-            is_remote = True if remote_label.count() > 0 else None
+            is_remote = remote_label.count() > 0
             experience = _parse_experience(card)
             snippet_requirement = _optional_text(card, sel.VACANCY_CARD_SNIPPET_REQUIREMENT) or ""
             snippet_responsibility = (

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -516,13 +516,17 @@ def search_vacancies(
             # Доп. признаки карточки для статистики/ML (issue #517). Все блоки
             # опциональны — мягкий парсинг, отсутствие не роняет сбор карточки.
             address = _optional_text(card, sel.VACANCY_CARD_ADDRESS) or ""
-            # Карточка уже гарантированно распарсилась (card_text/title выше не
-            # упали) — отсутствие лейбла здесь не «дрейф селектора», а законное
-            # наблюдение «вакансия не удалённая» (#532 review-финдинг: тристейт
-            # был декоративен, т.к. search.py никогда не эмитил явный False, и
-            # ранее сохранённый True было невозможно скорректировать обратно).
+            # is_remote — тристейт (#532): True если remote-лейбл найден (confident),
+            # None если нет. Locator.count() == 0 неоднозначен — это либо «вакансия
+            # не удалённая», либо дрейф/переименование НЕЗАВИСИМОГО remote-селектора;
+            # успешный парсинг title/href выше не доказывает его здоровье. Эмитить
+            # False (non-NULL) значило бы затирать ранее подтверждённый True при
+            # любом селектор-промахе — ровно класс бага #532. None → COALESCE в
+            # upsert_vacancy_seen сохранит прежнее значение. False намеренно не
+            # эмитится вовсе: вакансия не меняет remote-статус, поэтому
+            # подтверждённый True не нуждается в «корректировке обратно».
             remote_label = card.locator(sel.VACANCY_CARD_REMOTE_LABEL).first
-            is_remote = remote_label.count() > 0
+            is_remote = True if remote_label.count() > 0 else None
             experience = _parse_experience(card)
             snippet_requirement = _optional_text(card, sel.VACANCY_CARD_SNIPPET_REQUIREMENT) or ""
             snippet_responsibility = (

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -307,10 +307,10 @@ class VacancyCard:
     vacancy_text: str = ""
     portfolio_evidence_requirement: PortfolioEvidenceRequirement | None = None
     # Доп. признаки карточки для статистики/ML (issue #517, приоритет-1 из
-    # #516). Все блоки опциональны в разметке hh.ru — пустая строка/False,
-    # если карточка их не отдала (тот же паттерн, что salary/published_at).
+    # #516). Все блоки опциональны в разметке hh.ru — пустая строка/None,
+    # если карточка их не отдала (None не должен затирать историю в upsert).
     address: str = ""
-    is_remote: bool = False
+    is_remote: bool | None = None
     # Категория опыта как есть из data-qa (напр. "between1And3"), пустая
     # строка если блок не найден. Не нормализуем в enum — источник истины
     # для дальнейшего анализа остаётся значение hh.ru.
@@ -516,7 +516,8 @@ def search_vacancies(
             # Доп. признаки карточки для статистики/ML (issue #517). Все блоки
             # опциональны — мягкий парсинг, отсутствие не роняет сбор карточки.
             address = _optional_text(card, sel.VACANCY_CARD_ADDRESS) or ""
-            is_remote = bool(card.locator(sel.VACANCY_CARD_REMOTE_LABEL).first.count())
+            remote_label = card.locator(sel.VACANCY_CARD_REMOTE_LABEL).first
+            is_remote = True if remote_label.count() > 0 else None
             experience = _parse_experience(card)
             snippet_requirement = _optional_text(card, sel.VACANCY_CARD_SNIPPET_REQUIREMENT) or ""
             snippet_responsibility = (

--- a/tests/test_history_market.py
+++ b/tests/test_history_market.py
@@ -134,8 +134,8 @@ def test_upsert_keeps_previous_text_fields_when_scrape_misses_block(tmp_path):
     """address/experience/snippet_* опциональны в разметке hh.ru: пропуск
     блока при повторном scrape (транзиентный DOM-промах) НЕ должен затирать
     ранее собранное значение NULL'ом — COALESCE, как у published_at.
-    is_remote — исключение (см. docstring upsert_vacancy_seen): у него нет
-    промежуточного «не удалось прочитать», поэтому пишется безусловно."""
+    is_remote — тристейтный сигнал: None означает «не удалось прочитать», а
+    явный False остаётся валидным наблюдением."""
     h = History(tmp_path / "h.db")
     h.upsert_vacancy_seen(
         vacancy_id="123",
@@ -150,14 +150,14 @@ def test_upsert_keeps_previous_text_fields_when_scrape_misses_block(tmp_path):
     )
     # Повторный scrape: карточка не найдена/блоки не отрендерились —
     # caller шлёт None для текстовых полей (как _record_seen делает через
-    # `card.address or None`), но is_remote всегда bool.
+    # `card.address or None`) и для is_remote, если селектор не дал сигнала.
     h.upsert_vacancy_seen(
         vacancy_id="123",
         title="T",
         company="C",
         search_query="python",
         address=None,
-        is_remote=False,
+        is_remote=None,
         experience=None,
         snippet_requirement=None,
         snippet_responsibility=None,
@@ -167,7 +167,95 @@ def test_upsert_keeps_previous_text_fields_when_scrape_misses_block(tmp_path):
     assert row["experience"] == "between1And3"
     assert row["snippet_requirement"] == "req"
     assert row["snippet_responsibility"] == "resp"
-    assert row["is_remote"] == 0  # безусловно перезаписано, не COALESCE
+    assert row["is_remote"] == 1
+
+    # Явное наблюдение «не удалённая» всё ещё должно обновить true.
+    h.upsert_vacancy_seen(
+        vacancy_id="123",
+        title="T",
+        company="C",
+        search_query="python",
+        is_remote=False,
+    )
+    assert h.list_vacancies_seen()[0]["is_remote"] == 0
+
+
+def test_upsert_keeps_all_known_fields_when_scrape_returns_empty_values(tmp_path):
+    """Дрейф селектора не должен стирать best-known карточку (#532)."""
+    h = History(tmp_path / "h.db")
+    h.upsert_vacancy_seen(
+        vacancy_id="123",
+        search_query="python",
+        title="Backend",
+        company="Yandex",
+        salary_from=300000,
+        salary_to=400000,
+        salary_currency="RUB",
+        employer_tier="top_tech",
+        vacancy_text="Python and Docker",
+        published_at="2026-08-23T00:00:00",
+        address="Москва",
+        is_remote=True,
+        experience="between1And3",
+        snippet_requirement="req",
+        snippet_responsibility="resp",
+    )
+    h.upsert_vacancy_seen(
+        vacancy_id="123",
+        search_query="python",
+        title="",
+        company="",
+        salary_from=None,
+        salary_to=None,
+        salary_currency=None,
+        employer_tier=None,
+        vacancy_text="",
+        published_at=None,
+        address="",
+        is_remote=None,
+        experience="",
+        snippet_requirement="",
+        snippet_responsibility="",
+    )
+
+    row = h.list_vacancies_seen()[0]
+    assert row["title"] == "Backend"
+    assert row["company"] == "Yandex"
+    assert row["salary_from"] == 300000
+    assert row["salary_to"] == 400000
+    assert row["salary_currency"] == "RUB"
+    assert row["employer_tier"] == "top_tech"
+    assert row["vacancy_text"] == "Python and Docker"
+    assert row["published_at"] == "2026-08-23T00:00:00"
+    assert row["address"] == "Москва"
+    assert row["is_remote"] == 1
+    assert row["experience"] == "between1And3"
+    assert row["snippet_requirement"] == "req"
+    assert row["snippet_responsibility"] == "resp"
+
+
+def test_upsert_replaces_salary_bounds_as_one_observation(tmp_path):
+    """Частичная новая вилка не должна смешиваться со старой границей."""
+    h = History(tmp_path / "h.db")
+    h.upsert_vacancy_seen(
+        vacancy_id="123",
+        search_query="python",
+        salary_from=300000,
+        salary_to=400000,
+        salary_currency="RUB",
+    )
+    h.upsert_vacancy_seen(
+        vacancy_id="123",
+        search_query="python",
+        salary_from=350000,
+        salary_to=None,
+        salary_currency="RUB",
+    )
+
+    row = h.list_vacancies_seen()[0]
+    assert row["salary_from"] == 350000
+    assert row["salary_to"] is None
+    assert row["salary_currency"] == "RUB"
 
 
 def test_upsert_same_vacancy_different_query_keeps_both(tmp_path):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -140,6 +140,23 @@ def test_search_waits_for_delayed_cards_before_declaring_empty(monkeypatch):
     )
 
 
+def test_search_reports_is_remote_false_for_healthy_card_without_label(monkeypatch):
+    """Review-финдинг PR #539: карточка уже успешно распарсилась (title/href
+    прочитаны выше), значит отсутствие remote-лейбла здесь — не селектор-дрейф,
+    а законное наблюдение «вакансия не удалённая». До фикса search_vacancies
+    маппил это в None, из-за чего is_remote физически не мог зафиксировать
+    False через боевой путь парсинга — только через прямой upsert в тестах."""
+    page = _SearchPage([_VacancyCard()])
+    monkeypatch.setattr(search, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(search, "_has_next_page", lambda *args: False)
+    monkeypatch.setattr(search, "_optional_text", lambda *args: None)
+    monkeypatch.setattr(search, "_parse_employer_info", lambda *args: None)
+
+    cards = search.search_vacancies(page, _search_filters(), max_pages=1)
+
+    assert cards[0].is_remote is False
+
+
 def test_search_timeout_is_indeterminate_not_empty_result(monkeypatch):
     """Нулевой count без подтверждённого empty-state не должен обрывать обход."""
     page = _SearchPage([])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -74,6 +74,10 @@ class _TextLocator:
 
 
 class _VacancyCard:
+    def __init__(self, remote: bool = False):
+        # remote=True → на карточке есть remote-лейбл (count=1); False → нет.
+        self._remote = remote
+
     def locator(self, selector: str):
         if selector == search.sel.VACANCY_CARD_TITLE_LINK:
             return _TextLocator("Python developer", "/vacancy/42")
@@ -81,10 +85,9 @@ class _VacancyCard:
             return _TextLocator(count=0)
         # Доп. признаки карточки (#517) опциональны — как остальные блоки
         # этого мока, "не найдено" по умолчанию для любого нового селектора.
-        if selector in (
-            search.sel.VACANCY_CARD_REMOTE_LABEL,
-            search.sel.VACANCY_CARD_EXPERIENCE,
-        ):
+        if selector == search.sel.VACANCY_CARD_REMOTE_LABEL:
+            return _TextLocator(count=1 if self._remote else 0)
+        if selector == search.sel.VACANCY_CARD_EXPERIENCE:
             return _TextLocator(count=0)
         raise AssertionError(f"unexpected card selector: {selector}")
 
@@ -140,12 +143,14 @@ def test_search_waits_for_delayed_cards_before_declaring_empty(monkeypatch):
     )
 
 
-def test_search_reports_is_remote_false_for_healthy_card_without_label(monkeypatch):
-    """Review-финдинг PR #539: карточка уже успешно распарсилась (title/href
-    прочитаны выше), значит отсутствие remote-лейбла здесь — не селектор-дрейф,
-    а законное наблюдение «вакансия не удалённая». До фикса search_vacancies
-    маппил это в None, из-за чего is_remote физически не мог зафиксировать
-    False через боевой путь парсинга — только через прямой upsert в тестах."""
+def test_search_reports_is_remote_none_when_remote_label_absent(monkeypatch):
+    """Review-финдинг PR #539 (cycle 2): Locator.count() == 0 неоднозначен —
+    это либо «вакансия не удалённая», либо дрейф/переименование remote-селектора.
+    Успешный парсинг title/href выше НЕ доказывает здоровье НЕЗАВИСИМОГО
+    remote-селектора. Эмитить False (non-NULL) значило бы затирать ранее
+    подтверждённый True при любом селектор-промахе — ровно класс бага #532.
+    Поэтому отсутствие лейбла → None (COALESCE в upsert сохранит прежнее
+    значение), присутствие → True (confident)."""
     page = _SearchPage([_VacancyCard()])
     monkeypatch.setattr(search, "goto_hh", lambda *args, **kwargs: None)
     monkeypatch.setattr(search, "_has_next_page", lambda *args: False)
@@ -154,7 +159,22 @@ def test_search_reports_is_remote_false_for_healthy_card_without_label(monkeypat
 
     cards = search.search_vacancies(page, _search_filters(), max_pages=1)
 
-    assert cards[0].is_remote is False
+    assert cards[0].is_remote is None
+
+
+def test_search_reports_is_remote_true_when_remote_label_present(monkeypatch):
+    """PR #539 (cycle 2): remote-лейбл найден (count > 0) — confident True.
+    Контр-тест к отсутствию: присутствие лейбла обязано давать True, иначе
+    тристейт вырождается и confirmed-True никогда не фиксируется."""
+    page = _SearchPage([_VacancyCard(remote=True)])
+    monkeypatch.setattr(search, "goto_hh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(search, "_has_next_page", lambda *args: False)
+    monkeypatch.setattr(search, "_optional_text", lambda *args: None)
+    monkeypatch.setattr(search, "_parse_employer_info", lambda *args: None)
+
+    cards = search.search_vacancies(page, _search_filters(), max_pages=1)
+
+    assert cards[0].is_remote is True
 
 
 def test_search_timeout_is_indeterminate_not_empty_result(monkeypatch):

--- a/tests/test_search_command_output.py
+++ b/tests/test_search_command_output.py
@@ -104,6 +104,42 @@ def test_record_seen_writes_all_cards(tmp_path):
     assert by_id["2"]["salary_from"] is None
 
 
+def test_record_seen_preserves_history_when_company_selector_misses(tmp_path):
+    """Пустая company не должна превращать известного работодателя в unknown (#532)."""
+    from hhru_bot.commands.search import _record_seen
+    from hhru_bot.history import History
+
+    history = History(tmp_path / "h.db")
+    history.upsert_vacancy_seen(
+        vacancy_id="1",
+        search_query="python",
+        title="Backend",
+        company="Yandex",
+        employer_tier="top_tech",
+        is_remote=True,
+    )
+
+    _record_seen(
+        [
+            VacancyCard(
+                vacancy_id="1",
+                title="",
+                company="",
+                url="https://hh.ru/vacancy/1",
+                is_remote=None,
+            )
+        ],
+        "python",
+        history,
+    )
+
+    row = history.list_vacancies_seen()[0]
+    assert row["title"] == "Backend"
+    assert row["company"] == "Yandex"
+    assert row["employer_tier"] == "top_tech"
+    assert row["is_remote"] == 1
+
+
 def test_record_seen_failure_does_not_raise(tmp_path):
     """Сбой записи НЕ должен валить поиск — рынок лишь удобство."""
     from hhru_bot.commands.search import _record_seen

--- a/tests/test_search_command_output.py
+++ b/tests/test_search_command_output.py
@@ -176,6 +176,81 @@ def test_record_seen_preserves_employer_tier_when_rating_selector_misses(tmp_pat
     assert row["employer_tier"] == "mid"
 
 
+def test_record_seen_preserves_tier_when_reviews_count_selector_drifts(tmp_path):
+    """PR #539 (cycle 2): partial-failure path. employer_info есть (rating/trusted
+    выжили), но reviews_count-селектор дрейфнул → reviews_count is None. Для
+    нетоповой компании classify_employer возвращает "unknown" (mid требует
+    reviews_count >= порога), и round-1 гейт (employer_info is None) её не
+    ловил — employer_info-то не None. «unknown» затирал подтверждённый "mid"."""
+    from hhru_bot.commands.search import _record_seen
+    from hhru_bot.history import History
+    from hhru_bot.scoring import EmployerInfo
+
+    history = History(tmp_path / "h.db")
+    history.upsert_vacancy_seen(
+        vacancy_id="1",
+        search_query="python",
+        title="Backend",
+        company="ООО Ромашка",
+        employer_tier="mid",
+    )
+
+    _record_seen(
+        [
+            VacancyCard(
+                vacancy_id="1",
+                title="Backend",
+                company="ООО Ромашка",
+                url="https://hh.ru/vacancy/1",
+                # rating/trusted выжили, reviews_count-селектор промахнулся
+                employer_info=EmployerInfo(rating=4.5, reviews_count=None, trusted=True),
+            )
+        ],
+        "python",
+        history,
+    )
+
+    row = history.list_vacancies_seen()[0]
+    assert row["employer_tier"] == "mid"
+
+
+def test_record_seen_downgrades_to_unknown_when_reviews_count_genuinely_low(tmp_path):
+    """PR #539 (cycle 2): контр-тест к over-suppression. reviews_count реально
+    прочитан и ниже порога — это достоверное наблюдение «небольшой работодатель»,
+    «unknown» обязан затереть прежний «mid» (гейт не должен перегащивать
+    настоящий downgrade)."""
+    from hhru_bot.commands.search import _record_seen
+    from hhru_bot.history import History
+    from hhru_bot.scoring import EmployerInfo
+
+    history = History(tmp_path / "h.db")
+    history.upsert_vacancy_seen(
+        vacancy_id="1",
+        search_query="python",
+        title="Backend",
+        company="ООО Ромашка",
+        employer_tier="mid",
+    )
+
+    _record_seen(
+        [
+            VacancyCard(
+                vacancy_id="1",
+                title="Backend",
+                company="ООО Ромашка",
+                url="https://hh.ru/vacancy/1",
+                # reviews_count прочитан, но мал — genuine unknown
+                employer_info=EmployerInfo(rating=3.0, reviews_count=2, trusted=False),
+            )
+        ],
+        "python",
+        history,
+    )
+
+    row = history.list_vacancies_seen()[0]
+    assert row["employer_tier"] == "unknown"
+
+
 def test_record_seen_failure_does_not_raise(tmp_path):
     """Сбой записи НЕ должен валить поиск — рынок лишь удобство."""
     from hhru_bot.commands.search import _record_seen

--- a/tests/test_search_command_output.py
+++ b/tests/test_search_command_output.py
@@ -140,6 +140,42 @@ def test_record_seen_preserves_history_when_company_selector_misses(tmp_path):
     assert row["is_remote"] == 1
 
 
+def test_record_seen_preserves_employer_tier_when_rating_selector_misses(tmp_path):
+    """Company-имя есть, но rating/reviews-блок не отрендерился (селектор-промах,
+    не «компания реально неизвестна») — ранее подтверждённый tier не должен
+    затираться на "unknown" (review-финдинг PR #539: classify_employer(company,
+    None) для нетоповой компании возвращает непустую строку "unknown", которая
+    раньше проходила COALESCE(NULLIF(...)) как достоверное новое значение)."""
+    from hhru_bot.commands.search import _record_seen
+    from hhru_bot.history import History
+
+    history = History(tmp_path / "h.db")
+    history.upsert_vacancy_seen(
+        vacancy_id="1",
+        search_query="python",
+        title="Backend",
+        company="ООО Ромашка",
+        employer_tier="mid",
+    )
+
+    _record_seen(
+        [
+            VacancyCard(
+                vacancy_id="1",
+                title="Backend",
+                company="ООО Ромашка",
+                url="https://hh.ru/vacancy/1",
+                employer_info=None,  # rating/reviews-блок не найден на этом scrape
+            )
+        ],
+        "python",
+        history,
+    )
+
+    row = history.list_vacancies_seen()[0]
+    assert row["employer_tier"] == "mid"
+
+
 def test_record_seen_failure_does_not_raise(tmp_path):
     """Сбой записи НЕ должен валить поиск — рынок лишь удобство."""
     from hhru_bot.commands.search import _record_seen

--- a/tests/test_search_extra_fields.py
+++ b/tests/test_search_extra_fields.py
@@ -157,7 +157,7 @@ def test_snippets_missing_block_returns_none():
 def test_vacancy_card_new_fields_default_to_empty():
     c = VacancyCard(vacancy_id="1", title="T", company="C", url="https://hh.ru/vacancy/1")
     assert c.address == ""
-    assert c.is_remote is False
+    assert c.is_remote is None
     assert c.experience == ""
     assert c.snippet_requirement == ""
     assert c.snippet_responsibility == ""


### PR DESCRIPTION
## Summary
- preserve previously observed vacancy fields when a scrape supplies NULL/empty selector results
- treat `is_remote` as tri-state so an unavailable remote selector cannot overwrite a known value, while explicit `False` still updates
- keep salary bounds atomic and add regression coverage for selector misses and company classification

## Tests
- `pytest -q`
- focused pytest for history/search field tests
- `ruff check ...`
- `ruff format --check ...`

Closes #532
