### PR TITLE
fix(apply): recognize current hh.ru success marker

### DIFF
--- a/src/hhru_bot/apply/success.py
+++ b/src/hhru_bot/apply/success.py
@@ -51,6 +51,11 @@ APPLY_SUCCESS_MARKERS = (
     APPLY_SUCCESS_MARKER,
     "[data-qa='vacancy-response-success']",
     ".bloko-modal-response-success",
+    # Current Magritte response popup (captured in the post-submit form
+    # dumps).  The old selectors above belong to the legacy popup and remain
+    # as compatibility fallbacks.
+    "[data-qa='responded-success-attach-cover-letter']",
+    "[data-qa='vacancy-response-link-top']",
 )
 
 # Текстовые признаки отправленного отклика. Регистронезависимый regex (#7):

--- a/tests/test_apply_success.py
+++ b/tests/test_apply_success.py
@@ -143,6 +143,12 @@ def test_success_via_fallback_marker():
     assert success.wait_success_confirmation(page) is True
 
 
+def test_success_via_current_magritte_marker():
+    """The current response popup exposes the Magritte success attachment."""
+    page = _FakePage(markers={"[data-qa='responded-success-attach-cover-letter']"})
+    assert success.wait_success_confirmation(page) is True
+
+
 def test_success_via_text():
     page = _FakePage(success_texts={"Отклик отправлен"})
     assert success.wait_success_confirmation(page) is True


### PR DESCRIPTION
Closes #587

## Summary
- recognize the current Magritte `responded-success-attach-cover-letter` UI success marker and response link
- keep legacy selectors as fallbacks and preserve fail-closed external negotiations readback
- add regression coverage for the current marker

## Live READ evidence
- `probe --vacancy-id 136424350` ran against the configured saved session without submitting; it correctly skipped the already-applied vacancy.
- Recent `data/history.db` records show applications confirmed by `/applicant/negotiations`, with topics recorded.
- Existing post-submit form dumps contain `responded-success-attach-cover-letter` and `vacancy-response-link-top`; no WRITE was performed.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`

Full live post-submit DOM capture was not possible without a new WRITE; no real application was sent.