### PR TITLE
fix: harden competitor pagination and privacy

### DIFF
--- a/src/hhru_bot/competitor_privacy.py
+++ b/src/hhru_bot/competitor_privacy.py
@@ -1,0 +1,30 @@
+"""Shared privacy validation for applicant-controlled competitor skills."""
+
+from __future__ import annotations
+
+import re
+
+_CONTACT_RE = re.compile(
+    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|(?:\+?\d[\d\s().-]{8,}\d))",
+    re.I,
+)
+_DOMAIN_RE = re.compile(r"^(?P<host>[a-z0-9-]+(?:\.[a-z0-9-]+)+)(?P<path>/\S*)?$", re.I)
+_CONTACT_TLDS = {"com", "ru", "org", "me", "co", "рф"}
+
+
+def is_contact_skill(value: str) -> bool:
+    text = value.strip()
+    if not text or _CONTACT_RE.search(text):
+        return True
+    match = _DOMAIN_RE.fullmatch(text)
+    if not match:
+        return False
+    if match.group("path"):
+        return True
+    suffix = match.group("host").rsplit(".", 1)[-1].casefold()
+    return suffix in _CONTACT_TLDS or text == text.casefold()
+
+
+def sanitize_skill_name(value: str) -> str | None:
+    text = value.strip()
+    return None if not text or is_contact_skill(text) else text

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -265,7 +265,9 @@ def has_next_search_page(page: Page, page_num: int) -> bool:
 
     if pages.count() == 0 and links.count() == 0:
         try:
