### PR TITLE
feat(selector): enable guarded READ auto-update

### DIFF
--- a/.github/workflows/selector-refresh.yml
+++ b/.github/workflows/selector-refresh.yml
@@ -50,19 +50,31 @@ jobs:
           REFERENCE_ROOT: ${{ runner.temp }}/selector-references
         run: python scripts/selector_contracts.py refresh --dry-run --mode manual --reference-root "$REFERENCE_ROOT"
 
-      - name: Refresh selector map
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+      - name: Check selector baseline soak gate
+        if: ${{ github.event_name == 'schedule' }}
+        id: selector_soak_gate
+        continue-on-error: true
+        run: python scripts/selector_contracts.py check
+
+      - name: Refresh selector map (scheduled READ auto-update)
+        if: ${{ github.event_name == 'schedule' && steps.selector_soak_gate.outcome == 'success' }}
+        env:
+          REFERENCE_ROOT: ${{ runner.temp }}/selector-references
+        run: python scripts/selector_contracts.py refresh --mode read_auto --reference-root "$REFERENCE_ROOT"
+
+      - name: Refresh selector map (manual review)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != true }}
         env:
           REFERENCE_ROOT: ${{ runner.temp }}/selector-references
         run: python scripts/selector_contracts.py refresh --mode manual --reference-root "$REFERENCE_ROOT"
 
       - name: Verify generated contract
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+        if: ${{ (github.event_name == 'schedule' && steps.selector_soak_gate.outcome == 'success') || (github.event_name == 'workflow_dispatch' && inputs.dry_run != true) }}
         continue-on-error: true
         run: python scripts/selector_contracts.py check
 
       - name: Open or update manual-review PR
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+        if: ${{ (github.event_name == 'schedule' && steps.selector_soak_gate.outcome == 'success') || (github.event_name == 'workflow_dispatch' && inputs.dry_run != true) }}
         env:
           GH_TOKEN: ${{ github.token }}
           REFRESH_BRANCH: codex/selector-refresh

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -275,6 +275,8 @@ WRITE_REACHABILITY_IDS = frozenset(
         "search_page.VACANCY_CARD",
         "search_page.VACANCY_CARD_TITLE_LINK",
         "search_page.VACANCY_CARD_COMPANY",
+        "search_page.COMPANY_RATING_VALUE",
+        "search_page.COMPANY_RATING_REVIEWS_COUNT",
     }
 )
 

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -267,6 +267,17 @@ REFERENCE_BINDING_KEYS: dict[str, dict[str, tuple[str, ...]]] = {
     },
 }
 
+# Search results feed the irreversible apply path.  These selectors are read
+# from the DOM, but their reachability determines the vacancy identity and
+# safety scope, so they must not be eligible for read-only auto-updates.
+WRITE_REACHABILITY_IDS = frozenset(
+    {
+        "search_page.VACANCY_CARD",
+        "search_page.VACANCY_CARD_TITLE_LINK",
+        "search_page.VACANCY_CARD_COMPANY",
+    }
+)
+
 SOURCE_SUFFIXES = {".py", ".js", ".mjs", ".cjs", ".ts", ".tsx"}
 SELECTOR_MARKERS = ("[data-qa", "[data-qa-popup-error-code")
 _QUOTED = re.compile(r"(?P<quote>['\"`])(?P<body>(?:\\.|(?!\1).)*)(?P=quote)", re.DOTALL)
