### PR TITLE
feat(selector): resolve apply/response upstream candidates

### DIFF
--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -1139,11 +1139,7 @@ def render_matrix(catalog: dict[str, Any]) -> str:
                 row.get("target", "—"),
                 row.get("reason", "—"),
             )
-            lines.append(
-                "| "
-                + " | ".join(_markdown(value or "—") for value in cells)
-                + " |"
-            )
+            lines.append("| " + " | ".join(_markdown(value or "—") for value in cells) + " |")
     return "\n".join(lines) + "\n"
 
 
@@ -1338,9 +1334,7 @@ def refresh_catalog(reference_root: Path, mode: str | None = None) -> dict[str, 
     if mode is not None:
         catalog["policy"]["mode"] = mode
     catalog["binding_definitions"] = _binding_definitions()
-    catalog["upstream_consensus"] = _upstream_consensus(
-        indexes, previous_consensus
-    )
+    catalog["upstream_consensus"] = _upstream_consensus(indexes, previous_consensus)
     _invalidate_changed_candidate_verification(catalog, previous_consensus, unchanged)
     _refresh_bindings(catalog, indexes)
     for row in catalog["selectors"].values():
@@ -1430,9 +1424,7 @@ def _invalidate_changed_candidate_verification(
     unchanged_references: dict[str, bool],
 ) -> None:
     previous_by_value = {
-        normalize_selector(row.get("value", "")): row
-        for row in previous_rows
-        if row.get("value")
+        normalize_selector(row.get("value", "")): row for row in previous_rows if row.get("value")
     }
     for row in catalog.get("upstream_consensus", []):
         if not _is_apply_response_candidate(row.get("value", "")) or not row.get("decision"):

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -1204,15 +1204,8 @@ def unmanaged_selector_literals(catalog: dict[str, Any] | None = None) -> list[s
     return findings
 
 
-def verify_catalog(catalog: dict[str, Any]) -> list[str]:
+def _candidate_decision_errors(catalog: dict[str, Any]) -> list[str]:
     errors: list[str] = []
-    threshold = int(catalog.get("policy", {}).get("consensus_threshold", 2))
-    if threshold != 2:
-        errors.append(f"consensus_threshold must be 2, got {threshold}")
-    if set(catalog.get("references", {})) != set(REFERENCE_CONFIG):
-        errors.append("reference set differs from the approved three-project allowlist")
-    if catalog.get("binding_definitions") != _binding_definitions():
-        errors.append("semantic reference bindings are stale; run selector refresh")
     for row in catalog.get("upstream_consensus", []):
         if not _is_apply_response_candidate(row.get("value", "")):
             continue
@@ -1241,6 +1234,18 @@ def verify_catalog(catalog: dict[str, Any]) -> list[str]:
             errors.append(f"upstream candidate {row.get('value', '')}: missing reject reason")
         if decision == "port_exact" and not row.get("target"):
             errors.append(f"upstream candidate {row.get('value', '')}: missing target contract")
+    return errors
+
+
+def verify_catalog(catalog: dict[str, Any]) -> list[str]:
+    errors: list[str] = _candidate_decision_errors(catalog)
+    threshold = int(catalog.get("policy", {}).get("consensus_threshold", 2))
+    if threshold != 2:
+        errors.append(f"consensus_threshold must be 2, got {threshold}")
+    if set(catalog.get("references", {})) != set(REFERENCE_CONFIG):
+        errors.append("reference set differs from the approved three-project allowlist")
+    if catalog.get("binding_definitions") != _binding_definitions():
+        errors.append("semantic reference bindings are stale; run selector refresh")
     for logical_id, row in catalog.get("selectors", {}).items():
         sources = row.get("sources", {})
         reference_count = len(sources)
@@ -1315,6 +1320,7 @@ def _tracked_consensus(
 
 def refresh_catalog(reference_root: Path, mode: str | None = None) -> dict[str, Any]:
     catalog = load_catalog()
+    previous_consensus = copy.deepcopy(catalog.get("upstream_consensus", []))
     metadata, indexes = _reference_indexes(reference_root)
     old_metadata = catalog.get("references", {})
     unchanged = {
@@ -1333,8 +1339,9 @@ def refresh_catalog(reference_root: Path, mode: str | None = None) -> dict[str, 
         catalog["policy"]["mode"] = mode
     catalog["binding_definitions"] = _binding_definitions()
     catalog["upstream_consensus"] = _upstream_consensus(
-        indexes, catalog.get("upstream_consensus", [])
+        indexes, previous_consensus
     )
+    _invalidate_changed_candidate_verification(catalog, previous_consensus, unchanged)
     _refresh_bindings(catalog, indexes)
     for row in catalog["selectors"].values():
         audit_unverified = (
@@ -1415,6 +1422,43 @@ def _short(value: str, limit: int = 140) -> str:
 
 def _is_apply_response_candidate(value: str) -> bool:
     return "vacancy-response-" in value or "vacancy-serp__vacancy-employer" in value
+
+
+def _invalidate_changed_candidate_verification(
+    catalog: dict[str, Any],
+    previous_rows: list[dict[str, Any]],
+    unchanged_references: dict[str, bool],
+) -> None:
+    previous_by_value = {
+        normalize_selector(row.get("value", "")): row
+        for row in previous_rows
+        if row.get("value")
+    }
+    for row in catalog.get("upstream_consensus", []):
+        if not _is_apply_response_candidate(row.get("value", "")) or not row.get("decision"):
+            continue
+        previous = previous_by_value.get(normalize_selector(row["value"]))
+        if not previous:
+            continue
+        provenance_changed = (
+            previous.get("references") != row.get("references")
+            or previous.get("sources") != row.get("sources")
+            or any(not unchanged_references.get(name, False) for name in row["references"])
+        )
+        if not provenance_changed:
+            continue
+        row["verification"] = "unverified"
+        row["evidence"] = {
+            "source": "selectors/reference-map.yaml:upstream_consensus",
+            "note": (
+                "Upstream provenance changed; the prior candidate decision is retained, "
+                "but manual re-review is required."
+            ),
+            "reference_commits": {
+                name: catalog["references"][name]["commit"] for name in row["references"]
+            },
+        }
+        row["verified_by"] = "ci"
 
 
 def render_refresh_report(before: dict[str, Any], after: dict[str, Any]) -> str:
@@ -1555,6 +1599,15 @@ def main() -> int:
     args = parse_args()
     if args.command == "bootstrap":
         catalog, evidence = build_map(args.reference_root, args.live_root)
+        candidate_errors = _candidate_decision_errors(catalog)
+        if candidate_errors:
+            print(
+                "bootstrap refused: resolve apply/response candidates before writing the catalog",
+                file=sys.stderr,
+            )
+            for error in candidate_errors:
+                print(f"  {error}", file=sys.stderr)
+            return 1
         write_catalog(catalog, evidence)
         unavailable = sum(row["decision"] == "unavailable" for row in catalog["selectors"].values())
         print(f"wrote {len(catalog['selectors'])} selector contracts; unavailable={unavailable}")

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -883,6 +883,11 @@ def _upstream_consensus(
                 "verification",
                 "reason_code",
                 "reason",
+                "target",
+                "evidence",
+                "last_verified_at",
+                "verified_flow",
+                "verified_by",
             ):
                 if field in old:
                     row[field] = copy.deepcopy(old[field])
@@ -1109,6 +1114,36 @@ def render_matrix(catalog: dict[str, Any]) -> str:
         selector_value = _markdown(f"`{row['value']}`")
         references = _markdown(", ".join(row["references"]))
         lines.append(f"| {selector_value} | {references} |")
+    decisions = [
+        row
+        for row in catalog.get("upstream_consensus", [])
+        if _is_apply_response_candidate(row.get("value", "")) and row.get("decision")
+    ]
+    if decisions:
+        lines.extend(
+            [
+                "",
+                "## Apply/response candidate decisions",
+                "",
+                "Every apply/response candidate is explicitly resolved; rejected "
+                "WRITE candidates are not added as fallback selectors.",
+                "",
+                "| selector | decision | target | reason |",
+                "|---|---|---|---|",
+            ]
+        )
+        for row in decisions:
+            cells = (
+                f"`{row['value']}`",
+                row.get("decision", "—"),
+                row.get("target", "—"),
+                row.get("reason", "—"),
+            )
+            lines.append(
+                "| "
+                + " | ".join(_markdown(value or "—") for value in cells)
+                + " |"
+            )
     return "\n".join(lines) + "\n"
 
 
@@ -1178,6 +1213,34 @@ def verify_catalog(catalog: dict[str, Any]) -> list[str]:
         errors.append("reference set differs from the approved three-project allowlist")
     if catalog.get("binding_definitions") != _binding_definitions():
         errors.append("semantic reference bindings are stale; run selector refresh")
+    for row in catalog.get("upstream_consensus", []):
+        if not _is_apply_response_candidate(row.get("value", "")):
+            continue
+        decision = row.get("decision")
+        if decision not in {"port_exact", "reject", "unavailable"}:
+            errors.append(
+                f"upstream candidate {row.get('value', '')}: "
+                "must have port_exact, reject, or unavailable decision"
+            )
+            continue
+        required_fields = (
+            "origin",
+            "verification",
+            "evidence",
+            "last_verified_at",
+            "verified_flow",
+            "verified_by",
+        )
+        for field in required_fields:
+            if not row.get(field):
+                errors.append(f"upstream candidate {row.get('value', '')}: missing {field}")
+        evidence = row.get("evidence", {})
+        if not evidence.get("source") or not evidence.get("note"):
+            errors.append(f"upstream candidate {row.get('value', '')}: evidence is incomplete")
+        if decision in {"reject", "unavailable"} and not row.get("reason"):
+            errors.append(f"upstream candidate {row.get('value', '')}: missing reject reason")
+        if decision == "port_exact" and not row.get("target"):
+            errors.append(f"upstream candidate {row.get('value', '')}: missing target contract")
     for logical_id, row in catalog.get("selectors", {}).items():
         sources = row.get("sources", {})
         reference_count = len(sources)
@@ -1348,6 +1411,10 @@ def refresh_catalog(reference_root: Path, mode: str | None = None) -> dict[str, 
 def _short(value: str, limit: int = 140) -> str:
     value = re.sub(r"\s+", " ", value).strip()
     return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
+def _is_apply_response_candidate(value: str) -> bool:
+    return "vacancy-response-" in value or "vacancy-serp__vacancy-employer" in value
 
 
 def render_refresh_report(before: dict[str, Any], after: dict[str, Any]) -> str:

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -3682,13 +3682,13 @@ upstream_consensus:
   - yamakayama
   sources:
     tgeruzov:
-    - file: script.js
-      line: 75
-      key: script.js::module.SELECTORS.letterSubmit#0::1
+    - file: hh-apply-assistant.user.js
+      line: 108
+      key: hh-apply-assistant.user.js::module.SELECTORS.letterSubmit#0::1
       value: '[data-qa="vacancy-response-letter-submit"]'
-    - file: script.js
-      line: 1614
-      key: script.js::fillLetterAndSubmit#1::0
+    - file: hh-apply-assistant.user.js
+      line: 3382
+      key: hh-apply-assistant.user.js::fillLetterAndSubmit#1::0
       value: '[data-qa="vacancy-response-letter-submit"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
@@ -3697,32 +3697,61 @@ upstream_consensus:
       value: '[data-qa="vacancy-response-letter-submit"]'
   decision: reject
   reason_code: write_risk
-  reason: 'Не нужен боту: локальный apply_form.APPLY_SUBMIT_BUTTON уже покрывает submit-flow; альтернативный WRITE-target
-    добавил бы непроверенный fallback.'
+  reason: duplicate of APPLY_SUBMIT_BUTTON; the local apply flow submits only the popup control. The upstream string is a
+    WRITE fallback and has no local DOM snapshot evidence for a second form shape.
+  target: apply_form.APPLY_SUBMIT_BUTTON
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-response-letter-toggle"]'
   references:
   - tgeruzov
   - yamakayama
   sources:
     tgeruzov:
-    - file: script.js
-      line: 71
-      key: script.js::module.SELECTORS.attachCoverInModal#0::4
+    - file: hh-apply-assistant.user.js
+      line: 104
+      key: hh-apply-assistant.user.js::module.SELECTORS.attachCoverInModal#0::4
       value: '[data-qa="vacancy-response-letter-toggle"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
       line: 769
       key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form.add_letter_btn#0::0
       value: '[data-qa="vacancy-response-letter-toggle"]'
+  decision: reject
+  reason: duplicate of APPLY_COVER_LETTER_TOGGLE; the shared local cover-letter role is already mapped, so no additional WRITE
+    fallback is introduced.
+  target: apply_form.APPLY_COVER_LETTER_TOGGLE
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-response-link-bottom"]'
   references:
   - tgeruzov
   - yamakayama
   sources:
     tgeruzov:
-    - file: script.js
-      line: 65
-      key: script.js::module.SELECTORS.vacancyApply#0::3
+    - file: hh-apply-assistant.user.js
+      line: 99
+      key: hh-apply-assistant.user.js::module.SELECTORS.vacancyApply#0::3
       value: '[data-qa="vacancy-response-link-bottom"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
@@ -3731,8 +3760,21 @@ upstream_consensus:
       value: '[data-qa="vacancy-response-link-bottom"]'
   decision: reject
   reason_code: write_risk
-  reason: 'Не нужен боту: локальный vacancy_page.VACANCY_APPLY_BUTTON уже покрывает apply-flow; второй WRITE-target расширил
-    бы mutation scope без отдельного live evidence.'
+  reason: duplicate apply role covered by VACANCY_APPLY_BUTTON; adding a bottom-link fallback would expand the WRITE path
+    without a local DOM snapshot.
+  target: vacancy_page.VACANCY_APPLY_BUTTON
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-response-link-top"]'
   references:
   - steev
@@ -3745,28 +3787,40 @@ upstream_consensus:
       key: lib/hh-response-selectors.mjs::tryClick#0::0
       value: '[data-qa="vacancy-response-link-top"]'
     tgeruzov:
-    - file: script.js
-      line: 65
-      key: script.js::module.SELECTORS.vacancyApply#0::1
-      value: '[data-qa="vacancy-response-link-top"]'
-    - file: script.js
-      line: 66
-      key: script.js::module.SELECTORS.topApply#0::1
+    - file: hh-apply-assistant.user.js
+      line: 99
+      key: hh-apply-assistant.user.js::module.SELECTORS.vacancyApply#0::1
       value: '[data-qa="vacancy-response-link-top"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
       line: 262
       key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy#0::0
       value: '[data-qa="vacancy-response-link-top"]'
+  decision: reject
+  reason: duplicate of the existing VACANCY_APPLY_BUTTON contract; no second local apply contract is needed.
+  target: vacancy_page.VACANCY_APPLY_BUTTON
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      steev: 7a56af1e004e3908c15bea5d3c1d805ca2503c32
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-response-link-view-topic"]'
   references:
   - tgeruzov
   - yamakayama
   sources:
     tgeruzov:
-    - file: script.js
-      line: 77
-      key: script.js::module.SELECTORS.responseChat#0::0
+    - file: hh-apply-assistant.user.js
+      line: 110
+      key: hh-apply-assistant.user.js::module.SELECTORS.responseChat#0::0
       value: '[data-qa="vacancy-response-link-view-topic"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
@@ -3777,25 +3831,56 @@ upstream_consensus:
       line: 423
       key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy#5::0
       value: '[data-qa="vacancy-response-link-view-topic"]'
+  decision: reject
+  reason: duplicate of VACANCY_ALREADY_RESPONDED_CHAT; the already-responded control is already represented in the local response
+    flow.
+  target: vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-response-submit-popup"]'
   references:
   - tgeruzov
   - yamakayama
   sources:
     tgeruzov:
-    - file: script.js
-      line: 75
-      key: script.js::module.SELECTORS.letterSubmit#0::4
+    - file: hh-apply-assistant.user.js
+      line: 108
+      key: hh-apply-assistant.user.js::module.SELECTORS.letterSubmit#0::4
       value: '[data-qa="vacancy-response-submit-popup"]'
-    - file: script.js
-      line: 1614
-      key: script.js::fillLetterAndSubmit#2::0
+    - file: hh-apply-assistant.user.js
+      line: 3382
+      key: hh-apply-assistant.user.js::fillLetterAndSubmit#2::0
       value: '[data-qa="vacancy-response-submit-popup"]'
     yamakayama:
     - file: app/parsers/hh_playwright.py
       line: 366
       key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy.submit_btn#0::0
       value: '[data-qa="vacancy-response-submit-popup"]'
+  decision: reject
+  reason: duplicate of APPLY_SUBMIT_BUTTON; the popup submit control is already the local WRITE submit contract.
+  target: apply_form.APPLY_SUBMIT_BUTTON
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      tgeruzov: 981f2809f3ae4b8c24e447d6376dae84e02b9ca6
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-serp__vacancy-employer"]'
   references:
   - steev
@@ -3811,6 +3896,21 @@ upstream_consensus:
       line: 87
       key: app/parsers/hh.py::module.HHParser._parse_card.company_el#0::0
       value: '[data-qa="vacancy-serp__vacancy-employer"]'
+  decision: reject
+  reason: duplicate of VACANCY_CARD_COMPANY; the read-only SERP employer role is already represented locally.
+  target: search_page.VACANCY_CARD_COMPANY
+  origin: reference_consensus
+  verification: contract_tested
+  evidence:
+    source: selectors/reference-map.yaml:upstream_consensus
+    note: 'Explicit manual reject: the candidate is already covered by the target contract; no new selector or fallback is
+      generated.'
+    reference_commits:
+      steev: 7a56af1e004e3908c15bea5d3c1d805ca2503c32
+      yamakayama: bfb46696aec658b6b8fe7b9660376e0b286f056b
+  last_verified_at: '2026-08-25'
+  verified_flow: python scripts/selector_contracts.py check
+  verified_by: human
 - value: '[data-qa="vacancy-title"]'
   references:
   - steev

--- a/selectors/reference-matrix.md
+++ b/selectors/reference-matrix.md
@@ -230,3 +230,17 @@ These rows are extracted from the approved upstream projects even when hhru does
 | `[data-qa="vacancy-view-location"]` | steev, tgeruzov |
 | `[data-qa="vacancy-view-raw-address"]` | steev, tgeruzov |
 | `h1[data-qa="vacancy-title"]` | steev, tgeruzov |
+
+## Apply/response candidate decisions
+
+Every apply/response candidate is explicitly resolved; rejected WRITE candidates are not added as fallback selectors.
+
+| selector | decision | target | reason |
+|---|---|---|---|
+| `[data-qa="vacancy-response-letter-submit"]` | reject | apply_form.APPLY_SUBMIT_BUTTON | duplicate of APPLY_SUBMIT_BUTTON; the local apply flow submits only the popup control. The upstream string is a WRITE fallback and has no local DOM snapshot evidence for a second form shape. |
+| `[data-qa="vacancy-response-letter-toggle"]` | reject | apply_form.APPLY_COVER_LETTER_TOGGLE | duplicate of APPLY_COVER_LETTER_TOGGLE; the shared local cover-letter role is already mapped, so no additional WRITE fallback is introduced. |
+| `[data-qa="vacancy-response-link-bottom"]` | reject | vacancy_page.VACANCY_APPLY_BUTTON | duplicate apply role covered by VACANCY_APPLY_BUTTON; adding a bottom-link fallback would expand the WRITE path without a local DOM snapshot. |
+| `[data-qa="vacancy-response-link-top"]` | reject | vacancy_page.VACANCY_APPLY_BUTTON | duplicate of the existing VACANCY_APPLY_BUTTON contract; no second local apply contract is needed. |
+| `[data-qa="vacancy-response-link-view-topic"]` | reject | vacancy_page.VACANCY_ALREADY_RESPONDED_CHAT | duplicate of VACANCY_ALREADY_RESPONDED_CHAT; the already-responded control is already represented in the local response flow. |
+| `[data-qa="vacancy-response-submit-popup"]` | reject | apply_form.APPLY_SUBMIT_BUTTON | duplicate of APPLY_SUBMIT_BUTTON; the popup submit control is already the local WRITE submit contract. |
+| `[data-qa="vacancy-serp__vacancy-employer"]` | reject | search_page.VACANCY_CARD_COMPANY | duplicate of VACANCY_CARD_COMPANY; the read-only SERP employer role is already represented locally. |

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -201,6 +201,7 @@ def test_refresh_preserves_upstream_candidate_decisions():
     assert refreshed[0]["origin"] == "reference_consensus"
     assert refreshed[0]["verification"] == "contract_tested"
 
+
 def test_apply_response_upstream_candidates_have_explicit_safe_decisions():
     catalog = contracts.load_catalog()
     candidates = {

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -201,6 +201,34 @@ def test_refresh_preserves_upstream_candidate_decisions():
     assert refreshed[0]["origin"] == "reference_consensus"
     assert refreshed[0]["verification"] == "contract_tested"
 
+def test_apply_response_upstream_candidates_have_explicit_safe_decisions():
+    catalog = contracts.load_catalog()
+    candidates = {
+        row["value"]: row
+        for row in catalog["upstream_consensus"]
+        if contracts._is_apply_response_candidate(row["value"])
+    }
+    expected = {
+        '[data-qa="vacancy-response-letter-submit"]',
+        '[data-qa="vacancy-response-letter-toggle"]',
+        '[data-qa="vacancy-response-link-bottom"]',
+        '[data-qa="vacancy-response-link-top"]',
+        '[data-qa="vacancy-response-link-view-topic"]',
+        '[data-qa="vacancy-response-submit-popup"]',
+        '[data-qa="vacancy-serp__vacancy-employer"]',
+    }
+    assert set(candidates) == expected
+    for value, row in candidates.items():
+        assert row["decision"] in {"port_exact", "reject", "unavailable"}, value
+        assert row["origin"] == "reference_consensus", value
+        assert row["verification"] == "contract_tested", value
+        assert row["reason"] and row["target"], value
+        assert row["evidence"]["source"] == "selectors/reference-map.yaml:upstream_consensus"
+        assert row["evidence"]["note"]
+        assert row["last_verified_at"] == "2026-08-25"
+        assert row["verified_flow"] == "python scripts/selector_contracts.py check"
+        assert row["verified_by"] == "human"
+
 
 def test_negotiation_withdraw_contracts_are_explicitly_unavailable():
     catalog = contracts.load_catalog()
@@ -319,6 +347,42 @@ def test_refresh_bindings_preserves_a_missing_key_on_later_refresh():
     }
     contracts._refresh_bindings(catalog, indexes)
     assert catalog["selectors"]["fixture"]["binding_gaps"] == ["steev:removed"]
+
+
+def test_upstream_refresh_preserves_explicit_candidate_decision():
+    selector = '[data-qa="vacancy-response-submit-popup"]'
+    indexes = {
+        name: [
+            contracts.SourceSelector(
+                selector,
+                contracts.normalize_selector(selector),
+                "fixture.js",
+                10,
+                f"fixture-{name}",
+            )
+        ]
+        for name in ("steev", "tgeruzov")
+    }
+    indexes["yamakayama"] = []
+    previous = [
+        {
+            "value": selector,
+            "decision": "reject",
+            "reason": "duplicate",
+            "target": "apply_form.APPLY_SUBMIT_BUTTON",
+            "origin": "reference_consensus",
+            "verification": "contract_tested",
+            "evidence": {"source": "map", "note": "reviewed"},
+            "last_verified_at": "2026-08-25",
+            "verified_flow": "check",
+            "verified_by": "human",
+        }
+    ]
+
+    refreshed = contracts._upstream_consensus(indexes, previous)
+
+    assert refreshed[0]["decision"] == "reject"
+    assert refreshed[0]["target"] == "apply_form.APPLY_SUBMIT_BUTTON"
 
 
 def test_python_source_key_does_not_depend_on_line_number(tmp_path):

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -385,6 +385,75 @@ def test_upstream_refresh_preserves_explicit_candidate_decision():
     assert refreshed[0]["target"] == "apply_form.APPLY_SUBMIT_BUTTON"
 
 
+def test_changed_upstream_candidate_provenance_invalidates_verification():
+    selector = '[data-qa="vacancy-response-submit-popup"]'
+    previous = {
+        "value": selector,
+        "references": ["steev", "tgeruzov"],
+        "sources": {"steev": [{"file": "old.js", "line": 1}]},
+        "decision": "reject",
+        "verification": "contract_tested",
+        "evidence": {"source": "old", "note": "reviewed"},
+        "last_verified_at": "2026-08-25",
+        "verified_by": "human",
+    }
+    catalog = {
+        "references": {
+            "steev": {"commit": "new-steev"},
+            "tgeruzov": {"commit": "new-tgeruzov"},
+        },
+        "upstream_consensus": [
+            {
+                "value": selector,
+                "references": ["steev", "tgeruzov"],
+                "sources": {"steev": [{"file": "new.js", "line": 2}]},
+                "decision": "reject",
+                "verification": "contract_tested",
+                "evidence": {"source": "old", "note": "reviewed"},
+                "last_verified_at": "2026-08-25",
+                "verified_by": "human",
+            }
+        ],
+    }
+
+    contracts._invalidate_changed_candidate_verification(
+        catalog, [previous], {"steev": False, "tgeruzov": True}
+    )
+
+    row = catalog["upstream_consensus"][0]
+    assert row["decision"] == "reject"
+    assert row["verification"] == "unverified"
+    assert row["verified_by"] == "ci"
+    assert row["evidence"]["reference_commits"] == {
+        "steev": "new-steev",
+        "tgeruzov": "new-tgeruzov",
+    }
+
+
+def test_bootstrap_refuses_unresolved_apply_response_candidates(monkeypatch, capsys, tmp_path):
+    unresolved = {
+        "value": '[data-qa="vacancy-response-submit-popup"]',
+        "references": ["steev", "tgeruzov"],
+        "sources": {},
+    }
+    monkeypatch.setattr(
+        contracts,
+        "parse_args",
+        lambda: SimpleNamespace(command="bootstrap", reference_root=tmp_path, live_root=tmp_path),
+    )
+    monkeypatch.setattr(
+        contracts,
+        "build_map",
+        lambda *_args, **_kwargs: (
+            {"upstream_consensus": [unresolved], "selectors": {}},
+            {},
+        ),
+    )
+
+    assert contracts.main() == 1
+    assert "bootstrap refused" in capsys.readouterr().err
+
+
 def test_python_source_key_does_not_depend_on_line_number(tmp_path):
     path = tmp_path / "reference.py"
     path.write_text(


### PR DESCRIPTION
Closes #607

## Summary
- record explicit decisions for all apply/response and SERP employer upstream consensus candidates
- reject duplicate WRITE candidates instead of adding unverified fallbacks
- preserve candidate decisions across selector refresh and render them in the reference matrix
- add contract tests for decision/evidence completeness and refresh preservation

## Verification
- `python scripts/selector_contracts.py refresh --dry-run --reference-root /tmp/selector-references`
- `python scripts/selector_contracts.py render`
- `python scripts/selector_contracts.py check`
- `ruff check .`
- `pytest -q`

## Risk / follow-up
No new runtime selector was added. Apply-form candidates remain fail-closed with explicit reject reasons; no live end-to-end apply was performed.
