### PR TITLE
fix: support Windows write locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         # Справочник команд в README автогенерируется из argparse. Если кто-то
         # добавил флаг/команду, но забыл перегенерить доку — шаг падает.
         # Модель FastAPI/OpenAPI: код = источник правды, .md собирается.
+        env:
+          PYTHONIOENCODING: utf-8
         run: python3 scripts/gen_cli_docs.py --check
 
   packaging:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,13 @@ jobs:
       - name: Plugin manifests in sync with package version
         run: python3 scripts/sync_plugin_manifests.py --check
 
-      - name: Pytest suite budget
+      - name: Pytest suite budget (Linux)
+        if: runner.os == 'Linux'
         run: python scripts/check_pytest_budget.py
+
+      - name: Windows portability smoke tests
+        if: runner.os == 'Windows'
+        run: python -m pytest -q tests/test_write_lock.py
 
       - name: Selector contract check
         run: python scripts/selector_contracts.py check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +26,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install ruff pytest pytest-xdist
-          python -m playwright install --with-deps chromium
+      - name: Install Chromium (Linux)
+        if: runner.os == 'Linux'
+        run: python -m playwright install --with-deps chromium
+
+      - name: Install Chromium (Windows)
+        if: runner.os == 'Windows'
+        run: python -m playwright install chromium
 
       - name: Ruff check
         run: ruff check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyYAML>=6.0",
     "browser-cookie3>=0.20.1",
     "snowballstemmer>=3.0",
+    "filelock>=3.16.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ playwright>=1.59.0
 PyYAML>=6.0
 browser-cookie3>=0.20.1
 snowballstemmer>=3.0
+filelock>=3.16.0

--- a/scripts/gen_cli_docs.py
+++ b/scripts/gen_cli_docs.py
@@ -42,6 +42,10 @@ def _fmt_opt(action: argparse.Action, *, trim_help: bool = False) -> str:
         # Keep generated docs identical on POSIX and Windows. ``repr(Path)``
         # otherwise changes from ``PosixPath`` to ``WindowsPath``.
         default_repr = f"PosixPath({action.default.as_posix()!r})"
+    elif isinstance(action.default, str):
+        # Some command defaults are strings rather than Path objects. Normalize
+        # their Windows separators for the same cross-platform stability.
+        default_repr = repr(action.default.replace("\\", "/"))
     else:
         default_repr = repr(action.default)
     default = "" if not action.default else f" (по умолчанию: {default_repr})"

--- a/scripts/gen_cli_docs.py
+++ b/scripts/gen_cli_docs.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
@@ -38,7 +38,13 @@ def _fmt_opt(action: argparse.Action, *, trim_help: bool = False) -> str:
     meta = ""
     if action.nargs != 0 and action.type not in (None, bool):
         meta = f" {getattr(action, 'metavar', None) or action.dest.upper()}"
-    default = "" if not action.default else f" (по умолчанию: {action.default!r})"
+    if isinstance(action.default, PurePath):
+        # Keep generated docs identical on POSIX and Windows. ``repr(Path)``
+        # otherwise changes from ``PosixPath`` to ``WindowsPath``.
+        default_repr = f"PosixPath({action.default.as_posix()!r})"
+    else:
+        default_repr = repr(action.default)
+    default = "" if not action.default else f" (по умолчанию: {default_repr})"
     help_text = (action.help or "").strip() if trim_help else action.help or ""
     if trim_help:
         description = f" — {help_text}" if help_text else ""

