### PR TITLE
fix(settings): serialize settings writes with command lease

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -552,6 +552,7 @@ def run_supervised_command(
     requested_limit: int | None,
     body: Callable[[ApplyProgress], bool],
     reconcile: Callable[[ApplyProgress, History, str], None] | None = None,
+    print_summary: bool = True,
 ) -> bool | CommandExitCode:
     """Run ``body`` under a durable command_run ledger row + typed signal supervision.
 
@@ -658,7 +659,8 @@ def run_supervised_command(
                 skipped=progress.skipped_count,
                 detail=detail,
             )
-            print(progress.summary(final_status))
+            if print_summary:
+                print(progress.summary(final_status))
         except Exception:
             logger.exception(
                 "%s: не удалось финализировать durable ledger run_id=%s "

--- a/src/hhru_bot/commands/settings.py
+++ b/src/hhru_bot/commands/settings.py
@@ -24,6 +24,7 @@ def _value_type(value: str) -> str:
 
 def run(args: argparse.Namespace) -> None:
     from ..history import History
+    from ._common import ApplyProgress, run_supervised_command
 
     history = History(args.history)
     if args.key is None:
@@ -41,5 +42,21 @@ def run(args: argparse.Namespace) -> None:
         else:
             print(f'[INFO] настройка "{args.key}" не найдена')
     else:
-        history.set_setting(args.key, args.value)
-        print("[OK]")
+        def _set_setting(progress: ApplyProgress) -> bool:
+            progress.begin_attempt()
+            history.set_setting(args.key, args.value)
+            progress.applied_count += 1
+            print("[OK]")
+            return False
+
+        # Keep settings writes in the same SQLite lease as other durable
+        # commands.  This matters when --config and --history point at
+        # different roots: copy-resume's fcntl lock then cannot protect this
+        # direct history.db mutation by itself.
+        return run_supervised_command(
+            command="settings",
+            history=history,
+            requested_limit=1,
+            body=_set_setting,
+            print_summary=False,
+        )

--- a/src/hhru_bot/commands/settings.py
+++ b/src/hhru_bot/commands/settings.py
@@ -42,6 +42,7 @@ def run(args: argparse.Namespace) -> None:
         else:
             print(f'[INFO] настройка "{args.key}" не найдена')
     else:
+
         def _set_setting(progress: ApplyProgress) -> bool:
             progress.begin_attempt()
             history.set_setting(args.key, args.value)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -63,3 +63,29 @@ def test_run_get_missing_key_reports_info_not_silence(tmp_path, capsys):
     """
     settings.run(_args(tmp_path / "history.db", key="missing"))
     assert capsys.readouterr().out == '[INFO] настройка "missing" не найдена\n'
+
+
+def test_run_set_records_completed_command_run(tmp_path, capsys):
+    path = tmp_path / "history.db"
+
+    settings.run(_args(path, key="answer", value="42"))
+
+    assert capsys.readouterr().out == "[OK]\n"
+    row = History(path).command_runs()[-1]
+    assert row["command"] == "settings"
+    assert row["status"] == "completed"
+    assert row["requested_limit"] == 1
+    assert row["attempted"] == 1
+    assert row["success"] == 1
+
+
+def test_run_set_respects_command_run_lease(tmp_path, capsys):
+    path = tmp_path / "history.db"
+    history = History(path)
+    history.start_command_run(command="copy-resume", requested_limit=None)
+
+    result = settings.run(_args(path, key="answer", value="42"))
+
+    assert result is True
+    assert "supervised-команда уже выполняется" in capsys.readouterr().out
+    assert history.get_setting("answer") is None


### PR DESCRIPTION
Fixes #543

## Summary
- route `settings <key> <value>` through the existing `command_runs` SQLite lease
- preserve the existing `[OK]` output while recording successful settings mutations
- reject settings writes while another durable command owns the history lease

## Tests
- `pytest -q`
- `ruff check .`

## Risks / follow-ups
- settings reads remain unchanged; only writes acquire the durable command lease.