### PR TITLE
feat: collect competitor resumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,22 @@ codex plugin marketplace add axisrow/hhru --ref main
 ```bash
 /hhru whoami
 /hhru search --resume <id> --dry-run --max-pages 3
+/hhru competitors collect --text "AI" --max-pages 5
+/hhru competitors report --text "AI" --top 20
 /hhru apply --resume <id> --dry-run --limit 5
 /hhru responses
 ```
 
 Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-run` сначала и
 подтверждения перед боевым запуском. Вывод — только текст/ASCII, без эмодзи.
+
+`competitors collect` читает выдачу резюме под соискательской сессией и
+сохраняет в локальную SQLite-базу ID/ссылку и обезличенные профессиональные
+поля. Имена, контакты, фото, демография, местоположение, активность, HTML и
+полный текст страницы не сохраняются. Команда открывает все карточки на
+страницах, выбранных через `--max-pages`, с паузами из секции `throttle`.
+`competitors report` строит локальный детерминированный отчёт и не меняет
+AIProfile/config.yaml.
 
 ### Скиллы
 
@@ -373,6 +383,12 @@ Write-команды к hh.ru (`apply`/`bump`/`run`/...) требуют `--dry-r
 
 - `--reason` — Очистить только эту причину (по умолчанию — все причины)
 - `--dry-run` — Показать, сколько записей будет удалено, без реального удаления
