### PR TITLE
feat(packaging): centralize plugin release metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,11 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "version": "0.1.0"
     }
-  ]
+  ],
+  "metadata": {
+    "version": "0.1.0"
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Ruff format check
         run: ruff format --check src tests
 
+      - name: Plugin manifests in sync with package version
+        run: python3 scripts/sync_plugin_manifests.py --check
+
       - name: Pytest suite budget
         run: python scripts/check_pytest_budget.py
 

--- a/docs/plugin-packaging.md
+++ b/docs/plugin-packaging.md
@@ -1,0 +1,41 @@
+# Plugin packaging and release metadata
+
+## One version source
+
+`pyproject.toml` (`[project].version`) is the only version source. The four
+JSON files are generated artifacts for their respective consumers:
+
+```bash
+python3 scripts/sync_plugin_manifests.py
+python3 scripts/sync_plugin_manifests.py --check
+```
+
+The second command is a CI guard and must fail when a manifest is edited to a
+different version. It updates these fields:
+
+- `.codex-plugin/plugin.json:version`;
+- `.claude-plugin/plugin.json:version`;
+- `.claude-plugin/marketplace.json:metadata.version` and
+  `plugins[0].version`;
+- `.agents/plugins/marketplace.json:metadata.version` and
+  `plugins[0].version`.
+
+The marketplace files are both needed. `.claude-plugin/marketplace.json` is
+the Claude Code local marketplace entry (`source: "./"`), while
+`.agents/plugins/marketplace.json` is the Codex team marketplace entry (a Git
+URL, ref, and installation/authentication policy). They intentionally have
+different schemas and are not interchangeable; only their shared release
+metadata is generated.
+
+## Skill path and provenance
+
+`.codex-plugin/plugin.json` is metadata inside the plugin root. Codex copies
+the repository as the plugin root and resolves `skills: "./skills/"` from that
+root, so the path points to the checked-in top-level `skills/` directory; a
+`.codex-plugin/skills/` directory is neither required nor expected.
+
+Diagnostics include `environment.hhru.version` and
+`environment.hhru.commit_sha` together. The SHA is resolved from the actual
+checkout (or `HHRU_COMMIT_SHA`/`GITHUB_SHA` supplied by a build), rather than
+being copied into a tracked manifest. This avoids a self-referential hash in a
+floating branch manifest and identifies the exact installed source state.

--- a/docs/plugin-packaging.md
+++ b/docs/plugin-packaging.md
@@ -36,6 +36,8 @@ root, so the path points to the checked-in top-level `skills/` directory; a
 
 Diagnostics include `environment.hhru.version` and
 `environment.hhru.commit_sha` together. The SHA is resolved from the actual
-checkout (or `HHRU_COMMIT_SHA`/`GITHUB_SHA` supplied by a build), rather than
-being copied into a tracked manifest. This avoids a self-referential hash in a
-floating branch manifest and identifies the exact installed source state.
+checkout (or the package-specific `HHRU_COMMIT_SHA` supplied by a build),
+rather than being copied into a tracked manifest. A consuming workflow's
+ambient `GITHUB_SHA` is intentionally ignored because it identifies the
+consumer repository, not necessarily hhru. This avoids a self-referential hash
+in a floating branch manifest and identifies the exact installed source state.

--- a/scripts/sync_plugin_manifests.py
+++ b/scripts/sync_plugin_manifests.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Synchronize plugin metadata from ``pyproject.toml``.
+
+The Claude Code and Codex marketplace files are intentionally different
+schemas: Claude consumes the local ``source: ./`` entry, while the Codex team
+marketplace consumes a Git URL plus installation policy. They are two
+supported entry points, not interchangeable copies. This script keeps their
+shared release version generated from the package's single source of truth.
+
+Run ``python3 scripts/sync_plugin_manifests.py`` after changing the project
+version. CI can use ``--check`` to make a stale generated manifest fail.
+Commit provenance is not written into tracked manifests: a manifest in a
+floating checkout cannot contain its own commit hash. Runtime diagnostics
+resolve the actual checkout/cache SHA instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATHS = (
+    Path(".codex-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+    Path(".claude-plugin/marketplace.json"),
+    Path(".agents/plugins/marketplace.json"),
+)
+
+
+def project_version(root: Path = ROOT) -> str:
+    """Read the only supported version source."""
+    try:
+        with (root / "pyproject.toml").open("rb") as stream:
+            value = tomllib.load(stream)["project"]["version"]
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"cannot read project.version from {root / 'pyproject.toml'}") from exc
+    if not isinstance(value, str) or not value:
+        raise ValueError("project.version must be a non-empty string")
+    return value
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def expected_manifests(root: Path = ROOT) -> dict[Path, dict[str, Any]]:
+    """Return current manifests with all shared version fields regenerated."""
+    value = project_version(root)
+    manifests = {path: _load(root / path) for path in MANIFEST_PATHS}
+
+    codex = manifests[Path(".codex-plugin/plugin.json")]
+    codex["version"] = value
+
+    claude = manifests[Path(".claude-plugin/marketplace.json")]
+    claude.setdefault("metadata", {})["version"] = value
+    claude["plugins"][0]["version"] = value
+    manifests[Path(".claude-plugin/plugin.json")]["version"] = value
+
+    agents = manifests[Path(".agents/plugins/marketplace.json")]
+    agents.setdefault("metadata", {})["version"] = value
+    agents["plugins"][0]["version"] = value
+
+    return manifests
+
+
+def _dump(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+
+
+def synchronize(root: Path = ROOT, *, check: bool = False) -> bool:
+    """Write synchronized manifests, or report whether they are current."""
+    expected = expected_manifests(root)
+    stale: list[Path] = []
+    for relative, value in expected.items():
+        path = root / relative
+        rendered = _dump(value)
+        if path.read_text(encoding="utf-8") != rendered:
+            stale.append(relative)
+            if not check:
+                path.write_text(rendered, encoding="utf-8")
+    if stale and check:
+        print("Plugin manifests are stale; run:")
+        print("  python3 scripts/sync_plugin_manifests.py")
+        for path in stale:
+            print(f"  - {path}")
+        return False
+    if check:
+        print("Plugin manifests are synchronized.")
+    else:
+        print("Plugin manifests synchronized.")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=ROOT, help="checkout root (for tests and tooling)"
+    )
+    parser.add_argument("--check", action="store_true", help="fail when generated files are stale")
+    args = parser.parse_args(argv)
+    return 0 if synchronize(args.root.resolve(), check=args.check) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hhru_bot/_version.py
+++ b/src/hhru_bot/_version.py
@@ -1,8 +1,100 @@
-"""Единый источник правды версии пакета.
+"""Package version and source provenance.
 
-Дублируется в pyproject.toml (project.version) намеренно — см. риски плана:
-двойной source-of-truth допустим для простого проекта; hatch-vcs здесь оверкилл.
-При релизе менять в обоих местах.
+``pyproject.toml`` is the source of truth for the version. A checkout can
+read it directly; an installed wheel uses the version copied into its normal
+Python distribution metadata. The commit is deliberately resolved at runtime
+so diagnostics identify the actual checkout or plugin cache rather than a
+floating branch name.
 """
 
-__version__ = "0.1.0"
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tomllib
+from importlib.metadata import PackageNotFoundError, distribution
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+_PACKAGE_NAME = "hhru-bot"
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _checkout_root() -> Path | None:
+    """Return the repository root when running from a source checkout."""
+    candidate = Path(__file__).resolve().parents[2]
+    return candidate if (candidate / "pyproject.toml").is_file() else None
+
+
+def _project_version() -> str | None:
+    root = _checkout_root()
+    if root is None:
+        return None
+    try:
+        with (root / "pyproject.toml").open("rb") as stream:
+            value = tomllib.load(stream)["project"]["version"]
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError):
+        return None
+    return value if isinstance(value, str) else None
+
+
+def _installed_version() -> str:
+    try:
+        return distribution_version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        # This fallback is only used by an uninstalled source checkout whose
+        # pyproject could not be read; keep imports working for diagnostics.
+        return "unknown"
+
+
+__version__ = _project_version() or _installed_version()
+
+
+def _installed_commit_sha() -> str | None:
+    """Read the immutable VCS commit recorded by PEP 610 installations."""
+    try:
+        raw = distribution(_PACKAGE_NAME).read_text("direct_url.json")
+    except (FileNotFoundError, PackageNotFoundError, OSError):
+        return None
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw).get("vcs_info", {}).get("commit_id")
+    except (AttributeError, TypeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, str) and _SHA.fullmatch(value) else None
+
+
+def commit_sha() -> str:
+    """Return the immutable commit for this installation or ``unknown``."""
+    configured = os.environ.get("HHRU_COMMIT_SHA") or os.environ.get("GITHUB_SHA")
+    if configured and _SHA.fullmatch(configured):
+        return configured
+
+    root = _checkout_root()
+    if root is not None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "--verify", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (OSError, subprocess.SubprocessError):
+            pass
+        else:
+            value = result.stdout.strip()
+            if _SHA.fullmatch(value):
+                return value
+    installed = _installed_commit_sha()
+    if installed is not None:
+        return installed
+    return "unknown"
+
+
+def build_info() -> dict[str, str]:
+    """Return version and commit together for diagnostic/reporting callers."""
+    return {"version": __version__, "commit_sha": commit_sha()}

--- a/src/hhru_bot/_version.py
+++ b/src/hhru_bot/_version.py
@@ -69,7 +69,11 @@ def _installed_commit_sha() -> str | None:
 
 def commit_sha() -> str:
     """Return the immutable commit for this installation or ``unknown``."""
-    configured = os.environ.get("HHRU_COMMIT_SHA") or os.environ.get("GITHUB_SHA")
+    # GITHUB_SHA belongs to the workflow's checkout, which may be a consumer
+    # repository running an installed hhru wheel. Only accept the explicit
+    # package provenance variable; a package build may populate it from its
+    # own CI GITHUB_SHA before installation.
+    configured = os.environ.get("HHRU_COMMIT_SHA")
     if configured and _SHA.fullmatch(configured):
         return configured
 

--- a/src/hhru_bot/diagnostics.py
+++ b/src/hhru_bot/diagnostics.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+from ._version import build_info
+
 _SECRET = re.compile(
     r"(?i)(['\"]?(?:cookie|authorization|token|password|secret|api[_-]?key|csrf[_-]?token|session[_-]?id)['\"]?)\s*[:=]\s*[^\r\n,}]*"
 )
@@ -166,7 +168,11 @@ def build_bundle(
     return {
         "schema_version": "1.0.0",
         "bundle_version": "1",
-        "environment": {"python": platform.python_version(), "platform": platform.platform()},
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "hhru": build_info(),
+        },
         "run": run,
         "log_tail": lines,
         "selectors": {"hits": [], "misses": [], "evidence": []},

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from hhru_bot import __version__
 from hhru_bot.diagnostics import _same_path, build_bundle, redact
 
 pytestmark = pytest.mark.unit
@@ -105,3 +106,19 @@ def test_export_path_aliases_are_detected_and_history_is_read_only(tmp_path):
     before = Path(db).read_bytes()
     build_bundle(alias, run_id="r1")
     assert Path(db).read_bytes() == before
+
+
+def test_bundle_identifies_hhru_version_and_commit(monkeypatch, tmp_path):
+    db = tmp_path / "history.db"
+    with sqlite3.connect(db) as c:
+        c.execute("create table command_runs (run_id text)")
+        c.execute("insert into command_runs values ('r1')")
+    sha = "a" * 40
+    monkeypatch.setenv("HHRU_COMMIT_SHA", sha)
+
+    bundle = build_bundle(db, run_id="r1")
+
+    assert bundle["environment"]["hhru"] == {
+        "version": __version__,
+        "commit_sha": sha,
+    }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from hhru_bot import __version__
+from hhru_bot import _version as version_module
 from hhru_bot.diagnostics import _same_path, build_bundle, redact
 
 pytestmark = pytest.mark.unit
@@ -122,3 +123,12 @@ def test_bundle_identifies_hhru_version_and_commit(monkeypatch, tmp_path):
         "version": __version__,
         "commit_sha": sha,
     }
+
+
+def test_commit_does_not_use_consuming_workflow_sha(monkeypatch):
+    monkeypatch.delenv("HHRU_COMMIT_SHA", raising=False)
+    monkeypatch.setenv("GITHUB_SHA", "b" * 40)
+    monkeypatch.setattr(version_module, "_checkout_root", lambda: None)
+    monkeypatch.setattr(version_module, "_installed_commit_sha", lambda: None)
+
+    assert version_module.commit_sha() == "unknown"

--- a/tests/test_plugin_metadata.py
+++ b/tests/test_plugin_metadata.py
@@ -1,0 +1,92 @@
+"""Regression tests for the generated plugin release metadata."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hhru_bot import __version__
+
+pytestmark = pytest.mark.smoke
+
+MANIFEST_PATHS = (
+    Path(".codex-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+    Path(".claude-plugin/marketplace.json"),
+    Path(".agents/plugins/marketplace.json"),
+)
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/sync_plugin_manifests.py"
+
+
+def _project_version(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as stream:
+        return tomllib.load(stream)["project"]["version"]
+
+
+def _synchronize(root: Path, *, check: bool = False) -> bool:
+    command = [sys.executable, str(SCRIPT), "--root", str(root)]
+    if check:
+        command.append("--check")
+    result = subprocess.run(
+        command,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _copy_metadata_fixture(source: Path, destination: Path) -> None:
+    shutil.copy2(source / "pyproject.toml", destination / "pyproject.toml")
+    for relative in MANIFEST_PATHS:
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source / relative, target)
+
+
+def test_plugin_manifests_are_currently_generated_from_pyproject():
+    root = Path(__file__).resolve().parents[1]
+
+    assert _synchronize(root, check=True)
+    version = _project_version(root)
+    assert __version__ == version
+    codex = json.loads((root / ".codex-plugin/plugin.json").read_text())
+    claude_plugin = json.loads((root / ".claude-plugin/plugin.json").read_text())
+    claude = json.loads((root / ".claude-plugin/marketplace.json").read_text())
+    agents = json.loads((root / ".agents/plugins/marketplace.json").read_text())
+    assert codex["version"] == version
+    assert claude_plugin["version"] == version
+    assert claude["metadata"]["version"] == version
+    assert claude["plugins"][0]["version"] == version
+    assert agents["metadata"]["version"] == version
+    assert agents["plugins"][0]["version"] == version
+
+
+def test_manifest_check_fails_for_intentionally_drifted_version(tmp_path):
+    source = Path(__file__).resolve().parents[1]
+    _copy_metadata_fixture(source, tmp_path)
+    path = tmp_path / ".codex-plugin/plugin.json"
+    manifest = json.loads(path.read_text())
+    manifest["version"] = "9.9.9"
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
+
+    assert not _synchronize(tmp_path, check=True)
+    assert _synchronize(tmp_path)
+    assert json.loads(path.read_text())["version"] == _project_version(tmp_path)
+
+
+def test_claude_and_codex_marketplaces_are_distinct_supported_schemas():
+    root = Path(__file__).resolve().parents[1]
+    claude = json.loads((root / ".claude-plugin/marketplace.json").read_text())
+    agents = json.loads((root / ".agents/plugins/marketplace.json").read_text())
+
+    assert claude["plugins"][0]["source"] == "./"
+    assert agents["plugins"][0]["source"]["source"] == "url"
+    assert agents["plugins"][0]["policy"]["authentication"] == "ON_INSTALL"

--- a/tests/test_plugin_packaging.py
+++ b/tests/test_plugin_packaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -14,12 +15,22 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _project_version(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as stream:
+        return tomllib.load(stream)["project"]["version"]
+
+
 def test_codex_plugin_manifest_exposes_all_skills():
     root = _repo_root()
     manifest = json.loads((root / ".codex-plugin" / "plugin.json").read_text())
+    version = _project_version(root)
 
     assert manifest["name"] == "hhru-cc-plugin"
+    assert manifest["version"] == version
     assert manifest["skills"] == "./skills/"
+    # .codex-plugin is metadata inside the plugin root. Codex resolves this
+    # relative path from the checked-out plugin root, not from .codex-plugin/.
+    assert (root / manifest["skills"]).resolve() == (root / "skills").resolve()
     assert manifest["interface"]["capabilities"] == ["Read", "Write"]
     assert sorted(path.parent.name for path in (root / "skills").glob("*/SKILL.md")) == [
         "hhru",
@@ -33,9 +44,11 @@ def test_codex_repo_marketplace_points_to_the_team_plugin():
     root = _repo_root()
     marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
     plugin = marketplace["plugins"][0]
+    version = _project_version(root)
 
     assert marketplace["name"] == "hhru"
     assert plugin["name"] == "hhru-cc-plugin"
+    assert plugin["version"] == version
     assert plugin["source"] == {
         "source": "url",
         "url": "https://github.com/axisrow/hhru.git",
@@ -46,6 +59,7 @@ def test_codex_repo_marketplace_points_to_the_team_plugin():
         "authentication": "ON_INSTALL",
     }
     assert plugin["category"] == "Productivity"
+    assert marketplace["metadata"]["version"] == version
 
 
 def test_shared_skills_use_the_installed_hhru_cli():


### PR DESCRIPTION
Closes #673

## Summary
- make pyproject.toml the sole version source and add a checked-in synchronizer for all Claude/Codex manifest fields
- preserve both marketplace manifests because they serve different schemas and consumers; document the Codex root-relative skills path
- include hhru version and immutable commit SHA in diagnostics, including PEP 610 VCS provenance for direct installs
- add CI and regression coverage that intentionally fails on version drift

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest` (2575 passed, 3 deselected)
- `python3 scripts/sync_plugin_manifests.py --check`
- isolated Codex local marketplace install verified version `0.1.0` and top-level `skills/` resolution

## Risk
- diagnostics report `unknown` only when no checkout, build SHA, or PEP 610 VCS provenance is available; no runtime behavior outside metadata/diagnostics changes.