### PR TITLE
fix(about): support draft resume editor route

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -141,7 +141,7 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
             click_trigger=True,
             trigger_error="кнопка редактирования «Обо мне» не найдена однозначно",
             open_error="форма «Обо мне» не открылась",
-            wrong_route_error="форма «Обо мне» открыта не для того резюме",
+            wrong_route_error="маршрут формы «Обо мне» не подтверждён",
         )
     except RuntimeError as exc:
         raise AboutGenerationError(str(exc)) from exc

--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -8,6 +8,7 @@ HTTP endpoint.  hh.ru opens this editor inline on ``/resume/{id}``; the old
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -128,6 +129,9 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
             trigger_selector=resume_page.RESUME_EDIT_ABOUT_BUTTON,
             editor_selector=resume_page.RESUME_ABOUT_EDITOR,
             profile_path=f"/resume/{resume.resume_id}",
+            edit_path=re.compile(
+                rf"/resume(?:/{re.escape(resume.resume_id)}|/edit/{re.escape(resume.resume_id)}/about)"
+            ),
             # Pre-#339 behavior clicked unconditionally: the editor marker can
             # be present in the DOM before React hydrates it, so count() == 1
             # does not mean it is visible/functional yet. Without this, a

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -141,3 +141,27 @@ def test_open_about_editor_waits_for_hidden_but_present_field(monkeypatch):
     assert trigger.click.call_count == 1
     assert field.wait_for.call_count == 1
     assert result == "Реальный текст, который уже был в поле."
+
+
+def test_open_about_editor_accepts_draft_edit_route(monkeypatch):
+    """Draft resumes navigate to the dedicated about editor route (#527)."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    field.count.return_value = 0
+    field.input_value.return_value = ""
+    field.wait_for.return_value = None
+
+    def click_side_effect():
+        page.url = "https://hh.ru/resume/edit/resume-id/about"
+
+    trigger.click.side_effect = click_side_effect
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    assert open_about_editor(page, bare_resume("resume-id")) == ""

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -165,3 +165,29 @@ def test_open_about_editor_accepts_draft_edit_route(monkeypatch):
     monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
 
     assert open_about_editor(page, bare_resume("resume-id")) == ""
+
+
+def test_open_about_editor_still_fails_closed_on_unexpected_route(monkeypatch):
+    """The route guard must not be weakened: an unexpected editor route still
+    fails closed instead of silently editing the wrong resume (#527)."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    field.count.return_value = 0
+    field.input_value.return_value = ""
+    field.wait_for.return_value = None
+
+    def click_side_effect():
+        page.url = "https://hh.ru/resume/edit/resume-id/experience"
+
+    trigger.click.side_effect = click_side_effect
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AboutGenerationError):
+        open_about_editor(page, bare_resume("resume-id"))


### PR DESCRIPTION
Fixes #527

## Summary
- accept both inline published-resume and dedicated draft `/resume/edit/{id}/about` routes
- add regression coverage for draft navigation

## Tests
- `pytest -q tests/test_about.py`
- `ruff check src/hhru_bot/about.py tests/test_about.py`