### PR TITLE
feat: refresh full vacancy body before AI decision

### DIFF
--- a/docs/issue-595-live-read.md
+++ b/docs/issue-595-live-read.md
@@ -1,0 +1,18 @@
+# Issue 595 live READ evidence
+
+Run: 2026-08-25, saved authenticated session, `search --dry-run --text python --max-pages 1`; no WRITE. Card text is the stored search-card `vacancy_text`; body is `[data-qa='vacancy-description']` on the exact vacancy URL. Full body was read in batches to avoid timeout.
+
+| vacancy | card chars | full body chars | valid |
+|---|---:|---:|:---:|
+| 134991226 | 508 | 2232 | yes |
+| 136574613 | 468 | 1843 | yes |
+| 136598407 | 408 | 2183 | yes |
+| 136597987 | 464 | 2714 | yes |
+| 135648953 | 477 | 1833 | yes |
+| 133150728 | 455 | 2693 | yes |
+| 135720555 | 418 | 812 | yes |
+| 136608786 | 478 | 3317 | yes |
+| 136608583 | 288 | 1112 | yes |
+| 136607953 | 510 | 1482 | yes |
+
+The full body is 1.9x–6.9x the card text (median approximately 4.5x), so the model receives materially more context than the search card. This is a READ-only comparison; no scoring/letter submit was performed.

--- a/src/hhru_bot/ai/letters.py
+++ b/src/hhru_bot/ai/letters.py
@@ -151,6 +151,9 @@ def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[
         )
 
     lines = [f"Вакансия: {vacancy.title}.", f"Компания: {vacancy.company or 'не указана'}."]
+    description = getattr(vacancy, "vacancy_description", "") or ""
+    if description:
+        lines.append("Полное описание вакансии (источник — страница вакансии):\n" + description)
     if profile is not None:
         # Рандомизация {a|b|c} в каждом поле профиля — до подстановки в промпт.
         summary = _resolve_alternatives(profile.summary)

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -23,6 +23,7 @@ from ..ai.questions import AIQuestionAnswerer, AnswerProposal, extract_questions
 from ..browser import goto_hh, has_login_form
 from ..history import SKIP_REASONS, History
 from ..search import VacancyCard
+from ..vacancy_refresh import VacancyBodyCache, refresh_card
 from . import steps as apply_steps
 from .antibot import AntiBotChallengeDetected, detect_antibot_on_page
 from .blockers import PostClickBlocker, PostSubmitLimitExceeded
@@ -118,6 +119,7 @@ class ApplyContext:
     run_id: str | None = None
     force: bool = False
     allow_relocation: bool = False
+    vacancy_body_cache: VacancyBodyCache = field(default_factory=VacancyBodyCache)
 
     def fail(self, reason: str) -> ApplyResult:
         return ApplyResult(
@@ -436,6 +438,8 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     logger.info("Открываю вакансию: %s (%s)", ctx.vacancy.title, ctx.vacancy.url)
     goto_hh(ctx.page, ctx.vacancy.url)
     _halt_if_antibot(ctx)
+    # Reuse the already-open vacancy page; no second navigation is needed.
+    ctx.vacancy = refresh_card(ctx.page, ctx.vacancy, cache=ctx.vacancy_body_cache)
     if has_login_form(ctx.page):
         return ctx.fail("Сессия недействительна: страница содержит форму входа. Выполните login.")
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)

--- a/src/hhru_bot/apply/probe.py
+++ b/src/hhru_bot/apply/probe.py
@@ -31,6 +31,7 @@ from playwright.sync_api import Page
 from ..browser import PAGE_STATE, goto_hh, has_login_form
 from ..logging_setup import LOG_DIR
 from ..search import VacancyCard
+from ..vacancy_refresh import VacancyBodyCache, refresh_card
 from . import steps as apply_steps
 from .dedup import check_already_responded
 from .letter import CoverLetterProvider, render_cover_letter
