### PR TITLE
fix(competitors): разбирать резюме в обеих локалях hh.ru

### DIFF
--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -360,6 +360,31 @@ def _has_next_search_link(links, page_num: int) -> bool:
     return False
 
 
+# hh.ru рендерит подписи разделов на языке, которым соискатель ЗАПОЛНЯЛ анкету,
+# а не по локали браузера: `browser.py` ставит locale=ru-RU и <html lang="ru">,
+# но резюме, созданное в английской версии, всё равно приходит с «Work experience»
+# вместо «Опыт работы». Переключить нельзя — ни ?locale=RU, ни ?lang=RU не
+# действуют (проверено на живых страницах 26.08). Разбор по одним русским
+# подписям молча терял ВСЕ секции такого резюме: в базе оседали
+# specializations='[]', experience_months=NULL, 0 навыков при полной странице.
+# Потеря была смещена в самый технический сегмент (Machine Learning 34%,
+# Data Scientist 18%, «промпт инженер» 0%), потому что англоязычную анкету
+# заполняют в основном международные ИТ-специалисты.
+#
+# Каждая секция описана парой подписей RU/EN. Ключ разбора — русская подпись:
+# она остаётся каноническим именем внутри парсера, а `_canonical_heading`
+# приводит к нему английский вариант. Так двуязычность не расползается по коду
+# отдельными ветками if/else на каждую секцию.
+_SECTION_ALIASES = {
+    "Skills": "Навыки",
+    "Driving experience": "Опыт вождения",
+    "Education": "Образование",
+    "Languages": "Знание языков",
+    "Citizenship, travel time to work": "Гражданство, время в пути до работы",
+    "About me": "Обо мне",
+    "Key achievements": "Ключевые достижения",
+    "Specific achievements": "Конкретные достижения",
+}
 _SECTION_HEADINGS = {
     "Навыки",
     "Опыт вождения",
@@ -369,6 +394,14 @@ _SECTION_HEADINGS = {
     "Обо мне",
     "Ключевые достижения",
     "Конкретные достижения",
+    *_SECTION_ALIASES,
+}
+_PROFICIENCY_ALIASES = {
+    "Basic level": "Базовый уровень",
+    "Beginner level": "Начальный уровень",
+    "Medium level": "Средний уровень",
+    "Advanced level": "Продвинутый уровень",
+    "Level not specified": "Уровень не указан",
 }
 _PROFICIENCY = {
     "Базовый уровень",
@@ -376,7 +409,16 @@ _PROFICIENCY = {
     "Средний уровень",
     "Продвинутый уровень",
     "Уровень не указан",
+    *_PROFICIENCY_ALIASES,
 }
+# Строчные подписи-префиксы: у них после двоеточия идёт CSV-хвост (_csv_tail),
+# либо они открывают перечисление (специализации).
+_SPECIALIZATIONS_PREFIXES = ("Специализации:", "Specializations:")
+_EMPLOYMENT_PREFIXES = ("Тип занятости:", "Employment type:")
+_FORMAT_PREFIXES = ("Формат работы:", "Work format:")
+_EXPERIENCE_PREFIXES = ("Опыт работы", "Work experience")
+_CITIZENSHIP_PREFIXES = ("Гражданство", "Citizenship")
+_SKILL_LEVELS_CAPTION = ("Уровни владения навыками", "Skill proficiency levels")
 _SALARY_HEADING_RE = re.compile(
     r"\d.*(?:₽|\$|€|руб(?:\.|лей)?|RUB|USD|EUR|KZT|тенге|Br\b|so['’ʼʻ]m|сом|на руки)",
     re.IGNORECASE,
@@ -390,11 +432,17 @@ def redact_free_text(value: str) -> str | None:
 
 
 def _months(text: str) -> int | None:
-    years = re.search(r"(\d+)\s+(?:год|года|лет)", text, re.IGNORECASE)
-    months = re.search(r"(\d+)\s+месяц", text, re.IGNORECASE)
+    # «5 лет 3 месяца» и «9 years 11 months» — один разбор на обе локали.
+    years = re.search(r"(\d+)\s+(?:год|года|лет|years?)", text, re.IGNORECASE)
+    months = re.search(r"(\d+)\s+(?:месяц|months?)", text, re.IGNORECASE)
     if not years and not months:
         return None
     return (int(years.group(1)) * 12 if years else 0) + (int(months.group(1)) if months else 0)
+
+
+def _canonical_heading(line: str) -> str:
+    """Привести английскую подпись раздела к русской — канонической в парсере."""
+    return _SECTION_ALIASES.get(line, line)
 
 
 def _csv_tail(line: str) -> list[str]:
@@ -403,13 +451,17 @@ def _csv_tail(line: str) -> list[str]:
 
 
 def _section(lines: list[str], heading: str) -> list[str]:
-    try:
-        start = lines.index(heading) + 1
-    except ValueError:
+    """Строки раздела до следующей подписи. Ищет раздел в обеих локалях."""
+    aliases = [heading, *(en for en, ru in _SECTION_ALIASES.items() if ru == heading)]
+    start = next(
+        (lines.index(alias) + 1 for alias in aliases if alias in lines),
+        None,
+    )
+    if start is None:
         return []
     result: list[str] = []
     for line in lines[start:]:
-        if line in _SECTION_HEADINGS or line.startswith("Гражданство"):
+        if line in _SECTION_HEADINGS or line.startswith(_CITIZENSHIP_PREFIXES):
             break
         result.append(line)
     return result
@@ -439,8 +491,8 @@ def parse_competitor_resume_text(
         value.strip()
         for value in normalized_headings
         if value.strip()
-        and value.strip() not in _SECTION_HEADINGS
-        and not value.strip().startswith("Опыт работы")
+        and _canonical_heading(value.strip()) not in _SECTION_HEADINGS
+        and not value.strip().startswith(_EXPERIENCE_PREFIXES)
         and not is_salary_heading(value.strip())
     ]
     if not desired_candidates:
@@ -452,29 +504,33 @@ def parse_competitor_resume_text(
     )
     salary = parse_salary(salary_heading) if salary_heading else None
     experience_heading = next(
-        (value for value in normalized_headings if value.startswith("Опыт работы")), ""
+        (value for value in normalized_headings if value.startswith(_EXPERIENCE_PREFIXES)), ""
     )
 
     specializations: list[str] = []
-    if "Специализации:" in lines:
-        start = lines.index("Специализации:") + 1
-        for line in lines[start:]:
-            if line.startswith("Тип занятости:"):
+    spec_index = next(
+        (lines.index(prefix) for prefix in _SPECIALIZATIONS_PREFIXES if prefix in lines),
+        None,
+    )
+    if spec_index is not None:
+        for line in lines[spec_index + 1 :]:
+            if line.startswith(_EMPLOYMENT_PREFIXES):
                 break
             specializations.append(line.lstrip("— ").strip())
 
-    employment = next((line for line in lines if line.startswith("Тип занятости:")), "")
-    formats = next((line for line in lines if line.startswith("Формат работы:")), "")
+    employment = next((line for line in lines if line.startswith(_EMPLOYMENT_PREFIXES)), "")
+    formats = next((line for line in lines if line.startswith(_FORMAT_PREFIXES)), "")
 
     skill_lines = _section(lines, "Навыки")
     skills: list[CompetitorSkill] = []
     proficiency: str | None = None
     for line in skill_lines:
-        if line == "Уровни владения навыками":
+        if line in _SKILL_LEVELS_CAPTION:
             continue
-        normalized_level = line.replace("не указан", "не указан")
-        if normalized_level in _PROFICIENCY:
-            proficiency = normalized_level
+        if line in _PROFICIENCY:
+            # Уровень нормализуем к русскому имени: значение уезжает в БД и
+            # попадает в отчёты, где английский дубль расщепил бы бакет.
+            proficiency = _PROFICIENCY_ALIASES.get(line, line)
             continue
         skill_name = line.strip()
         if skill_name:

--- a/tests/test_competitors.py
+++ b/tests/test_competitors.py
@@ -7,6 +7,7 @@ from hhru_bot.competitors import (
     CompetitorResumeIndeterminate,
     CompetitorSearchCoverage,
     CompetitorSearchIndeterminate,
+    _months,
     available_search_page_count,
     build_competitor_search_url,
     coverage_warning,
@@ -52,6 +53,103 @@ FastAPI
 Гражданство, время в пути до работы
 Желательное время в пути до работы: Не имеет значения
 """
+
+
+# Резюме, заполненное в английской версии hh.ru. Подписи разделов приходят
+# английскими независимо от locale браузера — язык принадлежит анкете, а не
+# сессии (проверено на живом hh.ru 26.08, ?locale=RU не переключает). Слепок
+# снят с https://hh.ru/resume/016a96bb000522ca2e0039ed1f5a4c5a645465, где
+# прежний разбор по одним русским подписям терял ВСЕ секции сразу.
+DETAIL_EN = """
+Male
+Brazil, not willing to relocate, not prepared for business trips
+Machine Learning Engineer
+250 000 ₽ in hand
+Specializations:
+Programmer, developer
+Employment type: full time, part time
+Work format: at the employer's location, remote
+Work experience 9 years 11 months
+Skills
+Skill proficiency levels
+Advanced level
+Java
+Python
+Medium level
+Shell Scripting
+Level not specified
+Linux
+Education
+Higher education (Doctor of Science)
+Languages
+Portuguese — Native
+English — C2 — Proficiency
+Citizenship, travel time to work
+Desired travel time to work: not important
+"""
+
+
+def test_parse_detail_reads_english_resume_sections():
+    """hh.ru отдаёт подписи на языке анкеты — разбор обязан понимать обе локали.
+
+    Регрессия боевых данных: 472 из 6233 собранных резюме (7.6%) осели в базе
+    пустыми по ВСЕМ секциям сразу, потому что парсер знал только «Опыт работы»
+    и «Навыки». Потеря была смещена в самый технический сегмент — Machine
+    Learning 34%, Data Scientist 18% против 0% у «промпт инженер».
+    """
+    snapshot = parse_competitor_resume_text(
+        DETAIL_EN,
+        resume_id="en",
+        resume_url="https://hh.ru/resume/en",
+        headings=[
+            "Machine Learning Engineer",
+            "250 000 ₽ in hand",
+            "Work experience 9 years 11 months",
+            "Skills",
+            "Education",
+            "Languages",
+        ],
+    )
+    assert snapshot.desired_role == "Machine Learning Engineer"
+    assert snapshot.experience_months == 119
+    assert snapshot.specializations == ["Programmer, developer"]
+    assert snapshot.employment_types == ["full time", "part time"]
+    assert snapshot.work_formats == ["at the employer's location", "remote"]
+    assert snapshot.education == ["Higher education (Doctor of Science)"]
+    assert snapshot.languages == ["Portuguese — Native", "English — C2 — Proficiency"]
+    # Уровень владения нормализован к русскому имени: значение уходит в БД и
+    # отчёты, где английский дубль расщепил бы бакет.
+    assert [(skill.name, skill.proficiency) for skill in snapshot.skills] == [
+        ("Java", "Продвинутый уровень"),
+        ("Python", "Продвинутый уровень"),
+        ("Shell Scripting", "Средний уровень"),
+        ("Linux", "Уровень не указан"),
+    ]
+
+
+def test_parse_detail_english_headings_are_not_mistaken_for_desired_role():
+    """«Work experience …» — подпись раздела, а не должность."""
+    snapshot = parse_competitor_resume_text(
+        DETAIL_EN,
+        resume_id="en",
+        resume_url="https://hh.ru/resume/en",
+        headings=["Skills", "Machine Learning Engineer", "Work experience 9 years 11 months"],
+    )
+    assert snapshot.desired_role == "Machine Learning Engineer"
+
+
+@pytest.mark.parametrize(
+    ("heading", "expected"),
+    [
+        ("Опыт работы 5 лет 3 месяца", 63),
+        ("Work experience 9 years 11 months", 119),
+        ("Work experience 1 year 1 month", 13),
+        ("Work experience 6 months", 6),
+        ("Опыт работы", None),
+    ],
+)
+def test_experience_months_parses_both_locales(heading, expected):
+    assert _months(heading) == expected
 
 
 def test_search_url_is_keyword_only_and_page_numbered():


### PR DESCRIPTION
## Проблема

hh.ru рендерит подписи разделов резюме **на языке, которым соискатель заполнял анкету**, а не по локали браузера. `browser.py:265` уже ставит `locale: "ru-RU"`, страница приходит с `<html lang="ru">` — и всё равно подписи английские, если резюме создавалось в английской версии сайта. Переключить нельзя: ни `?locale=RU`, ни `?lang=RU` не действуют (проверено на живых страницах 26.08).

Разбор по одним русским подписям молча терял **все** секции такого резюме. В боевой базе это дало **472 из 6233 записей (7.6%)** с `specializations='[]'`, `experience_months=NULL` и нулём навыков при полностью заполненной странице.

Потеря была не случайной, а смещённой в самый ценный сегмент:

| Запрос | Резюме | Битых | Доля |
|---|---|---|---|
| Machine Learning | 149 | 51 | **34.2%** |
| Data Scientist | 752 | 136 | **18.1%** |
| Computer Vision | 57 | 8 | 14.0% |
| ML-инженер | 116 | 12 | 10.3% |
| AI | 5120 | 289 | 5.6% |
| промпт инженер / AI-тренер | — | 0 | 0% |

Причина смещения: англоязычную анкету заполняют в основном международные ИТ-специалисты. Подтверждение — у битых записей 88.6% должностей на латинице против 24.5% у целых. То есть выборка по AI-инженерам систематически занижалась, и любой анализ по ней был смещён.

Затрагивает не только иностранцев: резюме `01700b6c…` — «Графический дизайнер» с русскими навыками, но подписями `Work experience` / `Skills`.

## Решение

Каждая секция описана парой подписей RU/EN. Русская подпись остаётся **каноническим ключом** внутри парсера, а `_canonical_heading` приводит к ней английский вариант — так двуязычность не расползается ветками `if/else` по каждой секции.

- `_SECTION_ALIASES` / `_PROFICIENCY_ALIASES` — маппинг EN→RU
- `_section()` ищет раздел в обеих локалях
- `_months()` понимает `лет/месяц` и `years/months`
- префиксы строчных подписей вынесены в кортежи (`Специализации:` / `Specializations:` и т.д.)

Уровни владения нормализуются обратно к русским именам: значение уходит в БД и в отчёты, где английский дубль расщепил бы бакет.

## Проверено живьём на hh.ru

Резюме `016a96bb000522ca2e0039ed1f5a4c5a645465`, ранее пустое по всем полям:

```
role       : Machine Learning Engineer
experience : 119          (было NULL)
specializ  : ['Programmer, developer']            (было [])
education  : ['Higher education (Doctor of Science)']  (было [])
languages  : ['Portuguese — Native', 'English — C2 — Proficiency']
skills     : 7 шт.        (было 0)
```

Русское контрольное резюме — без регрессии (85 мес, 8 навыков). Смешанное (русский текст, английские подписи) — 114 мес, 11 навыков с уровнями, нормализованными в «Продвинутый уровень».

## Что проверено и багом НЕ является

Аудит базы заодно снял подозрения по остальным полям: зарплаты `1 ₽` / `60 ₽` действительно так написаны в резюме (сверено с `resume-block-salary` на живой странице), валюты корректны, сирот нет, `integrity_check` ok. Пустые `experience_summary`/`achievements` у всех записей — не поломка: «Обо мне» и «Ключевые достижения» анонимному посетителю не отдаются вовсе.

## Тесты

Англоязычная фикстура `DETAIL_EN` со слепком живой страницы + параметризация `_months` на обе локали + кейс на то, что «Work experience …» не принимается за должность. Существующие русские кейсы не правились — это и есть проверка обратной совместимости.

`ruff check`, `ruff format --check`, полный `pytest` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9n1sQxJ7nMEzCHCGGd3cW