-            pages.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
+            page.locator(f"{sel.PAGINATION_PAGE}, {sel.PAGINATION_LINK}").first.wait_for(
+                state="attached", timeout=RENDER_TIMEOUT_MS
+            )
         except PlaywrightError:
             raise CompetitorSearchIndeterminate(
                 f"пагинация страницы поиска резюме {page_num} не подтверждена: "
@@ -321,7 +323,8 @@ _SALARY_HEADING_RE = re.compile(
 )
 _CONTACT_RE = re.compile(
     r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|"
-    r"(?:\+?\d[\d\s().-]{8,}\d))",
+    r"(?:\+?\d[\d\s().-]{8,}\d)|"
+    r"(?:[a-z0-9-]+\.)+(?:com|ru|net|org|io|me|co|рф)(?:/\S*)?)",
     re.IGNORECASE,
 )
 

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -342,7 +342,12 @@ def redact_free_text(_value: str) -> None:
 def sanitize_skill_name(value: str) -> str | None:
     """Keep professional skill labels, but never persist contact tokens."""
     text = value.strip()
-    if not text or _CONTACT_RE.search(text):
+    if not text:
+        return None
+    # Dotted technology names are skills, not contact endpoints.
+    if text.casefold() in {"asp.net", "vb.net", "socket.io"}:
+        return text
+    if _CONTACT_RE.search(text):
         return None
     return text
 

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -14,6 +14,7 @@ from playwright.sync_api import Page
 
 from .apply.antibot import raise_for_antibot
 from .browser import HH_BASE_URL, goto_hh, require_authenticated_page, resume_identity_matches
+from .competitor_privacy import sanitize_skill_name
 from .search import parse_salary
 from .selector_groups import competitor_resume as sel
 
@@ -321,12 +322,6 @@ _PROFICIENCY = {
 _SALARY_HEADING_RE = re.compile(
     r"\d.*(?:₽|\$|€|руб(?:\.|лей)?|RUB|USD|EUR|KZT|тенге|на руки)", re.IGNORECASE
 )
-_CONTACT_RE = re.compile(
-    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|@[A-Za-z0-9_.-]+|"
-    r"(?:\+?\d[\d\s().-]{8,}\d)|"
-    r"(?:[a-z0-9-]+\.)+(?:com|ru|net|org|io|me|co|рф)(?:/\S*)?)",
-    re.IGNORECASE,
-)
 
 
 def redact_free_text(_value: str) -> None:
@@ -337,19 +332,6 @@ def redact_free_text(_value: str) -> None:
     parsed separately; free-form sections are dropped rather than persisted.
     """
     return None
-
-
-def sanitize_skill_name(value: str) -> str | None:
-    """Keep professional skill labels, but never persist contact tokens."""
-    text = value.strip()
-    if not text:
-        return None
-    # Dotted technology names are skills, not contact endpoints.
-    if text.casefold() in {"asp.net", "vb.net", "socket.io"}:
-        return text
-    if _CONTACT_RE.search(text):
-        return None
-    return text
 
 
 def _months(text: str) -> int | None:

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -291,7 +291,14 @@ CREATE TABLE IF NOT EXISTS competitor_resumes (
 
 CREATE TABLE IF NOT EXISTS competitor_resume_skills (
     resume_id TEXT NOT NULL,
-    skill TEXT NOT NULL,
+    skill TEXT NOT NULL CHECK (
+        instr(skill, '@') = 0
+        AND lower(skill) NOT LIKE 'http%'
+        AND lower(skill) NOT LIKE 'www.%'
+        AND lower(skill) NOT LIKE 't.me/%'
+        AND lower(skill) NOT LIKE 'linkedin.com/%'
+        AND skill NOT GLOB '*[0-9]*'
+    ),
     proficiency TEXT,
     first_seen_at TEXT NOT NULL,
     last_seen_at TEXT NOT NULL,

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .competitor_privacy import is_contact_skill
 from .external_forms.detect import normalize
 
 if TYPE_CHECKING:
@@ -23,13 +24,6 @@ if TYPE_CHECKING:
     from .search import SalaryInfo
 
 logger = logging.getLogger("hhru_bot.history")
-_COMPETITOR_CONTACT_SKILL_RE = re.compile(
-    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|"
-    r"(?:[a-z0-9-]+\.)+(?:com|ru|net|org|io|me|co|рф)(?:/\S*)?|"
-    r"(?:\+?\d[\d\s().-]{8,}\d))",
-    re.IGNORECASE,
-)
-
 
 # Схема SQLite — одна константа, CREATE TABLE IF NOT EXISTS для всех таблиц.
 # Системы миграций для такого маленького проекта не нужно (оверинжиниринг): при
@@ -298,18 +292,28 @@ CREATE TABLE IF NOT EXISTS competitor_resumes (
 
 CREATE TABLE IF NOT EXISTS competitor_resume_skills (
     resume_id TEXT NOT NULL,
-    skill TEXT NOT NULL CHECK (
-        instr(skill, '@') = 0
-        AND lower(skill) NOT LIKE 'http%'
-        AND lower(skill) NOT LIKE 'www.%'
-        AND lower(skill) NOT LIKE 't.me/%'
-        AND lower(skill) NOT LIKE 'linkedin.com/%'
-    ),
+    skill TEXT NOT NULL CHECK (instr(skill, '@') = 0 AND lower(skill) NOT LIKE 'http%'),
     proficiency TEXT,
     first_seen_at TEXT NOT NULL,
     last_seen_at TEXT NOT NULL,
     PRIMARY KEY (resume_id, skill)
 );
+
+CREATE TRIGGER IF NOT EXISTS competitor_resume_skills_no_contacts
+BEFORE INSERT ON competitor_resume_skills
+WHEN lower(NEW.skill) LIKE 'www.%'
+  OR lower(NEW.skill) LIKE 't.me/%'
+  OR lower(NEW.skill) LIKE 'linkedin.com/%'
+  OR (instr(NEW.skill, '.') > 0 AND lower(NEW.skill) = NEW.skill)
+  OR NEW.skill GLOB '*[0-9]*[0-9]*[0-9]*[0-9]*[0-9]*[0-9]*[0-9]*[0-9]*[0-9]*'
+BEGIN SELECT RAISE(ABORT, 'contact-like competitor skill'); END;
+CREATE TRIGGER IF NOT EXISTS competitor_resume_skills_no_contacts_update
+BEFORE UPDATE OF skill ON competitor_resume_skills
+WHEN lower(NEW.skill) LIKE 'www.%'
+  OR lower(NEW.skill) LIKE 't.me/%'
+  OR lower(NEW.skill) LIKE 'linkedin.com/%'
+  OR (instr(NEW.skill, '.') > 0 AND lower(NEW.skill) = NEW.skill)
+BEGIN SELECT RAISE(ABORT, 'contact-like competitor skill'); END;
 
 CREATE TABLE IF NOT EXISTS competitor_resume_queries (
     resume_id TEXT NOT NULL,
@@ -738,6 +742,9 @@ class History:
     @contextmanager
     def _connect(self):
         conn = sqlite3.connect(self.db_path)
+        conn.create_function(
+            "is_safe_competitor_skill", 1, lambda value: int(not is_contact_skill(value or ""))
+        )
         conn.row_factory = sqlite3.Row
         try:
             yield conn
@@ -2204,10 +2211,7 @@ class History:
             conn.execute("DELETE FROM competitor_resume_skills WHERE resume_id = ?", (resume_id,))
             for skill in snapshot.get("skills") or []:
                 name = str(skill["name"]).strip()
-                if not name or (
-                    name.casefold() not in {"asp.net", "vb.net", "socket.io"}
-                    and _COMPETITOR_CONTACT_SKILL_RE.search(name)
-                ):
+                if not name or is_contact_skill(name):
                     continue
                 conn.execute(
                     """INSERT INTO competitor_resume_skills
@@ -4527,28 +4531,42 @@ def _migrate_competitor_skills_schema(conn: sqlite3.Connection) -> None:
         "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
         ("competitor_resume_skills",),
     ).fetchone()
-    if not table or "CHECK" in (table[0] or "").upper():
+    trigger = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+        ("competitor_resume_skills_no_contacts",),
+    ).fetchone()
+    if not table or trigger:
         return
     conn.execute("ALTER TABLE competitor_resume_skills RENAME TO competitor_resume_skills_legacy")
     conn.execute("""CREATE TABLE competitor_resume_skills (
-        resume_id TEXT NOT NULL, skill TEXT NOT NULL CHECK (
-            instr(skill, '@') = 0 AND lower(skill) NOT LIKE 'http%'
-            AND lower(skill) NOT LIKE 'www.%' AND lower(skill) NOT LIKE 't.me/%'
-            AND lower(skill) NOT LIKE 'linkedin.com/%'
-        ), proficiency TEXT, first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL,
+        resume_id TEXT NOT NULL,
+        skill TEXT NOT NULL CHECK (instr(skill, '@') = 0 AND lower(skill) NOT LIKE 'http%'),
+        proficiency TEXT,
+        first_seen_at TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL,
         PRIMARY KEY (resume_id, skill)
     )""")
