### PR TITLE
fix(copy-resume): reject duplicate resume ids

### DIFF
--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -255,7 +255,13 @@ def write_resume_config(path: str | Path, resume, slug: str, new_resume_id: str)
 
     config_path = Path(path)
     text = config_path.read_text(encoding="utf-8")
-    before = {r.id for r in load_config(config_path).resumes}
+    existing_resumes = load_config(config_path).resumes
+    before = {r.id for r in existing_resumes}
+    if any(resume.resume_id == new_resume_id for resume in existing_resumes):
+        raise ConfigError(
+            f"Новое резюме с resume_id '{new_resume_id}' уже есть в config.yaml. "
+            "Файл не изменён."
+        )
     candidate_text = _config_with_resume(text, resume, slug, new_resume_id)
 
     fd, name = tempfile.mkstemp(

--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -259,8 +259,7 @@ def write_resume_config(path: str | Path, resume, slug: str, new_resume_id: str)
     before = {r.id for r in existing_resumes}
     if any(resume.resume_id == new_resume_id for resume in existing_resumes):
         raise ConfigError(
-            f"Новое резюме с resume_id '{new_resume_id}' уже есть в config.yaml. "
-            "Файл не изменён."
+            f"Новое резюме с resume_id '{new_resume_id}' уже есть в config.yaml. Файл не изменён."
         )
     candidate_text = _config_with_resume(text, resume, slug, new_resume_id)
 

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -283,6 +283,27 @@ def test_write_resume_config_refuses_when_slug_points_at_another_resume(tmp_path
     assert [r.id for r in load_config(config_path).resumes] == ["backend"]
 
 
+def test_write_resume_config_refuses_existing_resume_id(tmp_path):
+    """Новый slug не должен создавать второй алиас на уже настроенное резюме."""
+    from hhru_bot.config import ConfigError, load_config
+
+    config_path = tmp_path / "config.yaml"
+    original = _loadable_config(
+        "resumes:\n"
+        "  - id: backend\n"
+        f'    resume_url: "https://hh.ru/resume/{OLD_ID}"\n'
+        "    search:\n"
+        "      text: python\n"
+    )
+    config_path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="уже есть"):
+        cmd.write_resume_config(config_path, _backend_resume(), "backend-copy", OLD_ID)
+
+    assert config_path.read_text(encoding="utf-8") == original
+    assert [r.id for r in load_config(config_path).resumes] == ["backend"]
+
+
 def test_write_resume_config_refuses_duplicate_resumes_keys(tmp_path):
     """Два ключа resumes — валидный YAML, PyYAML берёт последний. Дописав в
     первый, мы бы отчитались об успехе, а резюме осталось бы незарегистрированным:


### PR DESCRIPTION
Closes #552

## Summary
- reject --write-config when the new resume_id already exists under another config slug
- preserve the existing atomic write behavior and add regression coverage

## Tests
- pytest -q tests/test_copy_resume_command.py -m integration
- git diff --check