### PR TITLE
Handle automatic resume dropdown closure before submitting

### DIFF
--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -504,26 +504,27 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
         )
         return False
 
-    # Панель выбора резюме НЕ закрывается сама после клика по опции — источник
-    # подтверждения боевой лог 2026-08-20 (`data/logs/hhru_bot.log`): Playwright
-    # в сообщении об интерсепте печатает ровно один `data-qa="drop-base"`
-    # (в probe-HTML-дампах этого атрибута нет вовсе — см. apply_form.py).
-    # Пока панель открыта, её абсолютно
-    # спозиционированный контейнер перекрывает submit в футере модалки: боевой
-    # прогон получал `subtree intercepts pointer events`, 30с ретраев и
-    # SubmitClickUncertain — ложную «неопределённость» при НЕотправленном
-    # отклике (жгла дневной лимит и навсегда блокировала вакансию).
-    #
-    # Поэтому закрываем панель явно кликом по контейнеру toggle. В live DOM
-    # повторный клик по внутреннему resume-title не закрывает drop-base:
-    # обработчик toggle привязан к div[role="button"]-предку. Escape не
-    # используем: в модалке он может закрыть всю форму отклика, а не только
-    # панель.
-    #
-    # Ждём скрытия САМОЙ ПАНЕЛИ, а не опции: опции внутри панели — постоянно
-    # видимые карточки (выбранная несёт aria-selected="true"), они остаются
-    # visible, пока панель открыта, поэтому ожидание скрытия опции никогда бы
-    # не выполнилось.
+    # Live DOM 2026-08-25: штатный option-click сам закрывает drop-base. Поэтому
+    # безусловный клик по toggle после выбора снова ОТКРЫВАЕТ список и блокирует
+    # submit. Сначала принимаем штатное автозакрытие; toggle нужен только как
+    # fallback для наблюдавшегося ранее варианта, где React оставлял панель
+    # открытой. Escape не используем: в модалке он может закрыть всю форму.
+    dropdown = page.locator(apply_form.APPLY_RESUME_DROPDOWN)
+    try:
+        dropdown.wait_for(state="hidden", timeout=RESUME_DROPDOWN_CLOSE_TIMEOUT_MS)
+        return True
+    except PlaywrightTimeoutError:
+        # Панель не закрылась штатно — пробуем подтверждённый live DOM toggle.
+        pass
+    except PlaywrightError as exc:
+        logger.warning(
+            "Не удалось проверить закрытие списка выбора резюме после выбора '%s' (%s) — "
+            "отправка отменена",
+            resume_id,
+            exc,
+        )
+        return False
+
     try:
         page.locator(apply_form.APPLY_RESUME_TOGGLE).click()
     except PlaywrightError as exc:
@@ -534,9 +535,7 @@ def _select_resume_in_form(page: Page, resume_id: str) -> bool:
         )
         return False
     try:
-        page.locator(apply_form.APPLY_RESUME_DROPDOWN).wait_for(
-            state="hidden", timeout=RESUME_DROPDOWN_CLOSE_TIMEOUT_MS
-        )
+        dropdown.wait_for(state="hidden", timeout=RESUME_DROPDOWN_CLOSE_TIMEOUT_MS)
     except PlaywrightError as exc:
         # fail-closed: submit при открытой панели гарантированно упрётся в
         # оверлей. Честный отказ ДО клика лучше ложного uncertain после него.

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -136,6 +136,8 @@ class _FakeLocator:
                     f"elements (resume_id={self._option_resume_id!r})"
                 )
             self._state.selected_resume_id = matches[0]
+            if self._state.dropdown_auto_closes:
+                self._state.dropdown_opened = False
         else:
             if self._resume_toggle:
                 # Live DOM: resume-title is nested inside div[role="button"];
@@ -229,6 +231,9 @@ class _SelectorState:
         # живой DOM: какой resume_id реально был кликнут (заменяет current_href).
         self.selected_resume_id: str | None = None
         self.dropdown_opened = False
+        # Current live behavior: selecting an option closes drop-base. Set False
+        # to model the older/stuck shape that needs the toggle fallback.
+        self.dropdown_auto_closes = True
         self.resume_title_clicks = 0
         self.resume_toggle_clicks = 0
         # Боевой случай 2026-08-20: после клика по опции React не закрыл dropdown,
@@ -785,6 +790,7 @@ def test_fill_form_open_dropdown_blocks_submit_and_refuses():
     page = FakeStepsPage()
     st = page.set_visible(apply_form.APPLY_RESUME_SELECT, True)
     st.option_resume_ids = ["RID"]
+    st.dropdown_auto_closes = False
     st.dropdown_stays_open = True
     page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
@@ -811,14 +817,28 @@ def test_fill_form_closed_dropdown_proceeds_to_submit():
 
 
 def test_fill_form_closes_resume_panel_before_submit():
-    """Панель выбора резюме hh.ru НЕ закрывается сама после клика по опции —
-    проверено живыми probe-дампами 2026-08-20 (drop-base: 0 элементов до клика
-    по триггеру, 1 после клика по опции). Пока она открыта, её абсолютно
-    спозиционированный оверлей перекрывает submit в футере модалки.
+    """Если option-click не закрыл панель, закрываем её toggle-контейнером."""
+    page = FakeStepsPage()
+    st = page.set_visible(apply_form.APPLY_RESUME_SELECT, True)
+    st.option_resume_ids = ["RID"]
+    st.dropdown_auto_closes = False
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 
-    Поэтому шаг обязан закрыть панель явно кликом по контейнеру
-    `div[role="button"]`; Escape не используем — в модалке он может закрыть
-    всю форму."""
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    # 3 клика: открыть, выбрать опцию, закрыть fallback-toggle.
+    assert st.clicks == 3
+    assert st.resume_title_clicks == 1
+    assert st.resume_toggle_clicks == 1
+    assert st.dropdown_opened is False
+    assert st.selected_resume_id == "RID"
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_does_not_reopen_dropdown_after_option_auto_closes():
+    """Live 2026-08-25: option-click уже закрыл drop-base; toggle открыл бы его снова."""
     page = FakeStepsPage()
     st = page.set_visible(apply_form.APPLY_RESUME_SELECT, True)
     st.option_resume_ids = ["RID"]
@@ -828,14 +848,9 @@ def test_fill_form_closes_resume_panel_before_submit():
     result = steps.fill_response_form(page, "RID", "письмо")
 
     assert result is None
-    # 3 клика: открыть внутренним resume-title, выбрать опцию, закрыть
-    # контейнером role=button. Повторный клик по внутреннему div сам по себе
-    # не закрыл бы live drop-base.
-    assert st.clicks == 3
-    assert st.resume_title_clicks == 1
-    assert st.resume_toggle_clicks == 1
-    assert st.dropdown_opened is False
     assert st.selected_resume_id == "RID"
+    assert st.dropdown_opened is False
+    assert st.resume_toggle_clicks == 0
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
 
 


### PR DESCRIPTION
## Summary
- Detect when the resume dropdown closes automatically after selecting an option.
- Use the toggle only as a fallback for older or stuck dropdown behavior.
- Add regression coverage to ensure the dropdown is not reopened before submission.

## Testing
- Updated unit tests cover both automatic closure and toggle fallback paths.