### PR TITLE
fix(search): перенос tri-state метро и точного HR-brand селектора (#555)

### DIFF
--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -158,7 +158,7 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
                 hh_rating=card.hh_rating or None,
                 hrbrand_winner=card.hrbrand_winner,
                 metro_stations=json.dumps(card.metro_stations, ensure_ascii=False)
-                if card.metro_stations
+                if card.metro_stations is not None
                 else None,
             )
         except Exception as e:  # noqa: BLE001 — рынок не должен валить поиск

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -719,17 +719,21 @@ def _optional_text(card, selector: str) -> str | None:
 def _parse_metro_stations(card) -> list[str] | None:
     """Parse the observed metro block, preserving its tri-state meaning.
 
-    No matching elements means the block was not observed (usually a transient
-    or incomplete card). Matching elements with no usable text is an observed
-    empty block and must be able to clear a previous snapshot.
+    A station element is the strongest observation.  When no station names
+    render, an observed address block is the independent signal that the card
+    was complete enough to record an empty station snapshot; without either
+    signal, preserve the previous history value.
     """
     locator = card.locator(sel.VACANCY_CARD_METRO_STATION)
+    station_count = locator.count()
     stations: list[str] = []
-    for index in range(locator.count()):
+    for index in range(station_count):
         station = locator.nth(index).inner_text().strip()
         if station and station not in stations:
             stations.append(station)
-    return stations if locator.count() else None
+    if station_count:
+        return stations
+    return [] if card.locator(sel.VACANCY_CARD_ADDRESS).count() else None
 
 
 # --- парсинг инфо о работодателе из карточки (issue #74, Этап 1) -------------

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
@@ -324,7 +324,9 @@ class VacancyCard:
     activity: str = ""
     hh_rating: str = ""
     hrbrand_winner: bool | None = None
-    metro_stations: list[str] = field(default_factory=list)
+    # None = station block was not observed; an empty list means the block was
+    # observed but contained no usable station names.
+    metro_stations: list[str] | None = None
 
     def __post_init__(self) -> None:
         if self.portfolio_evidence_requirement is None and self.vacancy_text:
