### PR TITLE
feat(selectors): resolve vacancy upstream consensus

### DIFF
--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -848,28 +848,45 @@ def _preserve_lines(items: list[SourceSelector], known: dict[str, int]) -> list[
     ]
 
 
-def _upstream_consensus(indexes: dict[str, list[SourceSelector]]) -> list[dict[str, Any]]:
+def _upstream_consensus(
+    indexes: dict[str, list[SourceSelector]],
+    previous: Iterable[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
     grouped: defaultdict[str, dict[str, list[SourceSelector]]] = defaultdict(
         lambda: defaultdict(list)
     )
     for reference, items in indexes.items():
         for item in items:
             grouped[item.normalized][reference].append(item)
+    previous_by_value = {
+        normalize_selector(row["value"]): row for row in previous or () if row.get("value")
+    }
     rows: list[dict[str, Any]] = []
     for _normalized, by_reference in sorted(grouped.items()):
         if len(by_reference) < 2:
             continue
         first = next(iter(next(iter(by_reference.values()))))
-        rows.append(
-            {
-                "value": first.value,
-                "references": sorted(by_reference),
-                "sources": {
-                    name: [_source_dict(item) for item in items[:8]]
-                    for name, items in sorted(by_reference.items())
-                },
-            }
-        )
+        row = {
+            "value": first.value,
+            "references": sorted(by_reference),
+            "sources": {
+                name: [_source_dict(item) for item in items[:8]]
+                for name, items in sorted(by_reference.items())
+            },
+        }
+        old = previous_by_value.get(_normalized)
+        if old:
+            for field in (
+                "decision",
+                "logical_id",
+                "origin",
+                "verification",
+                "reason_code",
+                "reason",
+            ):
+                if field in old:
+                    row[field] = copy.deepcopy(old[field])
+        rows.append(row)
     return rows
 
 
@@ -1252,7 +1269,9 @@ def refresh_catalog(reference_root: Path, mode: str | None = None) -> dict[str, 
     if mode is not None:
         catalog["policy"]["mode"] = mode
     catalog["binding_definitions"] = _binding_definitions()
-    catalog["upstream_consensus"] = _upstream_consensus(indexes)
+    catalog["upstream_consensus"] = _upstream_consensus(
+        indexes, catalog.get("upstream_consensus", [])
+    )
     _refresh_bindings(catalog, indexes)
     for row in catalog["selectors"].values():
         current_value = row["value"]

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -588,6 +588,14 @@ def classify_criticality(logical_id: str) -> str:
         return "read"
     if logical_id.startswith("professional_roles."):
         return "write" if logical_id == "professional_roles.TREE_LABEL" else "read"
+    if logical_id in {
+        "vacancy_page.VACANCY_DESCRIPTION",
+        "vacancy_page.VACANCY_EXPERIENCE",
+        "vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE",
+        "vacancy_page.VACANCY_VIEW_LOCATION",
+        "vacancy_page.VACANCY_VIEW_RAW_ADDRESS",
+    }:
+        return "read"
     write_prefixes = (
         "apply.",
         "apply_form.",
@@ -951,9 +959,7 @@ def load_catalog() -> dict[str, Any]:
         raise SystemExit(f"selector map missing: {MAP_PATH}")
     catalog = yaml.safe_load(MAP_PATH.read_text(encoding="utf-8"))
     evidence = (
-        json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
-        if EVIDENCE_PATH.exists()
-        else {}
+        json.loads(EVIDENCE_PATH.read_text(encoding="utf-8")) if EVIDENCE_PATH.exists() else {}
     )
     _ensure_extra_contracts(catalog, evidence)
     catalog["selectors"] = dict(sorted(catalog["selectors"].items()))

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -11,8 +11,8 @@ references:
   tgeruzov:
     repository: tgeruzov/hh-auto-responder
     license: MIT
-    commit: 3e30d85493fc4d050ec905e0ad04d9fe1767f833
-    selector_fingerprint: e6cc9eebd3da787771414a518f47c2c4e656a985730376b842b48e0bcba8579d
+    commit: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+    selector_fingerprint: 57edac16fdd7dea9247232aa9fd8b8a5a5347601dd86d85a96bdf8ce72387eca
   yamakayama:
     repository: YAMAKAYAMACO/hh-autoresponder
     license: MIT
@@ -2626,6 +2626,45 @@ selectors:
         line: 1359
         key: script.js::pick#2::0
         value: '[data-qa="vacancy-company-name"]'
+  vacancy_page.VACANCY_DESCRIPTION:
+    value: '[data-qa="vacancy-description"]'
+    active: true
+    criticality: read
+    declared_at: src/hhru_bot/selector_groups/vacancy_page.py:24
+    decision: consensus
+    origin: reference_consensus
+    verification: contract_tested
+    sources:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 19
+        key: lib/vacancy-parse.mjs::t#9::0
+        value: '[data-qa="vacancy-description"]'
+      - file: scripts/scan-telegram.mjs
+        line: 88
+        key: scripts/scan-telegram.mjs::t#5::0
+        value: '[data-qa="vacancy-description"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 154
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.desc_el#0::0
+        value: '[data-qa="vacancy-description"]'
+    live_matches: []
+    bindings:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 19
+        key: lib/vacancy-parse.mjs::t#9::0
+        value: '[data-qa="vacancy-description"]'
+      - file: scripts/scan-telegram.mjs
+        line: 88
+        key: scripts/scan-telegram.mjs::t#5::0
+        value: '[data-qa="vacancy-description"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 154
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.desc_el#0::0
+        value: '[data-qa="vacancy-description"]'
   vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT:
     value: '[data-qa="magritte-alert"]'
     criticality: write
@@ -2650,6 +2689,37 @@ selectors:
       note: Страница вакансии (/vacancy/{id}) — подтверждено curl-дампом."""
     active: true
     bindings: {}
+  vacancy_page.VACANCY_EXPERIENCE:
+    value: '[data-qa="vacancy-experience"]'
+    active: true
+    criticality: read
+    declared_at: src/hhru_bot/selector_groups/vacancy_page.py:25
+    decision: consensus
+    origin: reference_consensus
+    verification: contract_tested
+    sources:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 14
+        key: lib/vacancy-parse.mjs::t#4::0
+        value: '[data-qa="vacancy-experience"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 161
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.exp_el#0::0
+        value: '[data-qa="vacancy-experience"]'
+    live_matches: []
+    bindings:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 14
+        key: lib/vacancy-parse.mjs::t#4::0
+        value: '[data-qa="vacancy-experience"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 161
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.exp_el#0::0
+        value: '[data-qa="vacancy-experience"]'
   vacancy_page.VACANCY_HIDDEN_RESUME_WARNING:
     value: '[data-qa=''hidden-resume-warning'']'
     criticality: write
@@ -2790,6 +2860,99 @@ selectors:
         line: 151
         key: app/parsers/hh.py::module.HHParser.get_vacancy_details.title_el#0::0
         value: '[data-qa="vacancy-title"]'
+  vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE:
+    value: '[data-qa="vacancy-view-employment-mode"]'
+    active: true
+    criticality: read
+    declared_at: src/hhru_bot/selector_groups/vacancy_page.py:26
+    decision: consensus
+    origin: reference_consensus
+    verification: contract_tested
+    sources:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 15
+        key: lib/vacancy-parse.mjs::t#6::0
+        value: '[data-qa="vacancy-view-employment-mode"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 164
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.emp_el#0::0
+        value: '[data-qa="vacancy-view-employment-mode"]'
+    live_matches: []
+    bindings:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 15
+        key: lib/vacancy-parse.mjs::t#6::0
+        value: '[data-qa="vacancy-view-employment-mode"]'
+      yamakayama:
+      - file: app/parsers/hh.py
+        line: 164
+        key: app/parsers/hh.py::module.HHParser.get_vacancy_details.emp_el#0::0
+        value: '[data-qa="vacancy-view-employment-mode"]'
+  vacancy_page.VACANCY_VIEW_LOCATION:
+    value: '[data-qa="vacancy-view-location"]'
+    active: true
+    criticality: read
+    declared_at: src/hhru_bot/selector_groups/vacancy_page.py:27
+    decision: consensus
+    origin: reference_consensus
+    verification: contract_tested
+    sources:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 16
+        key: lib/vacancy-parse.mjs::t#7::0
+        value: '[data-qa="vacancy-view-location"]'
+      tgeruzov:
+      - file: hh-apply-assistant.user.js
+        line: 2946
+        key: hh-apply-assistant.user.js::pick#4::0
+        value: '[data-qa="vacancy-view-location"]'
+    live_matches: []
+    bindings:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 16
+        key: lib/vacancy-parse.mjs::t#7::0
+        value: '[data-qa="vacancy-view-location"]'
+      tgeruzov:
+      - file: hh-apply-assistant.user.js
+        line: 2946
+        key: hh-apply-assistant.user.js::pick#4::0
+        value: '[data-qa="vacancy-view-location"]'
+  vacancy_page.VACANCY_VIEW_RAW_ADDRESS:
+    value: '[data-qa="vacancy-view-raw-address"]'
+    active: true
+    criticality: read
+    declared_at: src/hhru_bot/selector_groups/vacancy_page.py:28
+    decision: consensus
+    origin: reference_consensus
+    verification: contract_tested
+    sources:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 16
+        key: lib/vacancy-parse.mjs::t#8::0
+        value: '[data-qa="vacancy-view-raw-address"]'
+      tgeruzov:
+      - file: hh-apply-assistant.user.js
+        line: 2948
+        key: hh-apply-assistant.user.js::pick#5::0
+        value: '[data-qa="vacancy-view-raw-address"]'
+    live_matches: []
+    bindings:
+      steev:
+      - file: lib/vacancy-parse.mjs
+        line: 16
+        key: lib/vacancy-parse.mjs::t#8::0
+        value: '[data-qa="vacancy-view-raw-address"]'
+      tgeruzov:
+      - file: hh-apply-assistant.user.js
+        line: 2948
+        key: hh-apply-assistant.user.js::pick#5::0
+        value: '[data-qa="vacancy-view-raw-address"]'
 upstream_consensus:
 - value: '[data-qa="vacancy-company-name"]'
   references:
@@ -2829,6 +2992,10 @@ upstream_consensus:
       line: 154
       key: app/parsers/hh.py::module.HHParser.get_vacancy_details.desc_el#0::0
       value: '[data-qa="vacancy-description"]'
+  decision: port_exact
+  logical_id: vacancy_page.VACANCY_DESCRIPTION
+  origin: reference_consensus
+  verification: contract_tested
 - value: '[data-qa="vacancy-experience"]'
   references:
   - steev
@@ -2844,6 +3011,10 @@ upstream_consensus:
       line: 161
       key: app/parsers/hh.py::module.HHParser.get_vacancy_details.exp_el#0::0
       value: '[data-qa="vacancy-experience"]'
+  decision: port_exact
+  logical_id: vacancy_page.VACANCY_EXPERIENCE
+  origin: reference_consensus
+  verification: contract_tested
 - value: '[data-qa="vacancy-response-letter-submit"]'
   references:
   - tgeruzov
@@ -2863,6 +3034,10 @@ upstream_consensus:
       line: 368
       key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy.submit_btn#1::0
       value: '[data-qa="vacancy-response-letter-submit"]'
+  decision: reject
+  reason_code: write_risk
+  reason: 'Не нужен боту: локальный apply_form.APPLY_SUBMIT_BUTTON уже покрывает submit-flow; альтернативный WRITE-target
+    добавил бы непроверенный fallback.'
 - value: '[data-qa="vacancy-response-letter-toggle"]'
   references:
   - tgeruzov
@@ -2893,6 +3068,10 @@ upstream_consensus:
       line: 263
       key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy#1::0
       value: '[data-qa="vacancy-response-link-bottom"]'
+  decision: reject
+  reason_code: write_risk
+  reason: 'Не нужен боту: локальный vacancy_page.VACANCY_APPLY_BUTTON уже покрывает apply-flow; второй WRITE-target расширил
+    бы mutation scope без отдельного live evidence.'
 - value: '[data-qa="vacancy-response-link-top"]'
   references:
   - steev
@@ -3007,6 +3186,10 @@ upstream_consensus:
       line: 164
       key: app/parsers/hh.py::module.HHParser.get_vacancy_details.emp_el#0::0
       value: '[data-qa="vacancy-view-employment-mode"]'
+  decision: port_exact
+  logical_id: vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE
+  origin: reference_consensus
+  verification: contract_tested
 - value: '[data-qa="vacancy-view-location"]'
   references:
   - steev
@@ -3022,6 +3205,10 @@ upstream_consensus:
       line: 1362
       key: script.js::pick#4::0
       value: '[data-qa="vacancy-view-location"]'
+  decision: port_exact
+  logical_id: vacancy_page.VACANCY_VIEW_LOCATION
+  origin: reference_consensus
+  verification: contract_tested
 - value: '[data-qa="vacancy-view-raw-address"]'
   references:
   - steev
@@ -3037,6 +3224,10 @@ upstream_consensus:
       line: 1364
       key: script.js::pick#5::0
       value: '[data-qa="vacancy-view-raw-address"]'
+  decision: port_exact
+  logical_id: vacancy_page.VACANCY_VIEW_RAW_ADDRESS
+  origin: reference_consensus
+  verification: contract_tested
 - value: h1[data-qa="vacancy-title"]
   references:
   - steev
@@ -3052,6 +3243,10 @@ upstream_consensus:
       line: 1356
       key: script.js::pick#1::0
       value: h1[data-qa="vacancy-title"]
+  decision: reject
+  reason_code: duplicate_local_role
+  reason: 'Дубликат локального vacancy_page.VACANCY_TITLE: canonical [data-qa="vacancy-title"] уже покрывает ту же роль; fallback
+    не добавляется.'
 binding_definitions:
   apply.success.APPLY_SUCCESS_MARKER:
     tgeruzov:

--- a/selectors/reference-matrix.md
+++ b/selectors/reference-matrix.md
@@ -194,8 +194,10 @@
 | vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT | `[data-qa='vacancy-response-link-view-topic']` | — | [data-qa="vacancy-response-link-view-topic"] | [data-qa="vacancy-response-link-view-topic"] | consensus |
 | vacancy_page.VACANCY_APPLY_BUTTON | `[data-qa='vacancy-response-link-top']` | [data-qa="vacancy-response-link-top"] | [data-qa="vacancy-response-link-top"] | [data-qa="vacancy-response-link-top"] | consensus |
 | vacancy_page.VACANCY_COMPANY_NAME | `[data-qa='vacancy-company-name']` | [data-qa="vacancy-company-name"] | [data-qa="vacancy-company-name"] | — | consensus |
+| vacancy_page.VACANCY_DESCRIPTION | `[data-qa="vacancy-description"]` | [data-qa="vacancy-description"] | — | [data-qa="vacancy-description"] | consensus |
 | vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT | `[data-qa="magritte-alert"]` | — | — | — | documented_live |
 | vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL | `[data-qa="vacancy-response-link-advertising-cancel"]` | — | — | — | documented_live |
+| vacancy_page.VACANCY_EXPERIENCE | `[data-qa="vacancy-experience"]` | [data-qa="vacancy-experience"] | — | [data-qa="vacancy-experience"] | consensus |
 | vacancy_page.VACANCY_HIDDEN_RESUME_WARNING | `[data-qa='hidden-resume-warning']` | — | — | — | live_dom |
 | vacancy_page.VACANCY_LIMIT_ERROR | `[data-qa-popup-error-code="negotiations-limit-exceeded"]` | — | — | — | documented_live |
 | vacancy_page.VACANCY_RELOCATION_CONFIRM | `[data-qa="relocation-warning-confirm"]` | — | [data-qa="relocation-warning-confirm"] | — | documented_live |
@@ -203,6 +205,9 @@
 | vacancy_page.VACANCY_RESPONSE_REJECT_WARNING | `[data-qa="response-reject-warning"]` | — | [data-qa="response-reject-warning"] | — | documented_live |
 | vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE | `[data-qa="vacancy-response-similar-vacancies-close"]` | — | — | — | documented_live |
 | vacancy_page.VACANCY_TITLE | `[data-qa='vacancy-title']` | [data-qa="vacancy-title"] | [data-qa="vacancy-title"] | [data-qa="vacancy-title"] | consensus |
+| vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE | `[data-qa="vacancy-view-employment-mode"]` | [data-qa="vacancy-view-employment-mode"] | — | [data-qa="vacancy-view-employment-mode"] | consensus |
+| vacancy_page.VACANCY_VIEW_LOCATION | `[data-qa="vacancy-view-location"]` | [data-qa="vacancy-view-location"] | [data-qa="vacancy-view-location"] | — | consensus |
+| vacancy_page.VACANCY_VIEW_RAW_ADDRESS | `[data-qa="vacancy-view-raw-address"]` | [data-qa="vacancy-view-raw-address"] | [data-qa="vacancy-view-raw-address"] | — | consensus |
 
 ## Raw 2-of-3 reference consensus
 

--- a/src/hhru_bot/selector_groups/_generated.py
+++ b/src/hhru_bot/selector_groups/_generated.py
@@ -189,15 +189,20 @@ VALUES: dict[str, str] = {
     "vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT": "[data-qa='vacancy-response-link-view-topic']",
     "vacancy_page.VACANCY_APPLY_BUTTON": "[data-qa='vacancy-response-link-top']",
     "vacancy_page.VACANCY_COMPANY_NAME": "[data-qa='vacancy-company-name']",
+    "vacancy_page.VACANCY_DESCRIPTION": "[data-qa=\"vacancy-description\"]",
     "vacancy_page.VACANCY_DIRECT_APPLICATION_ALERT": "[data-qa=\"magritte-alert\"]",
     "vacancy_page.VACANCY_DIRECT_APPLICATION_CANCEL": "[data-qa=\"vacancy-response-link-advertising-cancel\"]",
+    "vacancy_page.VACANCY_EXPERIENCE": "[data-qa=\"vacancy-experience\"]",
     "vacancy_page.VACANCY_HIDDEN_RESUME_WARNING": "[data-qa='hidden-resume-warning']",
     "vacancy_page.VACANCY_LIMIT_ERROR": "[data-qa-popup-error-code=\"negotiations-limit-exceeded\"]",
     "vacancy_page.VACANCY_RELOCATION_CONFIRM": "[data-qa=\"relocation-warning-confirm\"]",
     "vacancy_page.VACANCY_RESPONSE_ERROR": "[data-qa=\"vacancy-response-error-notification\"]",
     "vacancy_page.VACANCY_RESPONSE_REJECT_WARNING": "[data-qa=\"response-reject-warning\"]",
     "vacancy_page.VACANCY_SIMILAR_VACANCIES_CLOSE": "[data-qa=\"vacancy-response-similar-vacancies-close\"]",
-    "vacancy_page.VACANCY_TITLE": "[data-qa='vacancy-title']"
+    "vacancy_page.VACANCY_TITLE": "[data-qa='vacancy-title']",
+    "vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE": "[data-qa=\"vacancy-view-employment-mode\"]",
+    "vacancy_page.VACANCY_VIEW_LOCATION": "[data-qa=\"vacancy-view-location\"]",
+    "vacancy_page.VACANCY_VIEW_RAW_ADDRESS": "[data-qa=\"vacancy-view-raw-address\"]"
 }
 # fmt: on
 

--- a/src/hhru_bot/selector_groups/vacancy_page.py
+++ b/src/hhru_bot/selector_groups/vacancy_page.py
@@ -21,6 +21,11 @@ VACANCY_RESPONSE_REJECT_WARNING = _selector("vacancy_page.VACANCY_RESPONSE_REJEC
 VACANCY_RESPONSE_ERROR = _selector("vacancy_page.VACANCY_RESPONSE_ERROR")
 VACANCY_TITLE = _selector("vacancy_page.VACANCY_TITLE")
 VACANCY_COMPANY_NAME = _selector("vacancy_page.VACANCY_COMPANY_NAME")
+VACANCY_DESCRIPTION = _selector("vacancy_page.VACANCY_DESCRIPTION")
+VACANCY_EXPERIENCE = _selector("vacancy_page.VACANCY_EXPERIENCE")
+VACANCY_VIEW_EMPLOYMENT_MODE = _selector("vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE")
+VACANCY_VIEW_LOCATION = _selector("vacancy_page.VACANCY_VIEW_LOCATION")
+VACANCY_VIEW_RAW_ADDRESS = _selector("vacancy_page.VACANCY_VIEW_RAW_ADDRESS")
 
 # VACANCY_APPLY_BUTTON — это ссылка
 # (href="/applicant/vacancy_response?vacancyId=..&employerId=..&hhtmFrom=vacancy"),

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -21,6 +21,42 @@ SPEC.loader.exec_module(contracts)
 pytestmark = pytest.mark.unit
 
 
+VACANCY_CONSENSUS_PORTS = {
+    "vacancy_page.VACANCY_DESCRIPTION": {
+        "value": '[data-qa="vacancy-description"]',
+        "references": {"steev", "yamakayama"},
+    },
+    "vacancy_page.VACANCY_EXPERIENCE": {
+        "value": '[data-qa="vacancy-experience"]',
+        "references": {"steev", "yamakayama"},
+    },
+    "vacancy_page.VACANCY_VIEW_EMPLOYMENT_MODE": {
+        "value": '[data-qa="vacancy-view-employment-mode"]',
+        "references": {"steev", "yamakayama"},
+    },
+    "vacancy_page.VACANCY_VIEW_LOCATION": {
+        "value": '[data-qa="vacancy-view-location"]',
+        "references": {"steev", "tgeruzov"},
+    },
+    "vacancy_page.VACANCY_VIEW_RAW_ADDRESS": {
+        "value": '[data-qa="vacancy-view-raw-address"]',
+        "references": {"steev", "tgeruzov"},
+    },
+}
+
+
+VACANCY_CANDIDATE_VALUES = {
+    '[data-qa="vacancy-description"]',
+    '[data-qa="vacancy-experience"]',
+    '[data-qa="vacancy-response-letter-submit"]',
+    '[data-qa="vacancy-response-link-bottom"]',
+    '[data-qa="vacancy-view-employment-mode"]',
+    '[data-qa="vacancy-view-location"]',
+    '[data-qa="vacancy-view-raw-address"]',
+    'h1[data-qa="vacancy-title"]',
+}
+
+
 def _commit_repository(path: Path, selector: str) -> None:
     path.mkdir(parents=True, exist_ok=True)
     (path / "selectors.py").write_text(f'SELECTOR = "{selector}"\n', encoding="utf-8")
@@ -49,6 +85,46 @@ def test_current_repository_selector_contract_is_self_consistent():
     assert contracts.verify_catalog(catalog) == []
     assert len(catalog["references"]) == 3
     assert catalog["policy"]["consensus_threshold"] == 2
+
+
+@pytest.mark.parametrize("logical_id, expected", VACANCY_CONSENSUS_PORTS.items())
+def test_vacancy_consensus_ports_are_exact_reference_literals(logical_id, expected):
+    row = contracts.load_catalog()["selectors"][logical_id]
+
+    assert row["decision"] == "consensus"
+    assert row["origin"] == "reference_consensus"
+    assert row["verification"] == "contract_tested"
+    assert row["criticality"] == "read"
+    assert set(row["sources"]) == expected["references"]
+    for source_entries in row["sources"].values():
+        for source in source_entries:
+            assert source["file"]
+            assert isinstance(source["line"], int)
+            assert source["key"]
+            assert source["value"] == expected["value"]
+
+
+def test_every_vacancy_upstream_candidate_has_an_explicit_decision():
+    catalog = contracts.load_catalog()
+    candidates = {
+        contracts.normalize_selector(row["value"]): row
+        for row in catalog["upstream_consensus"]
+        if contracts.normalize_selector(row["value"])
+        in {contracts.normalize_selector(value) for value in VACANCY_CANDIDATE_VALUES}
+    }
+
+    assert set(candidates) == {
+        contracts.normalize_selector(value) for value in VACANCY_CANDIDATE_VALUES
+    }
+    for row in candidates.values():
+        assert row["decision"] in {"port_exact", "reject"}
+        if row["decision"] == "port_exact":
+            assert row["logical_id"] in VACANCY_CONSENSUS_PORTS
+            assert row["origin"] == "reference_consensus"
+            assert row["verification"] == "contract_tested"
+        else:
+            assert row["reason_code"] in {"duplicate_local_role", "write_risk"}
+            assert row["reason"]
 
 
 def test_catalog_load_does_not_require_generated_live_evidence(monkeypatch, tmp_path):
@@ -203,7 +279,7 @@ def test_refresh_dry_run_reports_baseline_and_never_writes(monkeypatch, capsys, 
     output = capsys.readouterr().out
     assert "DRY-RUN" in output
     assert "no files, branches, or PRs were written" in output
-    assert "local selector contracts: 199" in output
+    assert "local selector contracts: 204" in output
     assert "Semantic mismatches:" in output
 
 

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -127,6 +127,40 @@ def test_every_vacancy_upstream_candidate_has_an_explicit_decision():
             assert row["reason"]
 
 
+def test_refresh_preserves_upstream_candidate_decisions():
+    selector = '[data-qa="vacancy-description"]'
+    indexes = {
+        reference: [
+            contracts.SourceSelector(
+                selector,
+                contracts.normalize_selector(selector),
+                f"{reference}.py",
+                1,
+                f"{reference}#0",
+            )
+        ]
+        for reference in contracts.REFERENCE_CONFIG
+    }
+    previous = [
+        {
+            "value": selector,
+            "references": ["steev", "yamakayama"],
+            "sources": {},
+            "decision": "port_exact",
+            "logical_id": "vacancy_page.VACANCY_DESCRIPTION",
+            "origin": "reference_consensus",
+            "verification": "contract_tested",
+        }
+    ]
+
+    refreshed = contracts._upstream_consensus(indexes, previous)
+
+    assert refreshed[0]["decision"] == "port_exact"
+    assert refreshed[0]["logical_id"] == "vacancy_page.VACANCY_DESCRIPTION"
+    assert refreshed[0]["origin"] == "reference_consensus"
+    assert refreshed[0]["verification"] == "contract_tested"
+
+
 def test_catalog_load_does_not_require_generated_live_evidence(monkeypatch, tmp_path):
     monkeypatch.setattr(contracts, "MAP_PATH", contracts.ROOT / "selectors" / "reference-map.yaml")
     monkeypatch.setattr(contracts, "EVIDENCE_PATH", tmp_path / "live-evidence.json")


### PR DESCRIPTION
Closes #606

## Summary
- port five read-only vacancy-page selectors from exact 2-of-3 upstream consensus sources
- record file/line/key/value evidence plus `origin: reference_consensus` and `verification: contract_tested`
- explicitly reject the bottom apply, letter-submit, and `h1` fallback candidates with documented duplicate/write-risk reasons
- regenerate runtime selectors and reference matrix

## Tests
- `ruff check .`
- `ruff format --check .`
- `python scripts/selector_contracts.py check`
- `pytest -q`

## Risks / follow-ups
- The five new contracts are read-only and not wired into a new workflow; they are available through the generated selector contract for later use.
- No merge performed; maintainer review/merge remains pending.