+
+### `competitors`
+
+READ hh.ru: competitors collect --text QUERY --max-pages N; локальный отчёт: competitors report [--text QUERY] [--top N].
+
+- (без аргументов)
 
 ### `config`
 

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -50,6 +50,7 @@ BROWSER_COMMANDS = frozenset(
         "bump",
         "call-api",
         "clear-negotiations",
+        "competitors",
         "copy-resume",
         "create-resume",
         "delete-resume",
@@ -110,6 +111,7 @@ WRITE_COMMANDS = frozenset(
 WRITE_SUBCOMMANDS = frozenset(
     {
         ("account", "create"),
+        ("competitors", "collect"),
         # #482: questionnaire set/unset/learn правят локальные шаблоны и очередь;
         # pending/templates только читают и должны оставаться доступными во время
         # идущего apply.
@@ -125,6 +127,7 @@ WRITE_SUBCOMMANDS = frozenset(
 # WRITE_SUBCOMMANDS для неё просто никогда не совпадала бы (#482).
 SUBCOMMAND_DESTS = {
     "account": "account_command",
+    "competitors": "competitors_command",
     "questionnaire": "questionnaire_command",
 }
 
@@ -212,6 +215,8 @@ def _requires_browser(args: argparse.Namespace) -> bool:
         )
     if args.command == "professional-roles":
         return bool(getattr(args, "refresh", False))
+    if args.command == "competitors":
+        return getattr(args, "competitors_command", None) == "collect"
     return args.command in BROWSER_COMMANDS
 
 

--- a/src/hhru_bot/commands/competitors.py
+++ b/src/hhru_bot/commands/competitors.py
@@ -1,0 +1,166 @@
+"""Collect and report applicant-visible competitor resumes (#578)."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from playwright.sync_api import Error as PlaywrightError
+
+
+def _positive(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("значение должно быть >= 1")
+    return parsed
+
+
+def register(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "competitors",
+        help="Собрать и проанализировать обезличенные резюме конкурентов",
+        description=(
+            "READ hh.ru: competitors collect --text QUERY --max-pages N; "
+            "локальный отчёт: competitors report [--text QUERY] [--top N]."
+        ),
+    )
+    commands = parser.add_subparsers(dest="competitors_command", required=True)
+
+    collect = commands.add_parser("collect", help="Собрать резюме по ключевому слову (READ hh.ru)")
+    collect.add_argument("--text", required=True, help="Ключевое слово поиска резюме")
+    collect.add_argument(
+        "--max-pages",
+        type=_positive,
+        default=5,
+        help="Максимум страниц выдачи (по умолчанию 5)",
+    )
+    collect.set_defaults(func=run_collect)
+
+    report = commands.add_parser("report", help="Построить локальный отчёт по сохранённой базе")
+    report.add_argument("--text", help="Ограничить отчёт одним поисковым запросом")
+    report.add_argument(
+        "--top", type=_positive, default=20, help="Число строк в каждом топе (по умолчанию 20)"
+    )
+    report.set_defaults(func=run_report)
+
+
+def run_collect(args: argparse.Namespace) -> bool:
+    from ..browser import goto_hh, launch_context
+    from ..competitors import (
+        CompetitorResumeIndeterminate,
+        build_competitor_search_url,
+        fetch_competitor_resume,
+        has_next_search_page,
+        parse_search_page,
+    )
+    from ..config import load_config_or_exit
+    from ..history import History
+    from ..throttle import Throttle
+
+    query = args.text.strip()
+    if not query:
+        raise ValueError("--text не может быть пустым")
+
+    config = load_config_or_exit(args.config)
+    history = History(args.history)
+    throttle = Throttle(config.throttle, history)
+    run_id = history.start_competitor_collection(query, args.max_pages)
+
+    pages_fetched = 0
+    cards_seen = 0
+    details_saved = 0
+    details_failed = 0
+    new = updated = unchanged = 0
+    limited = False
+    detail_attempts = 0
+
+    try:
+        with launch_context(
+            config.storage_state_file, headless=args.headless, user_agent=config.user_agent
+        ) as context:
+            search_page = context.new_page()
+            detail_page = context.new_page()
+            for page_num in range(args.max_pages):
+                goto_hh(search_page, build_competitor_search_url(query, page_num))
+                cards = parse_search_page(search_page, rank_offset=cards_seen)
+                pages_fetched += 1
+                cards_seen += len(cards)
+                has_next = has_next_search_page(search_page, page_num)
+
+                for card in cards:
+                    if detail_attempts:
+                        throttle.wait("между карточками резюме конкурентов")
+                    detail_attempts += 1
+                    try:
+                        snapshot = fetch_competitor_resume(detail_page, card)
+                        payload = asdict(snapshot)
+                        payload["content_hash"] = snapshot.content_hash()
+                        outcome = history.upsert_competitor_resume(
+                            payload,
+                            search_query=query,
+                            search_rank=card.rank,
+                        )
+                    except (CompetitorResumeIndeterminate, PlaywrightError, ValueError) as exc:
+                        details_failed += 1
+                        print(f"[WARN] резюме rank={card.rank} не сохранено: {exc}")
+                        continue
+                    details_saved += 1
+                    if outcome == "new":
+                        new += 1
+                    elif outcome == "updated":
+                        updated += 1
+                    else:
+                        unchanged += 1
+
+                if not has_next:
+                    break
+                if page_num == args.max_pages - 1:
+                    limited = True
+    except BaseException as exc:
+        status = "partial" if details_saved else "failed"
+        history.finish_competitor_collection(
+            run_id,
+            status=status,
+            pages_fetched=pages_fetched,
+            cards_seen=cards_seen,
+            details_saved=details_saved,
+            details_failed=details_failed,
+            detail=f"{type(exc).__name__}: {exc}"[:1000],
+        )
+        raise
+
+    status = "partial" if details_failed else "limited" if limited else "complete"
+    detail = "limited_by_max_pages=1" if limited and details_failed else None
+    history.finish_competitor_collection(
+        run_id,
+        status=status,
+        pages_fetched=pages_fetched,
+        cards_seen=cards_seen,
+        details_saved=details_saved,
+        details_failed=details_failed,
+        detail=detail,
+    )
+    print(
+        "Конкуренты: "
+        f"страниц {pages_fetched}, найдено {cards_seen}, сохранено {details_saved}, "
+        f"новых {new}, обновлено {updated}, без изменений {unchanged}, ошибок {details_failed}"
+    )
+    if limited:
+        print(
+            f"[WARN] выдача ограничена --max-pages={args.max_pages}; "
+            "на hh.ru подтверждена следующая страница"
+        )
+    return details_failed > 0
+
+
+def run_report(args: argparse.Namespace) -> None:
+    from ..competitors import report_competitors
+    from ..history import History
+
+    query = args.text.strip() if args.text else None
+    if args.text is not None and not query:
+        raise ValueError("--text не может быть пустым")
+    history = History(args.history)
+    rows = history.list_competitor_resumes(query)
+    limited = history.count_limited_competitor_runs(query)
+    print(report_competitors(rows, top=args.top, limited_runs=limited))

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -155,8 +155,20 @@ def has_next_search_page(page: Page, page_num: int) -> bool:
     links = page.locator(sel.PAGINATION_LINK)
     pagination = page.locator(sel.PAGINATION_BLOCK)
     if pagination.count() == 0:
-        # Current applicant layout may render numbered links without data-qa.
-        return _has_next_search_link(links, page_num)
+        if links.count() == 0:
+            # Cards can render before either pagination representation. Wait
+            # once for the block or fallback links before declaring page end.
+            try:
+                page.locator(f"{sel.PAGINATION_BLOCK}, {sel.PAGINATION_LINK}").first.wait_for(
+                    state="attached", timeout=RENDER_TIMEOUT_MS
+                )
+            except PlaywrightError:
+                return False
+            pagination = page.locator(sel.PAGINATION_BLOCK)
+            links = page.locator(sel.PAGINATION_LINK)
+        if pagination.count() == 0:
+            # Current applicant layout may render numbered links without data-qa.
+            return _has_next_search_link(links, page_num)
 
     if pages.count() == 0 and links.count() == 0:
         try:
@@ -214,6 +226,11 @@ _PROFICIENCY = {
 _SALARY_HEADING_RE = re.compile(
     r"\d.*(?:₽|\$|€|руб(?:\.|лей)?|RUB|USD|EUR|KZT|тенге|на руки)", re.IGNORECASE
 )
+_CONTACT_RE = re.compile(
+    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|"
+    r"(?:\+?\d[\d\s().-]{8,}\d))",
+    re.IGNORECASE,
+)
 
 
 def redact_free_text(_value: str) -> None:
@@ -224,6 +241,14 @@ def redact_free_text(_value: str) -> None:
     parsed separately; free-form sections are dropped rather than persisted.
     """
     return None
+
+
+def sanitize_skill_name(value: str) -> str | None:
+    """Keep professional skill labels, but never persist contact tokens."""
+    text = value.strip()
+    if not text or _CONTACT_RE.search(text):
+        return None
+    return text
 
 
 def _months(text: str) -> int | None:
@@ -313,7 +338,9 @@ def parse_competitor_resume_text(
         if normalized_level in _PROFICIENCY:
             proficiency = normalized_level
             continue
-        skills.append(CompetitorSkill(line, proficiency))
+        skill_name = sanitize_skill_name(line)
+        if skill_name is not None:
+            skills.append(CompetitorSkill(skill_name, proficiency))
 
     education = _section(lines, "Образование")
     languages = _section(lines, "Знание языков")

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -152,6 +152,26 @@ def has_next_search_page(page: Page, page_num: int) -> bool:
     if page.locator(sel.PAGINATION_NEXT).count() > 0:
         return True
     pages = page.locator(sel.PAGINATION_PAGE)
+    links = page.locator(sel.PAGINATION_LINK)
+    pagination = page.locator(sel.PAGINATION_BLOCK)
+    if pagination.count() == 0:
+        # Current applicant layout may render numbered links without data-qa.
+        return _has_next_search_link(links, page_num)
+
+    if pages.count() == 0 and links.count() == 0:
+        try:
+            pages.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
+        except PlaywrightError:
+            raise CompetitorSearchIndeterminate(
+                f"пагинация страницы поиска резюме {page_num} не подтверждена: "
+                f"маркер страницы не появился за {RENDER_TIMEOUT_MS} мс"
+            ) from None
+        if pages.count() == 0 and links.count() == 0:
+            raise CompetitorSearchIndeterminate(
+                f"пагинация страницы поиска резюме {page_num} не подтверждена: "
+                "маркер страницы исчез после ожидания"
+            )
+
     for index in range(pages.count()):
         label = pages.nth(index).inner_text().strip()
         try:
@@ -159,8 +179,10 @@ def has_next_search_page(page: Page, page_num: int) -> bool:
                 return True
         except ValueError:
             continue
-    # Current applicant layout may render numbered links without data-qa.
-    links = page.locator(sel.PAGINATION_LINK)
+    return _has_next_search_link(links, page_num)
+
+
+def _has_next_search_link(links, page_num: int) -> bool:
     for index in range(links.count()):
         href = links.nth(index).get_attribute("href") or ""
         raw_page = parse_qs(urlsplit(href).query).get("page", [])
@@ -192,22 +214,16 @@ _PROFICIENCY = {
 _SALARY_HEADING_RE = re.compile(
     r"\d.*(?:₽|\$|€|руб(?:\.|лей)?|RUB|USD|EUR|KZT|тенге|на руки)", re.IGNORECASE
 )
-_CONTACT_RE = re.compile(
-    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|"
-    r"(?:\+?\d[\d\s().-]{8,}\d))",
-    re.IGNORECASE,
-)
-_NAME_LIKE_RE = re.compile(
-    r"(?:\b[А-ЯЁ][а-яё]{2,}\s+[А-ЯЁ][а-яё]{2,}\b|\b[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b)"
-)
 
 
-def redact_free_text(value: str) -> str | None:
-    """Remove contact tokens; drop text that still looks like a person's name."""
-    text = _CONTACT_RE.sub("[redacted]", value).strip()
-    if not text or "меня зовут" in text.casefold() or _NAME_LIKE_RE.search(text):
-        return None
-    return text
+def redact_free_text(_value: str) -> None:
+    """Never retain unstructured third-party resume text.
+
+    Regex redaction cannot reliably identify all names, demographics, and
+    locations in free-form applicant text. Structured professional fields are
+    parsed separately; free-form sections are dropped rather than persisted.
+    """
+    return None
 
 
 def _months(text: str) -> int | None:
@@ -326,6 +342,14 @@ def parse_competitor_resume_text(
     )
 
 
+def _median(values: list[int]) -> int:
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return round((ordered[middle - 1] + ordered[middle]) / 2)
+
+
 def fetch_competitor_resume(page: Page, card: CompetitorSearchCard) -> CompetitorResume:
     goto_hh(page, card.resume_url)
     raise_for_antibot(page)
@@ -390,13 +414,11 @@ def report_competitors(rows: list[dict], *, top: int, limited_runs: int = 0) -> 
     else:
         lines.append("  (нет данных)")
     if experience:
-        ordered = sorted(experience)
-        lines.append(f"\nМедианный опыт: {ordered[len(ordered) // 2]} мес.")
+        lines.append(f"\nМедианный опыт: {_median(experience)} мес.")
     if salaries:
         lines.append("\nЗарплата (медиана верхней границы, иначе нижней):")
         for currency, amounts in sorted(salaries.items()):
-            ordered = sorted(amounts)
-            lines.append(f"  {currency}: {ordered[len(ordered) // 2]} (n={len(ordered)})")
+            lines.append(f"  {currency}: {_median(amounts)} (n={len(amounts)})")
 
     lines.extend(
         [

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -1,0 +1,413 @@
+"""Read-only collection and deterministic reporting for competitor resumes (#578)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+
+from .apply.antibot import raise_for_antibot
+from .browser import HH_BASE_URL, goto_hh, require_authenticated_page, resume_identity_matches
+from .search import parse_salary
+from .selector_groups import competitor_resume as sel
+
+SEARCH_URL = f"{HH_BASE_URL}/search/resume"
+RENDER_TIMEOUT_MS = 30_000
+
+
+class CompetitorSearchIndeterminate(RuntimeError):
+    """The current page does not prove a valid resume-search result."""
+
+
+class CompetitorResumeIndeterminate(RuntimeError):
+    """The current page does not prove a valid competitor resume."""
+
+
+@dataclass(frozen=True)
+class CompetitorSearchCard:
+    resume_id: str
+    resume_url: str
+    desired_role: str
+    rank: int
+
+
+@dataclass(frozen=True)
+class CompetitorSkill:
+    name: str
+    proficiency: str | None = None
+
+
+@dataclass(frozen=True)
+class CompetitorResume:
+    resume_id: str
+    resume_url: str
+    desired_role: str
+    salary_from: int | None = None
+    salary_to: int | None = None
+    salary_currency: str | None = None
+    experience_months: int | None = None
+    specializations: list[str] = field(default_factory=list)
+    employment_types: list[str] = field(default_factory=list)
+    work_formats: list[str] = field(default_factory=list)
+    skills: list[CompetitorSkill] = field(default_factory=list)
+    languages: list[str] = field(default_factory=list)
+    education: list[str] = field(default_factory=list)
+    experience_summary: str | None = None
+    achievements: str | None = None
+
+    def content_hash(self) -> str:
+        payload = {
+            key: value
+            for key, value in self.__dict__.items()
+            if key not in {"resume_id", "resume_url"}
+        }
+        payload["skills"] = [skill.__dict__ for skill in self.skills]
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def build_competitor_search_url(text: str, page_num: int) -> str:
+    if not text.strip():
+        raise ValueError("--text не может быть пустым")
+    if page_num < 0:
+        raise ValueError("page_num должен быть >= 0")
+    params = {
+        "text": text,
+        "pos": "full_text",
+        "logic": "normal",
+        "exp_period": "all_time",
+        "ored_clusters": "true",
+        "order_by": "relevance",
+        "search_period": "0",
+        "page": str(page_num),
+    }
+    return f"{SEARCH_URL}?{urlencode(params)}"
+
+
+def _resume_identity(href: str) -> tuple[str, str] | None:
+    path = urlsplit(href).path.rstrip("/")
+    parts = [part for part in path.split("/") if part]
+    if len(parts) != 2 or parts[0] != "resume" or not parts[1]:
+        return None
+    resume_id = parts[1]
+    return resume_id, f"{HH_BASE_URL}/resume/{resume_id}"
+
+
+def parse_search_links(
+    rows: list[tuple[str, str]], *, rank_offset: int = 0
+) -> list[CompetitorSearchCard]:
+    """Parse already-observed (href, title) pairs without keeping personal data."""
+    result: list[CompetitorSearchCard] = []
+    seen: set[str] = set()
+    for href, title in rows:
+        identity = _resume_identity(href)
+        role = title.strip()
+        if identity is None or not role or identity[0] in seen:
+            continue
+        seen.add(identity[0])
+        result.append(
+            CompetitorSearchCard(
+                resume_id=identity[0],
+                resume_url=identity[1],
+                desired_role=role,
+                rank=rank_offset + len(result) + 1,
+            )
+        )
+    return result
+
+
+def parse_search_page(page: Page, *, rank_offset: int = 0) -> list[CompetitorSearchCard]:
+    raise_for_antibot(page)
+    require_authenticated_page(page)
+    links = page.locator(sel.SEARCH_RESULT_LINK)
+    try:
+        links.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
+    except PlaywrightError:
+        # Applicant search currently has no stable empty data-qa across layouts.
+        # Accept an explicit zero-result phrase only; every other blank page is unknown.
+        main_text = page.locator("main").inner_text().casefold()
+        if "резюме не найден" in main_text or "ничего не найден" in main_text:
+            return []
+        raise CompetitorSearchIndeterminate(
+            "карточки резюме или подтверждённый empty-state не появились"
+        ) from None
+
+    observed: list[tuple[str, str]] = []
+    for index in range(links.count()):
+        link = links.nth(index)
+        observed.append((link.get_attribute("href") or "", link.inner_text()))
+    cards = parse_search_links(observed, rank_offset=rank_offset)
+    if not cards:
+        raise CompetitorSearchIndeterminate("ссылки выдачи не содержат подтверждённых resume ID")
+    return cards
+
+
+def has_next_search_page(page: Page, page_num: int) -> bool:
+    if page.locator(sel.PAGINATION_NEXT).count() > 0:
+        return True
+    pages = page.locator(sel.PAGINATION_PAGE)
+    for index in range(pages.count()):
+        label = pages.nth(index).inner_text().strip()
+        try:
+            if int(label) > page_num + 1:
+                return True
+        except ValueError:
+            continue
+    # Current applicant layout may render numbered links without data-qa.
+    links = page.locator(sel.PAGINATION_LINK)
+    for index in range(links.count()):
+        href = links.nth(index).get_attribute("href") or ""
+        raw_page = parse_qs(urlsplit(href).query).get("page", [])
+        try:
+            if raw_page and int(raw_page[0]) > page_num:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+_SECTION_HEADINGS = {
+    "Навыки",
+    "Опыт вождения",
+    "Образование",
+    "Знание языков",
+    "Гражданство, время в пути до работы",
+    "Обо мне",
+    "Ключевые достижения",
+    "Конкретные достижения",
+}
+_PROFICIENCY = {
+    "Базовый уровень",
+    "Начальный уровень",
+    "Средний уровень",
+    "Продвинутый уровень",
+    "Уровень не указан",
+}
+_SALARY_HEADING_RE = re.compile(
+    r"\d.*(?:₽|\$|€|руб(?:\.|лей)?|RUB|USD|EUR|KZT|тенге|на руки)", re.IGNORECASE
+)
+_CONTACT_RE = re.compile(
+    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|"
+    r"(?:\+?\d[\d\s().-]{8,}\d))",
+    re.IGNORECASE,
+)
+_NAME_LIKE_RE = re.compile(
+    r"(?:\b[А-ЯЁ][а-яё]{2,}\s+[А-ЯЁ][а-яё]{2,}\b|\b[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b)"
+)
+
+
+def redact_free_text(value: str) -> str | None:
+    """Remove contact tokens; drop text that still looks like a person's name."""
+    text = _CONTACT_RE.sub("[redacted]", value).strip()
+    if not text or "меня зовут" in text.casefold() or _NAME_LIKE_RE.search(text):
+        return None
+    return text
+
+
+def _months(text: str) -> int | None:
+    years = re.search(r"(\d+)\s+(?:год|года|лет)", text, re.IGNORECASE)
+    months = re.search(r"(\d+)\s+месяц", text, re.IGNORECASE)
+    if not years and not months:
+        return None
+    return (int(years.group(1)) * 12 if years else 0) + (int(months.group(1)) if months else 0)
+
+
+def _csv_tail(line: str) -> list[str]:
+    _, _, tail = line.partition(":")
+    return [part.strip() for part in tail.split(",") if part.strip()]
+
+
+def _section(lines: list[str], heading: str) -> list[str]:
+    try:
+        start = lines.index(heading) + 1
+    except ValueError:
+        return []
+    result: list[str] = []
+    for line in lines[start:]:
+        if line in _SECTION_HEADINGS or line.startswith("Гражданство"):
+            break
+        result.append(line)
+    return result
+
+
+def parse_competitor_resume_text(
+    text: str,
+    *,
+    resume_id: str,
+    resume_url: str,
+    headings: list[str],
+) -> CompetitorResume:
+    """Parse the applicant-visible main section, excluding header identity fields."""
+    def normalize(value: str) -> str:
+        return value.replace("\u00a0", " ").replace("\u2009", " ").replace("\u202f", " ").strip()
+
+    lines = [normalize(line) for line in text.splitlines() if line.strip()]
+    normalized_headings = [normalize(value) for value in headings]
+    if not lines:
+        raise CompetitorResumeIndeterminate("основной блок резюме пуст")
+
+    def is_salary_heading(value: str) -> bool:
+        return bool(_SALARY_HEADING_RE.search(normalize(value)))
+
+    desired_candidates = [
+        value.strip()
+        for value in normalized_headings
+        if value.strip()
+        and value.strip() not in _SECTION_HEADINGS
+        and not value.strip().startswith("Опыт работы")
+        and not is_salary_heading(value.strip())
+    ]
+    if not desired_candidates:
+        raise CompetitorResumeIndeterminate("desired_role не подтверждён")
+    desired_role = desired_candidates[0]
+
+    salary_heading = next(
+        (value for value in normalized_headings if is_salary_heading(value)), None
+    )
+    salary = parse_salary(salary_heading) if salary_heading else None
+    experience_heading = next(
+        (value for value in normalized_headings if value.startswith("Опыт работы")), ""
+    )
+
+    specializations: list[str] = []
+    if "Специализации:" in lines:
+        start = lines.index("Специализации:") + 1
+        for line in lines[start:]:
+            if line.startswith("Тип занятости:"):
+                break
+            specializations.append(line.lstrip("— ").strip())
+
+    employment = next((line for line in lines if line.startswith("Тип занятости:")), "")
+    formats = next((line for line in lines if line.startswith("Формат работы:")), "")
+
+    skill_lines = _section(lines, "Навыки")
+    skills: list[CompetitorSkill] = []
+    proficiency: str | None = None
+    for line in skill_lines:
+        if line == "Уровни владения навыками":
+            continue
+        normalized_level = line.replace("не указан", "не указан")
+        if normalized_level in _PROFICIENCY:
+            proficiency = normalized_level
+            continue
+        skills.append(CompetitorSkill(line, proficiency))
+
+    education = _section(lines, "Образование")
+    languages = _section(lines, "Знание языков")
+    about = redact_free_text("\n".join(_section(lines, "Обо мне")))
+    achievements_lines = _section(lines, "Ключевые достижения") or _section(
+        lines, "Конкретные достижения"
+    )
+    achievements = redact_free_text("\n".join(achievements_lines))
+
+    return CompetitorResume(
+        resume_id=resume_id,
+        resume_url=resume_url,
+        desired_role=desired_role,
+        salary_from=salary.salary_from if salary else None,
+        salary_to=salary.salary_to if salary else None,
+        salary_currency=salary.currency if salary else None,
+        experience_months=_months(experience_heading),
+        specializations=specializations,
+        employment_types=_csv_tail(employment),
+        work_formats=_csv_tail(formats),
+        skills=skills,
+        languages=languages,
+        education=education,
+        experience_summary=about,
+        achievements=achievements,
+    )
+
+
+def fetch_competitor_resume(page: Page, card: CompetitorSearchCard) -> CompetitorResume:
+    goto_hh(page, card.resume_url)
+    raise_for_antibot(page)
+    require_authenticated_page(page)
+    if not resume_identity_matches(page, card.resume_id):
+        raise CompetitorResumeIndeterminate("identity открытого резюме не подтверждён")
+    main = page.locator(sel.DETAIL_MAIN)
+    try:
+        main.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
+    except PlaywrightError:
+        raise CompetitorResumeIndeterminate("основной блок резюме не появился") from None
+    headings = [value.strip() for value in page.locator(sel.DETAIL_HEADING).all_inner_texts()]
+    return parse_competitor_resume_text(
+        main.inner_text(),
+        resume_id=card.resume_id,
+        resume_url=card.resume_url,
+        headings=headings,
+    )
+
+
+def report_competitors(rows: list[dict], *, top: int, limited_runs: int = 0) -> str:
+    """Build a deterministic, PII-free report from latest stored snapshots."""
+    roles = Counter(str(row["desired_role"]) for row in rows if row.get("desired_role"))
+    skills = Counter(
+        skill["name"]
+        for row in rows
+        for skill in row.get("skills", [])
+        if skill.get("name")
+    )
+    specializations = Counter(
+        value for row in rows for value in row.get("specializations", []) if value
+    )
+    experience = [int(row["experience_months"]) for row in rows if row.get("experience_months")]
+    salaries: dict[str, list[int]] = {}
+    skill_pairs: Counter[tuple[str, str]] = Counter()
+    for row in rows:
+        amount = row.get("salary_to") or row.get("salary_from")
+        currency = row.get("salary_currency")
+        if amount and currency:
+            salaries.setdefault(str(currency), []).append(int(amount))
+        names = sorted({skill["name"] for skill in row.get("skills", []) if skill.get("name")})
+        for index, first in enumerate(names):
+            for second in names[index + 1 :]:
+                skill_pairs[(first, second)] += 1
+
+    lines = [f"Резюме в выборке: {len(rows)}"]
+    if limited_runs:
+        lines.append(f"Внимание: ограниченных запусков (--max-pages): {limited_runs}")
+
+    def add_counter(title: str, values: Counter) -> None:
+        lines.append(f"\n{title}:")
+        if not values:
+            lines.append("  (нет данных)")
+            return
+        for value, count in values.most_common(top):
+            lines.append(f"  {count}  {value}")
+
+    add_counter("Частые роли", roles)
+    add_counter("Частые специализации", specializations)
+    add_counter("Частые навыки", skills)
+    lines.append("\nЧастые сочетания навыков:")
+    if skill_pairs:
+        for (first, second), count in skill_pairs.most_common(top):
+            lines.append(f"  {count}  {first} + {second}")
+    else:
+        lines.append("  (нет данных)")
+    if experience:
+        ordered = sorted(experience)
+        lines.append(f"\nМедианный опыт: {ordered[len(ordered) // 2]} мес.")
+    if salaries:
+        lines.append("\nЗарплата (медиана верхней границы, иначе нижней):")
+        for currency, amounts in sorted(salaries.items()):
+            ordered = sorted(amounts)
+            lines.append(f"  {currency}: {ordered[len(ordered) // 2]} (n={len(ordered)})")
+
+    lines.extend(
+        [
+            "\nРекомендации для AIProfile:",
+            "  Используйте наблюдаемые названия ролей и навыков как поисковую лексику.",
+            "  Добавляйте навык только если он подтверждён вашим реальным опытом.",
+            "Рекомендации для cover letter:",
+            "  Выберите 3-5 подтверждённых навыков, совпадающих с конкретной вакансией.",
+            "  Подкрепите их собственным результатом; не копируйте факты из чужих резюме.",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -244,6 +244,7 @@ def parse_competitor_resume_text(
     headings: list[str],
 ) -> CompetitorResume:
     """Parse the applicant-visible main section, excluding header identity fields."""
+
     def normalize(value: str) -> str:
         return value.replace("\u00a0", " ").replace("\u2009", " ").replace("\u202f", " ").strip()
 
@@ -349,10 +350,7 @@ def report_competitors(rows: list[dict], *, top: int, limited_runs: int = 0) -> 
     """Build a deterministic, PII-free report from latest stored snapshots."""
     roles = Counter(str(row["desired_role"]) for row in rows if row.get("desired_role"))
     skills = Counter(
-        skill["name"]
-        for row in rows
-        for skill in row.get("skills", [])
-        if skill.get("name")
+        skill["name"] for row in rows for skill in row.get("skills", []) if skill.get("name")
     )
     specializations = Counter(
         value for row in rows for value in row.get("specializations", []) if value

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -242,6 +242,66 @@ CREATE TABLE IF NOT EXISTS vacancies_seen (
     UNIQUE (vacancy_id, search_query)
 );
 
+-- competitor_resumes — текущие обезличенные снимки чужих резюме (#578).
+-- resume_url сохраняется по явному решению пользователя; имя, контакты,
+-- возраст, пол, местоположение, активность и raw HTML не входят в схему.
+CREATE TABLE IF NOT EXISTS competitor_resumes (
+    resume_id TEXT PRIMARY KEY,
+    resume_url TEXT NOT NULL,
+    desired_role TEXT NOT NULL,
+    salary_from INTEGER,
+    salary_to INTEGER,
+    salary_currency TEXT,
+    experience_months INTEGER,
+    specializations TEXT NOT NULL DEFAULT '[]',
+    employment_types TEXT NOT NULL DEFAULT '[]',
+    work_formats TEXT NOT NULL DEFAULT '[]',
+    languages TEXT NOT NULL DEFAULT '[]',
+    education TEXT NOT NULL DEFAULT '[]',
+    experience_summary TEXT,
+    achievements TEXT,
+    content_hash TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS competitor_resume_skills (
+    resume_id TEXT NOT NULL,
+    skill TEXT NOT NULL,
+    proficiency TEXT,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    PRIMARY KEY (resume_id, skill)
+);
+
+CREATE TABLE IF NOT EXISTS competitor_resume_queries (
+    resume_id TEXT NOT NULL,
+    search_query TEXT NOT NULL,
+    search_rank INTEGER NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    PRIMARY KEY (resume_id, search_query)
+);
+CREATE INDEX IF NOT EXISTS idx_competitor_queries_query
+    ON competitor_resume_queries(search_query, search_rank);
+
+CREATE TABLE IF NOT EXISTS competitor_collection_runs (
+    run_id TEXT PRIMARY KEY,
+    search_query TEXT NOT NULL,
+    max_pages INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    pages_fetched INTEGER NOT NULL DEFAULT 0,
+    cards_seen INTEGER NOT NULL DEFAULT 0,
+    details_saved INTEGER NOT NULL DEFAULT 0,
+    details_failed INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    detail TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_competitor_runs_query
+    ON competitor_collection_runs(search_query, started_at);
+
 -- skipped — журнал отсева вакансий (#87, append-only).
 -- filter_candidates логирует ``[skip] причина``, но НЕ писал её в БД → повторный
 -- search пересматривал те же вакансии заново (трата LLM/времени, когда работают
@@ -1853,6 +1913,236 @@ class History:
             "dead": dead,
             "dead_rate": self._pct(dead, total_sent),
         }
+
+    # --- Конкуренты: обезличенные снимки резюме (#578) -------------------------
+
+    def start_competitor_collection(self, search_query: str, max_pages: int) -> str:
+        """Create a durable run row before opening the first search page."""
+        run_id = str(uuid.uuid4())
+        now = datetime.now().isoformat(timespec="seconds")
+        with self._connect() as conn:
+            conn.execute(
+                """INSERT INTO competitor_collection_runs
+                   (run_id, search_query, max_pages, status, started_at)
+                   VALUES (?, ?, ?, 'running', ?)""",
+                (run_id, search_query, max_pages, now),
+            )
+        return run_id
+
+    def finish_competitor_collection(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        pages_fetched: int,
+        cards_seen: int,
+        details_saved: int,
+        details_failed: int,
+        detail: str | None = None,
+    ) -> None:
+        allowed = {"complete", "limited", "partial", "failed"}
+        if status not in allowed:
+            raise ValueError(f"недопустимый статус competitor collection: {status}")
+        now = datetime.now().isoformat(timespec="seconds")
+        with self._connect() as conn:
+            cur = conn.execute(
+                """UPDATE competitor_collection_runs
+                   SET status = ?, pages_fetched = ?, cards_seen = ?, details_saved = ?,
+                       details_failed = ?, finished_at = ?, detail = ?
+                   WHERE run_id = ? AND status = 'running'""",
+                (
+                    status,
+                    pages_fetched,
+                    cards_seen,
+                    details_saved,
+                    details_failed,
+                    now,
+                    detail,
+                    run_id,
+                ),
+            )
+            if cur.rowcount != 1:
+                raise ValueError(f"running competitor collection не найден: {run_id}")
+
+    def upsert_competitor_resume(
+        self,
+        snapshot: dict,
+        *,
+        search_query: str,
+        search_rank: int,
+    ) -> str:
+        """Atomically replace one confirmed current snapshot and its skills."""
+        now = datetime.now().isoformat(timespec="seconds")
+        resume_id = str(snapshot["resume_id"])
+        content_hash = str(snapshot["content_hash"])
+        json_fields = (
+            "specializations",
+            "employment_types",
+            "work_formats",
+            "languages",
+            "education",
+        )
+        encoded = {
+            field: json.dumps(snapshot.get(field) or [], ensure_ascii=False, sort_keys=True)
+            for field in json_fields
+        }
+
+        with self._connect() as conn:
+            previous = conn.execute(
+                "SELECT content_hash FROM competitor_resumes WHERE resume_id = ?", (resume_id,)
+            ).fetchone()
+            outcome = (
+                "new"
+                if previous is None
+                else "unchanged"
+                if previous["content_hash"] == content_hash
+                else "updated"
+            )
+            conn.execute(
+                """INSERT INTO competitor_resumes
+                   (resume_id, resume_url, desired_role, salary_from, salary_to,
+                    salary_currency, experience_months, specializations, employment_types,
+                    work_formats, languages, education, experience_summary, achievements,
+                    content_hash, first_seen_at, last_seen_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(resume_id) DO UPDATE SET
+                     resume_url = excluded.resume_url,
+                     desired_role = excluded.desired_role,
+                     salary_from = excluded.salary_from,
+                     salary_to = excluded.salary_to,
+                     salary_currency = excluded.salary_currency,
+                     experience_months = excluded.experience_months,
+                     specializations = excluded.specializations,
+                     employment_types = excluded.employment_types,
+                     work_formats = excluded.work_formats,
+                     languages = excluded.languages,
+                     education = excluded.education,
+                     experience_summary = excluded.experience_summary,
+                     achievements = excluded.achievements,
+                     content_hash = excluded.content_hash,
+                     last_seen_at = excluded.last_seen_at,
+                     updated_at = CASE
+                       WHEN competitor_resumes.content_hash <> excluded.content_hash
+                       THEN excluded.updated_at ELSE competitor_resumes.updated_at END""",
+                (
+                    resume_id,
+                    snapshot["resume_url"],
+                    snapshot["desired_role"],
+                    snapshot.get("salary_from"),
+                    snapshot.get("salary_to"),
+                    snapshot.get("salary_currency"),
+                    snapshot.get("experience_months"),
+                    encoded["specializations"],
+                    encoded["employment_types"],
+                    encoded["work_formats"],
+                    encoded["languages"],
+                    encoded["education"],
+                    snapshot.get("experience_summary"),
+                    snapshot.get("achievements"),
+                    content_hash,
+                    now,
+                    now,
+                    now,
+                ),
+            )
+
+            old_skills = {
+                row["skill"]: row["first_seen_at"]
+                for row in conn.execute(
+                    "SELECT skill, first_seen_at FROM competitor_resume_skills WHERE resume_id = ?",
+                    (resume_id,),
+                )
+            }
+            conn.execute("DELETE FROM competitor_resume_skills WHERE resume_id = ?", (resume_id,))
+            for skill in snapshot.get("skills") or []:
+                name = str(skill["name"]).strip()
+                if not name:
+                    continue
+                conn.execute(
+                    """INSERT INTO competitor_resume_skills
+                       (resume_id, skill, proficiency, first_seen_at, last_seen_at)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (resume_id, name, skill.get("proficiency"), old_skills.get(name, now), now),
+                )
+
+            conn.execute(
+                """INSERT INTO competitor_resume_queries
+                   (resume_id, search_query, search_rank, first_seen_at, last_seen_at)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(resume_id, search_query) DO UPDATE SET
+                     search_rank = excluded.search_rank,
+                     last_seen_at = excluded.last_seen_at""",
+                (resume_id, search_query, search_rank, now, now),
+            )
+        return outcome
+
+    def list_competitor_resumes(self, search_query: str | None = None) -> list[dict]:
+        """Return current snapshots with PII-free skills, optionally scoped by query."""
+        with self._connect() as conn:
+            if search_query is None:
+                rows = conn.execute(
+                    "SELECT r.* FROM competitor_resumes r ORDER BY r.last_seen_at DESC, r.resume_id"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """SELECT r.* FROM competitor_resumes r
+                       JOIN competitor_resume_queries q ON q.resume_id = r.resume_id
+                       WHERE q.search_query = ?
+                       ORDER BY q.search_rank, r.resume_id""",
+                    (search_query,),
+                ).fetchall()
+            result: list[dict] = []
+            for row in rows:
+                item = dict(row)
+                for field in (
+                    "specializations",
+                    "employment_types",
+                    "work_formats",
+                    "languages",
+                    "education",
+                ):
+                    item[field] = json.loads(item[field])
+                item["skills"] = [
+                    {"name": skill["skill"], "proficiency": skill["proficiency"]}
+                    for skill in conn.execute(
+                        """SELECT skill, proficiency FROM competitor_resume_skills
+                           WHERE resume_id = ? ORDER BY skill COLLATE NOCASE""",
+                        (item["resume_id"],),
+                    )
+                ]
+                result.append(item)
+            return result
+
+    def count_limited_competitor_runs(self, search_query: str | None = None) -> int:
+        """Count queries whose latest finished collection has limited coverage."""
+        with self._connect() as conn:
+            if search_query is None:
+                row = conn.execute(
+                    """SELECT COUNT(*) AS total
+                       FROM competitor_collection_runs r
+                       WHERE r.finished_at IS NOT NULL
+                         AND r.rowid = (
+                           SELECT latest.rowid
+                           FROM competitor_collection_runs latest
+                           WHERE latest.search_query = r.search_query
+                             AND latest.finished_at IS NOT NULL
+                           ORDER BY latest.started_at DESC, latest.rowid DESC
+                           LIMIT 1
+                         )
+                         AND (r.status = 'limited'
+                              OR r.detail LIKE '%limited_by_max_pages=1%')"""
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """SELECT CASE
+                         WHEN status = 'limited' OR detail LIKE '%limited_by_max_pages=1%'
+                         THEN 1 ELSE 0 END AS total
+                       FROM competitor_collection_runs
+                       WHERE search_query = ? AND finished_at IS NOT NULL
+                       ORDER BY started_at DESC, rowid DESC LIMIT 1""",
+                    (search_query,),
+                ).fetchone()
+            return int(row["total"] if row else 0)
 
     # --- Рынок вакансий: собранные карточки (#66, Этап 1) ----------------------
     # Новые методы в конец файла (паттерн with self._connect(), существующие

--- a/src/hhru_bot/selector_groups/competitor_resume.py
+++ b/src/hhru_bot/selector_groups/competitor_resume.py
@@ -1,0 +1,12 @@
+"""Selectors for the applicant-visible resume search and public resume page."""
+
+# Keep the search link scoped to main: the header also contains resume links.
+SEARCH_RESULT_LINK = "main a[href^='/resume/']"
+SEARCH_EMPTY = "[data-qa='resume-search-empty'], [data-qa='bloko-header-2']"
+PAGINATION_NEXT = "[data-qa*='pager-next'], [data-qa*='pagination-next'], a[rel='next']"
+PAGINATION_BLOCK = "[data-qa*='pager-block'], [data-qa*='pagination']"
+PAGINATION_PAGE = "[data-qa*='pager-page'], [data-qa*='pagination-page']"
+PAGINATION_LINK = "main a[href*='/search/resume'][href*='page=']"
+
+DETAIL_MAIN = "main"
+DETAIL_HEADING = "main h2"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -118,6 +118,7 @@ def test_all_commands_registered():
         "profile",
         "questionnaire",
         "config",
+        "competitors",
         "call-api",
         "learn",
         "settings",
@@ -183,6 +184,7 @@ def test_register_commands_returns_names():
         "profile",
         "questionnaire",
         "config_cmd",
+        "competitors",
         "call_api",
         "learn",
         "settings",
@@ -217,6 +219,32 @@ def test_search_text_is_optional_without_resume():
 
     assert args.text == "Тестировщик"
     assert args.resume is None
+
+
+def test_competitors_collect_and_report_arguments():
+    parser = _build()
+    collect = parser.parse_args(["competitors", "collect", "--text", "AI"])
+    assert collect.competitors_command == "collect"
+    assert collect.text == "AI"
+    assert collect.max_pages == 5
+
+    report = parser.parse_args(["competitors", "report", "--text", "AI", "--top", "7"])
+    assert report.competitors_command == "report"
+    assert report.text == "AI"
+    assert report.top == 7
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["competitors", "collect"],
+        ["competitors", "collect", "--text", "AI", "--max-pages", "0"],
+        ["competitors", "report", "--top", "0"],
+    ],
+)
+def test_competitors_rejects_missing_or_nonpositive_args(argv):
+    with pytest.raises(SystemExit):
+        _build().parse_args(argv)
 
 
 def test_apply_has_limit():

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -4,12 +4,15 @@ import pytest
 
 from hhru_bot.competitors import (
     CompetitorResumeIndeterminate,
+    CompetitorSearchIndeterminate,
     build_competitor_search_url,
+    has_next_search_page,
     parse_competitor_resume_text,
     parse_search_links,
     redact_free_text,
     report_competitors,
 )
+from hhru_bot.selector_groups import competitor_resume as selectors
 
 pytestmark = pytest.mark.unit
 
@@ -137,16 +140,99 @@ def test_thin_space_salary_and_dashless_specialization_are_normalized():
 
 
 @pytest.mark.parametrize(
-    "raw, expected",
+    "raw",
     [
-        ("Пишите test@example.com или +7 999 123-45-67", "Пишите [redacted] или [redacted]"),
-        ("Меня зовут Иван", None),
-        ("Связаться с Иван Петров", None),
-        ("Построил RAG-поиск и сократил latency", "Построил RAG-поиск и сократил latency"),
+        "Пишите test@example.com или +7 999 123-45-67",
+        "Меня зовут Иван",
+        "Связаться с Иван Петров",
+        "Живу в Москве, мне 35 лет",
+        "Построил RAG-поиск и сократил latency",
     ],
 )
-def test_redact_free_text(raw, expected):
-    assert redact_free_text(raw) == expected
+def test_redact_free_text_drops_unstructured_third_party_text(raw):
+    assert redact_free_text(raw) is None
+
+
+def test_parse_detail_drops_free_text_even_without_obvious_name_or_contact():
+    snapshot = parse_competitor_resume_text(
+        "AI Engineer\nОбо мне\nЖиву в Москве, мне 35 лет\n"
+        "Ключевые достижения\nСократил расходы на 20%",
+        resume_id="free-text",
+        resume_url="https://hh.ru/resume/free-text",
+        headings=["AI Engineer"],
+    )
+    assert snapshot.experience_summary is None
+    assert snapshot.achievements is None
+
+
+class _Locator:
+    def __init__(self, values, delayed=None, *, links=False):
+        self.values = list(values)
+        self.delayed = list(delayed or [])
+        self.links = links
+        self.wait_calls = []
+
+    def count(self):
+        return len(self.values)
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state, timeout):
+        self.wait_calls.append((state, timeout))
+        self.values.extend(self.delayed)
+
+    def nth(self, index):
+        return _Text(self.values[index], links=self.links)
+
+    def inner_text(self):
+        return self.values[0]
+
+    def get_attribute(self, name):
+        assert self.links and name == "href"
+        return self.values[0]
+
+
+class _Text:
+    def __init__(self, value, *, links=False):
+        self.value = value
+        self.links = links
+
+    def inner_text(self):
+        return self.value
+
+    def get_attribute(self, name):
+        assert self.links and name == "href"
+        return self.value
+
+
+class _PaginationPage:
+    def __init__(self, pages, delayed_pages=None):
+        self.next = _Locator([])
+        self.block = _Locator(["block"])
+        self.pages = _Locator(pages, delayed_pages)
+        self.links = _Locator([])
+
+    def locator(self, selector):
+        return {
+            selectors.PAGINATION_NEXT: self.next,
+            selectors.PAGINATION_BLOCK: self.block,
+            selectors.PAGINATION_PAGE: self.pages,
+            selectors.PAGINATION_LINK: self.links,
+        }[selector]
+
+
+def test_pagination_waits_for_delayed_page_markers():
+    page = _PaginationPage([], delayed_pages=["1", "2"])
+    assert has_next_search_page(page, 0) is True
+    assert page.pages.wait_calls == [("attached", 30_000)]
+
+
+def test_pagination_timeout_is_indeterminate_not_last_page():
+    page = _PaginationPage([])
+    with pytest.raises(CompetitorSearchIndeterminate, match="не подтверждена"):
+        has_next_search_page(page, 0)
 
 
 def test_report_is_deterministic_and_warns_about_limited_coverage():
@@ -174,5 +260,6 @@ def test_report_is_deterministic_and_warns_about_limited_coverage():
     assert "2  AI Engineer" in report
     assert "2  Python" in report
     assert "1  Python + RAG" in report
-    assert "RUB: 200000 (n=2)" in report
+    assert "Медианный опыт: 42 мес." in report
+    assert "RUB: 150000 (n=2)" in report
     assert "Добавляйте навык только если он подтверждён" in report

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.competitors import (
+    CompetitorResumeIndeterminate,
+    build_competitor_search_url,
+    parse_competitor_resume_text,
+    parse_search_links,
+    redact_free_text,
+    report_competitors,
+)
+
+pytestmark = pytest.mark.unit
+
+
+DETAIL = """
+Был сегодня
+Мужчина
+Активно ищет работу
+Москва, готов работать удалённо
+AI Engineer / AI Infrastructure Engineer
+200 000 ₽ на руки
+Специализации:
+— Программист, разработчик
+— Системный инженер
+Тип занятости: полная занятость, проектная работа/разовое задание
+Формат работы: удалённо, гибрид
+Опыт работы 5 лет 3 месяца
+Навыки
+Уровни владения навыками
+Продвинутый уровень
+Python
+Docker
+Средний уровень
+RAG
+Базовый уровень
+FastAPI
+Образование
+Высшее образование
+Знание языков
+Русский — Родной
+Английский — B2 — Средне-продвинутый
+Гражданство, время в пути до работы
+Желательное время в пути до работы: Не имеет значения
+"""
+
+
+def test_search_url_is_keyword_only_and_page_numbered():
+    url = build_competitor_search_url("AI Engineer", 2)
+    assert "text=AI+Engineer" in url
+    assert "page=2" in url
+    assert "resume=" not in url
+
+
+def test_parse_search_links_normalizes_url_deduplicates_and_keeps_rank():
+    rows = [
+        ("/resume/abc?query=AI", " AI Engineer "),
+        ("/resume/abc?other=1", "duplicate"),
+        ("/vacancy/123", "not a resume"),
+        ("https://hh.ru/resume/def", "AI Creator"),
+    ]
+    cards = parse_search_links(rows, rank_offset=20)
+    assert [(card.resume_id, card.desired_role, card.rank) for card in cards] == [
+        ("abc", "AI Engineer", 21),
+        ("def", "AI Creator", 22),
+    ]
+    assert cards[0].resume_url == "https://hh.ru/resume/abc"
+
+
+def test_parse_detail_extracts_only_competitor_fields():
+    snapshot = parse_competitor_resume_text(
+        DETAIL,
+        resume_id="abc",
+        resume_url="https://hh.ru/resume/abc",
+        headings=[
+            "AI Engineer / AI Infrastructure Engineer",
+            "200 000 ₽ на руки",
+            "Опыт работы 5 лет 3 месяца",
+            "Навыки",
+            "Образование",
+            "Знание языков",
+        ],
+    )
+    assert snapshot.desired_role == "AI Engineer / AI Infrastructure Engineer"
+    assert snapshot.salary_from == 200_000
+    assert snapshot.salary_to == 200_000
+    assert snapshot.salary_currency == "RUB"
+    assert snapshot.experience_months == 63
+    assert snapshot.specializations == ["Программист, разработчик", "Системный инженер"]
+    assert snapshot.employment_types == [
+        "полная занятость",
+        "проектная работа/разовое задание",
+    ]
+    assert [(skill.name, skill.proficiency) for skill in snapshot.skills] == [
+        ("Python", "Продвинутый уровень"),
+        ("Docker", "Продвинутый уровень"),
+        ("RAG", "Средний уровень"),
+        ("FastAPI", "Базовый уровень"),
+    ]
+    # Header demographics and location are never fields on the DTO.
+    assert "Москва" not in snapshot.content_hash()
+
+
+def test_detail_without_confirmed_role_fails_closed():
+    with pytest.raises(CompetitorResumeIndeterminate, match="desired_role"):
+        parse_competitor_resume_text(
+            "Навыки\nPython",
+            resume_id="abc",
+            resume_url="https://hh.ru/resume/abc",
+            headings=["Навыки"],
+        )
+
+
+def test_numeric_role_title_is_not_misparsed_as_salary():
+    snapshot = parse_competitor_resume_text(
+        "3D Generalist - AI Generalist\nОпыт работы 4 года\nНавыки\nCinema 4D",
+        resume_id="3d",
+        resume_url="https://hh.ru/resume/3d",
+        headings=["3D Generalist - AI Generalist", "Опыт работы 4 года", "Навыки"],
+    )
+    assert snapshot.desired_role == "3D Generalist - AI Generalist"
+    assert snapshot.salary_from is None
+
+
+def test_thin_space_salary_and_dashless_specialization_are_normalized():
+    snapshot = parse_competitor_resume_text(
+        "AI Engineer\n2\u2009500\u00a0€ на\u00a0руки\nСпециализации:\nРазработчик\n"
+        "Тип занятости: полная занятость\nОпыт работы 1\u00a0год",
+        resume_id="thin",
+        resume_url="https://hh.ru/resume/thin",
+        headings=["AI Engineer", "2\u2009500\u00a0€ на\u00a0руки", "Опыт работы 1\u00a0год"],
+    )
+    assert snapshot.salary_from == 2500
+    assert snapshot.salary_currency == "EUR"
+    assert snapshot.specializations == ["Разработчик"]
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Пишите test@example.com или +7 999 123-45-67", "Пишите [redacted] или [redacted]"),
+        ("Меня зовут Иван", None),
+        ("Связаться с Иван Петров", None),
+        ("Построил RAG-поиск и сократил latency", "Построил RAG-поиск и сократил latency"),
+    ],
+)
+def test_redact_free_text(raw, expected):
+    assert redact_free_text(raw) == expected
+
+
+def test_report_is_deterministic_and_warns_about_limited_coverage():
+    rows = [
+        {
+            "desired_role": "AI Engineer",
+            "specializations": ["Разработчик"],
+            "skills": [{"name": "Python"}, {"name": "RAG"}],
+            "experience_months": 60,
+            "salary_to": 200_000,
+            "salary_currency": "RUB",
+        },
+        {
+            "desired_role": "AI Engineer",
+            "specializations": ["Разработчик"],
+            "skills": [{"name": "Python"}],
+            "experience_months": 24,
+            "salary_to": 100_000,
+            "salary_currency": "RUB",
+        },
+    ]
+    report = report_competitors(rows, top=10, limited_runs=1)
+    assert "Резюме в выборке: 2" in report
+    assert "ограниченных запусков" in report
+    assert "2  AI Engineer" in report
+    assert "2  Python" in report
+    assert "1  Python + RAG" in report
+    assert "RUB: 200000 (n=2)" in report
+    assert "Добавляйте навык только если он подтверждён" in report

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -11,6 +11,7 @@ from hhru_bot.competitors import (
     parse_search_links,
     redact_free_text,
     report_competitors,
+    sanitize_skill_name,
 )
 from hhru_bot.selector_groups import competitor_resume as selectors
 
@@ -115,6 +116,18 @@ def test_detail_without_confirmed_role_fails_closed():
         )
 
 
+def test_skill_contact_tokens_are_not_persisted():
+    snapshot = parse_competitor_resume_text(
+        "AI Engineer\nНавыки\nPython\ntest@example.com\n+7 999 123-45-67\nhttps://example.com",
+        resume_id="skill-contact",
+        resume_url="https://hh.ru/resume/skill-contact",
+        headings=["AI Engineer", "Навыки"],
+    )
+    assert [skill.name for skill in snapshot.skills] == ["Python"]
+    assert sanitize_skill_name("test@example.com") is None
+    assert sanitize_skill_name("+7 999 123-45-67") is None
+
+
 def test_numeric_role_title_is_not_misparsed_as_salary():
     snapshot = parse_competitor_resume_text(
         "3D Generalist - AI Generalist\nОпыт работы 4 года\nНавыки\nCinema 4D",
@@ -208,13 +221,16 @@ class _Text:
 
 
 class _PaginationPage:
-    def __init__(self, pages, delayed_pages=None):
+    def __init__(self, pages, delayed_pages=None, delayed_block=None):
         self.next = _Locator([])
-        self.block = _Locator(["block"])
+        self.block = _Locator(["block"] if delayed_block is None else [], delayed_block)
         self.pages = _Locator(pages, delayed_pages)
         self.links = _Locator([])
+        self.marker = self.block
 
     def locator(self, selector):
+        if selector == f"{selectors.PAGINATION_BLOCK}, {selectors.PAGINATION_LINK}":
+            return self.marker
         return {
             selectors.PAGINATION_NEXT: self.next,
             selectors.PAGINATION_BLOCK: self.block,
@@ -233,6 +249,12 @@ def test_pagination_timeout_is_indeterminate_not_last_page():
     page = _PaginationPage([])
     with pytest.raises(CompetitorSearchIndeterminate, match="не подтверждена"):
         has_next_search_page(page, 0)
+
+
+def test_pagination_waits_for_delayed_container_before_declaring_last_page():
+    page = _PaginationPage([], delayed_pages=["1", "2"], delayed_block=["block"])
+    assert has_next_search_page(page, 0) is True
+    assert page.block.wait_calls == [("attached", 30_000)]
 
 
 def test_report_is_deterministic_and_warns_about_limited_coverage():

--- a/tests/test_history_competitors.py
+++ b/tests/test_history_competitors.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hhru_bot.history import History
+
+pytestmark = pytest.mark.unit
+
+
+def _snapshot(*, role="AI Engineer", skills=None):
+    return {
+        "resume_id": "r1",
+        "resume_url": "https://hh.ru/resume/r1",
+        "desired_role": role,
+        "salary_from": 100_000,
+        "salary_to": 150_000,
+        "salary_currency": "RUB",
+        "experience_months": 48,
+        "specializations": ["Разработчик"],
+        "employment_types": ["полная занятость"],
+        "work_formats": ["удалённо"],
+        "languages": ["Русский — Родной"],
+        "education": ["Высшее образование"],
+        "experience_summary": None,
+        "achievements": None,
+        "skills": skills or [{"name": "Python", "proficiency": "Продвинутый уровень"}],
+        "content_hash": f"hash:{role}:{skills}",
+    }
+
+
+def test_history_creates_competitor_tables(tmp_path):
+    db = tmp_path / "history.db"
+    History(db)
+    with sqlite3.connect(db) as conn:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {
+        "competitor_resumes",
+        "competitor_resume_skills",
+        "competitor_resume_queries",
+        "competitor_collection_runs",
+    } <= tables
+
+
+def test_upsert_current_snapshot_and_query_relations_are_atomic(tmp_path):
+    history = History(tmp_path / "history.db")
+    assert history.upsert_competitor_resume(_snapshot(), search_query="AI", search_rank=1) == "new"
+    assert (
+        history.upsert_competitor_resume(_snapshot(), search_query="LLM", search_rank=2)
+        == "unchanged"
+    )
+    changed = _snapshot(role="AI Infrastructure Engineer", skills=[{"name": "Docker"}])
+    assert history.upsert_competitor_resume(changed, search_query="AI", search_rank=3) == "updated"
+
+    rows = history.list_competitor_resumes("AI")
+    assert len(rows) == 1
+    assert rows[0]["desired_role"] == "AI Infrastructure Engineer"
+    assert rows[0]["skills"] == [{"name": "Docker", "proficiency": None}]
+    assert len(history.list_competitor_resumes("LLM")) == 1
+
+
+def test_failed_write_rolls_back_previous_snapshot(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.upsert_competitor_resume(_snapshot(), search_query="AI", search_rank=1)
+    broken = _snapshot(role="broken", skills=[{}])
+    with pytest.raises(KeyError):
+        history.upsert_competitor_resume(broken, search_query="AI", search_rank=1)
+    row = history.list_competitor_resumes("AI")[0]
+    assert row["desired_role"] == "AI Engineer"
+    assert row["skills"][0]["name"] == "Python"
+
+
+def test_collection_run_status_and_limited_count(tmp_path):
+    history = History(tmp_path / "history.db")
+    run_id = history.start_competitor_collection("AI", 5)
+    history.finish_competitor_collection(
+        run_id,
+        status="limited",
+        pages_fetched=5,
+        cards_seen=100,
+        details_saved=100,
+        details_failed=0,
+    )
+    assert history.count_limited_competitor_runs("AI") == 1
+    assert history.count_limited_competitor_runs("other") == 0
+
+    complete_id = history.start_competitor_collection("AI", 5)
+    history.finish_competitor_collection(
+        complete_id,
+        status="complete",
+        pages_fetched=2,
+        cards_seen=30,
+        details_saved=30,
+        details_failed=0,
+    )
+    assert history.count_limited_competitor_runs("AI") == 0

--- a/tests/test_history_competitors.py
+++ b/tests/test_history_competitors.py
@@ -34,7 +34,9 @@ def test_history_creates_competitor_tables(tmp_path):
     db = tmp_path / "history.db"
     History(db)
     with sqlite3.connect(db) as conn:
-        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
     assert {
         "competitor_resumes",
         "competitor_resume_skills",

--- a/tests/test_sandbox_preflight.py
+++ b/tests/test_sandbox_preflight.py
@@ -19,6 +19,7 @@ def test_browser_command_registry_is_complete() -> None:
         "bump",
         "call-api",
         "clear-negotiations",
+        "competitors",
         "copy-resume",
         "create-resume",
         "delete-resume",
@@ -43,7 +44,11 @@ def test_browser_command_registry_is_complete() -> None:
         "run",
         "search",
     }
-    for command in cli.BROWSER_COMMANDS - {"clear-negotiations", "professional-roles"}:
+    for command in cli.BROWSER_COMMANDS - {
+        "clear-negotiations",
+        "competitors",
+        "professional-roles",
+    }:
         assert cli._requires_browser(Namespace(command=command))
 
 
@@ -67,6 +72,8 @@ def test_registry_covers_command_modules_that_call_launch_context() -> None:
         (Namespace(command="whoami", online=False), False),
         (Namespace(command="professional-roles", refresh=False), False),
         (Namespace(command="professional-roles", refresh=True), True),
+        (Namespace(command="competitors", competitors_command="collect"), True),
+        (Namespace(command="competitors", competitors_command="report"), False),
         (
             Namespace(command="clear-negotiations", account_wide=False, topic="77", dry_run=True),
             False,

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -86,6 +86,14 @@ def test_professional_roles_is_write_locked_only_for_refresh():
     assert _is_write_command(refresh)
 
 
+def test_competitors_is_write_locked_only_for_collect():
+    parser = cli.build_parser()
+    collect = parser.parse_args(["competitors", "collect", "--text", "AI"])
+    report = parser.parse_args(["competitors", "report", "--text", "AI"])
+    assert _is_write_command(collect)
+    assert not _is_write_command(report)
+
+
 def test_professional_roles_refresh_uses_cache_specific_lock(monkeypatch, tmp_path):
     from hhru_bot import professional_roles
 


### PR DESCRIPTION
## Summary

- add `competitors collect --text QUERY --max-pages N` for applicant-visible resume search and detailed card collection
- persist PII-minimized current snapshots, query sightings, skills, and durable collection-run coverage in SQLite
- add deterministic `competitors report` for roles, skills, combinations, experience, salary, and safe AIProfile/cover-letter guidance
- document the commands and classify collect as browser + local-write while report stays local

Related: #578

## Tests

- `ruff check src tests`
- `python scripts/gen_cli_docs.py --check`
- `pytest -q`
- live READ smoke: `competitors collect --text AI --max-pages 1` under an applicant account; 20 cards found and 20 stored, zero detail failures
- live local report verified query coverage warning, role/specialization/skill aggregates, and normalized RUB/USD/EUR salary values

## Privacy and risks

- stores HH resume ID/link by explicit scope, but excludes names, contacts, photos, demographics, location, activity, raw HTML, and full-page text
- free-text fields are scoped and redacted; unsafe text is discarded
- selectors may drift; required search/detail identity signals fail closed and partial runs remain explicit
- issue remains open pending review and acceptance/live verification
