### PR TITLE
feat: persistent vacancy blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ AIProfile/config.yaml.
 
 - `--output OUTPUT` — Путь к tar.gz
 
+### `blacklist`
+
+- (без аргументов)
+
 ### `bump`
 
 - `--resume` — Slug из конфига или resume_id HH.ru (по умолчанию — все)

--- a/src/hhru_bot/blacklist.py
+++ b/src/hhru_bot/blacklist.py
@@ -1,14 +1,18 @@
 """Persistent, deliberately narrow vacancy blacklist matching."""
+
 import re
+
 
 def normalize_value(value: str) -> str:
     return re.sub(r"\s+", " ", value.strip()).casefold()
+
 
 def validate_value(entry_type: str, value: str) -> None:
     if entry_type not in {"company", "keyword", "vacancy"}:
         raise ValueError("тип должен быть company, keyword или vacancy")
     if not value or (entry_type == "keyword" and len(value) < 2):
         raise ValueError("пустое или слишком широкое правило")
+
 
 def match(card, rules: dict[str, set[str]]) -> str | None:
     if normalize_value(card.company) in rules["company"]:

--- a/src/hhru_bot/blacklist.py
+++ b/src/hhru_bot/blacklist.py
@@ -1,0 +1,20 @@
+"""Persistent, deliberately narrow vacancy blacklist matching."""
+import re
+
+def normalize_value(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip()).casefold()
+
+def validate_value(entry_type: str, value: str) -> None:
+    if entry_type not in {"company", "keyword", "vacancy"}:
+        raise ValueError("тип должен быть company, keyword или vacancy")
+    if not value or (entry_type == "keyword" and len(value) < 2):
+        raise ValueError("пустое или слишком широкое правило")
+
+def match(card, rules: dict[str, set[str]]) -> str | None:
+    if normalize_value(card.company) in rules["company"]:
+        return f"blacklist company: {card.company}"
+    if normalize_value(card.vacancy_id) in rules["vacancy"]:
+        return f"blacklist vacancy: {card.vacancy_id}"
+    title = normalize_value(card.title)
+    hit = next((k for k in rules["keyword"] if k in title), None)
+    return f"blacklist keyword: {hit}" if hit else None

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -103,6 +103,7 @@ WRITE_COMMANDS = frozenset(
         "backup",
         "restore",
         "review",
+        "blacklist",
     }
 )
 

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -21,6 +21,7 @@ from ..apply import apply_to_vacancy
 from ..apply.antibot import AntiBotChallengeDetected, raise_for_antibot
 from ..apply.letter import CoverLetterProvider
 from ..apply.verify import verify_response_in_negotiations
+from ..blacklist import match as blacklist_match
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
 from ..config_sections.scoring import ScoringWeights
 from ..copy_resume import resolve_numeric_resume_ids