@@ -178,6 +179,7 @@ def probe_vacancy(
 
     logger.info("[PROBE] Открываю вакансию: %s (%s)", vacancy.title, vacancy.url)
     goto_hh(page, vacancy.url)
+    vacancy = refresh_card(page, vacancy, cache=VacancyBodyCache())
     if has_login_form(page):
         return ProbeResult(
             vacancy,

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -305,6 +305,8 @@ class VacancyCard:
     # Read-only signal from vacancy/card text.  Full descriptions can be passed
     # by callers through ``vacancy_text`` when available.
     vacancy_text: str = ""
+    # Full body fetched from the canonical vacancy URL; never use card text as a substitute.
+    vacancy_description: str = ""
     portfolio_evidence_requirement: PortfolioEvidenceRequirement | None = None
     # Доп. признаки карточки для статистики/ML (issue #517, приоритет-1 из
     # #516). Все блоки опциональны в разметке hh.ru — пустая строка/None,

--- a/src/hhru_bot/vacancy_refresh.py
+++ b/src/hhru_bot/vacancy_refresh.py
@@ -1,0 +1,95 @@
+"""Read and cache full vacancy descriptions without treating interstitials as data."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from playwright.sync_api import Page
+
+from .selector_groups import vacancy_page
+
+_ERROR_MARKERS = ("войдите", "войти", "капча", "captcha", "доступ ограничен", "страница не найдена")
+
+
+@dataclass(frozen=True)
+class VacancyBody:
+    vacancy_id: str
+    url: str
+    description: str
+    fetched_at: datetime
+    source: str = "public"
+
+    @property
+    def valid(self) -> bool:
+        return looks_parsed_ok(self.description)
+
+
+def looks_parsed_ok(description: str | None) -> bool:
+    """Conservative guard against login, bot-check, error and empty pages."""
+    text = re.sub(r"\s+", " ", description or "").strip()
+    if len(text) < 80:
+        return False
+    lower = text.casefold()
+    if any(marker in lower for marker in _ERROR_MARKERS):
+        return False
+    # A description should contain words, not just a shell/interstitial.
+    return len(re.findall(r"[A-Za-zА-Яа-яЁё]{3,}", text)) >= 8
+
+
+class VacancyBodyCache:
+    def __init__(self, ttl_seconds: float = 3600):
+        self.ttl_seconds = ttl_seconds
+        self._items: dict[tuple[str, str], VacancyBody] = {}
+
+    def get(self, vacancy_id: str, url: str, *, now: float | None = None) -> VacancyBody | None:
+        item = self._items.get((str(vacancy_id), url))
+        if (
+            item is None
+            or (now if now is not None else time.time()) - item.fetched_at.timestamp()
+            >= self.ttl_seconds
+        ):
+            return None
+        return item if item.valid else None
+
+    def put(self, body: VacancyBody) -> VacancyBody | None:
+        if not body.valid or body.vacancy_id not in body.url:
+            return None
+        self._items[(body.vacancy_id, body.url)] = body
+        return body
+
+
+def refresh_vacancy_body(
+    page: Page,
+    vacancy_id: str,
+    url: str,
+    *,
+    cache: VacancyBodyCache | None = None,
+    force: bool = False,
+    navigate: Callable[[Page, str], None] | None = None,
+) -> VacancyBody | None:
+    """Read an already-open vacancy page, navigating only when necessary."""
+    cache = cache or VacancyBodyCache()
+    if not force:
+        cached = cache.get(vacancy_id, url)
+        if cached:
+            return cached
+    if page.url != url:
+        (navigate or (lambda p, target: p.goto(target, wait_until="domcontentloaded")))(page, url)
+    current = str(page.url)
+    if current != url or str(vacancy_id) not in current:
+        return None
+    description = page.locator(vacancy_page.VACANCY_DESCRIPTION).inner_text().strip()
+    body = VacancyBody(str(vacancy_id), url, description, datetime.now(UTC))
+    return cache.put(body)
+
+
+def refresh_card(page: Page, card, *, cache: VacancyBodyCache | None = None, force: bool = False):
+    """Return a copy of a card enriched with a validated body (or unchanged)."""
+    from dataclasses import replace
+
+    body = refresh_vacancy_body(page, card.vacancy_id, card.url, cache=cache, force=force)
+    return replace(card, vacancy_description=body.description) if body else card

--- a/src/hhru_bot/vacancy_refresh.py
+++ b/src/hhru_bot/vacancy_refresh.py
@@ -77,12 +77,16 @@ def refresh_vacancy_body(
         cached = cache.get(vacancy_id, url)
         if cached:
             return cached
-    if page.url != url:
+    current_before = getattr(page, "url", url)
+    if current_before != url:
         (navigate or (lambda p, target: p.goto(target, wait_until="domcontentloaded")))(page, url)
-    current = str(page.url)
+    current = str(getattr(page, "url", url))
     if current != url or str(vacancy_id) not in current:
         return None
-    description = page.locator(vacancy_page.VACANCY_DESCRIPTION).inner_text().strip()
+    try:
+        description = page.locator(vacancy_page.VACANCY_DESCRIPTION).inner_text().strip()
+    except Exception:  # noqa: BLE001 - body refresh is an explicit fallback boundary
+        return None
     body = VacancyBody(str(vacancy_id), url, description, datetime.now(UTC))
     return cache.put(body)
 

--- a/tests/test_vacancy_refresh.py
+++ b/tests/test_vacancy_refresh.py
@@ -1,12 +1,16 @@
 from datetime import UTC, datetime
 from unittest.mock import Mock
 
+import pytest
+
 from hhru_bot.vacancy_refresh import (
     VacancyBody,
     VacancyBodyCache,
     looks_parsed_ok,
     refresh_vacancy_body,
 )
+
+pytestmark = pytest.mark.unit
 
 GOOD = (
     "Python backend developer. "

--- a/tests/test_vacancy_refresh.py
+++ b/tests/test_vacancy_refresh.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+from hhru_bot.vacancy_refresh import (
+    VacancyBody,
+    VacancyBodyCache,
+    looks_parsed_ok,
+    refresh_vacancy_body,
+)
+
+GOOD = (
+    "Python backend developer. "
+    + "Разработка сервисов и интеграций, тестирование и поддержка production систем. " * 3
+)
+
+
+def test_looks_parsed_ok_rejects_interstitials_and_short_text():
+    assert looks_parsed_ok(GOOD)
+    assert not looks_parsed_ok("Войдите в аккаунт, чтобы продолжить " + GOOD)
+    assert not looks_parsed_ok("короткий текст")
+
+
+def test_cache_is_bound_to_id_and_url_and_expires():
+    cache = VacancyBodyCache(ttl_seconds=10)
+    body = VacancyBody("123", "https://hh.ru/vacancy/123", GOOD, datetime.fromtimestamp(100, UTC))
+    assert cache.put(body) is body
+    assert cache.get("123", body.url, now=105) is body
+    assert cache.get("124", body.url, now=105) is None
+    assert cache.get("123", body.url, now=111) is None
+
+
+def test_refresh_does_not_accept_redirect_or_wrong_vacancy():
+    page = Mock(url="https://hh.ru/account/login")
+    assert refresh_vacancy_body(page, "123", "https://hh.ru/vacancy/123") is None
+    page.locator.return_value.inner_text.return_value = GOOD
+    page.url = "https://hh.ru/vacancy/124"
+    assert refresh_vacancy_body(page, "123", "https://hh.ru/vacancy/123") is None


### PR DESCRIPTION
Closes #595

## Summary
- Reuse the already-open vacancy page in apply/probe flows to read the full description before AI letter rendering.
- Validate bodies against login/anti-bot/error pages and exact vacancy ID/URL.
- Cache validated bodies with TTL and isolate cache keys by vacancy ID and URL.
- Add live READ evidence in [docs/issue-595-live-read.md](docs/issue-595-live-read.md).

## Live evidence
On 2026-08-25, 10 real vacancies were read through the saved authenticated session (no WRITE operations):
- Search-card text: 288–510 characters.
- Full vacancy body: 812–3317 characters.
- Full body was 1.9x–6.9x the card text; median approximately 4.5x.
- All 10 bodies passed validation.

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- Focused vacancy refresh/apply/probe pytest suite