### PR TITLE
fix(competitors): handle busy collection runs

### DIFF
--- a/src/hhru_bot/commands/competitors.py
+++ b/src/hhru_bot/commands/competitors.py
@@ -272,7 +272,7 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
         parse_search_page,
     )
     from ..config import load_config_or_exit
-    from ..history import History
+    from ..history import CommandRunBusy, History
 
     query = args.text.strip()
     if not query:
@@ -283,13 +283,17 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
     config = load_config_or_exit(args.config)
     history = History(args.history)
     require_authentication = args.auth_mode == "authenticated"
-    started = history.begin_competitor_collection(
-        query,
-        args.max_pages or 0,
-        requested_page_size=args.items_per_page,
-        auth_mode=args.auth_mode,
-        resume=bool(getattr(args, "resume", False)),
-    )
+    try:
+        started = history.begin_competitor_collection(
+            query,
+            args.max_pages or 0,
+            requested_page_size=args.items_per_page,
+            auth_mode=args.auth_mode,
+            resume=bool(getattr(args, "resume", False)),
+        )
+    except CommandRunBusy as exc:
+        print(f"[FAIL] {exc}")
+        return True
     run_id = started["run_id"]
     page_num = started["resume_page"]
     rank_offset_base = started["resume_rank_offset"]

--- a/tests/test_competitors_command.py
+++ b/tests/test_competitors_command.py
@@ -135,6 +135,21 @@ def _patch_runtime(monkeypatch) -> None:
     monkeypatch.setattr("hhru_bot.competitor_workers.DetailWorkerPool", _WorkerPool)
 
 
+def test_competing_collect_returns_fail_without_traceback(tmp_path, monkeypatch, capsys):
+    """A live collection lease is reported as a normal command failure."""
+    _patch_runtime(monkeypatch)
+    history = History(tmp_path / "history.db")
+    history.start_competitor_collection("AI", 1)
+
+    result = run_collect(_args(tmp_path))
+
+    captured = capsys.readouterr()
+    assert result is True
+    assert captured.out.startswith("[FAIL] ")
+    assert "Traceback" not in captured.out
+    assert captured.err == ""
+
+
 @pytest.mark.parametrize(
     ("signum", "expected"),
     [


### PR DESCRIPTION
Closes #666

## Summary
- Catch `CommandRunBusy` around `begin_competitor_collection` in `run_collect`.
- Match the existing `_common.py` contract exactly: print `[FAIL] {exc}` and return `True`.
- Add a regression test for a competing live collection lease.
- Audited the other throw site: `History.start_command_run` is only reached in production through `_common.py`'s `run_with_command_run`, which already catches `CommandRunBusy`; no additional hole exists.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest` — 2533 passed, 3 deselected
- Live two-process collision reproduction against the same SQLite DB (first process holds the lease after acquisition; second process competes):

Before fix:
```text
rc=1
stderr: .../competitors.py:286 in run_collect
stderr: .../history.py:2118 in begin_competitor_collection
stderr: hhru_bot.history.CommandRunBusy: supervised-команда уже выполняется: command=competitors collect, pid=72775, run_id=...
```

After fix:
```text
rc=0
stdout: [FAIL] supervised-команда уже выполняется: command=competitors collect, pid=72778, run_id=...
stdout: RESULT=True
stderr: (empty)
```

The reproduction used no hh.ru login and made no WRITE operation.