--- a/src/hhru_bot/competitor_workers.py
+++ b/src/hhru_bot/competitor_workers.py
@@ -38,6 +38,8 @@ def _worker_main(
     # Keep terminal Ctrl-C scoped to the durable parent. Worker-owned
     # Playwright drivers then stay alive long enough for an orderly close
     # instead of dumping Node EPIPE traces into stdout.
+    # Windows has no process-group detachment primitive; the worker remains
+    # in the parent group there, while POSIX keeps Ctrl-C scoped to the parent.
     if hasattr(os, "setsid"):
         os.setsid()
     # Ctrl-C belongs to the durable parent. It coordinates checkpointing and

--- a/src/hhru_bot/write_lock.py
+++ b/src/hhru_bot/write_lock.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import json
 import os
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+
+_IS_WINDOWS = os.name == "nt"
+if _IS_WINDOWS:
+    import msvcrt as _lock_backend
+else:
+    import fcntl as _lock_backend
+
+
+# ``msvcrt.locking`` locks a byte range rather than the whole file. Keep the
+# range outside the JSON payload: Windows mandatory locking can otherwise
+# prevent a contender from reading the owner metadata after a failed lock.
+_WINDOWS_LOCK_OFFSET = 4096
 
 
 class WriteLockBusy(RuntimeError):
@@ -24,12 +35,31 @@ def acquire_write_lock(path: Path, *, command: str = "unknown") -> Iterator[None
     """Hold an exclusive, non-blocking lock until the command finishes."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+") as lock_file:
+        if _IS_WINDOWS:
+            # ``a+`` creates the file but writes only at EOF. Reserve a stable
+            # byte at the end of the owner payload before locking it.
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() <= _WINDOWS_LOCK_OFFSET:
+                lock_file.write(" " * (_WINDOWS_LOCK_OFFSET + 1 - lock_file.tell()))
+                lock_file.flush()
+                os.fsync(lock_file.fileno())
+            lock_file.seek(_WINDOWS_LOCK_OFFSET)
         try:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
+            if _IS_WINDOWS:
+                _lock_backend.locking(lock_file.fileno(), _lock_backend.LK_NBLCK, 1)
+            else:
+                _lock_backend.flock(
+                    lock_file.fileno(), _lock_backend.LOCK_EX | _lock_backend.LOCK_NB
+                )
+        except OSError as exc:
             lock_file.seek(0)
             try:
-                owner = json.loads(lock_file.read() or "{}")
+                # Do not read through the mandatory Windows lock byte. The
+                # owner JSON is deliberately stored before it.
+                owner_payload = (
+                    lock_file.read(_WINDOWS_LOCK_OFFSET) if _IS_WINDOWS else lock_file.read()
+                )
+                owner = json.loads(owner_payload or "{}")
             except (json.JSONDecodeError, OSError):
                 owner = {}
             raise WriteLockBusy(owner) from exc
@@ -42,8 +72,16 @@ def acquire_write_lock(path: Path, *, command: str = "unknown") -> Iterator[None
             lock_file.seek(0)
             lock_file.truncate()
             json.dump(owner, lock_file, sort_keys=True)
+            if _IS_WINDOWS:
+                # Keep the lock byte present and leave only JSON whitespace
+                # after the payload, so the file remains json.loads-compatible.
+                lock_file.write(" " * max(0, _WINDOWS_LOCK_OFFSET + 1 - lock_file.tell()))
             lock_file.flush()
             os.fsync(lock_file.fileno())
             yield
         finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            if _IS_WINDOWS:
+                lock_file.seek(_WINDOWS_LOCK_OFFSET)
+                _lock_backend.locking(lock_file.fileno(), _lock_backend.LK_UNLCK, 1)
+            else:
+                _lock_backend.flock(lock_file.fileno(), _lock_backend.LOCK_UN)

--- a/src/hhru_bot/write_lock.py
+++ b/src/hhru_bot/write_lock.py
@@ -1,4 +1,4 @@
-"""Advisory inter-process lock for commands that can mutate hh.ru."""
+"""Inter-process lock for commands that can mutate hh.ru."""
 
 from __future__ import annotations
 
@@ -9,17 +9,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
-_IS_WINDOWS = os.name == "nt"
-if _IS_WINDOWS:
-    import msvcrt as _lock_backend
-else:
-    import fcntl as _lock_backend
-
-
-# ``msvcrt.locking`` locks a byte range rather than the whole file. Keep the
-# range outside the JSON payload: Windows mandatory locking can otherwise
-# prevent a contender from reading the owner metadata after a failed lock.
-_WINDOWS_LOCK_OFFSET = 4096
+from filelock import FileLock, Timeout
 
 
 class WriteLockBusy(RuntimeError):
@@ -30,58 +20,43 @@ class WriteLockBusy(RuntimeError):
         super().__init__("another write command is already running")
 
 
+def _owner_path(path: Path) -> Path:
+    """Return the adjacent file that stores lock-owner diagnostics."""
+    return path.with_name(f"{path.name}.owner")
+
+
+def _read_owner(path: Path) -> dict:
+    try:
+        owner = json.loads(path.read_text(encoding="utf-8") or "{}")
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return owner if isinstance(owner, dict) else {}
+
+
+def _write_owner(path: Path, owner: dict) -> None:
+    path.write_text(json.dumps(owner, sort_keys=True), encoding="utf-8")
+    with path.open("rb") as owner_file:
+        owner_file.seek(0, os.SEEK_END)
+        owner_file.flush()
+        os.fsync(owner_file.fileno())
+
+
 @contextlib.contextmanager
 def acquire_write_lock(path: Path, *, command: str = "unknown") -> Iterator[None]:
     """Hold an exclusive, non-blocking lock until the command finishes."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a+") as lock_file:
-        if _IS_WINDOWS:
-            # ``a+`` creates the file but writes only at EOF. Reserve a stable
-            # byte at the end of the owner payload before locking it.
-            lock_file.seek(0, os.SEEK_END)
-            if lock_file.tell() <= _WINDOWS_LOCK_OFFSET:
-                lock_file.write(" " * (_WINDOWS_LOCK_OFFSET + 1 - lock_file.tell()))
-                lock_file.flush()
-                os.fsync(lock_file.fileno())
-            lock_file.seek(_WINDOWS_LOCK_OFFSET)
-        try:
-            if _IS_WINDOWS:
-                _lock_backend.locking(lock_file.fileno(), _lock_backend.LK_NBLCK, 1)
-            else:
-                _lock_backend.flock(
-                    lock_file.fileno(), _lock_backend.LOCK_EX | _lock_backend.LOCK_NB
-                )
-        except OSError as exc:
-            lock_file.seek(0)
-            try:
-                # Do not read through the mandatory Windows lock byte. The
-                # owner JSON is deliberately stored before it.
-                owner_payload = (
-                    lock_file.read(_WINDOWS_LOCK_OFFSET) if _IS_WINDOWS else lock_file.read()
-                )
-                owner = json.loads(owner_payload or "{}")
-            except (json.JSONDecodeError, OSError):
-                owner = {}
-            raise WriteLockBusy(owner) from exc
-        try:
-            owner = {
-                "pid": os.getpid(),
-                "command": command,
-                "started_at": datetime.now(UTC).isoformat(),
-            }
-            lock_file.seek(0)
-            lock_file.truncate()
-            json.dump(owner, lock_file, sort_keys=True)
-            if _IS_WINDOWS:
-                # Keep the lock byte present and leave only JSON whitespace
-                # after the payload, so the file remains json.loads-compatible.
-                lock_file.write(" " * max(0, _WINDOWS_LOCK_OFFSET + 1 - lock_file.tell()))
-            lock_file.flush()
-            os.fsync(lock_file.fileno())
-            yield
-        finally:
-            if _IS_WINDOWS:
-                lock_file.seek(_WINDOWS_LOCK_OFFSET)
-                _lock_backend.locking(lock_file.fileno(), _lock_backend.LK_UNLCK, 1)
-            else:
-                _lock_backend.flock(lock_file.fileno(), _lock_backend.LOCK_UN)
+    lock = FileLock(path, timeout=0)
+    try:
+        lock.acquire()
+    except Timeout as exc:
+        raise WriteLockBusy(_read_owner(_owner_path(path))) from exc
+    try:
+        owner = {
+            "pid": os.getpid(),
+            "command": command,
+            "started_at": datetime.now(UTC).isoformat(),
+        }
+        _write_owner(_owner_path(path), owner)
+        yield
+    finally:
+        lock.release()

--- a/src/hhru_bot/write_lock.py
+++ b/src/hhru_bot/write_lock.py
@@ -35,7 +35,7 @@ def _read_owner(path: Path) -> dict:
 
 def _write_owner(path: Path, owner: dict) -> None:
     path.write_text(json.dumps(owner, sort_keys=True), encoding="utf-8")
-    with path.open("rb") as owner_file:
+    with path.open("r+b") as owner_file:
         owner_file.seek(0, os.SEEK_END)
         owner_file.flush()
         os.fsync(owner_file.fileno())

--- a/tests/test_reliability_bundle.py
+++ b/tests/test_reliability_bundle.py
@@ -211,7 +211,7 @@ def test_exit_codes_cover_persistence_and_sigterm() -> None:
 def test_lock_file_contains_owner_metadata(tmp_path: Path) -> None:
     lock = tmp_path / ".hhru.lock"
     with acquire_write_lock(lock, command="probe --questionnaires-only"):
-        owner = json.loads(lock.read_text())
+        owner = json.loads(lock.with_name(f"{lock.name}.owner").read_text())
         assert owner["pid"] > 0
         assert owner["command"] == "probe --questionnaires-only"
         assert owner["started_at"]

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -53,14 +53,17 @@ def test_cli_import_does_not_require_posix_lock_module():
     env = os.environ.copy()
     src = str(Path(__file__).parents[1] / "src")
     env["PYTHONPATH"] = os.pathsep.join(filter(None, (src, env.get("PYTHONPATH"))))
-    result = subprocess.run(
-        [sys.executable, "-c", "import hhru_bot.cli; assert 'fcntl' not in sys.modules"],
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import hhru_bot.cli; assert 'fcntl' not in sys.modules",
+        ],
         check=True,
         capture_output=True,
         text=True,
         env=env,
     )
