### PR TITLE
fix(resume-position): click visible currency control

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -25,6 +25,7 @@ EDIT = "[data-qa='edit-position-button']"
 TITLE = "[data-qa='resume-edit-title-suggest']"
 SALARY = "[data-qa='resume-salary-amount']"
 CURRENCY = {code: f"[data-qa='resume-currency-input-{code}']" for code in ("RUR", "EUR", "USD")}
+CURRENCY_LABELS = {"RUR": "Рубли", "EUR": "Евро", "USD": "Доллары"}
 EMPLOYMENT = "[data-qa='resume-edit-employment-forms']"
 WORK_FORMAT = "[data-qa='resume-edit-work-formats']"
 TRAVEL = "[data-qa='resume-edit-travel-time']"
@@ -289,10 +290,19 @@ def apply_position(page: Page, plan: PositionValues) -> None:
     if plan.salary is not None:
         page.locator(SALARY).fill(str(plan.salary))
     if plan.currency is not None:
-        currency = page.locator(CURRENCY[plan.currency])
-        if currency.count() != 1:
+        # The data-qa input is a hidden radio behind the visible Magritte
+        # button. Clicking it directly is intercepted by the button content.
+        # Use the confirmed accessible button instead of force-clicking the
+        # hidden input (which would bypass Playwright's hit-target checks).
+        currency_input = page.locator(CURRENCY[plan.currency])
+        if currency_input.count() != 1:
             raise RuntimeError(f"селектор валюты не подтверждён: {plan.currency}")
-        currency.click()
+        currency_button = page.get_by_role(
+            "button", name=CURRENCY_LABELS[plan.currency], exact=True
+        )
+        if currency_button.count() != 1:
+            raise RuntimeError(f"кнопка валюты не подтверждена: {plan.currency}")
+        currency_button.click()
     if plan.employment:
         for value in plan.employment:
             _set_control(page, EMPLOYMENT, value, EMPLOYMENT_LABELS)

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -90,6 +90,22 @@ def test_apply_position_none_title_leaves_unchanged():
     title.fill.assert_not_called()
 
 
+def test_apply_position_clicks_visible_currency_button_not_hidden_input():
+    page = MagicMock()
+    currency_input = MagicMock()
+    currency_input.count.return_value = 1
+    currency_button = MagicMock()
+    currency_button.count.return_value = 1
+    page.locator.return_value = currency_input
+    page.get_by_role.return_value = currency_button
+
+    resume_position.apply_position(page, PositionValues(currency="RUR"))
+
+    currency_input.click.assert_not_called()
+    page.get_by_role.assert_called_once_with("button", name="Рубли", exact=True)
+    currency_button.click.assert_called_once_with()
+
+
 def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     """#337: an SSR anchor has no handler until hydration, and URL stays put."""
     resume = bare_resume("resume-id")


### PR DESCRIPTION
Fixes #525

## Summary
- click the visible accessible currency button instead of the hidden radio input intercepted by Magritte content
- retain fail-closed checks for both the confirmed input selector and visible button
- add regression coverage proving the hidden input is not clicked

## Verification
- pytest -q tests/test_resume_position.py
- ruff check src/hhru_bot/resume_position.py tests/test_resume_position.py
- ruff format --check src/hhru_bot/resume_position.py tests/test_resume_position.py

## Risk
- relies on the live DOM accessible button names: Рубли, Евро, Доллары.