+    conn.executescript("""
+        CREATE TRIGGER competitor_resume_skills_no_contacts
+        BEFORE INSERT ON competitor_resume_skills
+        WHEN lower(NEW.skill) LIKE 'www.%' OR lower(NEW.skill) LIKE 't.me/%'
+          OR lower(NEW.skill) LIKE 'linkedin.com/%'
+          OR (instr(NEW.skill, '.') > 0 AND lower(NEW.skill) = NEW.skill)
+        BEGIN SELECT RAISE(ABORT, 'contact-like competitor skill'); END;
+        CREATE TRIGGER competitor_resume_skills_no_contacts_update
+        BEFORE UPDATE OF skill ON competitor_resume_skills
+        WHEN lower(NEW.skill) LIKE 'www.%' OR lower(NEW.skill) LIKE 't.me/%'
+          OR lower(NEW.skill) LIKE 'linkedin.com/%'
+          OR (instr(NEW.skill, '.') > 0 AND lower(NEW.skill) = NEW.skill)
+        BEGIN SELECT RAISE(ABORT, 'contact-like competitor skill'); END;
+    """)
     rows = conn.execute(
         """SELECT resume_id, skill, proficiency, first_seen_at, last_seen_at
            FROM competitor_resume_skills_legacy"""
     ).fetchall()
     for row in rows:
         skill = row[1].strip()
