### PR TITLE
feat(ai): consume feedback in scoring and letter prompts

### DIFF
--- a/src/hhru_bot/ai/feedback.py
+++ b/src/hhru_bot/ai/feedback.py
@@ -1,30 +1,57 @@
+"""Prompt adapters for persisted vacancy feedback (#592)."""
+
 from __future__ import annotations
 
-FEEDBACK_BUDGET = 4000
-FEEDBACK_TAIL = 20
+FEEDBACK_CONTEXT_MAX_CHARS = 4000
+FEEDBACK_RECENT_TAIL = 25
+REJECT_CONTEXT_MAX_ITEMS = 12
+STYLE_CONTEXT_MAX_ITEMS = 6
+
+_REJECT_HEADER = "Ранее вы отклоняли вакансии по таким причинам (учти при оценке):\n"
+_STYLE_HEADER = (
+    "Фрагменты после правок пользователя — учитывай только стиль и формулировки, "
+    "не копируй факты:\n"
+)
 
 
-def feedback_blocks(rows: list[dict], *, budget: int = FEEDBACK_BUDGET) -> tuple[str, str]:
-    """Build bounded reject and style context; rows are scoped to one resume."""
-    recent = rows[:FEEDBACK_TAIL]
-    rejects = [r for r in recent if r.get("action") == "reject" and r.get("reason")]
-    styles = [r for r in recent if r.get("edited_snippet")]
-    blocks = [
-        "Причины прошлых отклонений:\n" + "\n".join(f"- {r['reason']}" for r in reversed(rejects))
-        if rejects
-        else "",
-        "Правки прошлых писем (учитывай как стиль, не копируй факты):\n"
-        + "\n".join(f"- {r['edited_snippet']}" for r in reversed(styles))
-        if styles
-        else "",
+def _text(row: dict, key: str) -> str:
+    value = row.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _bounded_block(header: str, items: list[str], max_chars: int) -> str:
+    """Join recent items under one deterministic character budget."""
+    if not items or max_chars <= len(header):
+        return ""
+    parts: list[str] = []
+    used = len(header)
+    for item in items:
+        chunk = f"- {item}\n"
+        if used + len(chunk) > max_chars:
+            remaining = max_chars - used - 4
+            if remaining >= 1:
+                parts.append(f"- {item[:remaining]}…\n")
+            break
+        parts.append(chunk)
+        used += len(chunk)
+    return (header + "".join(parts)).rstrip() if parts else ""
+
+
+def build_reject_context(rows: list[dict], *, max_chars: int = FEEDBACK_CONTEXT_MAX_CHARS) -> str:
+    """Build the scoring-only narrative from recent rejects with reasons."""
+    recent = rows[:FEEDBACK_RECENT_TAIL]
+    newest = [
+        _text(row, "reason")
+        for row in recent
+        if row.get("action") == "reject" and _text(row, "reason")
+    ][:REJECT_CONTEXT_MAX_ITEMS]
+    return _bounded_block(_REJECT_HEADER, list(reversed(newest)), max_chars)
+
+
+def build_style_context(rows: list[dict], *, max_chars: int = FEEDBACK_CONTEXT_MAX_CHARS) -> str:
+    """Build the letter-only style block from already-redacted edit snippets."""
+    recent = rows[:FEEDBACK_RECENT_TAIL]
+    newest = [_text(row, "edited_snippet") for row in recent if _text(row, "edited_snippet")][
+        :STYLE_CONTEXT_MAX_ITEMS
     ]
-    result = []
-    used = 0
-    for block in blocks:
-        if block and used < budget:
-            value = block[: budget - used]
-            result.append(value)
-            used += len(value)
-        else:
-            result.append("")
-    return tuple(result)  # type: ignore[return-value]
+    return _bounded_block(_STYLE_HEADER, list(reversed(newest)), max_chars)

--- a/src/hhru_bot/ai/feedback.py
+++ b/src/hhru_bot/ai/feedback.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+FEEDBACK_BUDGET = 4000
+FEEDBACK_TAIL = 20
+
+
+def feedback_blocks(rows: list[dict], *, budget: int = FEEDBACK_BUDGET) -> tuple[str, str]:
+    """Build bounded reject and style context; rows are scoped to one resume."""
+    recent = rows[:FEEDBACK_TAIL]
+    rejects = [r for r in recent if r.get("action") == "reject" and r.get("reason")]
+    styles = [r for r in recent if r.get("edited_snippet")]
+    blocks = [
+        "Причины прошлых отклонений:\n" + "\n".join(f"- {r['reason']}" for r in reversed(rejects))
+        if rejects
+        else "",
+        "Правки прошлых писем (учитывай как стиль, не копируй факты):\n"
+        + "\n".join(f"- {r['edited_snippet']}" for r in reversed(styles))
+        if styles
+        else "",
+    ]
+    result = []
+    used = 0
+    for block in blocks:
+        if block and used < budget:
+            value = block[: budget - used]
+            result.append(value)
+            used += len(value)
+        else:
+            result.append("")
+    return tuple(result)  # type: ignore[return-value]

--- a/src/hhru_bot/ai/letters.py
+++ b/src/hhru_bot/ai/letters.py
@@ -35,6 +35,7 @@ from ..apply.letter import (
     _resolve_alternatives,
 )
 from ..search import VacancyCard
+from .feedback import feedback_blocks
 
 if TYPE_CHECKING:
     from ..config_sections.ai_profile import AIProfile
@@ -60,11 +61,13 @@ class AICoverLetterProvider(CoverLetterProvider):
         fallback_template: str = "",
         *,
         temperature: float = 0.7,
+        feedback: list[dict] | None = None,
     ):
         self._llm = llm_client
         self._profile = resume_profile
         self._fallback_template = fallback_template
         self._temperature = temperature