@@ -1073,6 +1074,13 @@ def _run_apply_for_resume(
         # history-based deduplication barrier on this explicit route too.
         if history.has_applied(resume.resume_id, approved_item["vacancy_id"]):
             history.finish_review(args.approved, "skipped")
+            approved_duplicate = True
+        elif (blacklist_reason := blacklist_match(cards[0], history.blacklist_sets())) is not None:
+            history.finish_review(args.approved, "skipped")
+            history.record_skip(
+                resume.resume_id, approved_item["vacancy_id"], SKIP_REASONS.BLACKLIST
+            )
+            print(f"[skip] {blacklist_reason} — отклик не отправлен")
             approved_duplicate = True
         elif (
             current_employer_hit(approved_item["company"], resume.search.current_employers)

--- a/src/hhru_bot/commands/blacklist.py
+++ b/src/hhru_bot/commands/blacklist.py
@@ -1,21 +1,34 @@
 """Manage persistent blacklist rules (local SQLite only)."""
+
 import argparse
+
 
 def register(subparsers) -> None:
     p = subparsers.add_parser("blacklist", help="Управление стоп-листом вакансий")
     s = p.add_subparsers(dest="blacklist_command", required=True)
-    a = s.add_parser("add"); a.add_argument("type", choices=("company", "keyword", "vacancy")); a.add_argument("value"); a.add_argument("--reason", required=True); a.add_argument("--by", default="cli")
+    a = s.add_parser("add")
+    a.add_argument("type", choices=("company", "keyword", "vacancy"))
+    a.add_argument("value")
+    a.add_argument("--reason", required=True)
+    a.add_argument("--by", default="cli")
     l = s.add_parser("list")
-    r = s.add_parser("remove"); r.add_argument("type", choices=("company", "keyword", "vacancy")); r.add_argument("value")
-    for x in (a, l, r): x.set_defaults(func=run)
+    r = s.add_parser("remove")
+    r.add_argument("type", choices=("company", "keyword", "vacancy"))
+    r.add_argument("value")
+    for x in (a, l, r):
+        x.set_defaults(func=run)
+
 
 def run(args: argparse.Namespace) -> bool:
     from ..history import History
+
     h = History(args.history)
     if args.blacklist_command == "add":
-        h.add_blacklist(args.type, args.value, args.reason, args.by); print("[OK] правило добавлено")
+        h.add_blacklist(args.type, args.value, args.reason, args.by)
+        print("[OK] правило добавлено")
     elif args.blacklist_command == "remove":
         print(f"[OK] удалено: {h.remove_blacklist(args.type, args.value)}")
     else:
-        for row in h.list_blacklist(): print(f"{row['entry_type']}\t{row['value']}\t{row['created_by']}\t{row['reason']}")
+        for row in h.list_blacklist():
+            print(f"{row['entry_type']}\t{row['value']}\t{row['created_by']}\t{row['reason']}")
     return False

--- a/src/hhru_bot/commands/blacklist.py
+++ b/src/hhru_bot/commands/blacklist.py
@@ -1,0 +1,21 @@
+"""Manage persistent blacklist rules (local SQLite only)."""
+import argparse
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser("blacklist", help="Управление стоп-листом вакансий")
+    s = p.add_subparsers(dest="blacklist_command", required=True)
+    a = s.add_parser("add"); a.add_argument("type", choices=("company", "keyword", "vacancy")); a.add_argument("value"); a.add_argument("--reason", required=True); a.add_argument("--by", default="cli")
+    l = s.add_parser("list")
+    r = s.add_parser("remove"); r.add_argument("type", choices=("company", "keyword", "vacancy")); r.add_argument("value")
+    for x in (a, l, r): x.set_defaults(func=run)
+
+def run(args: argparse.Namespace) -> bool:
+    from ..history import History
+    h = History(args.history)
+    if args.blacklist_command == "add":
+        h.add_blacklist(args.type, args.value, args.reason, args.by); print("[OK] правило добавлено")
+    elif args.blacklist_command == "remove":
+        print(f"[OK] удалено: {h.remove_blacklist(args.type, args.value)}")
+    else:
+        for row in h.list_blacklist(): print(f"{row['entry_type']}\t{row['value']}\t{row['created_by']}\t{row['reason']}")
+    return False

--- a/src/hhru_bot/commands/blacklist.py
+++ b/src/hhru_bot/commands/blacklist.py
@@ -11,11 +11,11 @@ def register(subparsers) -> None:
     a.add_argument("value")
     a.add_argument("--reason", required=True)
     a.add_argument("--by", default="cli")
-    l = s.add_parser("list")
+    list_parser = s.add_parser("list")
     r = s.add_parser("remove")
     r.add_argument("type", choices=("company", "keyword", "vacancy"))
     r.add_argument("value")
-    for x in (a, l, r):
+    for x in (a, list_parser, r):
         x.set_defaults(func=run)
 
 

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -587,6 +587,7 @@ SKIP_REASONS = _SkipReasons()
 #: Все стабильные причины отсева (для ``--reason`` choices в clear-skipped и
 #: валидации). Кортеж, не set — порядок стабилен для ``--help``.
 SKIP_REASON_VALUES = (
+    _SkipReasons.BLACKLIST,
     _SkipReasons.STOPWORD_TITLE,
     _SkipReasons.STOPWORD_EMPLOYER,
     _SkipReasons.CURRENT_EMPLOYER,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -2998,7 +2998,8 @@ class History:
         validate_value(entry_type, value)
         with self._connect() as conn:
             conn.execute(
-                "INSERT INTO blacklist(entry_type,value,reason,created_by,created_at) VALUES (?,?,?,?,?)",
+                "INSERT INTO blacklist(entry_type,value,reason,created_by,created_at) "
+                "VALUES (?,?,?,?,?)",
                 (entry_type, value, reason.strip(), created_by.strip(), datetime.now().isoformat()),
             )
 

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -2993,16 +2993,23 @@ class History:
 
     def add_blacklist(self, entry_type: str, value: str, reason: str, created_by: str) -> None:
         from .blacklist import normalize_value, validate_value
+
         value = normalize_value(value)
         validate_value(entry_type, value)
         with self._connect() as conn:
-            conn.execute("INSERT INTO blacklist(entry_type,value,reason,created_by,created_at) VALUES (?,?,?,?,?)",
-                         (entry_type, value, reason.strip(), created_by.strip(), datetime.now().isoformat()))
+            conn.execute(
+                "INSERT INTO blacklist(entry_type,value,reason,created_by,created_at) VALUES (?,?,?,?,?)",
+                (entry_type, value, reason.strip(), created_by.strip(), datetime.now().isoformat()),
+            )
 
     def remove_blacklist(self, entry_type: str, value: str) -> int:
         from .blacklist import normalize_value
+
         with self._connect() as conn:
-            cur = conn.execute("DELETE FROM blacklist WHERE entry_type=? AND value=?", (entry_type, normalize_value(value)))
+            cur = conn.execute(
+                "DELETE FROM blacklist WHERE entry_type=? AND value=?",
+                (entry_type, normalize_value(value)),
+            )
             conn.execute("DELETE FROM skipped WHERE reason=?", (SKIP_REASONS.BLACKLIST,))
             return cur.rowcount
 
@@ -3011,8 +3018,10 @@ class History:
             return [dict(r) for r in conn.execute("SELECT * FROM blacklist ORDER BY id")]
 
     def blacklist_sets(self) -> dict[str, set[str]]:
-        return {kind: {row["value"] for row in self.list_blacklist() if row["entry_type"] == kind}
-                for kind in ("company", "keyword", "vacancy")}
+        return {
+            kind: {row["value"] for row in self.list_blacklist() if row["entry_type"] == kind}
+            for kind in ("company", "keyword", "vacancy")
+        }
 
     def record_skip(self, resume_id: str, vacancy_id: str, reason: str) -> None:
         """Записывает причину отсева вакансии (идемпотентно по UNIQUE).

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -320,6 +320,16 @@ CREATE TABLE IF NOT EXISTS skipped (
     UNIQUE (resume_id, vacancy_id, reason)
 );
 
+CREATE TABLE IF NOT EXISTS blacklist (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_type TEXT NOT NULL CHECK(entry_type IN ('company','keyword','vacancy')),
+    value TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(entry_type, value)
+);
+
 -- review_queue — immutable, per-vacancy approval snapshots (#414).
 CREATE TABLE IF NOT EXISTS review_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -549,6 +559,7 @@ class _SkipReasons:
     """
 
     STOPWORD_TITLE = "stopword_title"  # exclude_keywords совпал в названии
+    BLACKLIST = "blacklist"
     STOPWORD_EMPLOYER = "stopword_employer"  # exclude_employers — стоп-компания
     CURRENT_EMPLOYER = "current_employer"  # account.current_employer
     ALREADY_APPLIED = "already_applied"  # history.has_applied — уже откликались
@@ -2979,6 +2990,29 @@ class History:
     # причины — разные строки, как actions/responses. record_skip идемпотентен
     # по UNIQUE (INSERT OR IGNORE). Координируется с #85 (pre-LLM фильтр пишет
     # свои причины сюда же) — слой общий, точки записи не конфликтуют.
+
+    def add_blacklist(self, entry_type: str, value: str, reason: str, created_by: str) -> None:
+        from .blacklist import normalize_value, validate_value
+        value = normalize_value(value)
+        validate_value(entry_type, value)
+        with self._connect() as conn:
+            conn.execute("INSERT INTO blacklist(entry_type,value,reason,created_by,created_at) VALUES (?,?,?,?,?)",
+                         (entry_type, value, reason.strip(), created_by.strip(), datetime.now().isoformat()))
+
+    def remove_blacklist(self, entry_type: str, value: str) -> int:
+        from .blacklist import normalize_value
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM blacklist WHERE entry_type=? AND value=?", (entry_type, normalize_value(value)))
+            conn.execute("DELETE FROM skipped WHERE reason=?", (SKIP_REASONS.BLACKLIST,))
+            return cur.rowcount
+
+    def list_blacklist(self) -> list[dict]:
+        with self._connect() as conn:
+            return [dict(r) for r in conn.execute("SELECT * FROM blacklist ORDER BY id")]
+
+    def blacklist_sets(self) -> dict[str, set[str]]:
+        return {kind: {row["value"] for row in self.list_blacklist() if row["entry_type"] == kind}
+                for kind in ("company", "keyword", "vacancy")}
 
     def record_skip(self, resume_id: str, vacancy_id: str, reason: str) -> None:
         """Записывает причину отсева вакансии (идемпотентно по UNIQUE).

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -834,11 +834,18 @@ def filter_candidates(
     причину — кэш консистентен по всем путям отсева.
     """
     from .scoring import employer_passes_prefilter  # локальный импорт: цикл search<->scoring
+    blacklist = history.blacklist_sets() if hasattr(history, "blacklist_sets") else {"company": set(), "keyword": set(), "vacancy": set()}
 
     candidates: list[VacancyCard] = []
     skipped: list[tuple[VacancyCard, str]] = []
 
     for card in cards:
+        from .blacklist import match as blacklist_match
+        blacklist_reason = blacklist_match(card, blacklist)
+        if blacklist_reason:
+            skipped.append((card, blacklist_reason))
+            history.record_skip(resume_id, card.vacancy_id, SKIP_REASONS.BLACKLIST)
+            continue
         # #87 кэш отсева: вакансия уже отсеяна ранее — пропускаем без повторного
         # разбора (и без дублирующей записи в журнал). Экономит LLM/время.
         if history.is_skipped(resume_id, card.vacancy_id):

--- a/src/hhru_bot/search.py
+++ b/src/hhru_bot/search.py
@@ -834,13 +834,19 @@ def filter_candidates(
     причину — кэш консистентен по всем путям отсева.
     """
     from .scoring import employer_passes_prefilter  # локальный импорт: цикл search<->scoring
-    blacklist = history.blacklist_sets() if hasattr(history, "blacklist_sets") else {"company": set(), "keyword": set(), "vacancy": set()}
+
+    blacklist = (
+        history.blacklist_sets()
+        if hasattr(history, "blacklist_sets")
+        else {"company": set(), "keyword": set(), "vacancy": set()}
+    )
 
     candidates: list[VacancyCard] = []
     skipped: list[tuple[VacancyCard, str]] = []
 
     for card in cards:
         from .blacklist import match as blacklist_match
+
         blacklist_reason = blacklist_match(card, blacklist)
         if blacklist_reason:
             skipped.append((card, blacklist_reason))

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -128,6 +128,7 @@ def test_all_commands_registered():
         "restore",
         "resume-views",
         "review",
+        "blacklist",
     }
 
 
@@ -193,6 +194,7 @@ def test_register_commands_returns_names():
         "backup",
         "resume_views",
         "review",
+        "blacklist",
     }
 
 

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -62,6 +62,7 @@ def test_lock_covers_all_hhru_write_commands():
         "config",
         "backup",
         "restore",
+        "blacklist",
     }
 
 


### PR DESCRIPTION
Closes #597

## Summary
- Add persistent SQLite blacklist rules for `company`, `keyword`, and `vacancy` with deterministic normalization and provenance.
- Apply exact normalized company/vacancy and title-substring keyword matching before scoring/LLM.
- Add `blacklist add/list/remove`; static config remains supported and is additive (either static or DB rule excludes).
- Update command-registry tests and regenerate README CLI reference via `scripts/gen_cli_docs.py`.

## Live hh.ru evidence (saved session, `marketing`, `--max-pages 1`)

### 1. Search before
```text
Найдено всего: 20, подходящих: 14, исключено: 6
[candidate] score=+1.00 Digital-маркетолог — ООО Фиджитех (https://hh.ru/vacancy/136228063) | text_match=+1.00
```

### 2. Add blacklist rule
```text
$ blacklist add company 'Фиджитех' --reason 'live #597 evidence' --by 'hhru-313'
[OK] правило добавлено
```

### 3. Search after add
```text
Найдено всего: 20, подходящих: 14, исключено: 6
[skip] Digital-маркетолог — Фиджитех (https://hh.ru/vacancy/136228063) — blacklist company: Фиджитех
```

### 4. Remove and search again
```text
$ blacklist remove company 'Фиджитех'
[OK] удалено: 1
Найдено всего: 20, подходящих: 15, исключено: 5
[candidate] score=+1.00 Digital-маркетолог — Фиджитех (https://hh.ru/vacancy/136228063) | text_match=+1.00
```

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` — 100% passed
- Command-registry expectations updated for the new command.