@@ -551,12 +553,7 @@ def search_vacancies(
             hh_rating = _optional_text(card, sel.VACANCY_CARD_HH_RATING) or ""
             hrbrand = card.locator(sel.VACANCY_CARD_HRBRAND_WINNER).first
             hrbrand_winner = True if hrbrand.count() > 0 else None
-            metro_locator = card.locator(sel.VACANCY_CARD_METRO_STATION)
-            metro_stations = [
-                metro_locator.nth(index).inner_text().strip()
-                for index in range(metro_locator.count())
-                if metro_locator.nth(index).inner_text().strip()
-            ]
+            metro_stations = _parse_metro_stations(card)
 
             if not vacancy_id:
                 logger.warning("Не удалось извлечь vacancy_id из href='%s', пропуск", href)
@@ -717,6 +714,22 @@ def _optional_text(card, selector: str) -> str | None:
         return None
     text = locator.inner_text().strip()
     return text or None
+
+
+def _parse_metro_stations(card) -> list[str] | None:
+    """Parse the observed metro block, preserving its tri-state meaning.
+
+    No matching elements means the block was not observed (usually a transient
+    or incomplete card). Matching elements with no usable text is an observed
+    empty block and must be able to clear a previous snapshot.
+    """
+    locator = card.locator(sel.VACANCY_CARD_METRO_STATION)
+    stations: list[str] = []
+    for index in range(locator.count()):
+        station = locator.nth(index).inner_text().strip()
+        if station and station not in stations:
+            stations.append(station)
+    return stations if locator.count() else None
 
 
 # --- парсинг инфо о работодателе из карточки (issue #74, Этап 1) -------------

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -719,10 +719,11 @@ def _optional_text(card, selector: str) -> str | None:
 def _parse_metro_stations(card) -> list[str] | None:
     """Parse the observed metro block, preserving its tri-state meaning.
 
-    A station element is the strongest observation.  When no station names
-    render, an observed address block is the independent signal that the card
-    was complete enough to record an empty station snapshot; without either
-    signal, preserve the previous history value.
+    Only station-specific elements are evidence about the metro block.  A
+    generic address match is deliberately not treated as evidence: if the
+    station selector drifts, clearing a previously known station list would
+    lose data.  A matching station element with no usable text is an observed
+    empty block; without one, preserve the previous history value.
     """
     locator = card.locator(sel.VACANCY_CARD_METRO_STATION)
     station_count = locator.count()
@@ -731,9 +732,7 @@ def _parse_metro_stations(card) -> list[str] | None:
         station = locator.nth(index).inner_text().strip()
         if station and station not in stations:
             stations.append(station)
-    if station_count:
-        return stations
-    return [] if card.locator(sel.VACANCY_CARD_ADDRESS).count() else None
+    return stations if station_count else None
 
 
 # --- парсинг инфо о работодателе из карточки (issue #74, Этап 1) -------------

--- a/src/hhru_bot/selector_groups/search_page.py
+++ b/src/hhru_bot/selector_groups/search_page.py
@@ -73,5 +73,9 @@ VACANCY_CARD_NO_RESUME = "[data-qa='vacancy-label-no-resume']"
 # как наблюдены, без попытки угадать их семантику или формат.
 VACANCY_CARD_ACTIVITY = "[data-qa='vacancy-serp-item-activity']"
 VACANCY_CARD_HH_RATING = "[data-qa='vacancy-serp__vacancy_employer-hh-rating']"
-VACANCY_CARD_HRBRAND_WINNER = ".vacancy-serp__vacancy_hrbrand.vacancy-serp__vacancy_hrbrand_winners"
+# Exact data-qa value from the issue/live-card schema; class names are not a
+# stable contract for this marker.
+VACANCY_CARD_HRBRAND_WINNER = (
+    "[data-qa='vacancy-serp__vacancy_hrbrand vacancy-serp__vacancy_hrbrand_winners']"
+)
 VACANCY_CARD_METRO_STATION = "[data-qa='address-metro-station-name']"

--- a/tests/test_history_market.py
+++ b/tests/test_history_market.py
@@ -123,6 +123,18 @@ def test_upsert_extra_card_fields_default_to_null(tmp_path):
     assert row["metro_stations"] is None
 
 
+def test_empty_metro_snapshot_is_persisted_and_missing_snapshot_is_preserved(tmp_path):
+    h = History(tmp_path / "h.db")
+    h.upsert_vacancy_seen(
+        vacancy_id="123", search_query="python", metro_stations='["Динамо"]'
+    )
+    h.upsert_vacancy_seen(vacancy_id="123", search_query="python", metro_stations="[]")
+    assert h.list_vacancies_seen()[0]["metro_stations"] == "[]"
+
+    h.upsert_vacancy_seen(vacancy_id="123", search_query="python", metro_stations=None)
+    assert h.list_vacancies_seen()[0]["metro_stations"] == "[]"
+
+
 def test_upsert_refreshes_extra_card_fields_with_new_nonempty_value(tmp_path):
     """При повторном scrape новое НЕпустое значение address перезаписывает
     старое (карточка могла реально поменять город/формат работы)."""

--- a/tests/test_history_market.py
+++ b/tests/test_history_market.py
@@ -125,9 +125,7 @@ def test_upsert_extra_card_fields_default_to_null(tmp_path):
 
 def test_empty_metro_snapshot_is_persisted_and_missing_snapshot_is_preserved(tmp_path):
     h = History(tmp_path / "h.db")
-    h.upsert_vacancy_seen(
-        vacancy_id="123", search_query="python", metro_stations='["Динамо"]'
-    )
+    h.upsert_vacancy_seen(vacancy_id="123", search_query="python", metro_stations='["Динамо"]')
     h.upsert_vacancy_seen(vacancy_id="123", search_query="python", metro_stations="[]")
     assert h.list_vacancies_seen()[0]["metro_stations"] == "[]"
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -91,6 +91,8 @@ class _VacancyCard:
             return _TextLocator(count=1 if self._remote else 0)
         if selector == search.sel.VACANCY_CARD_EXPERIENCE:
             return _TextLocator(count=0)
+        if selector == search.sel.VACANCY_CARD_ADDRESS:
+            return _TextLocator(count=0)
         if selector == search.sel.VACANCY_CARD_SIDE_JOB:
             return _TextLocator(count=1 if self._side_job else 0)
         if selector == search.sel.VACANCY_CARD_NO_RESUME:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -91,8 +91,6 @@ class _VacancyCard:
             return _TextLocator(count=1 if self._remote else 0)
         if selector == search.sel.VACANCY_CARD_EXPERIENCE:
             return _TextLocator(count=0)
-        if selector == search.sel.VACANCY_CARD_ADDRESS:
-            return _TextLocator(count=0)
         if selector == search.sel.VACANCY_CARD_SIDE_JOB:
             return _TextLocator(count=1 if self._side_job else 0)
         if selector == search.sel.VACANCY_CARD_NO_RESUME:

--- a/tests/test_search_command_output.py
+++ b/tests/test_search_command_output.py
@@ -96,6 +96,7 @@ def test_record_seen_writes_all_cards(tmp_path):
             company="Acme",
             url="https://hh.ru/vacancy/2",
             salary=None,
+            metro_stations=[],
         ),
     ]
     _record_seen(cards, "python backend", history)
@@ -114,6 +115,7 @@ def test_record_seen_writes_all_cards(tmp_path):
     assert by_id["1"]["metro_stations"] == '["Таганская", "Марксистская"]'
     # вакансия без зарплаты тоже записана
     assert by_id["2"]["salary_from"] is None
+    assert by_id["2"]["metro_stations"] == "[]"
 
 
 def test_record_seen_preserves_history_when_company_selector_misses(tmp_path):