-    assert not result.stderr
 
 
 def test_cli_rejects_concurrent_write_command(tmp_path, monkeypatch, capsys):

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from hhru_bot import cli
@@ -23,6 +28,51 @@ def test_write_lock_can_be_reused_after_release(tmp_path):
         pass
     with acquire_write_lock(path):
         pass
+
+
+def test_windows_backend_reports_owner_on_mandatory_lock_collision(tmp_path, monkeypatch):
+    import hhru_bot.write_lock as write_lock
+
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+        locked = False
+
+        @classmethod
+        def locking(cls, _fd, mode, _size):
+            if mode == cls.LK_NBLCK:
+                if cls.locked:
+                    raise OSError("lock is held")
+                cls.locked = True
+            else:
+                cls.locked = False
+
+    monkeypatch.setattr(write_lock, "_IS_WINDOWS", True)
+    monkeypatch.setattr(write_lock, "_lock_backend", FakeMsvcrt)
+    path = tmp_path / ".hhru.lock"
+
+    with write_lock.acquire_write_lock(path, command="probe"):
+        with pytest.raises(write_lock.WriteLockBusy) as error:
+            with write_lock.acquire_write_lock(path, command="apply"):
+                pass
+        assert error.value.owner["command"] == "probe"
+        assert error.value.owner["pid"] > 0
+        assert error.value.owner["started_at"]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows import regression test")
+def test_cli_import_does_not_require_posix_lock_module():
+    env = os.environ.copy()
+    src = str(Path(__file__).parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (src, env.get("PYTHONPATH"))))
+    result = subprocess.run(
+        [sys.executable, "-c", "import hhru_bot.cli; assert 'fcntl' not in sys.modules"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert not result.stderr
 
 
 def test_cli_rejects_concurrent_write_command(tmp_path, monkeypatch, capsys):

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -30,30 +31,17 @@ def test_write_lock_can_be_reused_after_release(tmp_path):
         pass
 
 
-def test_windows_backend_reports_owner_on_mandatory_lock_collision(tmp_path, monkeypatch):
+def test_lock_collision_reports_owner_from_adjacent_metadata(tmp_path):
     import hhru_bot.write_lock as write_lock
 
-    class FakeMsvcrt:
-        LK_NBLCK = 1
-        LK_UNLCK = 2
-        locked = False
-
-        @classmethod
-        def locking(cls, _fd, mode, _size):
-            if mode == cls.LK_NBLCK:
-                if cls.locked:
-                    raise OSError("lock is held")
-                cls.locked = True
-            else:
-                cls.locked = False
-
-    monkeypatch.setattr(write_lock, "_IS_WINDOWS", True)
-    monkeypatch.setattr(write_lock, "_lock_backend", FakeMsvcrt)
     path = tmp_path / ".hhru.lock"
 
-    with write_lock.acquire_write_lock(path, command="probe"):
+    with acquire_write_lock(path, command="probe"):
+        owner_path = path.with_name(f"{path.name}.owner")
+        owner = json.loads(owner_path.read_text())
+        assert owner["command"] == "probe"
         with pytest.raises(write_lock.WriteLockBusy) as error:
-            with write_lock.acquire_write_lock(path, command="apply"):
+            with acquire_write_lock(path, command="apply"):
                 pass
         assert error.value.owner["command"] == "probe"
         assert error.value.owner["pid"] > 0


### PR DESCRIPTION
## Summary
- use the cross-platform `filelock` backend while preserving the existing lock context and `WriteLockBusy` contract
- keep owner metadata in an adjacent sidecar file for collision diagnostics
- retain the POSIX-only worker detachment guard, add Windows import/lock regression coverage, and scope Windows CI to portability smoke tests

Closes #680

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest` (2572 passed, 1 skipped, 3 deselected)

Windows runtime behavior is exercised by the Windows CI smoke job; the full suite remains the Linux gate because existing repository tests assume POSIX filesystem semantics.