### PR TITLE
fix: delete resumes through actions menu

### DIFF
--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -11,10 +11,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from playwright.sync_api import Error as PlaywrightError
-from playwright.sync_api import Page
+from playwright.sync_api import Locator, Page
 
 from .browser import RESUMES_FULL_LIST_URL, goto_hh
 from .selector_groups.resume_list import (
+    RESUME_DELETE_MENU_ACTION,
+    RESUME_LIST_ACTION_MORE,
     RESUME_LIST_CARD,
     RESUME_LIST_CARD_LINK_TPL,
 )
@@ -50,6 +52,38 @@ def _wait_resume_list_ready(page: Page) -> None:
     )
 
 
+def _resolve_delete_action(page: Page, card) -> tuple[Locator | None, str]:
+    """Resolve one delete control without losing the card identity boundary.
+
+    Draft cards render ``resume-delete`` inside the card.  A different list
+    renderer may put the delete item in a portal after opening the card's
+    actions menu, so that item must be searched globally only after the menu
+    was opened from this exact card.  Missing or duplicate controls remain a
+    normal fail-closed result.
+    """
+    direct = card.locator(RESUME_DELETE_BUTTON)
+    direct_count = direct.count()
+    if direct_count > 1:
+        return None, "кнопка удаления не подтверждена однозначно"
+    if direct_count == 1:
+        return direct.first, ""
+
+    more = card.locator(RESUME_LIST_ACTION_MORE)
+    if more.count() != 1:
+        return None, "меню действий карточки не подтверждено однозначно"
+
+    menu_action = page.locator(RESUME_DELETE_MENU_ACTION)
+    try:
+        more.first.click()
+        menu_action.first.wait_for(state="visible", timeout=15000)
+    except PlaywrightError as exc:
+        return None, f"не удалось открыть действие удаления в меню: {exc}"
+    menu_count = menu_action.count()
+    if menu_count != 1:
+        return None, "действие удаления в меню не подтверждено однозначно"
+    return menu_action.first, ""
+
+
 def delete_resume_on_hh(
     page: Page,
     resume,
@@ -82,11 +116,9 @@ def delete_resume_on_hh(
         return DeleteResumeResult(
             resume_id, False, f"карточка resume_id={resume_id} не подтверждена однозначно", False
         )
-    button = card.locator(RESUME_DELETE_BUTTON)
-    if button.count() != 1:
-        return DeleteResumeResult(
-            resume_id, False, "кнопка удаления не подтверждена однозначно", False
-        )
+    button, action_error = _resolve_delete_action(page, card)
+    if action_error:
+        return DeleteResumeResult(resume_id, False, action_error, False)
     if dry_run:
         return DeleteResumeResult(resume_id, True, "dry-run; кнопка удаления не нажата")
 
@@ -95,7 +127,7 @@ def delete_resume_on_hh(
             # The action can be present in SSR while its React handler is not
             # attached yet.  A bounded pre-click wait plus one safe reload
             # avoids treating that hydration race as a permanent failure.
-            button.first.wait_for(state="visible", timeout=15000)
+            button.wait_for(state="visible", timeout=15000)
             button.first.click()
             # The confirm dialog renders asynchronously after the click (React);
             # an immediate count() can observe the DOM before it mounts (same
@@ -129,14 +161,9 @@ def delete_resume_on_hh(
                     f"карточка resume_id={resume_id} не подтверждена после recovery reload",
                     False,
                 )
-            button = card.locator(RESUME_DELETE_BUTTON)
-            if button.count() != 1:
-                return DeleteResumeResult(
-                    resume_id,
-                    False,
-                    "кнопка удаления не подтверждена после recovery reload",
-                    False,
-                )
+            button, action_error = _resolve_delete_action(page, card)
+            if action_error:
+                return DeleteResumeResult(resume_id, False, action_error, False)
 
     confirm = page.locator(RESUME_DELETE_CONFIRM)
     if page.locator(RESUME_DELETE_HIDE_CONFIRM).count() > 1 or confirm.count() != 1:

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -76,8 +76,23 @@ def _resolve_delete_action(page: Page, card) -> tuple[Locator | None, str]:
     try:
         more.first.click()
         menu_action.first.wait_for(state="visible", timeout=15000)
-    except PlaywrightError as exc:
-        return None, f"не удалось открыть действие удаления в меню: {exc}"
+    except PlaywrightError:
+        # The SSR actions button can accept a Playwright click before its React
+        # handler is hydrated. Reload once and resolve the same card again so
+        # the second click is a real menu-open attempt, not a stale locator.
+        try:
+            page.reload(wait_until="domcontentloaded")
+            card.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
+            if card.count() != 1:
+                return None, "карточка для recovery меню не подтверждена однозначно"
+            more = card.locator(RESUME_LIST_ACTION_MORE)
+            if more.count() != 1:
+                return None, "меню действий карточки не подтверждено после recovery"
+            more.first.click()
+            menu_action = page.locator(RESUME_DELETE_MENU_ACTION)
+            menu_action.first.wait_for(state="visible", timeout=15000)
+        except PlaywrightError as recovery_exc:
+            return None, f"не удалось открыть действие удаления в меню: {recovery_exc}"
     menu_count = menu_action.count()
     if menu_count != 1:
         return None, "действие удаления в меню не подтверждено однозначно"

--- a/src/hhru_bot/selector_groups/resume_list.py
+++ b/src/hhru_bot/selector_groups/resume_list.py
@@ -41,7 +41,7 @@ RESUME_DELETE_MENU_ACTION = (
     "[data-qa='operations-list-delete-resume'], "
     "[data-qa='resume-delete-action'], "
     "[data-qa='resume-delete-menu-item'], "
-    "button:has-text('Удалить резюме')"
+    "[role='dialog'] button:has-text('Удалить резюме')"
 )
 
 # Дополнительный (не обязательный) маркер завершённого client render. Карточка

--- a/src/hhru_bot/selector_groups/resume_list.py
+++ b/src/hhru_bot/selector_groups/resume_list.py
@@ -34,6 +34,16 @@ RESUME_LIST_CARD_LINK_TPL = "[data-qa='resume-card-link-{resume_id}']"
 # Кнопка «...» (меню действий) на карточке резюме.
 RESUME_LIST_ACTION_MORE = "[data-qa='resume-list-action-more']"
 
+# Delete is normally an inline action on an unpublished resume card.  Some
+# list renderers expose the same action through the portal-backed actions menu,
+# so keep the menu candidates separate from the identity-bound card selector.
+RESUME_DELETE_MENU_ACTION = (
+    "[data-qa='operations-list-delete-resume'], "
+    "[data-qa='resume-delete-action'], "
+    "[data-qa='resume-delete-menu-item'], "
+    "button:has-text('Удалить резюме')"
+)
+
 # Дополнительный (не обязательный) маркер завершённого client render. Карточка
 # приходит из SSR раньше, но actions ещё не подключены: на наблюдавшемся живом
 # hh.ru кнопка «...» начинала работать после появления этого текста. Истиной

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -10,7 +10,11 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page as PlaywrightPage
 
 import hhru_bot.delete_resume as delete
-from hhru_bot.selector_groups.resume_list import RESUME_LIST_CARD
+from hhru_bot.selector_groups.resume_list import (
+    RESUME_DELETE_MENU_ACTION,
+    RESUME_LIST_ACTION_MORE,
+    RESUME_LIST_CARD,
+)
 from hhru_bot.selector_groups.resume_page import RESUME_DELETE_BUTTON, RESUME_DELETE_CONFIRM
 
 pytestmark = pytest.mark.integration
@@ -34,15 +38,20 @@ class Locator:
         return self._count
 
     def locator(self, selector):
-        assert selector == RESUME_DELETE_BUTTON
-        return Locator(self.page, selector)
+        if selector == RESUME_DELETE_BUTTON:
+            return Locator(self.page, selector, self.page.direct_count)
+        if selector == RESUME_LIST_ACTION_MORE:
+            return Locator(self.page, selector, self.page.more_count)
+        raise AssertionError(selector)
 
     @property
     def first(self):
         return self
 
     def click(self):
-        if self.selector == RESUME_DELETE_BUTTON:
+        if self.selector == RESUME_LIST_ACTION_MORE:
+            self.page.menu_opened = True
+        elif self.selector in (RESUME_DELETE_BUTTON, RESUME_DELETE_MENU_ACTION):
             self.page.dialog_opened = True
         else:
             assert self.selector == RESUME_DELETE_CONFIRM
@@ -50,6 +59,8 @@ class Locator:
 
     def wait_for(self, *, state, timeout):
         if state == "visible":
+            if self.selector == RESUME_DELETE_MENU_ACTION and not self.page.menu_opened:
+                raise PlaywrightError("menu action not mounted")
             if (
                 self.selector == RESUME_DELETE_CONFIRM
                 and self.page.confirm_error
@@ -79,6 +90,9 @@ class Page:
         remaining=0,
         ready_count=1,
         confirm_error=None,
+        direct_count=1,
+        more_count=1,
+        menu_count=0,
     ):
         self.url = delete.RESUMES_FULL_LIST_URL
         self.dialog_opened = False
@@ -95,6 +109,10 @@ class Page:
         self._confirm_failed = False
         self.recovery_hydration = False
         self._recovery_hydrated = False
+        self.direct_count = direct_count
+        self.more_count = more_count
+        self.menu_count = menu_count
+        self.menu_opened = False
 
     def reload(self, *, wait_until):
         self.reloaded = wait_until
@@ -105,6 +123,8 @@ class Page:
     def locator(self, selector):
         if selector == RESUME_DELETE_CONFIRM:
             return Locator(self, selector)
+        if selector == RESUME_DELETE_MENU_ACTION:
+            return Locator(self, selector, self.menu_count)
         if self.clicked:
             if selector == RESUME_LIST_CARD:
                 return Locator(
@@ -163,3 +183,49 @@ def test_recovery_reload_waits_for_card_hydration(monkeypatch):
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is True
     assert page.reloaded == "domcontentloaded"
+
+
+def test_dry_run_resolves_direct_delete_action_without_menu(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page()
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is True
+    assert page.menu_opened is False
+    assert page.clicked is False
+
+
+def test_dry_run_resolves_menu_delete_action(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(direct_count=0, menu_count=1)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is True
+    assert page.menu_opened is True
+    assert page.clicked is False
+
+
+def test_menu_delete_action_preserves_post_click_verification(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(direct_count=0, menu_count=1)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+    assert result.success is True
+    assert result.uncertain is False
+    assert page.menu_opened is True
+    assert page.clicked is True
+
+
+def test_missing_menu_delete_action_fails_closed(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(direct_count=0, menu_count=0)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is False
+    assert result.uncertain is False
+    assert "действие удаления" in result.reason
+
+
+def test_ambiguous_menu_delete_action_fails_closed(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(direct_count=0, menu_count=2)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is False
+    assert result.uncertain is False
+    assert "однозначно" in result.reason

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -50,6 +50,9 @@ class Locator:
 
     def click(self):
         if self.selector == RESUME_LIST_ACTION_MORE:
+            if self.page.menu_click_error and not self.page._menu_click_failed:
+                self.page._menu_click_failed = True
+                raise self.page.menu_click_error
             self.page.menu_opened = True
         elif self.selector in (RESUME_DELETE_BUTTON, RESUME_DELETE_MENU_ACTION):
             self.page.dialog_opened = True
@@ -93,6 +96,7 @@ class Page:
         direct_count=1,
         more_count=1,
         menu_count=0,
+        menu_click_error=None,
     ):
         self.url = delete.RESUMES_FULL_LIST_URL
         self.dialog_opened = False
@@ -113,6 +117,8 @@ class Page:
         self.more_count = more_count
         self.menu_count = menu_count
         self.menu_opened = False
+        self.menu_click_error = menu_click_error
+        self._menu_click_failed = False
 
     def reload(self, *, wait_until):
         self.reloaded = wait_until
@@ -211,6 +217,20 @@ def test_menu_delete_action_preserves_post_click_verification(monkeypatch):
     assert result.uncertain is False
     assert page.menu_opened is True
     assert page.clicked is True
+
+
+def test_menu_action_retries_after_hydration_recovery(monkeypatch):
+    _patch_goto(monkeypatch)
+    page = Page(
+        direct_count=0,
+        menu_count=1,
+        menu_click_error=PlaywrightError("menu handler not hydrated yet"),
+    )
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is True
+    assert page.menu_opened is True
+    assert page.reloaded == "domcontentloaded"
+    assert page.clicked is False
 
 
 def test_missing_menu_delete_action_fails_closed(monkeypatch):

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -229,3 +229,8 @@ def test_ambiguous_menu_delete_action_fails_closed(monkeypatch):
     assert result.success is False
     assert result.uncertain is False
     assert "однозначно" in result.reason
+
+
+def test_menu_text_fallback_is_scoped_to_portal_dialog():
+    assert "[role='dialog'] button:has-text('Удалить резюме')" in RESUME_DELETE_MENU_ACTION
+    assert ", button:has-text('Удалить резюме')" not in RESUME_DELETE_MENU_ACTION


### PR DESCRIPTION
## Summary\n- preserve direct delete for draft resume cards\n- add identity-bound actions-menu fallback for portal-rendered delete actions\n- fail closed when menu or delete action is missing/ambiguous\n- cover direct/menu DOM variants, hydration recovery, post-delete verification, and uncertain post-click errors\n\n## Tests\n- python3 -m pytest tests/test_delete_resume_browser.py tests/test_delete_resume_command.py tests/test_cli_commands.py tests/test_write_lock.py tests/test_sandbox_preflight.py -q\n- python3 -m ruff check src/hhru_bot/delete_resume.py src/hhru_bot/selector_groups/resume_list.py tests/test_delete_resume_browser.py\n- git diff --check\n\nCloses #573