+        self._feedback = feedback or []
 
     def render(
         self,
@@ -72,7 +75,7 @@ class AICoverLetterProvider(CoverLetterProvider):
         resume_profile: AIProfile | None = None,
     ) -> LetterOutcome:
         profile = resume_profile or self._profile
-        messages = _build_prompt(vacancy, profile)
+        messages = _build_prompt(vacancy, profile, self._feedback)
         try:
             response = self._llm.chat(messages, temperature=self._temperature)
         except Exception as e:  # noqa: BLE001 — намеренно широкий: любой сбой AI → fallback
@@ -108,7 +111,11 @@ class AICoverLetterProvider(CoverLetterProvider):
         return outcome
 
 
-def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[str, str]]:
+def _build_prompt(
+    vacancy: VacancyCard,
+    profile: AIProfile | None,
+    feedback: list[dict] | None = None,
+) -> list[dict[str, str]]:
     """Собирает chat-completion сообщения: системная инструкция + контекст.
 
     Контекст вакансии берём из VacancyCard (title/company) — подтверждённые
@@ -133,6 +140,10 @@ def _build_prompt(vacancy: VacancyCard, profile: AIProfile | None) -> list[dict[
     )
 
     messages: list[dict[str, str]] = [{"role": "system", "content": system}]
+    reject, style = feedback_blocks(feedback or [])
+    for block in (reject, style):
+        if block:
+            messages.append({"role": "user", "content": block})
 
     # #96: few-shot стиль — образцы прошлых писём идут первым user-сообщением,
     # до контекста вакансии и запроса. Рандомизация {a|b|c} (#86) применяется к

--- a/src/hhru_bot/ai/letters.py
+++ b/src/hhru_bot/ai/letters.py
@@ -35,7 +35,7 @@ from ..apply.letter import (
     _resolve_alternatives,
 )
 from ..search import VacancyCard
-from .feedback import feedback_blocks
+from .feedback import build_style_context
 
 if TYPE_CHECKING:
     from ..config_sections.ai_profile import AIProfile
@@ -140,11 +140,6 @@ def _build_prompt(
     )
 
     messages: list[dict[str, str]] = [{"role": "system", "content": system}]
-    reject, style = feedback_blocks(feedback or [])
-    for block in (reject, style):
-        if block:
-            messages.append({"role": "user", "content": block})
-
     # #96: few-shot стиль — образцы прошлых писём идут первым user-сообщением,
     # до контекста вакансии и запроса. Рандомизация {a|b|c} (#86) применяется к
     # каждому примеру до подстановки — примеры тоже варьируются между запусками.
@@ -160,6 +155,10 @@ def _build_prompt(
                 ),
             }
         )
+
+    style = build_style_context(feedback or [])
+    if style:
+        messages.append({"role": "user", "content": style})
 
     lines = [f"Вакансия: {vacancy.title}.", f"Компания: {vacancy.company or 'не указана'}."]
     if profile is not None:

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -221,7 +221,7 @@ def _build_letter_provider(
         llm_client=llm_client,
         resume_profile=profile,
         fallback_template=cover_letter_template,
-        feedback=history.list_feedback(resume_id=resume.id) if history else None,
+        feedback=history.list_feedback(resume_id=resume.id, limit=25) if history else None,
     )
 
 
@@ -345,7 +345,7 @@ def _build_scoring_provider(
         llm_client=llm_client,
         fallback=heuristic,
         resume_profile=profile,
-        feedback=history.list_feedback(resume_id=resume.id) if history else None,
+        feedback=history.list_feedback(resume_id=resume.id, limit=25) if history else None,
     )
 
 

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -183,6 +183,7 @@ def _build_letter_provider(
     config: AppConfig,
     resume: ResumeConfig,
     cover_letter_template: str,
+    history: History | None = None,
 ) -> CoverLetterProvider | None:
     """Строит AI-провайдер писем, если AI включён (#17).
 
@@ -220,6 +221,7 @@ def _build_letter_provider(
         llm_client=llm_client,
         resume_profile=profile,
         fallback_template=cover_letter_template,
+        feedback=history.list_feedback(resume_id=resume.id) if history else None,
     )
 
 
@@ -287,6 +289,7 @@ def _build_question_answerer(
 def _build_scoring_provider(
     config: AppConfig,
     resume: ResumeConfig,
+    history: History | None = None,
 ) -> LLMScoringProvider | None:
     """Строит ML scoring-провайдер для ранжирования, если AI включён (#81).
 
@@ -342,6 +345,7 @@ def _build_scoring_provider(
         llm_client=llm_client,
         fallback=heuristic,
         resume_profile=profile,
+        feedback=history.list_feedback(resume_id=resume.id) if history else None,
     )
 
 
@@ -726,8 +730,8 @@ def _build_apply_providers(
     learn: bool = False,
 ) -> ApplyProviders:
     return ApplyProviders(
-        scoring_provider=_build_scoring_provider(config, resume),
-        letter_provider=_build_letter_provider(config, resume, cover_letter_template),
+        scoring_provider=_build_scoring_provider(config, resume, history),
+        letter_provider=_build_letter_provider(config, resume, cover_letter_template, history),
         question_answerer=_build_question_answerer(
             config,
             resume,
@@ -1107,7 +1111,7 @@ def _run_apply_for_resume(
         else (
             providers.scoring_provider
             if providers is not None
-            else _build_scoring_provider(config, resume)
+            else _build_scoring_provider(config, resume, history)
         )
     )
     plan = (
@@ -1143,7 +1147,7 @@ def _run_apply_for_resume(
         letter_provider = providers.letter_provider
         question_answerer = providers.question_answerer
     else:
-        letter_provider = _build_letter_provider(config, resume, cover_letter_template)
+        letter_provider = _build_letter_provider(config, resume, cover_letter_template, history)
         question_answerer = _build_question_answerer(
             config,
             resume,

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -221,7 +221,7 @@ def _build_letter_provider(
         llm_client=llm_client,
         resume_profile=profile,
         fallback_template=cover_letter_template,
-        feedback=history.list_feedback(resume_id=resume.id, limit=25) if history else None,
+        feedback=history.list_feedback(resume_id=resume.resume_id, limit=25) if history else None,
     )
 
 
@@ -289,7 +289,7 @@ def _build_question_answerer(
 def _build_scoring_provider(
     config: AppConfig,
     resume: ResumeConfig,
-    history: History | None = None,
+    history: History,
 ) -> LLMScoringProvider | None:
     """Строит ML scoring-провайдер для ранжирования, если AI включён (#81).
 
@@ -345,7 +345,7 @@ def _build_scoring_provider(
         llm_client=llm_client,
         fallback=heuristic,
         resume_profile=profile,
-        feedback=history.list_feedback(resume_id=resume.id, limit=25) if history else None,
+        feedback=history.list_feedback(resume_id=resume.resume_id, limit=25),
     )
 
 

--- a/src/hhru_bot/commands/apply.py
+++ b/src/hhru_bot/commands/apply.py
@@ -125,7 +125,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 raise_for_antibot(page)
             routing_resumes = [r for r in routing_resumes if r.id not in unconfirmed_resume_ids]
             merged = merge_vacancies(feeds)
-            providers = {r.id: _build_scoring_provider(config, r) for r in routing_resumes}
+            providers = {r.id: _build_scoring_provider(config, r, history) for r in routing_resumes}
             routed = route_vacancies(
                 merged,
                 routing_resumes,

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -37,6 +37,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from ..browser import PAGE_STATE, goto_hh, has_login_form
 from ..config import is_resume_url_placeholder
 from ..exit_codes import CommandExitCode
+from ..history import History
 from ._common import _build_letter_provider, add_common_args, resolve_resumes
 
 logger = logging.getLogger("hhru_bot.cli")
@@ -520,7 +521,9 @@ def run(args: argparse.Namespace) -> bool | CommandExitCode | None:
     # #17 (follow-up #54): AI-письмо в probe-дампе. Провайдер строится по тому же
     # правилу, что и в apply (ai + ai_profile); None → статичный шаблон. Атомарность
     # probe не страдает: провайдер только генерирует текст письма, submit не кликается.
-    letter_provider = _build_letter_provider(config, resume, cover_letter_template)
+    history_path = getattr(args, "history", None)
+    history = History(history_path) if history_path else None
+    letter_provider = _build_letter_provider(config, resume, cover_letter_template, history)
 
     print(f"=== probe для резюме: {resume.id} ===")
     print(f"Целевая вакансия: {vacancy.url}")

--- a/src/hhru_bot/scoring/vacancy.py
+++ b/src/hhru_bot/scoring/vacancy.py
@@ -21,7 +21,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-from ..ai.feedback import feedback_blocks
+from ..ai.feedback import build_reject_context
 from .employer import TIER_BOOST, classify_employer
 from .types import ScoreOutcome
 
@@ -291,11 +291,9 @@ def _build_scoring_prompt(
     )
 
     lines = [f"Вакансия: {card.title}.", f"Компания: {card.company or 'не указана'}."]
-    reject, style = feedback_blocks(feedback or [])
+    reject = build_reject_context(feedback or [])
     if reject:
         lines.append(reject)
-    if style:
-        lines.append(style)
     salary = card.salary
     if salary is not None:
         lines.append(f"Зарплата: {salary.raw}.")

--- a/src/hhru_bot/scoring/vacancy.py
+++ b/src/hhru_bot/scoring/vacancy.py
@@ -21,6 +21,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
+from ..ai.feedback import feedback_blocks
 from .employer import TIER_BOOST, classify_employer
 from .types import ScoreOutcome
 
@@ -149,6 +150,7 @@ class LLMScoringProvider:
         max_tokens: int = _LLM_MAX_TOKENS,
         timeout: float = _LLM_TIMEOUT,
         circuit_failure_threshold: int = _LLM_CIRCUIT_FAILURE_THRESHOLD,
+        feedback: list[dict] | None = None,
     ):
         self._llm = llm_client
         self._fallback = fallback
@@ -162,6 +164,7 @@ class LLMScoringProvider:
         self._circuit_failure_threshold = circuit_failure_threshold
         # Счётчик подряд идущих fallback'ов (circuit breaker). Обнуляется на успехе.
         self._consecutive_failures = 0
+        self._feedback = feedback or []
 
     def score(self, card: VacancyCard, resume_profile=None) -> ScoreOutcome:
         profile = resume_profile or self._profile
@@ -175,7 +178,7 @@ class LLMScoringProvider:
             )
             return self._fallback.score(card, profile)
 
-        messages = _build_scoring_prompt(card, profile)
+        messages = _build_scoring_prompt(card, profile, self._feedback)
         try:
             response = self._llm.chat(
                 messages,
@@ -262,7 +265,11 @@ def _parse_llm_score(content: str | None, card: VacancyCard) -> ScoreOutcome | N
     return ScoreOutcome(score_0_100=score, mode="llm", rationale=rationale, breakdown=breakdown)
 
 
-def _build_scoring_prompt(card: VacancyCard, profile: AIProfile | None) -> list[dict[str, str]]:
+def _build_scoring_prompt(
+    card: VacancyCard,
+    profile: AIProfile | None,
+    feedback: list[dict] | None = None,
+) -> list[dict[str, str]]:
     """Собирает chat-completion сообщения для скоринга вакансии под кандидата.
 
     Контекст — карточка поиска (title/company/salary + employer_info: рейтинг/
@@ -284,6 +291,11 @@ def _build_scoring_prompt(card: VacancyCard, profile: AIProfile | None) -> list[
     )
 
     lines = [f"Вакансия: {card.title}.", f"Компания: {card.company or 'не указана'}."]
+    reject, style = feedback_blocks(feedback or [])
+    if reject:
+        lines.append(reject)
+    if style:
+        lines.append(style)
     salary = card.salary
     if salary is not None:
         lines.append(f"Зарплата: {salary.raw}.")

--- a/tests/test_ai_feedback.py
+++ b/tests/test_ai_feedback.py
@@ -1,0 +1,91 @@
+"""Characterization tests for the reference feedback-context flow (#592)."""
+
+import pytest
+
+from hhru_bot.ai.feedback import (
+    FEEDBACK_RECENT_TAIL,
+    REJECT_CONTEXT_MAX_ITEMS,
+    STYLE_CONTEXT_MAX_ITEMS,
+    build_reject_context,
+    build_style_context,
+)
+from hhru_bot.ai.letters import _build_prompt
+from hhru_bot.config_sections.ai_profile import AIProfile
+from hhru_bot.scoring.vacancy import _build_scoring_prompt
+from hhru_bot.search import VacancyCard
+
+pytestmark = pytest.mark.unit
+
+
+def _card() -> VacancyCard:
+    return VacancyCard("42", "AI Engineer", "Acme", "https://hh.ru/vacancy/42")
+
+
+def _row(i: int, **overrides) -> dict:
+    row = {
+        "action": "reject",
+        "reason": f"reason-{i}",
+        "edited_snippet": f"snippet-{i}",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_empty_feedback_preserves_existing_prompt_structure():
+    profile = AIProfile(summary="Engineer")
+    assert _build_prompt(_card(), profile) == _build_prompt(_card(), profile, [])
+    assert _build_scoring_prompt(_card(), profile) == _build_scoring_prompt(_card(), profile, [])
+
+
+def test_reject_context_uses_only_valid_reject_reasons():
+    rows = [
+        _row(1),
+        _row(2, action="approve"),
+        _row(3, reason="  "),
+        _row(4, reason=None),
+        _row(5, reason=123),
+    ]
+    context = build_reject_context(rows)
+    assert "reason-1" in context
+    assert "reason-2" not in context
+    assert "reason-3" not in context
+    assert "123" not in context
+
+
+def test_contexts_use_reference_recent_limits_and_stable_order():
+    rows = [_row(i) for i in range(FEEDBACK_RECENT_TAIL + 5)]  # newest first
+    rejects = build_reject_context(rows)
+    styles = build_style_context(rows)
+
+    assert rejects.count("\n- ") == REJECT_CONTEXT_MAX_ITEMS
+    assert rejects.index("reason-11") < rejects.index("reason-0")
+    assert "reason-12" not in rejects
+    assert styles.count("\n- ") == STYLE_CONTEXT_MAX_ITEMS
+    assert styles.index("snippet-5") < styles.index("snippet-0")
+    assert "snippet-6" not in styles
+
+
+def test_context_budget_is_shared_constant_and_deterministic():
+    rows = [_row(1, reason="r" * 100, edited_snippet="s" * 100)]
+    assert len(build_reject_context(rows, max_chars=90)) <= 90
+    assert len(build_style_context(rows, max_chars=110)) <= 110
+    assert build_reject_context(rows, max_chars=90) == build_reject_context(rows, max_chars=90)
+
+
+def test_scoring_gets_rejects_but_not_style_snippets():
+    content = "\n".join(
+        message["content"] for message in _build_scoring_prompt(_card(), None, [_row(1)])
+    )
+    assert "reason-1" in content
+    assert "snippet-1" not in content
+
+
+def test_letters_get_style_snippets_but_not_rejects_after_static_examples():
+    profile = AIProfile(cover_letter_examples=["static-example"])
+    messages = _build_prompt(_card(), profile, [_row(1)])
+    content = "\n".join(message["content"] for message in messages)
+    assert "snippet-1" in content
+    assert "reason-1" not in content
+    assert next(i for i, m in enumerate(messages) if "static-example" in m["content"]) < next(
+        i for i, m in enumerate(messages) if "snippet-1" in m["content"]
+    )

--- a/tests/test_apply_scoring_integration.py
+++ b/tests/test_apply_scoring_integration.py
@@ -140,6 +140,26 @@ def test_run_apply_passes_llm_provider_when_ai_on(tmp_path, monkeypatch):
     assert captured["llm_shortlist"] == 10
 
 
+def test_ai_providers_query_feedback_by_canonical_resume_id(tmp_path, monkeypatch):
+    class _FakeHistory:
+        def __init__(self):
+            self.calls = []
+
+        def list_feedback(self, *, resume_id, limit):  # noqa: ANN001
+            self.calls.append((resume_id, limit))
+            return []
+
+    monkeypatch.setattr("hhru_bot.ai.llm_client.LLMClient", lambda cfg: object())
+    resume = _resume_with_profile()
+    config = _config_with_ai(tmp_path, resume)
+    history = _FakeHistory()
+
+    _common._build_scoring_provider(config, resume, history)
+    _common._build_letter_provider(config, resume, "template", history)
+
+    assert history.calls == [("AAA111", 25), ("AAA111", 25)]
+
+
 def test_run_apply_passes_none_when_ai_off(tmp_path, monkeypatch):
     """AI выключен → rank_candidates получает None (эвристика #15, совместимость)."""
     captured: dict = {}

--- a/tests/test_reject_feedback.py
+++ b/tests/test_reject_feedback.py
@@ -41,6 +41,17 @@ def test_record_reject_bounds_letter_diff_input(tmp_path):
     assert len(row["edited_snippet"]) <= History.FEEDBACK_SNIPPET_MAX
 
 
+def test_list_feedback_never_crosses_explicit_resume_scope(tmp_path):
+    history = History(tmp_path / "history.db")
+    history.record_reject("resume-a", "v1", "reason-a", generated_letter="old", edited_letter="a")
+    history.record_reject("resume-b", "v2", "reason-b", generated_letter="old", edited_letter="b")
+
+    rows = history.list_feedback(resume_id="resume-a", limit=25)
+
+    assert [row["resume_id"] for row in rows] == ["resume-a"]
+    assert [row["reason"] for row in rows] == ["reason-a"]
+
+
 def test_reject_command_records_feedback(tmp_path, capsys):
     result = reject_cmd.run(
         argparse.Namespace(


### PR DESCRIPTION
## Summary

- consume persisted, resume-scoped reject reasons in subsequent LLM scoring prompts
- consume only persisted redacted generated-to-edited snippets in subsequent cover-letter style prompts
- port the reference bounds: recent tail 25, last 12 reject reasons, last 6 edit snippets, shared 4,000-character context limit and deterministic oldest-to-newest prompt order
- preserve the existing prompt structure exactly when feedback is absent

Closes #592

## Source mapping

| Reference | Local |
|---|---|
| `loadRecentFeedback(25)` | `History.list_feedback(resume_id=..., limit=25)` |
| `buildFeedbackNarrative(...).slice(-12)` | `build_reject_context()` |
| `readRecentUserEditSnippets(6)` | `build_style_context()` |
| scoring prompt insertion | `scoring.vacancy._build_scoring_prompt()` |
| letter style context | `ai.letters._build_prompt()` |

## Live before/after evidence

Read-only hh.ru search/apply dry-runs used the saved session and the same live vacancies. No submit/save/send occurred.

The available production DBs were checked first; both contained `vacancy_feedback = 0`. To exercise the consumer without modifying production history, the after run used an isolated copy of `history.db` with one clearly controlled reject reason and one snippet produced through the real `History.record_reject()` redaction/diff path. Full prompts/results remain local under `/tmp/hhru592-live-ai.json`; full letter text was not added to application logs.

### Vacancy 135661875 — AI Tooling Engineer / Senior python developer

| | Before | After feedback |
|---|---:|---:|
| scoring prompt | 694 chars, SHA `3a11cf6371e2` | 836 chars, SHA `b89ca3534175` |
| LLM score | 88 | 42 |
| rationale | strong direct match to Python/AI tooling profile | identifies the prior tooling-vs-product concern |
| letter prompt | 552 chars, SHA `7f7d90878d8c` | 791 chars, SHA `b2271bd944b9` |
| letter opening | `Здравствуйте!` | `Добрый день!` |
| letter result | general LLM/RAG/tooling match | shifts wording toward product LLM work, following the edit snippet |

Exact scoring prompt addition:

```text
Ранее вы отклоняли вакансии по таким причинам (учти при оценке):
- слишком сильный акцент на внутреннем tooling, мало продуктовых LLM-задач
```

Exact letter prompt addition (the content is already a bounded/redacted diff, not a full letter):

```text
Фрагменты после правок пользователя — учитывай только стиль и формулировки, не копируй факты:
- -З
+Добрый 
-равствуйт
+
-И
+Особенно и
...
```

### Vacancy 136188903 — Senior AI Engineer (LLM / AI-продукты)

| | Before | After feedback |
|---|---:|---:|
| scoring prompt | 671 chars, SHA `e454941aa00f` | 813 chars, SHA `2773d6542761` |
| LLM score | 92 | 82 |
| rationale | near-complete role/stack match | explicitly weighs product focus against the prior tooling concern |
| letter prompt | 529 chars, SHA `1b2b8e2453b8` | 768 chars, SHA `8c8c2b454d87` |
| letter opening | `Здравствуйте!` | `Добрый день!` |
| letter result | generic industrial LLM-product interest | adopts the corrected style and emphasizes product LLM solutions |

This comparison demonstrates both consumers independently: reject reasons affect scoring but never letter prompts; edited snippets affect letter style but never scoring prompts.

## Tests

- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` (100%)
- live `search --dry-run --max-pages 1`
- live `apply --resume ai-engineer --dry-run --limit 1 --max-pages 1`
- live LLM scoring and letter generation on vacancies `135661875` and `136188903`, before/after on isolated DB copies

## Risks / follow-ups

- Current production history has no feedback rows, so production behavior remains unchanged until the user records feedback.
- No embeddings, training, new feedback entities, or weighting changes are included.