@@ -586,6 +597,8 @@ def classify_criticality(logical_id: str) -> str:
     """
     if SPECIAL_POLICIES.get(logical_id, (None,))[0] == "structural_read_fallback":
         return "read"
+    if logical_id in WRITE_REACHABILITY_IDS:
+        return "write"
     if logical_id.startswith("professional_roles."):
         return "write" if logical_id == "professional_roles.TREE_LABEL" else "read"
     if logical_id in {

--- a/selectors/README.md
+++ b/selectors/README.md
@@ -19,13 +19,17 @@ CI rejects:
 - unresolved upstream drift.
 
 The daily GitHub Action reads, but never executes, the three reference
-checkouts. It follows the stored source keys across upstream commits. In the
-current `manual` phase, a changed selector produces a review PR and cannot
-merge while drift is unresolved. `--mode read_auto` is reserved for a later
-phase: it may update only READ selectors with new 2-of-3 consensus. WRITE
-selectors always remain manual. Criticality is based on reachability: a title,
-status, or container is WRITE-critical when a mutation uses it for identity,
-scoping, or post-save verification, even if that element itself is only read.
+checkouts. It follows the stored source keys across upstream commits. The
+scheduled run first checks the current catalog; only a green check opens the
+`read_auto` phase. In `read_auto`, a changed selector is accepted only when the
+same tracked source keys provide a new 2-of-3 consensus for a READ selector.
+WRITE, conflicting, and single-source selectors remain `manual` and produce a
+review PR instead. Criticality is based on reachability: a title, status, or
+container is WRITE-critical when a mutation uses it for identity, scoping, or
+post-save verification, even if that element itself is only read.
+
+`workflow_dispatch` is unchanged: its dry-run uses `manual` without writing,
+and its non-dry-run path uses `manual` for a review PR.
 
 Local commands:
 

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -2813,7 +2813,7 @@ selectors:
     bindings: {}
   search_page.VACANCY_CARD:
     value: '[data-qa=''vacancy-serp__vacancy'']'
-    criticality: read
+    criticality: write
     declared_at: src/hhru_bot/selector_groups/search_page.py:5
     decision: live_dom
     sources:
@@ -2868,7 +2868,7 @@ selectors:
         value: '[data-qa="vacancy-serp__vacancy-address"]'
   search_page.VACANCY_CARD_COMPANY:
     value: '[data-qa=''vacancy-serp__vacancy-employer'']'
-    criticality: read
+    criticality: write
     declared_at: src/hhru_bot/selector_groups/search_page.py:11
     decision: consensus
     sources:
@@ -3052,7 +3052,7 @@ selectors:
     bindings: {}
   search_page.VACANCY_CARD_TITLE_LINK:
     value: '[data-qa=''serp-item__title'']'
-    criticality: read
+    criticality: write
     declared_at: src/hhru_bot/selector_groups/search_page.py:10
     decision: live_dom
     sources:

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -2747,7 +2747,7 @@ selectors:
     bindings: {}
   search_page.COMPANY_RATING_REVIEWS_COUNT:
     value: '[data-qa=''company-review-rating-reviews-count'']'
-    criticality: read
+    criticality: write
     declared_at: src/hhru_bot/selector_groups/search_page.py:26
     decision: live_dom
     sources: {}
@@ -2757,7 +2757,7 @@ selectors:
     bindings: {}
   search_page.COMPANY_RATING_VALUE:
     value: '[data-qa=''company-review-rating-value'']'
-    criticality: read
+    criticality: write
     declared_at: src/hhru_bot/selector_groups/search_page.py:25
     decision: live_dom
     sources: {}

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -460,9 +460,7 @@ def test_scheduled_read_auto_is_fail_closed_behind_green_check():
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["refresh"]["steps"]
     soak_gate = next(step for step in steps if step.get("id") == "selector_soak_gate")
-    read_auto = next(
-        step for step in steps if "--mode read_auto" in step.get("run", "")
-    )
+    read_auto = next(step for step in steps if "--mode read_auto" in step.get("run", ""))
 
     assert soak_gate["if"] == "${{ github.event_name == 'schedule' }}"
     assert soak_gate["run"] == "python scripts/selector_contracts.py check"

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -224,6 +224,15 @@ def test_negotiation_withdraw_contracts_are_explicitly_unavailable():
         assert logical_id not in contracts.render_generated(catalog)
 
 
+def test_apply_reachable_search_selectors_are_write_critical():
+    logical_ids = {
+        "search_page.VACANCY_CARD",
+        "search_page.VACANCY_CARD_TITLE_LINK",
+        "search_page.VACANCY_CARD_COMPANY",
+    }
+    assert {contracts.classify_criticality(logical_id) for logical_id in logical_ids} == {"write"}
+
+
 def test_catalog_load_does_not_require_generated_live_evidence(monkeypatch, tmp_path):
     monkeypatch.setattr(contracts, "MAP_PATH", contracts.ROOT / "selectors" / "reference-map.yaml")
     monkeypatch.setattr(contracts, "EVIDENCE_PATH", tmp_path / "live-evidence.json")

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -229,6 +229,8 @@ def test_apply_reachable_search_selectors_are_write_critical():
         "search_page.VACANCY_CARD",
         "search_page.VACANCY_CARD_TITLE_LINK",
         "search_page.VACANCY_CARD_COMPANY",
+        "search_page.COMPANY_RATING_VALUE",
+        "search_page.COMPANY_RATING_REVIEWS_COUNT",
     }
     assert {contracts.classify_criticality(logical_id) for logical_id in logical_ids} == {"write"}
 

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "selector_contracts.py"
+WORKFLOW_PATH = Path(__file__).parents[1] / ".github" / "workflows" / "selector-refresh.yml"
 SPEC = importlib.util.spec_from_file_location("selector_contracts", SCRIPT_PATH)
 assert SPEC and SPEC.loader
 contracts = importlib.util.module_from_spec(SPEC)
@@ -453,3 +454,20 @@ def test_refresh_tracks_source_keys_and_never_auto_updates_write(tmp_path, monke
     assert automatic["selectors"]["resume_page.fixture_WRITE"]["decision"] == "drift_pending"
     assert automatic["selectors"]["resume_page.fixture_UNVERIFIED_WRITE"]["decision"] == "live_dom"
     assert automatic["selectors"]["resume_page.fixture_UNVERIFIED_WRITE"]["active"] is True
+
+
+def test_scheduled_read_auto_is_fail_closed_behind_green_check():
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["refresh"]["steps"]
+    soak_gate = next(step for step in steps if step.get("id") == "selector_soak_gate")
+    read_auto = next(
+        step for step in steps if "--mode read_auto" in step.get("run", "")
+    )
+
+    assert soak_gate["if"] == "${{ github.event_name == 'schedule' }}"
+    assert soak_gate["run"] == "python scripts/selector_contracts.py check"
+    assert soak_gate["continue-on-error"] is True
+    assert (
+        read_auto["if"]
+        == "${{ github.event_name == 'schedule' && steps.selector_soak_gate.outcome == 'success' }}"
+    )


### PR DESCRIPTION
Closes #614

## Summary
- add a scheduled-only selector check soak gate and run `read_auto` only after a green baseline check
- keep workflow_dispatch dry-run and manual review paths on `manual` unchanged
- document refresh modes and add selector/workflow guard tests

## Tests
- `ruff check .`
- `pytest -q`

## Risks / follow-ups
- Scheduled refresh is fail-closed: a red baseline check skips refresh and PR steps.