### PR TITLE
fix: delete published resumes from confirmed profile

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,10 +10,11 @@
 - `live_write` — обратимая мутация своего аккаунта, незаметная посторонним
   (например, создать и удалить черновик резюме).
 - `live_write_danger` — необратимая мутация или действие, видимое посторонним
-  (публикация резюме на модерацию, отклик, bump, ответ в чате, отзыв отклика).
+  (удаление/публикация резюме, отклик, bump, ответ в чате, отзыв отклика).
 
-Граница для команд: `copy-resume` — `live_write`; `edit-education`, `publish-resume`, `apply`,
-`bump`, `run`, `reply-employers`, `edit-education` и `clear-negotiations` — `live_write_danger`.
+Граница для команд: `copy-resume` — `live_write`; `delete-resume`, `edit-education`,
+`publish-resume`, `apply`, `bump`, `run`, `reply-employers` и `clear-negotiations` —
+`live_write_danger`.
 
 Обычный `pytest` безопасен по умолчанию: live-тесты исключены из сбора. Тесты
 без `live_*` дополнительно получают защиту от случайного запуска браузера:

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -1,6 +1,7 @@
-"""Browser step for irreversible resume deletion (#293).
+"""Browser step for irreversible resume deletion (#293/#573).
 
-The operation is intentionally bound to one card containing the requested hash.
+The operation is first bound to one list card containing the requested hash.
+Published resumes then repeat the identity proof on the exact resume page.
 No endpoint is called directly: both destructive steps are UI clicks.
 """
 
@@ -13,10 +14,8 @@ from dataclasses import dataclass
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 
-from .browser import RESUMES_FULL_LIST_URL, goto_hh
+from .browser import RESUMES_FULL_LIST_URL, goto_hh, open_confirmed_resume
 from .selector_groups.resume_list import (
-    RESUME_DELETE_MENU_ACTION,
-    RESUME_LIST_ACTION_MORE,
     RESUME_LIST_CARD,
     RESUME_LIST_CARD_LINK_TPL,
 )
@@ -52,51 +51,44 @@ def _wait_resume_list_ready(page: Page) -> None:
     )
 
 
-def _resolve_delete_action(page: Page, card) -> tuple[Locator | None, str]:
-    """Resolve one delete control without losing the card identity boundary.
+def _resolve_profile_delete_action(page: Page, resume_id: str) -> tuple[Locator | None, str]:
+    """Resolve deletion on the identity-confirmed resume page.
 
-    Draft cards render ``resume-delete`` inside the card.  A different list
-    renderer may put the delete item in a portal after opening the card's
-    actions menu, so that item must be searched globally only after the menu
-    was opened from this exact card.  Missing or duplicate controls remain a
-    normal fail-closed result.
+    The live published-resume menu has visibility/edit/duplicate/share actions
+    but no delete action.  Navigating to the exact public resume URL is safe
+    only after the list card was already bound to ``resume_id``;
+    ``open_confirmed_resume`` independently proves the same identity before
+    this resolver can authorize a click.
     """
+    try:
+        open_confirmed_resume(page, resume_id)
+    except (ValueError, PlaywrightError) as exc:
+        return None, f"страница целевого резюме не подтверждена: {exc}"
+
+    button = page.locator(RESUME_DELETE_BUTTON)
+    button_count = button.count()
+    if button_count > 1:
+        return None, "кнопка удаления на странице резюме подтверждена неоднозначно"
+    try:
+        button.first.wait_for(state="visible", timeout=DELETE_VERIFY_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        return None, f"кнопка удаления на странице резюме не появилась: {exc}"
+    if button.count() != 1:
+        return None, "кнопка удаления на странице резюме не подтверждена однозначно"
+    return button.first, ""
+
+
+def _resolve_delete_action(page: Page, card, resume_id: str) -> tuple[Locator | None, str, bool]:
+    """Resolve an inline draft action or an identity-confirmed profile action."""
     direct = card.locator(RESUME_DELETE_BUTTON)
     direct_count = direct.count()
     if direct_count > 1:
-        return None, "кнопка удаления не подтверждена однозначно"
+        return None, "кнопка удаления в карточке подтверждена неоднозначно", False
     if direct_count == 1:
-        return direct.first, ""
+        return direct.first, "", False
 
-    more = card.locator(RESUME_LIST_ACTION_MORE)
-    if more.count() != 1:
-        return None, "меню действий карточки не подтверждено однозначно"
-
-    menu_action = page.locator(RESUME_DELETE_MENU_ACTION)
-    try:
-        more.first.click()
-        menu_action.first.wait_for(state="visible", timeout=15000)
-    except PlaywrightError:
-        # The SSR actions button can accept a Playwright click before its React
-        # handler is hydrated. Reload once and resolve the same card again so
-        # the second click is a real menu-open attempt, not a stale locator.
-        try:
-            page.reload(wait_until="domcontentloaded")
-            card.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
-            if card.count() != 1:
-                return None, "карточка для recovery меню не подтверждена однозначно"
-            more = card.locator(RESUME_LIST_ACTION_MORE)
-            if more.count() != 1:
-                return None, "меню действий карточки не подтверждено после recovery"
-            more.first.click()
-            menu_action = page.locator(RESUME_DELETE_MENU_ACTION)
-            menu_action.first.wait_for(state="visible", timeout=15000)
-        except PlaywrightError as recovery_exc:
-            return None, f"не удалось открыть действие удаления в меню: {recovery_exc}"
-    menu_count = menu_action.count()
-    if menu_count != 1:
-        return None, "действие удаления в меню не подтверждено однозначно"
-    return menu_action.first, ""
+    button, error = _resolve_profile_delete_action(page, resume_id)
+    return button, error, button is not None
 
 
 def delete_resume_on_hh(
@@ -131,9 +123,14 @@ def delete_resume_on_hh(
         return DeleteResumeResult(
             resume_id, False, f"карточка resume_id={resume_id} не подтверждена однозначно", False
         )
-    button, action_error = _resolve_delete_action(page, card)
-    if action_error:
-        return DeleteResumeResult(resume_id, False, action_error, False)
+    button, action_error, profile_fallback_used = _resolve_delete_action(page, card, resume_id)
+    if action_error or button is None:
+        return DeleteResumeResult(
+            resume_id,
+            False,
+            action_error or "кнопка удаления не подтверждена",
+            False,
+        )
     if dry_run:
         return DeleteResumeResult(resume_id, True, "dry-run; кнопка удаления не нажата")
 
@@ -154,6 +151,24 @@ def delete_resume_on_hh(
                 return DeleteResumeResult(
                     resume_id, False, f"не удалось открыть подтверждение: {exc}"
                 )
+            if profile_fallback_used:
+                try:
+                    page.reload(wait_until="domcontentloaded")
+                except PlaywrightError as reload_exc:
+                    return DeleteResumeResult(
+                        resume_id,
+                        False,
+                        f"recovery страницы резюме не завершён: {reload_exc}",
+                    )
+                button, action_error = _resolve_profile_delete_action(page, resume_id)
+                if action_error or button is None:
+                    return DeleteResumeResult(
+                        resume_id,
+                        False,
+                        action_error or "кнопка удаления не подтверждена после recovery",
+                        False,
+                    )
+                continue
             page.reload(wait_until="domcontentloaded")
             # Same commit-vs-hydration guard as above: after domcontentloaded the
             # React card may not be attached yet, so a bare count()==0 right after
@@ -176,9 +191,16 @@ def delete_resume_on_hh(
                     f"карточка resume_id={resume_id} не подтверждена после recovery reload",
                     False,
                 )
-            button, action_error = _resolve_delete_action(page, card)
-            if action_error:
-                return DeleteResumeResult(resume_id, False, action_error, False)
+            button, action_error, profile_fallback_used = _resolve_delete_action(
+                page, card, resume_id
+            )
+            if action_error or button is None:
+                return DeleteResumeResult(
+                    resume_id,
+                    False,
+                    action_error or "кнопка удаления не подтверждена после recovery",
+                    False,
+                )
 
     confirm = page.locator(RESUME_DELETE_CONFIRM)
     if page.locator(RESUME_DELETE_HIDE_CONFIRM).count() > 1 or confirm.count() != 1:
@@ -192,11 +214,12 @@ def delete_resume_on_hh(
     except PlaywrightError as exc:
         return DeleteResumeResult(resume_id, False, f"ошибка destructive-клика: {exc}", True)
 
-    # The list URL already matches before the click, so wait_for_url alone is
-    # not a post-click signal: Playwright may return immediately.  Waiting for
-    # this identity-bound card to detach proves the rendered list changed after
-    # the destructive click.  Any verification error stays uncertain because
-    # hh.ru may already have accepted the deletion.
+    # On the list-card path, detachment is a useful transition signal.  The
+    # published-resume profile fallback has no list card in the current DOM, so
+    # detachment can return immediately there; the fresh list reload and exact
+    # target absence below remain the authoritative proof for both paths.  Any
+    # verification error stays uncertain because hh.ru may already have
+    # accepted the deletion.
     try:
         card.wait_for(state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS)
         # A different card may have existed before the click.  Waiting for

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -215,13 +215,20 @@ def delete_resume_on_hh(
         return DeleteResumeResult(resume_id, False, f"ошибка destructive-клика: {exc}", True)
 
     # On the list-card path, detachment is a useful transition signal.  The
-    # published-resume profile fallback has no list card in the current DOM, so
-    # detachment can return immediately there; the fresh list reload and exact
-    # target absence below remain the authoritative proof for both paths.  Any
-    # verification error stays uncertain because hh.ru may already have
-    # accepted the deletion.
+    # published-resume profile fallback has no list card in the current DOM;
+    # wait for the profile-side confirm control to leave the DOM instead.  The
+    # dialog is kept mounted until the profile delete action completes, so this
+    # prevents a reload from racing the asynchronous mutation.  The fresh list
+    # reload and exact target absence below remain the authoritative proof for
+    # both paths.  Any verification error stays uncertain because hh.ru may
+    # already have accepted the deletion.
     try:
-        card.wait_for(state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS)
+        if profile_fallback_used:
+            page.locator(RESUME_DELETE_CONFIRM).first.wait_for(
+                state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS
+            )
+        else:
+            card.wait_for(state="detached", timeout=DELETE_VERIFY_TIMEOUT_MS)
         # A different card may have existed before the click.  Waiting for
         # that card alone can therefore succeed before the post-delete render
         # settles.  Force a fresh list document so the readiness marker below

--- a/src/hhru_bot/selector_groups/resume_list.py
+++ b/src/hhru_bot/selector_groups/resume_list.py
@@ -34,16 +34,6 @@ RESUME_LIST_CARD_LINK_TPL = "[data-qa='resume-card-link-{resume_id}']"
 # Кнопка «...» (меню действий) на карточке резюме.
 RESUME_LIST_ACTION_MORE = "[data-qa='resume-list-action-more']"
 
-# Delete is normally an inline action on an unpublished resume card.  Some
-# list renderers expose the same action through the portal-backed actions menu,
-# so keep the menu candidates separate from the identity-bound card selector.
-RESUME_DELETE_MENU_ACTION = (
-    "[data-qa='operations-list-delete-resume'], "
-    "[data-qa='resume-delete-action'], "
-    "[data-qa='resume-delete-menu-item'], "
-    "[role='dialog'] button:has-text('Удалить резюме')"
-)
-
 # Дополнительный (не обязательный) маркер завершённого client render. Карточка
 # приходит из SSR раньше, но actions ещё не подключены: на наблюдавшемся живом
 # hh.ru кнопка «...» начинала работать после появления этого текста. Истиной

--- a/src/hhru_bot/selector_groups/resume_page.py
+++ b/src/hhru_bot/selector_groups/resume_page.py
@@ -83,10 +83,10 @@ RESUME_LANGUAGE_FORM_DEGREE_SELECT = (
 RESUME_LANGUAGE_DEGREE_OPTION = "[data-qa='magritte-select-option-{}']"  # lowercase CEFR code
 RESUME_LANGUAGE_SAVE = "[data-qa='profile-modal-button-save']"
 
-# Live read-only research for issue #293 (2026-08-18).  These controls are
-# rendered on the resume list card, but are kept here with the resume-page
-# controls because they address one resume and the dialog is shared by both
-# list/profile renderers.  The destructive confirm is deliberately distinct
+# Live read-only research for issues #293/#573 (2026-08-18, 2026-08-25).
+# Drafts expose the delete control on the resume-list card; published resumes
+# expose it only on the identity-confirmed resume page.  The confirmation dialog
+# is shared by both renderers.  The destructive confirm is deliberately distinct
 # from the reversible "hide" action.
 RESUME_DELETE_BUTTON = "[data-qa='resume-delete']"
 RESUME_DELETE_TITLE = "[data-qa='resume-delete-title']"

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -67,6 +67,8 @@ class Locator:
                 self.page._recovery_hydrated = True
         else:
             assert state == "detached"
+            if self.selector == RESUME_DELETE_CONFIRM:
+                self.page.profile_completion_waited = timeout
             self.page.waited = timeout
         self.page.waited = timeout
         if self.detached_error:
@@ -90,6 +92,7 @@ class Page:
         self.waited = None
         self.ready_waited = None
         self.confirm_waited = None
+        self.profile_completion_waited = None
         self.reloaded = None
         self.detached_error = detached_error
         self.readiness_error = readiness_error
@@ -205,6 +208,7 @@ def test_profile_action_preserves_confirm_and_post_delete_verification(monkeypat
     assert page.profile_opened is True
     assert page.dialog_opened is True
     assert page.clicked is True
+    assert page.profile_completion_waited == 30_000
 
 
 def test_profile_action_rejects_identity_mismatch_before_click(monkeypatch):

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -1,4 +1,4 @@
-"""Fail-closed post-click verification for delete-resume (#293)."""
+"""Fail-closed post-click verification for delete-resume (#293/#573)."""
 
 from __future__ import annotations
 
@@ -10,11 +10,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page as PlaywrightPage
 
 import hhru_bot.delete_resume as delete
-from hhru_bot.selector_groups.resume_list import (
-    RESUME_DELETE_MENU_ACTION,
-    RESUME_LIST_ACTION_MORE,
-    RESUME_LIST_CARD,
-)
+from hhru_bot.selector_groups.resume_list import RESUME_LIST_CARD
 from hhru_bot.selector_groups.resume_page import RESUME_DELETE_BUTTON, RESUME_DELETE_CONFIRM
 
 pytestmark = pytest.mark.integration
@@ -32,7 +28,6 @@ class Locator:
         self.hydration = hydration
 
     def count(self):
-        # Hydration locator: attached only after the recovery attached-wait.
         if self.hydration and not self.page._recovery_hydrated:
             return 0
         return self._count
@@ -40,21 +35,14 @@ class Locator:
     def locator(self, selector):
         if selector == RESUME_DELETE_BUTTON:
             return Locator(self.page, selector, self.page.direct_count)
-        if selector == RESUME_LIST_ACTION_MORE:
-            return Locator(self.page, selector, self.page.more_count)
         raise AssertionError(selector)
 
     @property
     def first(self):
         return self
 
-    def click(self):
-        if self.selector == RESUME_LIST_ACTION_MORE:
-            if self.page.menu_click_error and not self.page._menu_click_failed:
-                self.page._menu_click_failed = True
-                raise self.page.menu_click_error
-            self.page.menu_opened = True
-        elif self.selector in (RESUME_DELETE_BUTTON, RESUME_DELETE_MENU_ACTION):
+    def click(self, *, timeout=None):  # noqa: ARG002
+        if self.selector == RESUME_DELETE_BUTTON:
             self.page.dialog_opened = True
         else:
             assert self.selector == RESUME_DELETE_CONFIRM
@@ -62,8 +50,8 @@ class Locator:
 
     def wait_for(self, *, state, timeout):
         if state == "visible":
-            if self.selector == RESUME_DELETE_MENU_ACTION and not self.page.menu_opened:
-                raise PlaywrightError("menu action not mounted")
+            if self.count() != 1:
+                raise PlaywrightError("control not mounted")
             if (
                 self.selector == RESUME_DELETE_CONFIRM
                 and self.page.confirm_error
@@ -94,9 +82,7 @@ class Page:
         ready_count=1,
         confirm_error=None,
         direct_count=1,
-        more_count=1,
-        menu_count=0,
-        menu_click_error=None,
+        profile_count=0,
     ):
         self.url = delete.RESUMES_FULL_LIST_URL
         self.dialog_opened = False
@@ -114,23 +100,19 @@ class Page:
         self.recovery_hydration = False
         self._recovery_hydrated = False
         self.direct_count = direct_count
-        self.more_count = more_count
-        self.menu_count = menu_count
-        self.menu_opened = False
-        self.menu_click_error = menu_click_error
-        self._menu_click_failed = False
+        self.profile_count = profile_count
+        self.profile_opened = False
+        self.opened_resume_id = ""
 
     def reload(self, *, wait_until):
         self.reloaded = wait_until
-        # After the recovery reload the card must be re-established through the
-        # attached-wait before its count is trusted (commit-vs-hydration race).
         self.recovery_hydration = True
 
     def locator(self, selector):
+        if selector == RESUME_DELETE_BUTTON:
+            return Locator(self, selector, self.profile_count)
         if selector == RESUME_DELETE_CONFIRM:
             return Locator(self, selector)
-        if selector == RESUME_DELETE_MENU_ACTION:
-            return Locator(self, selector, self.menu_count)
         if self.clicked:
             if selector == RESUME_LIST_CARD:
                 return Locator(
@@ -145,12 +127,18 @@ class Page:
         return Locator(self, selector, detached_error=self.detached_error)
 
 
-def _patch_goto(monkeypatch):
+def _patch_navigation(monkeypatch):
     monkeypatch.setattr(delete, "goto_hh", lambda page, url: None)
+
+    def open_resume(page, resume_id):
+        page.profile_opened = True
+        page.opened_resume_id = resume_id
+
+    monkeypatch.setattr(delete, "open_confirmed_resume", open_resume)
 
 
 def test_success_waits_for_identity_card_to_detach(monkeypatch):
-    _patch_goto(monkeypatch)
+    _patch_navigation(monkeypatch)
     page = Page()
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is True
@@ -162,7 +150,7 @@ def test_success_waits_for_identity_card_to_detach(monkeypatch):
 
 
 def test_post_click_verification_error_is_uncertain(monkeypatch):
-    _patch_goto(monkeypatch)
+    _patch_navigation(monkeypatch)
     page = Page(detached_error=RuntimeError("context closed"))
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is False
@@ -171,7 +159,7 @@ def test_post_click_verification_error_is_uncertain(monkeypatch):
 
 
 def test_detachment_without_ready_list_is_uncertain(monkeypatch):
-    _patch_goto(monkeypatch)
+    _patch_navigation(monkeypatch)
     page = Page(ready_count=0, readiness_error=RuntimeError("list is still rendering"))
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is False
@@ -179,78 +167,102 @@ def test_detachment_without_ready_list_is_uncertain(monkeypatch):
     assert "проверить результат" in result.reason
 
 
-def test_recovery_reload_waits_for_card_hydration(monkeypatch):
-    # Первый клик подтверждения не дождался (hydration), recovery перезагрузил
-    # страницу; после reload карточка появляется только через attached-wait, а
-    # не как мгновенный count()==0 → ложный отказ «не подтверждена после
-    # recovery reload». Без фикса (голый count()==0) удаление ошибочно падало бы.
-    _patch_goto(monkeypatch)
+def test_direct_recovery_reload_waits_for_card_hydration(monkeypatch):
+    _patch_navigation(monkeypatch)
     page = Page(confirm_error=PlaywrightError("confirm not mounted yet"))
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is True
     assert page.reloaded == "domcontentloaded"
 
 
-def test_dry_run_resolves_direct_delete_action_without_menu(monkeypatch):
-    _patch_goto(monkeypatch)
+def test_dry_run_resolves_direct_delete_action_without_profile(monkeypatch):
+    _patch_navigation(monkeypatch)
     page = Page()
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
     assert result.success is True
-    assert page.menu_opened is False
+    assert page.profile_opened is False
+    assert page.dialog_opened is False
     assert page.clicked is False
 
 
-def test_dry_run_resolves_menu_delete_action(monkeypatch):
-    _patch_goto(monkeypatch)
-    page = Page(direct_count=0, menu_count=1)
+def test_published_resume_uses_identity_confirmed_profile_in_dry_run(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(direct_count=0, profile_count=1)
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
     assert result.success is True
-    assert page.menu_opened is True
+    assert page.profile_opened is True
+    assert page.opened_resume_id == RESUME_ID
+    assert page.dialog_opened is False
     assert page.clicked is False
 
 
-def test_menu_delete_action_preserves_post_click_verification(monkeypatch):
-    _patch_goto(monkeypatch)
-    page = Page(direct_count=0, menu_count=1)
+def test_profile_action_preserves_confirm_and_post_delete_verification(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(direct_count=0, profile_count=1)
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
     assert result.success is True
     assert result.uncertain is False
-    assert page.menu_opened is True
+    assert page.profile_opened is True
+    assert page.dialog_opened is True
     assert page.clicked is True
 
 
-def test_menu_action_retries_after_hydration_recovery(monkeypatch):
-    _patch_goto(monkeypatch)
-    page = Page(
-        direct_count=0,
-        menu_count=1,
-        menu_click_error=PlaywrightError("menu handler not hydrated yet"),
-    )
-    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
-    assert result.success is True
-    assert page.menu_opened is True
-    assert page.reloaded == "domcontentloaded"
+def test_profile_action_rejects_identity_mismatch_before_click(monkeypatch):
+    _patch_navigation(monkeypatch)
+
+    def reject_identity(page, resume_id):  # noqa: ARG001
+        raise ValueError("identity резюме не подтверждён")
+
+    monkeypatch.setattr(delete, "open_confirmed_resume", reject_identity)
+    page = Page(direct_count=0, profile_count=1)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+    assert result.success is False
+    assert result.uncertain is False
+    assert "identity резюме" in result.reason
+    assert page.dialog_opened is False
     assert page.clicked is False
 
 
-def test_missing_menu_delete_action_fails_closed(monkeypatch):
-    _patch_goto(monkeypatch)
-    page = Page(direct_count=0, menu_count=0)
+def test_profile_action_missing_fails_closed(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(direct_count=0, profile_count=0)
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
     assert result.success is False
     assert result.uncertain is False
-    assert "действие удаления" in result.reason
+    assert "не появилась" in result.reason
+    assert page.clicked is False
 
 
-def test_ambiguous_menu_delete_action_fails_closed(monkeypatch):
-    _patch_goto(monkeypatch)
-    page = Page(direct_count=0, menu_count=2)
+def test_profile_action_ambiguous_fails_closed(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(direct_count=0, profile_count=2)
     result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
     assert result.success is False
     assert result.uncertain is False
-    assert "однозначно" in result.reason
+    assert "неоднозначно" in result.reason
+    assert page.clicked is False
 
 
-def test_menu_text_fallback_is_scoped_to_portal_dialog():
-    assert "[role='dialog'] button:has-text('Удалить резюме')" in RESUME_DELETE_MENU_ACTION
-    assert ", button:has-text('Удалить резюме')" not in RESUME_DELETE_MENU_ACTION
+def test_profile_action_recovers_before_confirm_click(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(
+        direct_count=0,
+        profile_count=1,
+        confirm_error=PlaywrightError("confirm not mounted yet"),
+    )
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+    assert result.success is True
+    assert result.uncertain is False
+    assert page.profile_opened is True
+    assert page.clicked is True
+
+
+def test_ambiguous_direct_action_does_not_fall_back_to_profile(monkeypatch):
+    _patch_navigation(monkeypatch)
+    page = Page(direct_count=2, profile_count=1)
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=True)
+    assert result.success is False
+    assert result.uncertain is False
+    assert "неоднозначно" in result.reason
+    assert page.profile_opened is False
+    assert page.clicked is False


### PR DESCRIPTION
## Summary
- keep draft deletion bound to the exact list card
- delete published resumes from the exact identity-confirmed resume page because the live card menu has no delete action
- preserve durable intent, uncertain outcomes, and fresh-list post-delete verification
- classify delete-resume as live_write_danger

## Tests
- python3 -m pytest tests/test_delete_resume_browser.py tests/test_delete_resume_command.py tests/test_cli_commands.py tests/test_write_lock.py tests/test_sandbox_preflight.py -q
- python3 scripts/check_pytest_budget.py
- python3 -m ruff check src tests
- python3 -m ruff format --check src tests
- python3 scripts/gen_cli_docs.py --check
- git diff --check

## Live dry-run
- confirmed LIVE TEST POSITION as published and LIVE TEST COPY V3 2026-08-24 as draft via list-resumes
- dry-run succeeded for both exact resume IDs on commit bb7fd65
- destructive force runs remain pending the explicit post-dry-run confirmation gate

Closes #573