### PR TITLE
feat(release): build CLI and plugins from one tag

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,15 +1,19 @@
 {
   "name": "hhru",
+  "metadata": {
+    "version": "0.1.0"
+  },
   "interface": {
     "displayName": "HH.ru"
   },
   "plugins": [
     {
       "name": "hhru-cc-plugin",
+      "version": "0.1.0",
       "source": {
         "source": "url",
         "url": "https://github.com/axisrow/hhru.git",
-        "ref": "main"
+        "ref": "v0.1.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
+    needs: [lint-test, packaging]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
 
 jobs:
@@ -58,10 +59,45 @@ jobs:
         run: |
           python -m pip install --upgrade pip build
           python -m build --wheel
+          VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          python scripts/build_release.py \
+            --tag "v${VERSION}" \
+            --commit "$(git rev-parse HEAD)" \
+            --output dist/release
           python -m venv /tmp/venv
           /tmp/venv/bin/pip install --upgrade pip
           /tmp/venv/bin/pip install dist/*.whl
           /tmp/venv/bin/pip install playwright PyYAML
 
       - name: Smoke — History works from installed wheel
-        run: /tmp/venv/bin/python tests/packaging_smoke.py
+        run: /tmp/venv/bin/python tests/packaging_smoke.py --plugin-archive dist/release/hhru-cc-plugin-*.tar.gz
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the CLI wheel and tagged plugin bundle
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+          python scripts/build_release.py \
+            --tag "$RELEASE_TAG" \
+            --commit "$RELEASE_SHA" \
+            --output dist/release
+
+      - name: Publish one tagged release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/*.whl dist/release/* --generate-notes

--- a/README.md
+++ b/README.md
@@ -256,18 +256,24 @@ claude plugin install hhru-cc-plugin@hhru --scope user
 
 ### Установка для команды в Codex
 
-Каждый участник устанавливает CLI, затем добавляет marketplace из проверенной
-ветки `main`:
+Каждый участник устанавливает CLI и plugin из **одного release tag**. Подставьте
+один и тот же опубликованный tag в обе команды (например, `v0.1.0`):
 
 ```bash
-pip install "git+https://github.com/axisrow/hhru.git@main"
-codex plugin marketplace add axisrow/hhru --ref main
+RELEASE=v0.1.0
+pip install "git+https://github.com/axisrow/hhru.git@${RELEASE}"
+codex plugin marketplace add axisrow/hhru --ref "${RELEASE}"
 ```
 
 В Codex CLI открой `/plugins`, выбери marketplace `hhru`, установи
 `hhru-cc-plugin` и начни новый чат. Repo marketplace зарегистрирован в
 `.agents/plugins/marketplace.json`; public submission в OpenAI Plugins Directory
 для командной установки не требуется.
+
+Release bundle содержит версии, release tag и полный commit SHA во всех
+manifest-файлах и в `release.json`. CI собирает wheel и plugin bundle из одного
+тега и отклоняет расхождение provenance. Уже начатая задача Codex продолжает
+использовать загруженный skill; после обновления начните новый чат.
 
 ### Команда `/hhru`
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Build and validate the release bundle for hhru's CLI and plugins.
+
+The Python package and the agent plugins are released from the same checked-out
+tag.  This script creates the plugin/marketplace part of that release and
+stamps every manifest with the tag and commit that produced it.  It deliberately
+does not mutate the working tree: checked-in manifests are development
+templates, while the files in the archive are the installable release files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPOSITORY_URL = "https://github.com/axisrow/hhru.git"
+TAG_PREFIX = "v"
+RELEASE_FILE = "release.json"
+MANIFESTS = (
+    Path(".codex-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+    Path(".claude-plugin/marketplace.json"),
+    Path(".agents/plugins/marketplace.json"),
+)
+PLUGIN_FILES = (
+    Path(".codex-plugin"),
+    Path(".claude-plugin"),
+    Path(".agents"),
+    Path("commands"),
+    Path("skills"),
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ReleaseError(ValueError):
+    """Raised when a release cannot be proven to be self-consistent."""
+
+
+def _read_version(source_root: Path) -> str:
+    try:
+        import tomllib
+
+        pyproject = tomllib.loads((source_root / "pyproject.toml").read_text(encoding="utf-8"))
+        version = pyproject["project"]["version"]
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        raise ReleaseError("pyproject.toml does not contain project.version") from exc
+    if not isinstance(version, str) or not version:
+        raise ReleaseError("project.version must be a non-empty string")
+    return version
+
+
+def _validate_release_identity(version: str, tag: str, commit_sha: str) -> None:
+    expected_tag = f"{TAG_PREFIX}{version}"
+    if tag != expected_tag:
+        raise ReleaseError(
+            f"release tag {tag!r} does not match project version {version!r}; "
+            f"expected {expected_tag!r}"
+        )
+    if not SHA_RE.fullmatch(commit_sha):
+        raise ReleaseError("commit SHA must be a full 40-character lowercase Git SHA")
+
+
+def _git(source_root: Path, *args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", *args], cwd=source_root, text=True, stderr=subprocess.STDOUT
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = exc.output.strip() if isinstance(exc, subprocess.CalledProcessError) else str(exc)
+        raise ReleaseError(f"cannot determine Git release provenance: {detail}") from exc
+
+
+def _resolve_identity(
+    source_root: Path, tag: str | None, commit_sha: str | None
+) -> tuple[str, str]:
+    resolved_tag = tag or os.environ.get("GITHUB_REF_NAME")
+    if not resolved_tag:
+        resolved_tag = _git(source_root, "describe", "--exact-match", "--tags", "HEAD")
+    resolved_commit = (
+        commit_sha or os.environ.get("GITHUB_SHA") or _git(source_root, "rev-parse", "HEAD")
+    )
+    return resolved_tag, resolved_commit
+
+
+def _assert_tag_points_to_commit(source_root: Path, tag: str, commit_sha: str) -> None:
+    # Pull requests use a synthetic tag for packaging validation.  A real tag,
+    # however, must point at the exact source commit used to build the files.
+    try:
+        tagged_commit = _git(source_root, "rev-parse", f"{tag}^{{commit}}")
+    except ReleaseError:
+        return
+    if tagged_commit != commit_sha:
+        raise ReleaseError(f"tag {tag} points to {tagged_commit}, not build commit {commit_sha}")
+
+
+def _provenance(version: str, tag: str, commit_sha: str) -> dict[str, str]:
+    return {
+        "version": version,
+        "release": tag,
+        "tag": tag,
+        "commit_sha": commit_sha,
+    }
+
+
+def _stamp_manifest(
+    manifest: dict[str, Any], provenance: dict[str, str], relative_path: Path
+) -> None:
+    """Stamp a supported manifest without changing its install-time shape."""
+
+    if relative_path.name == "marketplace.json":
+        metadata = manifest.setdefault("metadata", {})
+        metadata.update(provenance)
+        for plugin in manifest.get("plugins", []):
+            if isinstance(plugin, dict):
+                plugin.update(provenance)
+                source = plugin.get("source")
+                if isinstance(source, dict) and source.get("source") == "url":
+                    source["ref"] = provenance["tag"]
+                    source["commit_sha"] = provenance["commit_sha"]
+    else:
+        manifest.update(provenance)
+
+
+def _load_and_stamp_manifest(path: Path, provenance: dict[str, str]) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReleaseError(f"invalid JSON manifest: {path}") from exc
+    if not isinstance(manifest, dict):
+        raise ReleaseError(f"manifest must be a JSON object: {path}")
+    _stamp_manifest(manifest, provenance, path)
+    return manifest
+
+
+def _manifest_provenance(manifest: dict[str, Any], relative_path: Path) -> dict[str, str]:
+    if relative_path.name == "marketplace.json":
+        metadata = manifest.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ReleaseError(f"marketplace manifest has no metadata: {relative_path}")
+        values = {key: metadata.get(key) for key in ("version", "release", "tag", "commit_sha")}
+    else:
+        values = {key: manifest.get(key) for key in ("version", "release", "tag", "commit_sha")}
+    if any(not isinstance(value, str) or not value for value in values.values()):
+        raise ReleaseError(f"manifest is missing release provenance: {relative_path}")
+    return values  # type: ignore[return-value]
+
+
+def validate_bundle(bundle_root: Path, expected: dict[str, str]) -> None:
+    """Fail if any generated manifest differs from the release identity."""
+
+    values: list[dict[str, str]] = []
+    for relative_path in MANIFESTS:
+        path = bundle_root / relative_path
+        if not path.is_file():
+            raise ReleaseError(f"release bundle is missing manifest {relative_path}")
+        try:
+            manifest = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReleaseError(f"invalid generated manifest: {relative_path}") from exc
+        if not isinstance(manifest, dict):
+            raise ReleaseError(f"generated manifest must be an object: {relative_path}")
+        actual = _manifest_provenance(manifest, relative_path)
+        if actual != expected:
+            raise ReleaseError(
+                f"manifest {relative_path} was not built from "
+                f"{expected['commit_sha']} / {expected['tag']}: {actual}"
+            )
+        if relative_path.name == "marketplace.json":
+            for plugin in manifest.get("plugins", []):
+                if not isinstance(plugin, dict):
+                    raise ReleaseError(
+                        f"marketplace plugin entry is not an object: {relative_path}"
+                    )
+                plugin_identity = {
+                    key: plugin.get(key) for key in ("version", "release", "tag", "commit_sha")
+                }
+                if plugin_identity != expected:
+                    raise ReleaseError(
+                        f"marketplace plugin entry in {relative_path} has different provenance: "
+                        f"{plugin_identity}"
+                    )
+                source = plugin.get("source")
+                if isinstance(source, dict) and source.get("source") == "url":
+                    if (
+                        source.get("ref") != expected["tag"]
+                        or source.get("commit_sha") != expected["commit_sha"]
+                    ):
+                        raise ReleaseError(
+                            f"marketplace source in {relative_path} does not point to "
+                            "the release tag"
+                        )
+        values.append(actual)
+
+    if not values or any(value != values[0] for value in values[1:]):
+        raise ReleaseError("release manifests were assembled from different commits or tags")
+
+    skill = bundle_root / "skills/hhru/SKILL.md"
+    if not skill.is_file():
+        raise ReleaseError("release bundle is missing skills/hhru/SKILL.md")
+    skill_text = skill.read_text(encoding="utf-8")
+    if (
+        "--execution-mode foreground" not in skill_text
+        or "--progress-verbosity 1" not in skill_text
+    ):
+        raise ReleaseError("release bundle does not contain the #660 foreground/heartbeat skill")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def build_release(source_root: Path, output_dir: Path, tag: str, commit_sha: str) -> Path:
+    version = _read_version(source_root)
+    _validate_release_identity(version, tag, commit_sha)
+    _assert_tag_points_to_commit(source_root, tag, commit_sha)
+    provenance = _provenance(version, tag, commit_sha)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = f"hhru-cc-plugin-{version}.tar.gz"
+    archive_path = output_dir / archive_name
+
+    with tempfile.TemporaryDirectory(prefix="hhru-release-") as temporary:
+        staging = Path(temporary) / f"hhru-cc-plugin-{version}"
+        staging.mkdir()
+        for relative_path in PLUGIN_FILES:
+            source = source_root / relative_path
+            destination = staging / relative_path
+            if not source.exists():
+                raise ReleaseError(f"release source is missing {relative_path}")
+            if source.is_dir():
+                shutil.copytree(source, destination)
+            else:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+
+        for relative_path in MANIFESTS:
+            path = staging / relative_path
+            _write_json(path, _load_and_stamp_manifest(path, provenance))
+        _write_json(staging / RELEASE_FILE, {"product": "hhru", **provenance})
+        validate_bundle(staging, provenance)
+
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(staging, arcname=staging.name)
+
+    metadata_path = output_dir / RELEASE_FILE
+    _write_json(metadata_path, {"product": "hhru", **provenance, "plugin_archive": archive_name})
+    return archive_path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--tag", help="release tag; defaults to GITHUB_REF_NAME or the exact tag at HEAD"
+    )
+    parser.add_argument(
+        "--commit", dest="commit_sha", help="full commit SHA; defaults to GITHUB_SHA or HEAD"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    source_root = args.source.resolve()
+    try:
+        tag, commit_sha = _resolve_identity(source_root, args.tag, args.commit_sha)
+        archive = build_release(source_root, args.output.resolve(), tag, commit_sha)
+    except ReleaseError as exc:
+        print(f"release build failed: {exc}", file=sys.stderr)
+        return 2
+    print(f"release bundle: {archive}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/packaging_smoke.py
+++ b/tests/packaging_smoke.py
@@ -12,9 +12,13 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import os
 import sys
+import tarfile
 import tempfile
+from pathlib import Path
 
 try:
     import pytest
@@ -25,6 +29,14 @@ pytestmark = pytest.mark.smoke if pytest is not None else ()
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--plugin-archive",
+        type=Path,
+        help="also install and inspect the built plugin archive in a clean temporary directory",
+    )
+    args = parser.parse_args()
+
     # History создаёт таблицу actions и пишет/читает запись (схема применилась).
     from hhru_bot.history import History
 
@@ -32,6 +44,24 @@ def main() -> None:
         h = History(os.path.join(d, "h.db"))
         h.record_action("r1", "v1", "apply", "success")
         assert h.has_applied("r1", "v1")
+
+    if args.plugin_archive:
+        with tempfile.TemporaryDirectory() as d:
+            with tarfile.open(args.plugin_archive, "r:gz") as archive:
+                archive.extractall(d, filter="data")
+            roots = list(Path(d).iterdir())
+            assert len(roots) == 1, roots
+            bundle = roots[0]
+            manifest = json.loads(
+                (bundle / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+            )
+            assert manifest["name"] == "hhru-cc-plugin"
+            skills_path = bundle / manifest["skills"].lstrip("./")
+            skill = skills_path / "hhru" / "SKILL.md"
+            assert skill.is_file(), skill
+            skill_text = skill.read_text(encoding="utf-8")
+            assert "--execution-mode foreground" in skill_text
+            assert "--progress-verbosity 1" in skill_text
 
     print("packaging smoke OK")
     sys.exit(0)

--- a/tests/test_plugin_packaging.py
+++ b/tests/test_plugin_packaging.py
@@ -29,7 +29,7 @@ def test_codex_plugin_manifest_exposes_all_skills():
     ]
 
 
-def test_codex_repo_marketplace_points_to_the_team_plugin():
+def test_codex_repo_marketplace_points_to_a_release_not_floating_main():
     root = _repo_root()
     marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
     plugin = marketplace["plugins"][0]
@@ -39,7 +39,7 @@ def test_codex_repo_marketplace_points_to_the_team_plugin():
     assert plugin["source"] == {
         "source": "url",
         "url": "https://github.com/axisrow/hhru.git",
-        "ref": "main",
+        "ref": "v0.1.0",
     }
     assert plugin["policy"] == {
         "installation": "AVAILABLE",

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -1,0 +1,68 @@
+"""Release/tag packaging invariants."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from scripts.build_release import ReleaseError, build_release, validate_bundle  # noqa: E402
+
+pytestmark = pytest.mark.smoke
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+def test_release_bundle_stamps_every_manifest_and_contains_installed_skill(tmp_path):
+    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+
+    with tarfile.open(archive, "r:gz") as opened:
+        opened.extractall(tmp_path / "installed", filter="data")
+    bundle = next((tmp_path / "installed").iterdir())
+    expected = {
+        "version": "0.1.0",
+        "release": "v0.1.0",
+        "tag": "v0.1.0",
+        "commit_sha": COMMIT,
+    }
+
+    plugin = json.loads((bundle / ".codex-plugin/plugin.json").read_text(encoding="utf-8"))
+    assert {key: plugin[key] for key in expected} == expected
+    assert (bundle / "skills/hhru/SKILL.md").is_file()
+    assert "--progress-verbosity 1" in (bundle / "skills/hhru/SKILL.md").read_text(encoding="utf-8")
+    assert json.loads((bundle / "release.json").read_text(encoding="utf-8")) == {
+        "product": "hhru",
+        **expected,
+    }
+
+
+def test_release_validation_rejects_manifest_from_another_commit(tmp_path):
+    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+    with tarfile.open(archive, "r:gz") as opened:
+        opened.extractall(tmp_path / "installed", filter="data")
+    bundle = next((tmp_path / "installed").iterdir())
+    path = bundle / ".codex-plugin/plugin.json"
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["commit_sha"] = "fedcba9876543210fedcba9876543210fedcba98"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ReleaseError, match="was not built"):
+        validate_bundle(
+            bundle,
+            {
+                "version": "0.1.0",
+                "release": "v0.1.0",
+                "tag": "v0.1.0",
+                "commit_sha": COMMIT,
+            },
+        )
+
+
+def test_release_tag_must_match_canonical_package_version(tmp_path):
+    with pytest.raises(ReleaseError, match="does not match project version"):
+        build_release(Path(__file__).parents[1], tmp_path, "v9.9.9", COMMIT)


### PR DESCRIPTION
## Summary

- Build the Codex/Claude plugin bundle and marketplace manifests from the same release tag and commit SHA as the CLI wheel.
- Reject tag/version or manifest provenance mismatches in the release builder; release sources never use floating `main`.
- Verify the installed plugin archive contains the `#660` foreground/heartbeat skill, not just the checkout tree.
- Run tagged releases through the same CI job and publish the wheel, bundle, and provenance metadata together.

#673 and #675 are still open and have no PRs currently. This change reads the canonical version from `pyproject.toml` and leaves the update-flow seam explicit: the future update command can consume the tagged `release.json`/manifest provenance without introducing a second version source.

Closes #676

## Tests

- `ruff check src tests`
- `ruff format --check src tests`
- `pytest` (2574 passed, 3 deselected)
- Built wheel with `python -m build --wheel`
- Built and inspected installed plugin bundle with `tests/packaging_smoke.py --plugin-archive ...`

## Known follow-up

- The checked-in marketplace template points at the current release tag (`v0.1.0`); the release builder stamps the actual tag/SHA into the published bundle.
