### PR TITLE
fix: complete selector contract migration

### DIFF
--- a/src/hhru_bot/commands/clear_negotiations.py
+++ b/src/hhru_bot/commands/clear_negotiations.py
@@ -91,6 +91,12 @@ def _withdraw_topic(page, topic: str) -> tuple[bool, str, bool]:
     to that same card.  Disappearance of a card is not evidence of success.
     """
     acted = False
+    if not all((NEGOTIATION_WITHDRAW, NEGOTIATION_WITHDRAW_CONFIRM, NEGOTIATION_WITHDRAW_SUCCESS)):
+        return (
+            False,
+            "селекторы отзыва не подтверждены картой; destructive click отключён",
+            acted,
+        )
     try:
         url = f"{HH_BASE_URL}/applicant/negotiations?topic={quote(str(topic), safe='')}"
         goto_hh(page, url)

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -255,6 +255,10 @@ def edit_experience_on_hh(
             # The add selector was not confirmed by the research dump.  It is
             # accepted only as a single exact data-qa match, never by button
             # text or a broad CSS selector.
+            if EXPERIENCE_ADD_BUTTON is None:
+                return results + [
+                    ExperienceResult(f"строка опыта {index}: add-триггер не подтверждён однозначно")
+                ]
             add = page.locator(EXPERIENCE_ADD_BUTTON)
             if add.count() != 1:
                 return results + [

--- a/src/hhru_bot/publish_resume.py
+++ b/src/hhru_bot/publish_resume.py
@@ -24,7 +24,6 @@ from .browser import (
 from .config import ResumeConfig
 from .resume_state import ResumeState, is_published, parse_resume_state
 from .selector_groups.resume_page import (
-    RESUME_PUBLISH_BUTTON,
     RESUME_PUBLISH_BUTTON_DATA_QA,
     RESUME_VISIBILITY_BUTTON,
 )
@@ -126,7 +125,15 @@ def publish_resume_on_hh(
             state.is_searchable,
         )
 
-    publish = page.locator(RESUME_PUBLISH_BUTTON).or_(page.locator(RESUME_PUBLISH_BUTTON_DATA_QA))
+    if RESUME_PUBLISH_BUTTON_DATA_QA is None:
+        return PublishResumeResult(
+            resume.id,
+            False,
+            "селектор публикации не подтверждён картой; клик отключён",
+            state.status,
+            state.is_searchable,
+        )
+    publish = page.locator(RESUME_PUBLISH_BUTTON_DATA_QA)
     count = publish.count()
     if count == 0:
         try:

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -497,20 +497,10 @@ def search_vacancies(
 
             # Зарплата (issue #14). Блок опционален: hh.ru не рендерит
             # compensation, если з/п не указана.
-            # ЗП: сначала пробуем data-qa селектор, потом regex-fallback
-            # по HTML карточки (hh.ru перешёл на magritte, #73).
-            salary_text = _optional_text(card, sel.VACANCY_CARD_COMPENSATION)
-            if salary_text is None:
-                try:
-                    # #93: textContent (inner_text) вместо innerHTML. Аудит показал,
-                    # что hh.ru для части вакансий отдаёт ЗП только в textContent
-                    # (JS-рендер в текстовый узел), а в innerHTML блока нет — регексп
-                    # по innerHTML пропускал такие ЗП (5/15 → 19/20 ловится по тексту).
-                    # extract_salary_text корректно работает и с HTML, и с голым текстом
-                    # (удаление тегов на тексте = no-op), поэтому кормим её textContent.
-                    salary_text = extract_salary_text(card_text)
-                except Exception:
-                    logger.warning("Не удалось получить inner_text для ЗП-fallback", exc_info=True)
+            # Устаревший data-qa намеренно отключён контрактом селекторов.
+            # Зарплата извлекается из уже прочитанного текста карточки: это
+            # read-only parser, а не второй угаданный DOM-селектор.
+            salary_text = extract_salary_text(card_text)
             salary = parse_salary(salary_text)
             published_at = parse_publication_time(
                 _optional_text(card, sel.VACANCY_CARD_PUBLICATION_TIME)

--- a/src/hhru_bot/selector_groups/account_profile.py
+++ b/src/hhru_bot/selector_groups/account_profile.py
@@ -16,26 +16,28 @@
 
 from __future__ import annotations
 
+from ._generated import selector as _selector
+
 # ``/profile/me`` redirects to ``/applicant/profile/me``.  Its single visible,
 # non-empty h1 is the current name/readiness marker; it must not by itself
 # authorize absence-based cleanup of the older field schema below.
 ACCOUNT_PROFILE_PATH = "/profile/me"
-ACCOUNT_PROFILE_READY = "h1[data-qa='title']"
+ACCOUNT_PROFILE_READY = _selector("account_profile.ACCOUNT_PROFILE_READY")
 
 # Account-level fields from the authenticated live DOM observed on 2026-08-18.
 # The common-card name/city selectors were absent on 2026-08-24, so the first
 # name remains a separate schema marker before any stale values may be removed.
-ACCOUNT_PROFILE_FIRST_NAME = "[data-qa='profile-common-card-firstname']"
-ACCOUNT_PROFILE_LAST_NAME = "[data-qa='profile-common-card-lastname']"
-ACCOUNT_PROFILE_CITY = "[data-qa='profile-common-card-city']"
-ACCOUNT_PROFILE_PHONE = "[data-qa='profile-contact-item-phone']"
-ACCOUNT_PROFILE_EMAIL = "[data-qa='profile-contact-item-email']"
+ACCOUNT_PROFILE_FIRST_NAME = _selector("account_profile.ACCOUNT_PROFILE_FIRST_NAME")
+ACCOUNT_PROFILE_LAST_NAME = _selector("account_profile.ACCOUNT_PROFILE_LAST_NAME")
+ACCOUNT_PROFILE_CITY = _selector("account_profile.ACCOUNT_PROFILE_CITY")
+ACCOUNT_PROFILE_PHONE = _selector("account_profile.ACCOUNT_PROFILE_PHONE")
+ACCOUNT_PROFILE_EMAIL = _selector("account_profile.ACCOUNT_PROFILE_EMAIL")
 
 # Resume-level contact fields: confirmed in the authenticated live DOM of
 # /resume/{resume_id}; name and city were not rendered as account fields there.
-RESUME_CONTACT_PHONE = "[data-qa='resume-contact-phone-value-preferred']"
-RESUME_CONTACT_EMAIL = "[data-qa='resume-contact-email-value']"
+RESUME_CONTACT_PHONE = _selector("account_profile.RESUME_CONTACT_PHONE")
+RESUME_CONTACT_EMAIL = _selector("account_profile.RESUME_CONTACT_EMAIL")
 
 # /applicant/resumes: confirmed only as profile-header name; no contact fields
 # were present in the observed DOM. Kept separate from account-level selectors.
-RESUME_LIST_PROFILE_NAME = "[data-qa='profile-activator-fullname']"
+RESUME_LIST_PROFILE_NAME = _selector("account_profile.RESUME_LIST_PROFILE_NAME")

--- a/src/hhru_bot/selector_groups/apply_form.py
+++ b/src/hhru_bot/selector_groups/apply_form.py
@@ -9,6 +9,8 @@ toggle/textarea, submit), которые #3 и #7 не трогают. Селе�
 
 from __future__ import annotations
 
+from ._generated import selector as _selector
+
 # сверено живым DOM (F12, /applicant/vacancy_response,
 # multi-resume аккаунт, 2026-08-20). APPLY_RESUME_SELECT был непроверенной
 # заглушкой и не существует на реальной форме (`resume-topic-title` не
@@ -43,12 +45,13 @@ from __future__ import annotations
 #
 # Обе ветки поддержаны в steps.fill_response_form через Locator.or_. Full-page
 # селекторы НЕ удалять: оба shape наблюдались в дампах одного дня (08-16).
-APPLY_RESUME_SELECT = "[data-qa='resume-title']"
+APPLY_RESUME_SELECT = _selector("apply_form.APPLY_RESUME_SELECT")
 # The text node is nested inside the actual Magritte toggle container.  Keep
 # APPLY_RESUME_SELECT for discovery/opening, but use this ancestor for closing.
-APPLY_RESUME_TOGGLE = "[data-qa='resume-title'] >> xpath=ancestor::*[@role='button'][1]"
-APPLY_RESUME_OPTION_PREFIX = "magritte-select-option-"
-APPLY_COVER_LETTER_TOGGLE = "[data-qa='vacancy-response-letter-toggle']"
+APPLY_RESUME_TOGGLE = _selector("apply_form.APPLY_RESUME_TOGGLE")
+APPLY_RESUME_OPTION = _selector("apply_form.APPLY_RESUME_OPTION")
+APPLY_RESUME_OPTION_PREFIX = "magritte-select-option-"  # compatibility for fakes/tests
+APPLY_COVER_LETTER_TOGGLE = _selector("apply_form.APPLY_COVER_LETTER_TOGGLE")
 # Тоггл письма МОДАЛКИ. Подтверждён дампами 2026-08-20 (apply_136190065/136190066):
 #   <button type="button" data-qa="add-cover-letter"> внутри data-qa="actions-container"
 # Живёт ВНЕ <form>, а раскрываемая им textarea (APPLY_COVER_LETTER_TEXTAREA,
@@ -68,7 +71,7 @@ APPLY_COVER_LETTER_TOGGLE = "[data-qa='vacancy-response-letter-toggle']"
 # (hh.ru ЗАМЕНЯЕТ тоггл на textarea — probe_136190065: initial тоггл=1/ta=0,
 # form тоггл=0/ta=1). Поэтому безусловный клик по видимому тогглу не может свернуть
 # уже развёрнутое поле.
-APPLY_COVER_LETTER_TOGGLE_POPUP = "[data-qa='add-cover-letter']"
+APPLY_COVER_LETTER_TOGGLE_POPUP = _selector("apply_form.APPLY_COVER_LETTER_TOGGLE_POPUP")
 # Всплывающая панель со списком резюме (Magritte drop-base). Источник подтверждения —
 # боевой лог 2026-08-20 (`data/logs/hhru_bot.log`): в сообщении Playwright об
 # интерсепте напечатан РОВНО ОДИН элемент
@@ -86,21 +89,21 @@ APPLY_COVER_LETTER_TOGGLE_POPUP = "[data-qa='add-cover-letter']"
 # (`magritte-select-option-{resume_id}`, выбранная несёт aria-selected="true"),
 # поэтому ждать СКРЫТИЯ ОПЦИИ нельзя: она остаётся visible, пока панель открыта.
 # Закрывать нужно саму панель, а её исчезновение — по этому селектору.
-APPLY_RESUME_DROPDOWN = "[data-qa='drop-base']"
-APPLY_COVER_LETTER_TEXTAREA = "textarea[data-qa='vacancy-response-popup-form-letter-input']"
-APPLY_SUBMIT_BUTTON = "[data-qa='vacancy-response-submit-popup']"
+APPLY_RESUME_DROPDOWN = _selector("apply_form.APPLY_RESUME_DROPDOWN")
+APPLY_COVER_LETTER_TEXTAREA = _selector("apply_form.APPLY_COVER_LETTER_TEXTAREA")
+APPLY_SUBMIT_BUTTON = _selector("apply_form.APPLY_SUBMIT_BUTTON")
 
 # --- #95: детекция тест-вопросов/анкет в форме отклика (detect-only, NO auto-answer) ---
 # Подтверждено konard reference (hh-selectors.mjs / qa.mjs, production hh.ru automation).
 # task-body — контейнер вопроса; task-question — текст вопроса внутри него. На нашем
 # аккаунте НЕ сверялись живым дампом, но konard использует их в боевом коде.
-APPLY_QUESTION_BODY = "[data-qa='task-body']"  # подтверждено (konard)
-APPLY_QUESTION_TEXT = "[data-qa='task-question']"  # подтверждено (konard), внутри task-body
-APPLY_QUESTION_FORM_BODY = "form[name='vacancy_response'] [data-qa='task-body']"
+APPLY_QUESTION_BODY = _selector("apply_form.APPLY_QUESTION_BODY")
+APPLY_QUESTION_TEXT = _selector("apply_form.APPLY_QUESTION_TEXT")
+APPLY_QUESTION_FORM_BODY = _selector("apply_form.APPLY_QUESTION_FORM_BODY")
 
 # Второй (full-page) вариант textarea сопроводительного письма — нужен heuristic-фильтру,
 # чтобы не принять cover-letter textarea за ответ на вопрос. konard: coverLetterTextareaForm.
-APPLY_COVER_LETTER_TEXTAREA_FORM = "textarea[data-qa='vacancy-response-form-letter-input']"
+APPLY_COVER_LETTER_TEXTAREA_FORM = _selector("apply_form.APPLY_COVER_LETTER_TEXTAREA_FORM")
 
 # Heuristic-селекторы (НЕ data-qa, поэтому живут в apply/questions.py, а не в selector_groups):
 # input[type='radio'], input[type='checkbox'], голый textarea — они используются

--- a/src/hhru_bot/selector_groups/competitor_resume.py
+++ b/src/hhru_bot/selector_groups/competitor_resume.py
@@ -1,12 +1,14 @@
 """Selectors for the applicant-visible resume search and public resume page."""
 
+from ._generated import selector as _selector
+
 # Keep the search link scoped to main: the header also contains resume links.
 SEARCH_RESULT_LINK = "main a[href^='/resume/']"
 SEARCH_MAIN = "main"
-SEARCH_EMPTY = "[data-qa='resume-search-empty'], [data-qa='bloko-header-2']"
-PAGINATION_NEXT = "[data-qa*='pager-next'], [data-qa*='pagination-next'], a[rel='next']"
-PAGINATION_BLOCK = "[data-qa*='pager-block'], [data-qa*='pagination']"
-PAGINATION_PAGE = "[data-qa*='pager-page'], [data-qa*='pagination-page']"
+SEARCH_EMPTY = _selector("competitor_resume.SEARCH_EMPTY")
+PAGINATION_NEXT = _selector("competitor_resume.PAGINATION_NEXT")
+PAGINATION_BLOCK = _selector("competitor_resume.PAGINATION_BLOCK")
+PAGINATION_PAGE = _selector("competitor_resume.PAGINATION_PAGE")
 PAGINATION_LINK = "main a[href*='/search/resume'][href*='page=']"
 
 DETAIL_MAIN = "main"

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -13,15 +13,18 @@
 
 from __future__ import annotations
 
+from ._generated import optional_selector as _optional_selector
+from ._generated import selector as _selector
+
 # Карточка одной переписки в списке откликов/приглашений.
-NEGOTIATION_ITEM = "[data-qa='negotiations-item']"
+NEGOTIATION_ITEM = _selector("negotiations.NEGOTIATION_ITEM")
 # Вакансия внутри карточки. Живая разметка (#44) — <span> без href, вложенный
 # в <a href="/vacancy/...">; vacancy_id/chat_url достаёт _href_or_ancestor_href()
 # в responses.py, поднимаясь до предка <a>, если у самого узла href нет.
-NEGOTIATION_VACANCY_LINK = "[data-qa='negotiations-item-vacancy']"
+NEGOTIATION_VACANCY_LINK = _selector("negotiations.NEGOTIATION_VACANCY_LINK")
 # Название компании-работодода. Опционально (hh.ru иногда прячет для анонимных
 # вакансий) — пустая строка, если элемента нет.
-NEGOTIATION_EMPLOYER = "[data-qa='negotiations-item-company']"
+NEGOTIATION_EMPLOYER = _selector("negotiations.NEGOTIATION_EMPLOYER")
 # Бейдж текущего статуса переписки (текст нормализуется: Приглашение→invitation
 # и т.д.). Опциональный: для свежего отклика без ответа статуса-бейджа может не быть.
 # Точное совпадение data-qa со значением, содержащим пробел ("negotiations-tag
@@ -30,36 +33,36 @@ NEGOTIATION_EMPLOYER = "[data-qa='negotiations-item-company']"
 # Статус определяется по нормализации ТЕКСТА бейджа (normalize_status в
 # responses.py), а не по различению viewed/not-viewed на уровне CSS, поэтому
 # один префиксный селектор покрывает оба состояния.
-NEGOTIATION_STATUS = "[data-qa^='negotiations-tag']"
+NEGOTIATION_STATUS = _selector("negotiations.NEGOTIATION_STATUS")
 # Дата ответа/последнего сообщения в карточке (как текст; парсинг конкретной
 # даты не делается — форматы hh.ru зависят от локали).
 # Опциональна: hh.ru не всегда рендерит блок даты.
-NEGOTIATION_DATE = "[data-qa='negotiations-item-date']"
+NEGOTIATION_DATE = _selector("negotiations.NEGOTIATION_DATE")
 # Ссылка «перейти в чат» с работодателем — chat_url (опциональна: у части статусов
 # чата нет, напр. discard). Берётся из href, как fallback — href ссылки вакансии.
-NEGOTIATION_CHAT_LINK = "[data-qa='open_chat']"
+NEGOTIATION_CHAT_LINK = _selector("negotiations.NEGOTIATION_CHAT_LINK")
 # Кнопка «следующая страница» пагинации списка (та же data-qa, что и в поиске,
 # но вынесена сюда, чтобы responses.py не зависел от search_page).
-NEGOTIATIONS_PAGINATION_NEXT = "[data-qa='pager-next']"
+NEGOTIATIONS_PAGINATION_NEXT = _selector("negotiations.NEGOTIATIONS_PAGINATION_NEXT")
 # Номера страниц — fallback для A/B-варианта hh.ru без pager-next.
-NEGOTIATIONS_PAGINATION_PAGE = "[data-qa='pager-page']"
+NEGOTIATIONS_PAGINATION_PAGE = _selector("negotiations.NEGOTIATIONS_PAGINATION_PAGE")
 # Контейнер пагинации общего компонента hh.ru; нет на честной единственной странице.
-NEGOTIATIONS_PAGINATION_BLOCK = "[data-qa='pager-block']"
+NEGOTIATIONS_PAGINATION_BLOCK = _selector("negotiations.NEGOTIATIONS_PAGINATION_BLOCK")
 
 # Write controls are intentionally kept separate from the read selectors above.
 # The exact data-qa names below must be rechecked against a logged-in DOM before
 # the first real withdrawal; an unknown or changed selector is a refusal, never
 # a reason to fall back to a guessed button or a direct HTTP request.
-NEGOTIATION_WITHDRAW = "[data-qa='negotiations-item-withdraw']"
-NEGOTIATION_WITHDRAW_CONFIRM = "[data-qa='negotiations-withdraw-confirm']"
-NEGOTIATION_WITHDRAW_SUCCESS = "[data-qa='negotiations-item-withdrawn']"
+NEGOTIATION_WITHDRAW = _optional_selector("negotiations.NEGOTIATION_WITHDRAW")
+NEGOTIATION_WITHDRAW_CONFIRM = _optional_selector("negotiations.NEGOTIATION_WITHDRAW_CONFIRM")
+NEGOTIATION_WITHDRAW_SUCCESS = _optional_selector("negotiations.NEGOTIATION_WITHDRAW_SUCCESS")
 
 # Compatibility with old saved markup fixtures during selector migration.
-LEGACY_NEGOTIATION_VACANCY_LINK = "[data-qa='negotiations-item__vacancy-link']"
-LEGACY_NEGOTIATION_EMPLOYER = "[data-qa='negotiations-item__employer']"
-LEGACY_NEGOTIATION_STATUS = "[data-qa='negotiations-item__state']"
-LEGACY_NEGOTIATION_DATE = "[data-qa='negotiations-item__date']"
-LEGACY_NEGOTIATION_CHAT_LINK = "[data-qa='negotiations-item__messages-link']"
+LEGACY_NEGOTIATION_VACANCY_LINK = _selector("negotiations.LEGACY_NEGOTIATION_VACANCY_LINK")
+LEGACY_NEGOTIATION_EMPLOYER = _selector("negotiations.LEGACY_NEGOTIATION_EMPLOYER")
+LEGACY_NEGOTIATION_STATUS = _selector("negotiations.LEGACY_NEGOTIATION_STATUS")
+LEGACY_NEGOTIATION_DATE = _selector("negotiations.LEGACY_NEGOTIATION_DATE")
+LEGACY_NEGOTIATION_CHAT_LINK = _selector("negotiations.LEGACY_NEGOTIATION_CHAT_LINK")
 
 # Chat route (chatik.hh.ru/chat/<chatId>), confirmed by probe --negotiations
 # --topic (#107). The text node is message-specific; its ancestor carries
@@ -68,14 +71,13 @@ LEGACY_NEGOTIATION_CHAT_LINK = "[data-qa='negotiations-item__messages-link']"
 # system message (e.g. "отклик отправлен") is excluded — it carries no
 # message_my/message_other marker, so without this exclusion it would be
 # treated as an employer message by any :not(message_my) check.
-CHAT_MESSAGE_TEXT = (
-    '[data-qa^="chatik-chat-message-"][data-qa$="-text"]'
-    ':not([data-qa="chatik-chat-message-applicant-action-text"])'
-)
+CHAT_MESSAGE_TEXT = _selector("negotiations.CHAT_MESSAGE_TEXT")
+CHAT_MESSAGE_ROOT = _selector("negotiations.CHAT_MESSAGE_ROOT")
+CHAT_AUTHOR_HINT = _selector("negotiations.CHAT_AUTHOR_HINT")
 CHAT_MESSAGE_MY_MARKER = "message_my"
 CHAT_MESSAGE_OTHER_MARKER = "message_other"
 
 # Composer controls on chatik.hh.ru.  Keep these here with the read selectors so
 # a markup change cannot leave the write path with a private, stale selector.
-CHAT_MESSAGE_INPUT = "textarea[data-qa='chatik-chat-message-input']"
-CHAT_MESSAGE_SEND = "button[data-qa='chatik-chat-message-send']"
+CHAT_MESSAGE_INPUT = _selector("negotiations.CHAT_MESSAGE_INPUT")
+CHAT_MESSAGE_SEND = _selector("negotiations.CHAT_MESSAGE_SEND")

--- a/src/hhru_bot/selector_groups/resume_experience.py
+++ b/src/hhru_bot/selector_groups/resume_experience.py
@@ -6,17 +6,20 @@ resume page and the form lives at ``/profile/edit/experience/{rowId}``.
 
 from __future__ import annotations
 
-EXPERIENCE_EDIT_BUTTON = "[data-qa='edit-experience-button-{index}']"
-EXPERIENCE_COMPANY = "[data-qa='resume-profile-experience-specific-company-input-{index}']"
-EXPERIENCE_POSITION = "[data-qa='resume-profile-experience-specific-position-input-{index}']"
-EXPERIENCE_COMPANY_URL = "[data-qa='resume-editor-experience-company-url-input']"
-EXPERIENCE_START_YEAR = "[data-qa='resume-editor-experience-start-year-input']"
-EXPERIENCE_END_YEAR = "[data-qa='resume-editor-experience-end-year-input']"
-EXPERIENCE_DESCRIPTION = "[data-qa='resume-editor-experience-description-input']"
-EXPERIENCE_CANCEL = "[data-qa='profile-layout-cancel-button']"
-EXPERIENCE_SAVE = "[data-qa='profile-layout-save-button']"
+from ._generated import optional_selector as _optional_selector
+from ._generated import selector as _selector
+
+EXPERIENCE_EDIT_BUTTON = _selector("resume_experience.EXPERIENCE_EDIT_BUTTON")
+EXPERIENCE_COMPANY = _selector("resume_experience.EXPERIENCE_COMPANY")
+EXPERIENCE_POSITION = _selector("resume_experience.EXPERIENCE_POSITION")
+EXPERIENCE_COMPANY_URL = _selector("resume_experience.EXPERIENCE_COMPANY_URL")
+EXPERIENCE_START_YEAR = _selector("resume_experience.EXPERIENCE_START_YEAR")
+EXPERIENCE_END_YEAR = _selector("resume_experience.EXPERIENCE_END_YEAR")
+EXPERIENCE_DESCRIPTION = _selector("resume_experience.EXPERIENCE_DESCRIPTION")
+EXPERIENCE_CANCEL = _selector("resume_experience.EXPERIENCE_CANCEL")
+EXPERIENCE_SAVE = _selector("resume_experience.EXPERIENCE_SAVE")
 
 # The add trigger is intentionally a candidate: unlike the row/editor fields,
 # it was not present in the read-only research dump.  Code must require one
 # unambiguous match and fail closed rather than click a text button by guess.
-EXPERIENCE_ADD_BUTTON = "[data-qa='resume-profile-experience-add-button']"
+EXPERIENCE_ADD_BUTTON = _optional_selector("resume_experience.EXPERIENCE_ADD_BUTTON")

--- a/src/hhru_bot/selector_groups/resume_list.py
+++ b/src/hhru_bot/selector_groups/resume_list.py
@@ -24,15 +24,18 @@
 
 from __future__ import annotations
 
+from ._generated import selector as _selector
+
 # Карточка одного резюме в списке.
-RESUME_LIST_CARD = "[data-qa='resume']"
+RESUME_LIST_CARD = _selector("resume_list.RESUME_LIST_CARD")
 
 # Ссылка на резюме внутри карточки; hash — resume_id из URL резюме.
 # Используется для привязки карточки к конкретному резюме (identity-bound, #33).
-RESUME_LIST_CARD_LINK_TPL = "[data-qa='resume-card-link-{resume_id}']"
+RESUME_LIST_CARD_LINK_TPL = _selector("resume_list.RESUME_LIST_CARD_LINK_TPL")
+RESUME_LIST_CARD_LINK_PREFIX = _selector("resume_list.RESUME_LIST_CARD_LINK_PREFIX")
 
 # Кнопка «...» (меню действий) на карточке резюме.
-RESUME_LIST_ACTION_MORE = "[data-qa='resume-list-action-more']"
+RESUME_LIST_ACTION_MORE = _selector("resume_list.RESUME_LIST_ACTION_MORE")
 
 # Дополнительный (не обязательный) маркер завершённого client render. Карточка
 # приходит из SSR раньше, но actions ещё не подключены: на наблюдавшемся живом
@@ -41,10 +44,10 @@ RESUME_LIST_ACTION_MORE = "[data-qa='resume-list-action-more']"
 RESUME_PROFILE_READY = "button:has-text('подходящие вакансии')"
 
 # Пункт «Дублировать» в открытом меню «...».
-RESUME_DUPLICATE_MENU_ITEM = "[data-qa='operations-list-duplicate-resume']"
+RESUME_DUPLICATE_MENU_ITEM = _selector("resume_list.RESUME_DUPLICATE_MENU_ITEM")
 
 # Инлайн-кнопка «Дублировать» (второй вариант рендера того же действия).
-RESUME_DUPLICATE_INLINE = "[data-qa='resume-dublicate']"
+RESUME_DUPLICATE_INLINE = _selector("resume_list.RESUME_DUPLICATE_INLINE")
 
 # Заголовок (название) резюме внутри карточки — НЕ ПОДТВЕРЖДЕНО (см. докстринг).
-RESUME_LIST_CARD_TITLE = "[data-qa='resume-title']"
+RESUME_LIST_CARD_TITLE = _selector("resume_list.RESUME_LIST_CARD_TITLE")

--- a/src/hhru_bot/selector_groups/resume_page.py
+++ b/src/hhru_bot/selector_groups/resume_page.py
@@ -8,14 +8,17 @@
 
 from __future__ import annotations
 
+from ._generated import optional_selector as _optional_selector
+from ._generated import selector as _selector
+
 # Existing bump selectors (confirmed by the bump feature's live check).
-RESUME_BUMP_BUTTON = "[data-qa='resume-update-button']"
-RESUME_BUMP_DISABLED_HINT = "[data-qa='resume-update-button-disabled']"
+RESUME_BUMP_BUTTON = _selector("resume_page.RESUME_BUMP_BUTTON")
+RESUME_BUMP_DISABLED_HINT = _selector("resume_page.RESUME_BUMP_DISABLED_HINT")
 
 # Кандидаты из исходного флоу (#219); на заблокированной копии #225 ни один не
 # присутствовал в живом DOM. Команда обязана проверять count и не угадывать.
 RESUME_PUBLISH_BUTTON = "button:has-text('Опубликовать')"
-RESUME_PUBLISH_BUTTON_DATA_QA = "[data-qa='resume-publish']"
+RESUME_PUBLISH_BUTTON_DATA_QA = _optional_selector("resume_page.RESUME_PUBLISH_BUTTON_DATA_QA")
 # Только read-only сообщение о текущей видимости; команда его не нажимает.
 RESUME_VISIBILITY_BUTTON = "button:has-text('Изменить видимость')"
 
@@ -24,38 +27,36 @@ RESUME_VISIBILITY_BUTTON = "button:has-text('Изменить видимость
 # found the same claim false for the neighbouring position/skills editors on
 # this same profile page — this claim is unaudited against #328's finding and
 # should not be trusted until re-verified on live DOM (see #328 follow-up).
-RESUME_EDIT_ABOUT_BUTTON = "[data-qa='resume-edit-button-about']"
-RESUME_ABOUT_EDITOR = "[data-qa='resume-editor-about']"
-RESUME_ABOUT_NO_EXPERIENCE_REASON = "[data-qa^='resume-editor-about-no-experience-reason-']"
+RESUME_EDIT_ABOUT_BUTTON = _selector("resume_page.RESUME_EDIT_ABOUT_BUTTON")
+RESUME_ABOUT_EDITOR = _selector("resume_page.RESUME_ABOUT_EDITOR")
+RESUME_ABOUT_NO_EXPERIENCE_REASON = _selector("resume_page.RESUME_ABOUT_NO_EXPERIENCE_REASON")
 
 # The profile-page control routes to /resume/edit/{id}/keySkills before the
 # editor is mounted (authenticated live audit, #328).
-RESUME_SKILLS_EDIT_BUTTON = "[data-qa='skills-add']"
-RESUME_SKILLS_INPUT = "[data-qa='resume-editor-skills-input']"
-RESUME_SKILLS_CHIP_INPUT = "[data-qa='chips-trigger-input']"
-RESUME_SKILLS_RECOMMENDED = "[data-qa^='resume-editor-skills-recommended-']"
-RESUME_SKILLS_CHIP = "[data-qa^='chips-trigger-chip-']"
-RESUME_PARTIAL_EDIT_CANCEL = "[data-qa='resume-partial-edit-cancel']"
-RESUME_PARTIAL_EDIT_SAVE = "[data-qa='resume-partial-edit-save']"
+RESUME_SKILLS_EDIT_BUTTON = _selector("resume_page.RESUME_SKILLS_EDIT_BUTTON")
+RESUME_SKILLS_INPUT = _selector("resume_page.RESUME_SKILLS_INPUT")
+RESUME_SKILLS_CHIP_INPUT = _selector("resume_page.RESUME_SKILLS_CHIP_INPUT")
+RESUME_SKILLS_RECOMMENDED = _selector("resume_page.RESUME_SKILLS_RECOMMENDED")
+RESUME_SKILLS_CHIP = _selector("resume_page.RESUME_SKILLS_CHIP")
+RESUME_PARTIAL_EDIT_CANCEL = _selector("resume_page.RESUME_PARTIAL_EDIT_CANCEL")
+RESUME_PARTIAL_EDIT_SAVE = _selector("resume_page.RESUME_PARTIAL_EDIT_SAVE")
 
 # The Magritte select panel used by the position editor.  The panel remains
 # mounted after selecting an option, so callers must close it explicitly and
 # wait for this panel (rather than an option) to become hidden.
-RESUME_POSITION_DROPDOWN = "[data-qa='drop-base']"
+RESUME_POSITION_DROPDOWN = _selector("resume_page.RESUME_POSITION_DROPDOWN")
 
 # Specializations in the position editor are a nested, multi-select tree.  The
 # full tree (including the search and confirmation controls) was confirmed in
 # the authenticated live DOM of the position editor on 2026-08-24 (issue
 # #521).  The modal can remain open after selecting an option, so callers must
 # wait for this dialog to hide after submitting it.
-RESUME_SPECIALIZATION_ADD = "[data-qa='resume-position-professional-role-add-button']"
-RESUME_SPECIALIZATION_MODAL = "[data-qa='professional-roles-modal']"
-RESUME_SPECIALIZATION_SEARCH = "[data-qa='tree-selector-search-input']"
-RESUME_SPECIALIZATION_OPTION = (
-    "[data-qa^='tree-selector-item tree-selector-item-'][data-qa*='tree-selector-child-']"
-)
-RESUME_SPECIALIZATION_DELETE = "[data-qa='resume-position-professional-role-card-delete']"
-RESUME_SPECIALIZATION_SUBMIT = "[data-qa='professional-roles-submit']"
+RESUME_SPECIALIZATION_ADD = _selector("resume_page.RESUME_SPECIALIZATION_ADD")
+RESUME_SPECIALIZATION_MODAL = _selector("resume_page.RESUME_SPECIALIZATION_MODAL")
+RESUME_SPECIALIZATION_SEARCH = _selector("resume_page.RESUME_SPECIALIZATION_SEARCH")
+RESUME_SPECIALIZATION_OPTION = _selector("resume_page.RESUME_SPECIALIZATION_OPTION")
+RESUME_SPECIALIZATION_DELETE = _selector("resume_page.RESUME_SPECIALIZATION_DELETE")
+RESUME_SPECIALIZATION_SUBMIT = _selector("resume_page.RESUME_SPECIALIZATION_SUBMIT")
 
 # Language block and modal selectors confirmed on the authenticated read-only
 # DOM of /applicant/profile/me on 2026-08-20 (issue #265).  Languages are a
@@ -69,42 +70,38 @@ RESUME_SPECIALIZATION_SUBMIT = "[data-qa='professional-roles-submit']"
 # that structure, not by splitting the row's combined text.  The degree
 # select shows only the six CEFR options (A1-C2); there is no guessed CEFR for
 # an existing "Родной" (native) entry, so that value is out of scope for #265.
-RESUME_LANGUAGE_CARD = "[data-qa='profile-language-card']"
-RESUME_LANGUAGE_ROW = "[data-qa^='profile-language-card-row-']"
-RESUME_LANGUAGE_ROW_CELL_TEXT = "[data-qa='cell-text']"
-RESUME_LANGUAGE_ADD_BUTTON = "[data-qa='profile-language-add']"
-RESUME_LANGUAGE_ADD_FORM = "[data-qa='profile-language-add-form']"
-RESUME_LANGUAGE_FORM_LANGUAGE_SELECT = (
-    "[data-qa='profile-language-add-form-language'] [data-qa='magritte-select-activator']"
-)
-RESUME_LANGUAGE_FORM_DEGREE_SELECT = (
-    "[data-qa='profile-language-add-form-degree'] [data-qa='magritte-select-activator']"
-)
-RESUME_LANGUAGE_DEGREE_OPTION = "[data-qa='magritte-select-option-{}']"  # lowercase CEFR code
-RESUME_LANGUAGE_SAVE = "[data-qa='profile-modal-button-save']"
+RESUME_LANGUAGE_CARD = _selector("resume_page.RESUME_LANGUAGE_CARD")
+RESUME_LANGUAGE_ROW = _selector("resume_page.RESUME_LANGUAGE_ROW")
+RESUME_LANGUAGE_ROW_CELL_TEXT = _selector("resume_page.RESUME_LANGUAGE_ROW_CELL_TEXT")
+RESUME_LANGUAGE_ADD_BUTTON = _selector("resume_page.RESUME_LANGUAGE_ADD_BUTTON")
+RESUME_LANGUAGE_ADD_FORM = _selector("resume_page.RESUME_LANGUAGE_ADD_FORM")
+RESUME_LANGUAGE_FORM_LANGUAGE_SELECT = _selector("resume_page.RESUME_LANGUAGE_FORM_LANGUAGE_SELECT")
+RESUME_LANGUAGE_FORM_DEGREE_SELECT = _selector("resume_page.RESUME_LANGUAGE_FORM_DEGREE_SELECT")
+RESUME_LANGUAGE_DEGREE_OPTION = _selector("resume_page.RESUME_LANGUAGE_DEGREE_OPTION")
+RESUME_LANGUAGE_SAVE = _selector("resume_page.RESUME_LANGUAGE_SAVE")
 
 # Live read-only research for issues #293/#573 (2026-08-18, 2026-08-25).
 # Drafts expose the delete control on the resume-list card; published resumes
 # expose it only on the identity-confirmed resume page.  The confirmation dialog
 # is shared by both renderers.  The destructive confirm is deliberately distinct
 # from the reversible "hide" action.
-RESUME_DELETE_BUTTON = "[data-qa='resume-delete']"
-RESUME_DELETE_TITLE = "[data-qa='resume-delete-title']"
-RESUME_DELETE_CONTENT = "[data-qa='resume-delete-content']"
-RESUME_DELETE_CONFIRM = "[data-qa='resume-delete-confirm']"
-RESUME_DELETE_HIDE_CONFIRM = "[data-qa='resume-hide-confirm']"
-RESUME_DELETE_CLOSE = "[data-qa='resume-delete-close']"
+RESUME_DELETE_BUTTON = _selector("resume_page.RESUME_DELETE_BUTTON")
+RESUME_DELETE_TITLE = _selector("resume_page.RESUME_DELETE_TITLE")
+RESUME_DELETE_CONTENT = _selector("resume_page.RESUME_DELETE_CONTENT")
+RESUME_DELETE_CONFIRM = _selector("resume_page.RESUME_DELETE_CONFIRM")
+RESUME_DELETE_HIDE_CONFIRM = _selector("resume_page.RESUME_DELETE_HIDE_CONFIRM")
+RESUME_DELETE_CLOSE = _selector("resume_page.RESUME_DELETE_CLOSE")
 
 # Create-resume wizard (#304), confirmed against the authenticated live DOM
 # on 2026-08-18.  The catalog is a live tree: top-level rows expand, while
 # leaf professions have checkboxes.  Do not replace this with a hand-copied
 # partial list; the tree search exposes the full current catalog.
-RESUME_CREATE_BUTTON = "[data-qa='mainmenu_createResume']"
+RESUME_CREATE_BUTTON = _selector("resume_page.RESUME_CREATE_BUTTON")
 RESUME_CREATION_URL = "/profile/resume/professional_role"
-RESUME_CREATION_SELECT_JOB = "[data-qa='resume-profile-card-select-job']"
-RESUME_CREATION_POSITION = "[data-qa='resume-profile-position-input']"
-RESUME_CREATION_POSITION_CLEAR = "[data-qa='input-clearable-button']"
-RESUME_CREATION_NEXT = "[data-qa='resume-profile-next-screen']"
-RESUME_CREATION_CATEGORY_SEARCH = "[data-qa='tree-selector-search-input']"
-RESUME_CREATION_CATEGORY_SUBMIT = "[data-qa='category-modal-submit']"
-RESUME_CREATION_CATEGORY_INPUT = "[data-qa~='tree-selector-input-{}']"
+RESUME_CREATION_SELECT_JOB = _selector("resume_page.RESUME_CREATION_SELECT_JOB")
+RESUME_CREATION_POSITION = _selector("resume_page.RESUME_CREATION_POSITION")
+RESUME_CREATION_POSITION_CLEAR = _selector("resume_page.RESUME_CREATION_POSITION_CLEAR")
+RESUME_CREATION_NEXT = _selector("resume_page.RESUME_CREATION_NEXT")
+RESUME_CREATION_CATEGORY_SEARCH = _selector("resume_page.RESUME_CREATION_CATEGORY_SEARCH")
+RESUME_CREATION_CATEGORY_SUBMIT = _selector("resume_page.RESUME_CREATION_CATEGORY_SUBMIT")
+RESUME_CREATION_CATEGORY_INPUT = _selector("resume_page.RESUME_CREATION_CATEGORY_INPUT")

--- a/src/hhru_bot/selector_groups/search_page.py
+++ b/src/hhru_bot/selector_groups/search_page.py
@@ -2,32 +2,35 @@
 
 from __future__ import annotations
 
-VACANCY_CARD = "[data-qa='vacancy-serp__vacancy']"
+from ._generated import optional_selector as _optional_selector
+from ._generated import selector as _selector
+
+VACANCY_CARD = _selector("search_page.VACANCY_CARD")
 # Подтверждён curl-дампом пустого запроса (2026-08-11). Это единственный
 # достоверный случай, в котором отсутствие VACANCY_CARD означает пустую выдачу,
 # а не медленный JS-рендер или дрейф карточного селектора.
-VACANCY_SEARCH_EMPTY = "[data-qa='empty-vacancy-search-block']"
-VACANCY_CARD_TITLE_LINK = "[data-qa='serp-item__title']"
-VACANCY_CARD_COMPANY = "[data-qa='vacancy-serp__vacancy-employer']"
+VACANCY_SEARCH_EMPTY = _selector("search_page.VACANCY_SEARCH_EMPTY")
+VACANCY_CARD_TITLE_LINK = _selector("search_page.VACANCY_CARD_TITLE_LINK")
+VACANCY_CARD_COMPANY = _selector("search_page.VACANCY_CARD_COMPANY")
 # Зарплата в карточке списка (issue #14).
 # VACANCY_CARD_COMPENSATION: НЕ работает на живом hh.ru с 2025 — hh.ru
 # перешёл на magritte-разметку, блок ЗП рендерится без этого data-qa (#73).
 # search.py использует regex-fallback по innerHTML карточки когда селектор
 # пуст. Селектор оставлен для обратной совместимости (старые кэши/curl-дампы).
-VACANCY_CARD_COMPENSATION = "[data-qa='vacancy-serp__vacancy-compensation']"
+VACANCY_CARD_COMPENSATION = _optional_selector("search_page.VACANCY_CARD_COMPENSATION")
 # Подтверждено фикстурами карточки (тексты вида "сегодня"/"вчера"/"N дней
 # назад", см. tests/fixtures/vacancy_card_*.html). В анонимном SSR-дампе от
 # 2026-08-20 поле не рендерится, поэтому парсер обязан считать его опциональным.
-VACANCY_CARD_PUBLICATION_TIME = "[data-qa='vacancy-serp__vacancy-date']"
+VACANCY_CARD_PUBLICATION_TIME = _selector("search_page.VACANCY_CARD_PUBLICATION_TIME")
 # Инфо о работодателе из карточки поиска (issue #74, Этап 1). Подтверждено в
 # DOM-дампе (read-only, 2026-07-28): rating/trusted рендерятся в карточке
 # списка для работодателей с отзывами. Блоки опциональны.
-COMPANY_RATING_VALUE = "[data-qa='company-review-rating-value']"
-COMPANY_RATING_REVIEWS_COUNT = "[data-qa='company-review-rating-reviews-count']"
-TRUSTED_EMPLOYER_LINK = "[data-qa='trusted-employer-link']"
+COMPANY_RATING_VALUE = _selector("search_page.COMPANY_RATING_VALUE")
+COMPANY_RATING_REVIEWS_COUNT = _selector("search_page.COMPANY_RATING_REVIEWS_COUNT")
+TRUSTED_EMPLOYER_LINK = _selector("search_page.TRUSTED_EMPLOYER_LINK")
 # Кнопка отклика прямо в карточке списка (ведёт на
 # /applicant/vacancy_response?vacancyId=...&employerId=...)
-VACANCY_CARD_RESPONSE_BUTTON = "[data-qa='vacancy-serp__vacancy_response']"
+VACANCY_CARD_RESPONSE_BUTTON = _selector("search_page.VACANCY_CARD_RESPONSE_BUTTON")
 # Пагинация (#123). hh.ru отдаёт ДВА варианта разметки пагинации, и это
 # подтверждено живым залогиненным дампом (2026-08-01):
 #   1. с кнопками навигации — есть [data-qa='pager-next'];
@@ -38,44 +41,40 @@ VACANCY_CARD_RESPONSE_BUTTON = "[data-qa='vacancy-serp__vacancy_response']"
 # признак «есть следующая страница» берётся от них, а не от pager-next.
 # Вариант вёрстки прилетает независимо от запроса (похоже на A/B-тест), так
 # что опираться на один только PAGINATION_NEXT нельзя.
-PAGINATION_NEXT = "[data-qa='pager-next']"
-PAGINATION_PAGE = "[data-qa='pager-page']"
+PAGINATION_NEXT = _selector("search_page.PAGINATION_NEXT")
+PAGINATION_PAGE = _selector("search_page.PAGINATION_PAGE")
 # pager-block присутствует только когда hh.ru действительно рисует пагинацию.
 # Его отсутствие после готовой выдачи означает нормальную единственную страницу.
-PAGINATION_BLOCK = "[data-qa='pager-block']"
+PAGINATION_BLOCK = _selector("search_page.PAGINATION_BLOCK")
 
 # Анонимному curl-запросу hh.ru не показывает маркер "уже откликались" в
 # разметке — этот статус виден только залогиненному пользователю. Дедупликация
 # в этом проекте не полагается на разметку hh.ru, а делается через локальную
 # историю (history.py), поэтому отсутствие проверенного селектора не критично.
-VACANCY_CARD_RESPONSE_STATUS = (
-    "[data-qa='vacancy-serp__vacancy_response_status']"  # НЕ подтверждено
-)
+VACANCY_CARD_RESPONSE_STATUS = _selector("search_page.VACANCY_CARD_RESPONSE_STATUS")
 
 # Доп. признаки карточки для статистики/ML (issue #517, приоритет-1 из #516).
 # Подтверждено ВРУЧНУЮ через DevTools/JS в браузере 2026-08-23 (read-only
 # просмотр живой выдачи /search/vacancy) — НЕ curl-дамп и НЕ боевой
 # Playwright-лог, уровень подтверждения ниже, чем у остальных селекторов
 # этого файла. Все блоки опциональны (не у каждой карточки).
-VACANCY_CARD_ADDRESS = "[data-qa='vacancy-serp__vacancy-address']"
-VACANCY_CARD_REMOTE_LABEL = "[data-qa='vacancy-label-work-schedule-remote']"
+VACANCY_CARD_ADDRESS = _selector("search_page.VACANCY_CARD_ADDRESS")
+VACANCY_CARD_REMOTE_LABEL = _selector("search_page.VACANCY_CARD_REMOTE_LABEL")
 # Категория опыта закодирована в САМОМ суффиксе data-qa, а не в тексте
 # элемента: noExperience/between1And3/between3And6/moreThan6.
-VACANCY_CARD_EXPERIENCE = "[data-qa^='vacancy-serp__vacancy-work-experience-']"
-VACANCY_CARD_SNIPPET_REQUIREMENT = "[data-qa='vacancy-serp__vacancy_snippet_requirement']"
-VACANCY_CARD_SNIPPET_RESPONSIBILITY = "[data-qa='vacancy-serp__vacancy_snippet_responsibility']"
+VACANCY_CARD_EXPERIENCE = _selector("search_page.VACANCY_CARD_EXPERIENCE")
+VACANCY_CARD_SNIPPET_REQUIREMENT = _selector("search_page.VACANCY_CARD_SNIPPET_REQUIREMENT")
+VACANCY_CARD_SNIPPET_RESPONSIBILITY = _selector("search_page.VACANCY_CARD_SNIPPET_RESPONSIBILITY")
 # Приоритет-2 из issue #516: опциональные бейджи типа занятости/отклика.
 # Подтверждено вручную через DevTools/JS в браузере 2026-08-23 (read-only,
 # живая выдача /search/vacancy); это не curl-дамп и не боевой Playwright-лог.
-VACANCY_CARD_SIDE_JOB = "[data-qa='vacancy-label-side-job']"
-VACANCY_CARD_NO_RESUME = "[data-qa='vacancy-label-no-resume']"
+VACANCY_CARD_SIDE_JOB = _selector("search_page.VACANCY_CARD_SIDE_JOB")
+VACANCY_CARD_NO_RESUME = _selector("search_page.VACANCY_CARD_NO_RESUME")
 # Приоритет-3 из issue #551. Поля редкие/опциональные; значения сохраняются
 # как наблюдены, без попытки угадать их семантику или формат.
-VACANCY_CARD_ACTIVITY = "[data-qa='vacancy-serp-item-activity']"
-VACANCY_CARD_HH_RATING = "[data-qa='vacancy-serp__vacancy_employer-hh-rating']"
+VACANCY_CARD_ACTIVITY = _selector("search_page.VACANCY_CARD_ACTIVITY")
+VACANCY_CARD_HH_RATING = _selector("search_page.VACANCY_CARD_HH_RATING")
 # Exact data-qa value from the issue/live-card schema; class names are not a
 # stable contract for this marker.
-VACANCY_CARD_HRBRAND_WINNER = (
-    "[data-qa='vacancy-serp__vacancy_hrbrand vacancy-serp__vacancy_hrbrand_winners']"
-)
-VACANCY_CARD_METRO_STATION = "[data-qa='address-metro-station-name']"
+VACANCY_CARD_HRBRAND_WINNER = _selector("search_page.VACANCY_CARD_HRBRAND_WINNER")
+VACANCY_CARD_METRO_STATION = _selector("search_page.VACANCY_CARD_METRO_STATION")

--- a/src/hhru_bot/selector_groups/vacancy_page.py
+++ b/src/hhru_bot/selector_groups/vacancy_page.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
-VACANCY_APPLY_BUTTON = "[data-qa='vacancy-response-link-top']"
+from ._generated import selector as _selector
+
+VACANCY_APPLY_BUTTON = _selector("vacancy_page.VACANCY_APPLY_BUTTON")
 # Status controls shown instead of the apply button after an existing response.
 # The "again" control opens a modal with a separate repeat-submit action.
-VACANCY_ALREADY_RESPONDED_AGAIN = "[data-qa='vacancy-response-link-top-again']"
-VACANCY_ALREADY_RESPONDED_CHAT = "[data-qa='vacancy-response-link-view-topic']"
+VACANCY_ALREADY_RESPONDED_AGAIN = _selector("vacancy_page.VACANCY_ALREADY_RESPONDED_AGAIN")
+VACANCY_ALREADY_RESPONDED_CHAT = _selector("vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT")
 # Rendered in the response modal when the selected resume is not visible to
 # client companies.  This can appear while the URL remains the vacancy URL.
-VACANCY_HIDDEN_RESUME_WARNING = "[data-qa='hidden-resume-warning']"
-VACANCY_RELOCATION_CONFIRM = '[data-qa="relocation-warning-confirm"]'
-VACANCY_SIMILAR_VACANCIES_CLOSE = '[data-qa="vacancy-response-similar-vacancies-close"]'
-VACANCY_DIRECT_APPLICATION_CANCEL = '[data-qa="vacancy-response-link-advertising-cancel"]'
-VACANCY_DIRECT_APPLICATION_ALERT = '[data-qa="magritte-alert"]'
-VACANCY_LIMIT_ERROR = '[data-qa-popup-error-code="negotiations-limit-exceeded"]'
-VACANCY_RESPONSE_REJECT_WARNING = '[data-qa="response-reject-warning"]'
-VACANCY_RESPONSE_ERROR = '[data-qa="vacancy-response-error-notification"]'
-VACANCY_TITLE = "[data-qa='vacancy-title']"
-VACANCY_COMPANY_NAME = "[data-qa='vacancy-company-name']"
+VACANCY_HIDDEN_RESUME_WARNING = _selector("vacancy_page.VACANCY_HIDDEN_RESUME_WARNING")
+VACANCY_RELOCATION_CONFIRM = _selector("vacancy_page.VACANCY_RELOCATION_CONFIRM")
+VACANCY_SIMILAR_VACANCIES_CLOSE = _selector("vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE")
+VACANCY_DIRECT_APPLICATION_CANCEL = _selector("vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL")
+VACANCY_DIRECT_APPLICATION_ALERT = _selector("vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT")
+VACANCY_LIMIT_ERROR = _selector("vacancy_page.VACANCY_LIMIT_ERROR")
+VACANCY_RESPONSE_REJECT_WARNING = _selector("vacancy_page.VACANCY_RESPONSE_REJECT_WARNING")
+VACANCY_RESPONSE_ERROR = _selector("vacancy_page.VACANCY_RESPONSE_ERROR")
+VACANCY_TITLE = _selector("vacancy_page.VACANCY_TITLE")
+VACANCY_COMPANY_NAME = _selector("vacancy_page.VACANCY_COMPANY_NAME")
 
 # VACANCY_APPLY_BUTTON — это ссылка
 # (href="/applicant/vacancy_response?vacancyId=..&employerId=..&hhtmFrom=vacancy"),

--- a/src/hhru_bot/selectors.py
+++ b/src/hhru_bot/selectors.py
@@ -19,6 +19,13 @@ from .selector_groups.apply_form import (
     APPLY_RESUME_SELECT,
     APPLY_SUBMIT_BUTTON,
 )
+from .selector_groups.login import (
+    LOGIN_CODE_INPUT,
+    LOGIN_CODE_REQUEST_BUTTON,
+    LOGIN_EMAIL_INPUT,
+    LOGIN_EMAIL_TYPE,
+    LOGIN_PHONE_INPUT,
+)
 from .selector_groups.resume_page import RESUME_BUMP_BUTTON, RESUME_BUMP_DISABLED_HINT
 from .selector_groups.search_page import (
     COMPANY_RATING_REVIEWS_COUNT,
@@ -54,15 +61,6 @@ from .selector_groups.vacancy_page import (
     VACANCY_COMPANY_NAME,
     VACANCY_TITLE,
 )
-
-# Подтверждено headless-рендером https://hh.ru/account/login от 2026-08-13
-# (после первого перехода на форму учётных данных, chromium, ru-RU).
-LOGIN_CODE_REQUEST_BUTTON = "[data-qa='submit-button']"
-LOGIN_EMAIL_TYPE = "input[data-qa='credential-type-email']"
-LOGIN_EMAIL_INPUT = "[data-qa='applicant-login-input-email']"
-LOGIN_PHONE_INPUT = "[data-qa='magritte-phone-input-national-number-input']"
-# Подтверждено live DOM после запроса кода (2026-08-19); ввод запускает авто-submit.
-LOGIN_CODE_INPUT = "[data-qa='magritte-pincode-input-field']"
 
 __all__ = [
     "LOGIN_CODE_REQUEST_BUTTON",

--- a/tests/test_audit_launch_and_navigation.py
+++ b/tests/test_audit_launch_and_navigation.py
@@ -168,6 +168,18 @@ def test_withdraw_failure_after_destructive_click_is_uncertain_and_not_retried(
     from hhru_bot.commands import clear_negotiations as module
     from hhru_bot.history import History
 
+    monkeypatch.setattr(module, "NEGOTIATION_WITHDRAW", "[data-qa='confirmed-withdraw']")
+    monkeypatch.setattr(
+        module,
+        "NEGOTIATION_WITHDRAW_CONFIRM",
+        "[data-qa='confirmed-withdraw-confirm']",
+    )
+    monkeypatch.setattr(
+        module,
+        "NEGOTIATION_WITHDRAW_SUCCESS",
+        "[data-qa='confirmed-withdraw-success']",
+    )
+
     history = History(str(tmp_path / "history.db"))
     topic = "5503922709"
     withdraw_clicked: list[str] = []

--- a/tests/test_clear_negotiations_command.py
+++ b/tests/test_clear_negotiations_command.py
@@ -146,6 +146,17 @@ class _Throttle:
 
 
 def _patch_withdraw_page(monkeypatch):
+    monkeypatch.setattr(command, "NEGOTIATION_WITHDRAW", "[data-qa='confirmed-withdraw']")
+    monkeypatch.setattr(
+        command,
+        "NEGOTIATION_WITHDRAW_CONFIRM",
+        "[data-qa='confirmed-withdraw-confirm']",
+    )
+    monkeypatch.setattr(
+        command,
+        "NEGOTIATION_WITHDRAW_SUCCESS",
+        "[data-qa='confirmed-withdraw-success']",
+    )
     monkeypatch.setattr(command, "goto_hh", lambda page, url: None)
     monkeypatch.setattr(command, "topic_refs", lambda html: [type("Ref", (), {"topic_id": "77"})()])
 

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,69 +1,32 @@
 import pytest
 
-from hhru_bot.experience import (
-    ExperienceEntry,
-    _merge_fill_plan,
-    build_prompt,
-    parse_plan,
-    plan_experience,
-)
+from hhru_bot import experience
 
 pytestmark = pytest.mark.unit
 
 
-def test_parse_plan_accepts_multiple_entries_and_achievements():
-    entries = parse_plan(
-        '[{"company":"Acme","position":"Engineer","start_year":"2020",'
-        '"end_year":"2022","current":false,"duties":"API",'
-        '"achievements":["-20% latency"],"company_url":""},'
-        '{"company":"Beta","position":"Lead","start_year":"2022",'
-        '"end_year":"","current":true,"duties":"Team",'
-        '"achievements":[],"company_url":""}]'
+class _Locator:
+    def count(self):
+        return 0
+
+
+class _Page:
+    def locator(self, selector):
+        assert selector is not None
+        return _Locator()
+
+
+def test_edit_experience_fails_closed_when_add_selector_is_unavailable(monkeypatch):
+    monkeypatch.setattr(experience, "open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr(experience, "EXPERIENCE_ADD_BUTTON", None)
+
+    results = experience.edit_experience_on_hh(
+        _Page(),
+        "resume-1",
+        experience.ExperiencePlan([experience.ExperienceEntry(company="Acme")]),
+        dry_run=True,
     )
-    assert entries is not None
-    assert len(entries) == 2
-    assert entries[0].description() == "API\n\nДостижения:\n- -20% latency"
-    assert entries[1].current is True
 
-
-def test_parse_plan_rejects_non_json_or_partial_shape():
-    assert parse_plan("не JSON") is None
-    assert parse_plan('[{"company":"Acme"}]') is not None
-    assert parse_plan('[{"company":3}]') is None
-
-
-def test_plan_fallback_preserves_existing_without_fabrication():
-    existing = [ExperienceEntry(company="Acme", duties="old")]
-
-    class Failing:
-        def chat(self, *args, **kwargs):
-            raise RuntimeError("offline")
-
-    plan = plan_experience(Failing(), mode="fill", career="facts", existing=existing)
-    assert plan.used_fallback is True
-    assert plan.entries == existing
-
-
-def test_prompt_contains_fill_context_and_fact_guard():
-    prompt = build_prompt("fill", "facts", [ExperienceEntry(company="Acme")])
-    assert "только сведения пользователя" in prompt[0]["content"]
-    assert '"existing"' in prompt[1]["content"]
-
-
-def test_fill_plan_preserves_existing_fields_and_text():
-    old = ExperienceEntry(company="Acme", position="Engineer", duties="existing")
-    proposed = ExperienceEntry(
-        company="Acme", position="Engineer", duties="new", achievements=["metric"]
-    )
-    merged = _merge_fill_plan([old], [proposed])
-    assert merged == [
-        ExperienceEntry(
-            company="Acme", position="Engineer", duties="existing", achievements=["metric"]
-        )
+    assert results == [
+        experience.ExperienceResult("строка опыта 0: add-триггер не подтверждён однозначно")
     ]
-
-
-def test_fill_plan_rejects_identity_or_count_changes():
-    old = ExperienceEntry(company="Acme")
-    assert _merge_fill_plan([old], [ExperienceEntry(company="Other")]) is None
-    assert _merge_fill_plan([old], []) is None

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,8 +1,75 @@
 import pytest
 
-from hhru_bot import experience
+from hhru_bot.experience import (
+    ExperienceEntry,
+    ExperiencePlan,
+    ExperienceResult,
+    _merge_fill_plan,
+    build_prompt,
+    edit_experience_on_hh,
+    parse_plan,
+    plan_experience,
+)
 
 pytestmark = pytest.mark.unit
+
+
+def test_parse_plan_accepts_multiple_entries_and_achievements():
+    entries = parse_plan(
+        '[{"company":"Acme","position":"Engineer","start_year":"2020",'
+        '"end_year":"2022","current":false,"duties":"API",'
+        '"achievements":["-20% latency"],"company_url":""},'
+        '{"company":"Beta","position":"Lead","start_year":"2022",'
+        '"end_year":"","current":true,"duties":"Team",'
+        '"achievements":[],"company_url":""}]'
+    )
+    assert entries is not None
+    assert len(entries) == 2
+    assert entries[0].description() == "API\n\nДостижения:\n- -20% latency"
+    assert entries[1].current is True
+
+
+def test_parse_plan_rejects_non_json_or_partial_shape():
+    assert parse_plan("не JSON") is None
+    assert parse_plan('[{"company":"Acme"}]') is not None
+    assert parse_plan('[{"company":3}]') is None
+
+
+def test_plan_fallback_preserves_existing_without_fabrication():
+    existing = [ExperienceEntry(company="Acme", duties="old")]
+
+    class Failing:
+        def chat(self, *args, **kwargs):
+            raise RuntimeError("offline")
+
+    plan = plan_experience(Failing(), mode="fill", career="facts", existing=existing)
+    assert plan.used_fallback is True
+    assert plan.entries == existing
+
+
+def test_prompt_contains_fill_context_and_fact_guard():
+    prompt = build_prompt("fill", "facts", [ExperienceEntry(company="Acme")])
+    assert "только сведения пользователя" in prompt[0]["content"]
+    assert '"existing"' in prompt[1]["content"]
+
+
+def test_fill_plan_preserves_existing_fields_and_text():
+    old = ExperienceEntry(company="Acme", position="Engineer", duties="existing")
+    proposed = ExperienceEntry(
+        company="Acme", position="Engineer", duties="new", achievements=["metric"]
+    )
+    merged = _merge_fill_plan([old], [proposed])
+    assert merged == [
+        ExperienceEntry(
+            company="Acme", position="Engineer", duties="existing", achievements=["metric"]
+        )
+    ]
+
+
+def test_fill_plan_rejects_identity_or_count_changes():
+    old = ExperienceEntry(company="Acme")
+    assert _merge_fill_plan([old], [ExperienceEntry(company="Other")]) is None
+    assert _merge_fill_plan([old], []) is None
 
 
 class _Locator:
@@ -17,16 +84,14 @@ class _Page:
 
 
 def test_edit_experience_fails_closed_when_add_selector_is_unavailable(monkeypatch):
-    monkeypatch.setattr(experience, "open_confirmed_resume", lambda page, resume_id: None)
-    monkeypatch.setattr(experience, "EXPERIENCE_ADD_BUTTON", None)
+    monkeypatch.setattr("hhru_bot.experience.open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr("hhru_bot.experience.EXPERIENCE_ADD_BUTTON", None)
 
-    results = experience.edit_experience_on_hh(
+    results = edit_experience_on_hh(
         _Page(),
         "resume-1",
-        experience.ExperiencePlan([experience.ExperienceEntry(company="Acme")]),
+        ExperiencePlan([ExperienceEntry(company="Acme")]),
         dry_run=True,
     )
 
-    assert results == [
-        experience.ExperienceResult("строка опыта 0: add-триггер не подтверждён однозначно")
-    ]
+    assert results == [ExperienceResult("строка опыта 0: add-триггер не подтверждён однозначно")]

--- a/tests/test_publish_resume.py
+++ b/tests/test_publish_resume.py
@@ -12,6 +12,16 @@ pytestmark = pytest.mark.integration
 RESUME_ID = "a" * 38
 
 
+@pytest.fixture(autouse=True)
+def _confirmed_publish_selector(monkeypatch):
+    """Exercise publish behavior only after the selector contract approved it."""
+    monkeypatch.setattr(
+        publish,
+        "RESUME_PUBLISH_BUTTON_DATA_QA",
+        "[data-qa='confirmed-resume-publish']",
+    )
+
+
 def _resume():
     return ResumeConfig(
         id="python",
@@ -98,6 +108,14 @@ def _run(page, monkeypatch, *, preserve_url=False):
 
     monkeypatch.setattr(publish, "open_confirmed_resume", open_confirmed)
     return publish.publish_resume_on_hh(page, _resume(), dry_run=False)
+
+
+def test_publish_is_disabled_without_catalog_selector(monkeypatch):
+    monkeypatch.setattr(publish, "RESUME_PUBLISH_BUTTON_DATA_QA", None)
+    result = _run(_Page(_markup()), monkeypatch)
+    assert not result.success
+    assert result.uncertain is False
+    assert "клик отключён" in result.reason
 
 
 def test_parse_resume_state_keeps_independent_fields():


### PR DESCRIPTION
Переводит оставшиеся 10 selector-файлов на selector contract runtime.

Diff относительно актуального main:
- 10 файлов
- +175 / -164 строк

`scripts/selector_contracts.py` уже находится в main после PR #600 (1 477 строк), поэтому повторно не добавляется.