--- a/tests/test_search_extra_fields.py
+++ b/tests/test_search_extra_fields.py
@@ -188,6 +188,18 @@ def test_parse_metro_stations_distinguishes_missing_and_empty_blocks():
     assert _parse_metro_stations(_EmptyCard()) == []
 
 
+def test_parse_metro_stations_uses_observed_address_for_empty_snapshot():
+    class _AddressOnlyCard:
+        def locator(self, selector):
+            if selector == search.sel.VACANCY_CARD_ADDRESS:
+                return _TextLocator("Москва", count=1)
+            if selector == search.sel.VACANCY_CARD_METRO_STATION:
+                return _TextLocator("", count=0)
+            return _TextLocator("", count=0)
+
+    assert _parse_metro_stations(_AddressOnlyCard()) == []
+
+
 # --- side_job / no_resume ----------------------------------------------------
 
 

--- a/tests/test_search_extra_fields.py
+++ b/tests/test_search_extra_fields.py
@@ -188,18 +188,6 @@ def test_parse_metro_stations_distinguishes_missing_and_empty_blocks():
     assert _parse_metro_stations(_EmptyCard()) == []
 
 
-def test_parse_metro_stations_uses_observed_address_for_empty_snapshot():
-    class _AddressOnlyCard:
-        def locator(self, selector):
-            if selector == search.sel.VACANCY_CARD_ADDRESS:
-                return _TextLocator("Москва", count=1)
-            if selector == search.sel.VACANCY_CARD_METRO_STATION:
-                return _TextLocator("", count=0)
-            return _TextLocator("", count=0)
-
-    assert _parse_metro_stations(_AddressOnlyCard()) == []
-
-
 # --- side_job / no_resume ----------------------------------------------------
 
 

--- a/tests/test_search_extra_fields.py
+++ b/tests/test_search_extra_fields.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 import hhru_bot.search as search
-from hhru_bot.search import VacancyCard, _optional_text, _parse_experience
+from hhru_bot.search import VacancyCard, _optional_text, _parse_experience, _parse_metro_stations
 
 pytestmark = pytest.mark.unit
 
@@ -151,6 +151,42 @@ def test_snippets_missing_block_returns_none():
     assert _optional_text(card, search.sel.VACANCY_CARD_SNIPPET_RESPONSIBILITY) is None
 
 
+def test_parse_metro_stations_deduplicates_and_filters_empty_names():
+    class _StationsLocator:
+        def __init__(self, values):
+            self.values = values
+
+        def count(self):
+            return len(self.values)
+
+        def nth(self, index):
+            return _TextLocator(self.values[index])
+
+    class _Card:
+        def locator(self, selector):
+            if selector == search.sel.VACANCY_CARD_METRO_STATION:
+                return _StationsLocator(["Белорусская", "", "Белорусская", "Динамо"])
+            return _TextLocator("", count=0)
+
+    assert _parse_metro_stations(_Card()) == ["Белорусская", "Динамо"]
+
+
+def test_parse_metro_stations_distinguishes_missing_and_empty_blocks():
+    class _EmptyCard:
+        def locator(self, selector):
+            if selector == search.sel.VACANCY_CARD_METRO_STATION:
+                class _EmptyLocator(_TextLocator):
+                    def nth(self, index):
+                        assert index == 0
+                        return self
+
+                return _EmptyLocator("", count=1)
+            return _TextLocator("", count=0)
+
+    assert _parse_metro_stations(_FixtureCard({})) is None
+    assert _parse_metro_stations(_EmptyCard()) == []
+
+
 # --- side_job / no_resume ----------------------------------------------------
 
 
@@ -183,6 +219,7 @@ def test_vacancy_card_new_fields_default_to_empty():
     assert c.snippet_responsibility == ""
     assert c.side_job is None
     assert c.no_resume is None
+    assert c.metro_stations is None
 
 
 def test_vacancy_card_accepts_new_fields():

--- a/tests/test_search_extra_fields.py
+++ b/tests/test_search_extra_fields.py
@@ -175,6 +175,7 @@ def test_parse_metro_stations_distinguishes_missing_and_empty_blocks():
     class _EmptyCard:
         def locator(self, selector):
             if selector == search.sel.VACANCY_CARD_METRO_STATION:
+
                 class _EmptyLocator(_TextLocator):
                     def nth(self, index):
                         assert index == 0


### PR DESCRIPTION
## Summary
- preserve metro selector absence vs observed empty snapshot and persist `[]` correctly
- filter empty station names and deduplicate stations
- use the exact HR-brand `data-qa` selector
- retain activity/HH-rating text parsing because #554 provides no DOM artifact to validate the claimed presence-only schema

Closes #555

## Tests
- `pytest -q tests/test_search_extra_fields.py tests/test_history_market.py tests/test_search.py tests/test_search_command_output.py`
- `git diff --check