### PR TITLE
feat(selectors): fail-closed negotiations contracts

### DIFF
--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -861,6 +861,10 @@ selectors:
     decision: unavailable
     sources: {}
     live_matches: []
+    unavailable_reason: >-
+      Read-only audit 2026-08-25 found no saved DOM snapshot and no approved
+      reference source with a browser/UI withdrawal selector control flow;
+      selector remains unproven and cannot authorize a destructive click.
     active: false
     bindings: {}
   negotiations.NEGOTIATION_WITHDRAW_CONFIRM:
@@ -870,6 +874,11 @@ selectors:
     decision: unavailable
     sources: {}
     live_matches: []
+    unavailable_reason: >-
+      Read-only audit 2026-08-25 found no saved DOM snapshot and no approved
+      reference source with a browser/UI withdrawal confirmation selector
+      control flow; selector remains unproven and cannot authorize a
+      destructive click.
     active: false
     bindings: {}
   negotiations.NEGOTIATION_WITHDRAW_SUCCESS:
@@ -879,6 +888,11 @@ selectors:
     decision: unavailable
     sources: {}
     live_matches: []
+    unavailable_reason: >-
+      Read-only audit 2026-08-25 found no saved DOM snapshot and no approved
+      reference source with a browser/UI withdrawal success selector control
+      flow; selector remains unproven and cannot be used to report a
+      destructive action as successful.
     active: false
     bindings: {}
   professional_roles.FILTER_TRIGGER:

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -161,6 +161,27 @@ def test_refresh_preserves_upstream_candidate_decisions():
     assert refreshed[0]["verification"] == "contract_tested"
 
 
+def test_negotiation_withdraw_contracts_are_explicitly_unavailable():
+    catalog = contracts.load_catalog()
+    expected = {
+        "negotiations.NEGOTIATION_WITHDRAW",
+        "negotiations.NEGOTIATION_WITHDRAW_CONFIRM",
+        "negotiations.NEGOTIATION_WITHDRAW_SUCCESS",
+    }
+    fail_closed = {
+        logical_id
+        for logical_id, row in catalog["selectors"].items()
+        if logical_id.startswith("negotiations.") and row.get("decision") == "unavailable"
+    }
+
+    assert fail_closed == expected
+    for logical_id in sorted(expected):
+        row = catalog["selectors"][logical_id]
+        assert row["active"] is False
+        assert row["unavailable_reason"]
+        assert logical_id not in contracts.render_generated(catalog)
+
+
 def test_catalog_load_does_not_require_generated_live_evidence(monkeypatch, tmp_path):
     monkeypatch.setattr(contracts, "MAP_PATH", contracts.ROOT / "selectors" / "reference-map.yaml")
     monkeypatch.setattr(contracts, "EVIDENCE_PATH", tmp_path / "live-evidence.json")


### PR DESCRIPTION
## Summary
- record read-only audit outcomes for the three negotiations withdrawal contracts
- keep withdrawal, confirmation, and success selectors unavailable and inactive without DOM/reference evidence
- add regression coverage preventing accidental activation

Closes #608

## Tests
- `python scripts/selector_contracts.py check`
- `ruff check .`
- `pytest` (2440 passed, 3 deselected)

## Safety
- no live account-changing actions performed; only saved docs and reference source were inspected

## Risks / follow-up
- withdrawal remains intentionally disabled until a saved DOM snapshot or browser/UI reference control flow is reviewed.