-        if skill.casefold() not in {
-            "asp.net",
-            "vb.net",
-            "socket.io",
-        } and _COMPETITOR_CONTACT_SKILL_RE.search(skill):
+        if is_contact_skill(skill):
             continue
         conn.execute(
             "INSERT OR IGNORE INTO competitor_resume_skills VALUES (?, ?, ?, ?, ?)", tuple(row)

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -23,6 +23,13 @@ if TYPE_CHECKING:
     from .search import SalaryInfo
 
 logger = logging.getLogger("hhru_bot.history")
+_COMPETITOR_CONTACT_SKILL_RE = re.compile(
+    r"(?:[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-я]{2,}|https?://\S+|www\.\S+|"
+    r"(?:[a-z0-9-]+\.)+(?:com|ru|net|org|io|me|co|рф)(?:/\S*)?|"
+    r"(?:\+?\d[\d\s().-]{8,}\d))",
+    re.IGNORECASE,
+)
+
 
 # Схема SQLite — одна константа, CREATE TABLE IF NOT EXISTS для всех таблиц.
 # Системы миграций для такого маленького проекта не нужно (оверинжиниринг): при
@@ -297,7 +304,6 @@ CREATE TABLE IF NOT EXISTS competitor_resume_skills (
         AND lower(skill) NOT LIKE 'www.%'
         AND lower(skill) NOT LIKE 't.me/%'
         AND lower(skill) NOT LIKE 'linkedin.com/%'
-        AND skill NOT GLOB '*[0-9]*'
     ),
     proficiency TEXT,
     first_seen_at TEXT NOT NULL,
@@ -756,6 +762,7 @@ class History:
             # упадёт на "table command_runs already exists".
             _rename_apply_runs_to_command_runs(conn)
             conn.executescript(SCHEMA)
+            _migrate_competitor_skills_schema(conn)
             _ensure_column(conn, "actions", "letter_variant", "TEXT")
             _ensure_column(conn, "actions", "search_query", "TEXT")
             _ensure_column(conn, "actions", "run_id", "TEXT")
@@ -2197,7 +2204,10 @@ class History:
             conn.execute("DELETE FROM competitor_resume_skills WHERE resume_id = ?", (resume_id,))
             for skill in snapshot.get("skills") or []:
                 name = str(skill["name"]).strip()
-                if not name:
+                if not name or (
+                    name.casefold() not in {"asp.net", "vb.net", "socket.io"}
+                    and _COMPETITOR_CONTACT_SKILL_RE.search(name)
+                ):
                     continue
                 conn.execute(
                     """INSERT INTO competitor_resume_skills
@@ -4509,3 +4519,38 @@ def _ensure_apply_index(conn: sqlite3.Connection) -> None:
         return
     conn.execute("DROP INDEX IF EXISTS idx_resume_vacancy_apply")
     conn.execute(_APPLY_INDEX_SQL)
+
+
+def _migrate_competitor_skills_schema(conn: sqlite3.Connection) -> None:
+    """Rebuild the skills table so old databases gain the privacy invariant."""
+    table = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        ("competitor_resume_skills",),
+    ).fetchone()
+    if not table or "CHECK" in (table[0] or "").upper():
+        return
+    conn.execute("ALTER TABLE competitor_resume_skills RENAME TO competitor_resume_skills_legacy")
+    conn.execute("""CREATE TABLE competitor_resume_skills (
+        resume_id TEXT NOT NULL, skill TEXT NOT NULL CHECK (
+            instr(skill, '@') = 0 AND lower(skill) NOT LIKE 'http%'
+            AND lower(skill) NOT LIKE 'www.%' AND lower(skill) NOT LIKE 't.me/%'
+            AND lower(skill) NOT LIKE 'linkedin.com/%'
+        ), proficiency TEXT, first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL,
+        PRIMARY KEY (resume_id, skill)
+    )""")
+    rows = conn.execute(
+        """SELECT resume_id, skill, proficiency, first_seen_at, last_seen_at
+           FROM competitor_resume_skills_legacy"""
+    ).fetchall()
+    for row in rows:
+        skill = row[1].strip()
+        if skill.casefold() not in {
+            "asp.net",
+            "vb.net",
+            "socket.io",
+        } and _COMPETITOR_CONTACT_SKILL_RE.search(skill):
+            continue
+        conn.execute(
+            "INSERT OR IGNORE INTO competitor_resume_skills VALUES (?, ?, ?, ?, ?)", tuple(row)
+        )
+    conn.execute("DROP TABLE competitor_resume_skills_legacy")

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -157,6 +157,14 @@ def test_skill_contact_tokens_are_not_persisted():
     assert [skill.name for skill in snapshot.skills] == ["Python"]
     assert sanitize_skill_name("test@example.com") is None
     assert sanitize_skill_name("+7 999 123-45-67") is None
+    for contact in ("www.example.com", "t.me/alice", "linkedin.com/in/alice"):
+        assert sanitize_skill_name(contact) is None
+    assert [sanitize_skill_name(v) for v in ("Python", "C++", "Node.js", "Разработка ПО")] == [
+        "Python",
+        "C++",
+        "Node.js",
+        "Разработка ПО",
+    ]
 
 
 def test_numeric_role_title_is_not_misparsed_as_salary():
@@ -260,8 +268,15 @@ class _PaginationPage:
         self.marker = self.block
 
     def locator(self, selector):
-        if selector == f"{selectors.PAGINATION_BLOCK}, {selectors.PAGINATION_LINK}":
-            return self.marker
+        if selector in (
+            f"{selectors.PAGINATION_BLOCK}, {selectors.PAGINATION_LINK}",
+            f"{selectors.PAGINATION_PAGE}, {selectors.PAGINATION_LINK}",
+        ):
+            return (
+                self.marker
+                if selector == f"{selectors.PAGINATION_BLOCK}, {selectors.PAGINATION_LINK}"
+                else self.pages
+            )
         return {
             selectors.PAGINATION_NEXT: self.next,
             selectors.PAGINATION_BLOCK: self.block,


### PR DESCRIPTION
Closes #584

## Summary
- wait for either numbered pagination markers or fallback links in both hydration phases
- reject contact-like skill labels, including bare domains and social URLs
- enforce no-contact constraints in the persisted SQLite skill schema
- retain regression coverage for pagination timing and valid skills

## Tests
- pytest -q (all passed)
- ruff check src tests
- ruff format --check src tests

## Live verification
- Ran authenticated read-only competitors collect with saved session and --max-pages 3. The run reached page 1 with 20 cards and 2 saved before manual stop due the configured 11-20 second per-card throttle; no write action or login was performed. Full four-way timing permutation evidence remains a follow-up risk.