### PR TITLE
feat(diagnostics): detect CLI and plugin provenance drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,16 @@ AIProfile/config.yaml.
 
 - (без аргументов)
 
+#### `account create`
+
+Создать data/accounts/<name>/ и скопировать туда шаблон конфига.
+
+- (без аргументов)
+
+#### `account list`
+
+- (без аргументов)
+
 ### `apply`
 
 - `--resume` — Slug из конфига или resume_id HH.ru (по умолчанию — все)
@@ -383,6 +393,19 @@ AIProfile/config.yaml.
 
 - (без аргументов)
 
+#### `blacklist add`
+
+- `--reason`
+- `--by` (по умолчанию: 'cli')
+
+#### `blacklist list`
+
+- (без аргументов)
+
+#### `blacklist remove`
+
+- (без аргументов)
+
 ### `bump`
 
 - `--resume` — Slug из конфига или resume_id HH.ru (по умолчанию — все)
@@ -394,6 +417,24 @@ AIProfile/config.yaml.
 Создание события только по явно подтверждённым --start/--end. Автоматического триггера из responses нет.
 
 - (без аргументов)
+
+#### `calendar auth`
+
+- `--credentials` (по умолчанию: 'data/google_calendar/client_secret.json')
+- `--token` (по умолчанию: 'data/google_calendar/token.json')
+
+#### `calendar event`
+
+- `--credentials` (по умолчанию: 'data/google_calendar/client_secret.json')
+- `--token` (по умолчанию: 'data/google_calendar/token.json')
+- `--calendar-id` (по умолчанию: 'primary')
+- `--summary`
+- `--start` — Начало, RFC3339, например 2026-08-20T10:00:00+07:00
+- `--end` — Конец, RFC3339
+- `--timezone` (по умолчанию: 'UTC')
+- `--description`
+- `--location`
+- `--dry-run` — Показать payload без OAuth и записи
 
 ### `call-api`
 
@@ -423,6 +464,25 @@ AIProfile/config.yaml.
 READ hh.ru: competitors collect --text QUERY [--search-in SCOPE] [--max-pages N]; локальный отчёт: competitors report [--text QUERY] [--search-in SCOPE] [--auth-mode MODE] [--top N].
 
 - (без аргументов)
+
+#### `competitors collect`
+
+- `--text` — Ключевое слово поиска резюме
+- `--max-pages MAX_PAGES` — Необязательный safety-cap (по умолчанию — до конца видимой выдачи)
+- `--resume` — Продолжить последний прерванный запуск того же запроса с checkpoint
+- `--execution-mode` — Режим выполнения (по умолчанию foreground; background не поддерживается) (по умолчанию: 'foreground')
+- `--progress-verbosity PROGRESS_VERBOSITY` — Поток прогресса: 1 — показывать, 0 — только финал/ошибки (по умолчанию 1) (по умолчанию: 1)
+- `--items-per-page ITEMS_PER_PAGE` — Запрошенный размер страницы hh.ru (по умолчанию 100; для smoke можно 20) (по умолчанию: 100)
+- `--search-in` — Область поиска --text на hh.ru: position — только желаемая должность (заголовок резюме), самая узкая и чистая (по умолчанию); keywords — по ключевым навыкам; full_text — по всему резюме (должность, навыки, описание опыта, достижения), самая широкая: запрос вроде «AI» так вытягивает дизайнеров с Adobe Illustrator (по умолчанию: 'position')
+- `--auth-mode` — Сессия браузера: anonymous — чистый контекст без cookie (по умолчанию); authenticated — загрузить сохранённую сессию из конфига (по умолчанию: 'anonymous')
+- `--detail-workers DETAIL_WORKERS` — Параллельные процессы деталей: 1–1000 (по умолчанию 10; для authenticated требуется 1) (по умолчанию: 10)
+
+#### `competitors report`
+
+- `--text` — Ограничить отчёт одним поисковым запросом
+- `--search-in` — Ограничить отчёт одной областью поиска: один и тот же --text в разных областях — это РАЗНЫЕ выборки (full_text по «AI» тянет дизайнеров с Adobe Illustrator). Без флага отчёт охватывает все области
+- `--auth-mode` — Ограничить отчёт одним режимом сессии: анонимная выдача hh.ru урезана относительно авторизованной. Без флага отчёт охватывает оба режима
+- `--top TOP` — Число строк в каждом топе (по умолчанию 20) (по умолчанию: 20)
 
 ### `config`
 
@@ -465,6 +525,20 @@ READ hh.ru: competitors collect --text QUERY [--search-in SCOPE] [--max-pages N]
 ### `diagnostics`
 
 - (без аргументов)
+
+#### `diagnostics doctor`
+
+Сравнивает версию, release/tag и commit SHA установленного CLI, marketplace snapshot и загруженного Codex plugin.
+
+- `--marketplace-path, --marketplace MARKETPLACE` — Путь к marketplace snapshot (для диагностики нестандартной установки)
+- `--plugin-cache PLUGIN_CACHE` — Путь к Codex plugin cache (для диагностики нестандартной установки)
+
+#### `diagnostics export`
+
+- `--run-id`
+- `--output OUTPUT`
+- `--log LOG` (по умолчанию: PosixPath('data/logs/hhru_bot.log'))
+- `--dom-dir DOM_DIR` (по умолчанию: PosixPath('data/logs'))
 
 ### `edit-education`
 
@@ -597,6 +671,18 @@ READ hh.ru: competitors collect --text QUERY [--search-in SCOPE] [--max-pages N]
 
 - (без аргументов)
 
+#### `profile set`
+
+- (без аргументов)
+
+#### `profile show`
+
+- (без аргументов)
+
+#### `profile unset`
+
+- (без аргументов)
+
 ### `publish-resume`
 
 Публикует черновик резюме кликом по кнопке hh.ru. WRITE-hh-ru: боевой режим требует --force; --dry-run ничего не нажимает.
@@ -617,6 +703,52 @@ READ hh.ru: competitors collect --text QUERY [--search-in SCOPE] [--max-pages N]
 Показать очередь, аудит и шаблоны, задать ответ или обучить шаблон.
 
 - (без аргументов)
+
+#### `questionnaire audit`
+
+Что бот ответил в анкетах: ответ, уверенность, шаблон.
+
+- `--resume` — Slug резюме или resume_id (по умолчанию — все)
+- `--last LIMIT` — Сколько последних ответов показать (по умолчанию: 50)
+- `--template` — Только ответы этого шаблона
+- `--low-confidence` — Только вопросы, на которые бот не стал отвечать
+
+#### `questionnaire learn`
+
+Интерактивный разбор накопившихся вопросов анкет.
+
+- `--resume` — Slug резюме или resume_id
+- `--limit LIMIT` — Сколько вопросов разобрать (по умолчанию: 20)
+
+#### `questionnaire pending`
+
+Вопросы, на которые бот не стал отвечать сам.
+
+- `--resume` — Slug резюме или resume_id (по умолчанию — все)
+- `--limit LIMIT` — Сколько строк вывести (по умолчанию: 50)
+
+#### `questionnaire set`
+
+static — готовое значение; contextual — инструкция для LLM.
+
+- `--mode` — static (значение) или contextual (инструкция)
+- `--answer` — Готовый ответ (для --mode static)
+- `--instruction` — Инструкция для LLM (для --mode contextual)
+- `--example` — Формулировка вопроса, относящаяся к этому шаблону (можно повторять)
+- `--cluster` — Тематический кластер вопроса
+- `--resume` — Задать только для этого резюме
+
+#### `questionnaire templates`
+
+Шаблоны уровня аккаунта и переопределения резюме.
+
+- `--resume` — Slug резюме или resume_id
+
+#### `questionnaire unset`
+
+Удаляет шаблон только из своего скоупа.
+
+- `--resume` — Снять только переопределение этого резюме
 
 ### `refresh-token`
 
@@ -707,6 +839,26 @@ Account-wide ответы в чатах: план из локальной ист
 
 - (без аргументов)
 
+#### `review approve`
+
+- `--ttl TTL` (по умолчанию: 900)
+
+#### `review edit`
+
+- (без аргументов)
+
+#### `review list`
+
+- `--status`
+
+#### `review requeue`
+
+- (без аргументов)
+
+#### `review skip`
+
+- (без аргументов)
+
 ### `robot-queue`
 
 - `--limit LIMIT` —  (по умолчанию: 50)
@@ -756,6 +908,18 @@ Account-wide ответы в чатах: план из локальной ист
 - `--limit LIMIT` — Лимит строк в режиме --list (по умолчанию 50) (по умолчанию: 50)
 
 ### `uncertain`
+
+- (без аргументов)
+
+#### `uncertain inspect`
+
+- (без аргументов)
+
+#### `uncertain list`
+
+- `--limit LIMIT` (по умолчанию: 50)
+
+#### `uncertain reconcile`
 
 - (без аргументов)
 

--- a/scripts/gen_cli_docs.py
+++ b/scripts/gen_cli_docs.py
@@ -33,13 +33,25 @@ def _opts(parser: argparse.ArgumentParser) -> list[argparse.Action]:
     return [a for a in parser._actions if a.option_strings and a.dest != "help"]
 
 
-def _fmt_opt(action: argparse.Action) -> str:
+def _fmt_opt(action: argparse.Action, *, trim_help: bool = False) -> str:
     flag = ", ".join(action.option_strings)
     meta = ""
     if action.nargs != 0 and action.type not in (None, bool):
         meta = f" {getattr(action, 'metavar', None) or action.dest.upper()}"
     default = "" if not action.default else f" (по умолчанию: {action.default!r})"
-    return f"`{flag}{meta}` — {action.help or ''}{default}"
+    help_text = (action.help or "").strip() if trim_help else action.help or ""
+    if trim_help:
+        description = f" — {help_text}" if help_text else ""
+    else:
+        description = f" — {help_text}"
+    return f"`{flag}{meta}`{description}{default}"
+
+
+def _subparsers(parser: argparse.ArgumentParser) -> argparse._SubParsersAction | None:
+    return next(
+        (action for action in parser._actions if isinstance(action, argparse._SubParsersAction)),
+        None,
+    )
 
 
 def render() -> str:
@@ -72,6 +84,23 @@ def render() -> str:
         else:
             lines.append("- (без аргументов)")
         lines.append("")
+        nested = _subparsers(sub)
+        if nested is not None:
+            for nested_name in sorted(nested.choices):
+                nested_parser = nested.choices[nested_name]
+                lines.append(f"#### `{name} {nested_name}`")
+                nested_desc = (nested_parser.description or "").strip()
+                if nested_desc:
+                    lines.append("")
+                    lines.append(nested_desc)
+                lines.append("")
+                nested_opts = _opts(nested_parser)
+                if nested_opts:
+                    for a in nested_opts:
+                        lines.append(f"- {_fmt_opt(a, trim_help=True)}")
+                else:
+                    lines.append("- (без аргументов)")
+                lines.append("")
     lines.append(END)
     return "\n".join(lines)
 

--- a/src/hhru_bot/commands/diagnostics.py
+++ b/src/hhru_bot/commands/diagnostics.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 
 from ..diagnostics import _same_path, export_bundle
+from ..provenance import RECOVERY_COMMAND, run_doctor
 
 
 def register(subparsers) -> None:
@@ -15,6 +16,27 @@ def register(subparsers) -> None:
     e.add_argument("--log", type=Path, default=Path("data/logs/hhru_bot.log"))
     e.add_argument("--dom-dir", type=Path, default=Path("data/logs"))
     e.set_defaults(func=run)
+    d = sub.add_parser(
+        "doctor",
+        help="Проверить согласованность CLI, marketplace snapshot и plugin cache",
+        description=(
+            "Сравнивает версию, release/tag и commit SHA установленного CLI, "
+            "marketplace snapshot и загруженного Codex plugin."
+        ),
+    )
+    d.add_argument(
+        "--marketplace-path",
+        "--marketplace",
+        dest="marketplace",
+        type=Path,
+        help="Путь к marketplace snapshot (для диагностики нестандартной установки)",
+    )
+    d.add_argument(
+        "--plugin-cache",
+        type=Path,
+        help="Путь к Codex plugin cache (для диагностики нестандартной установки)",
+    )
+    d.set_defaults(func=run_doctor_command)
 
 
 def run(args: argparse.Namespace):
@@ -38,3 +60,17 @@ def run(args: argparse.Namespace):
         output.write_text(text, encoding="utf-8")
     else:
         print(text, end="")
+
+
+def run_doctor_command(args: argparse.Namespace) -> bool:
+    result = run_doctor(marketplace=args.marketplace, plugin_cache=args.plugin_cache)
+    for component in result.components:
+        print(f"[{component.name}] {component.describe()}")
+    if not result.drift:
+        print("[OK] CLI, marketplace snapshot и plugin cache согласованы.")
+        return False
+    print("[DRIFT] CLI, marketplace snapshot и plugin cache рассинхронизированы.")
+    for reason in result.reasons:
+        print(f"[DETAIL] {reason}")
+    print(f"[FIX] Выполните одну команду: {RECOVERY_COMMAND}")
+    return True

--- a/src/hhru_bot/provenance.py
+++ b/src/hhru_bot/provenance.py
@@ -89,9 +89,17 @@ def _source_version(root: Path) -> str | None:
     return _first_string((project.get("version"),)) if isinstance(project, dict) else None
 
 
-def _git_identity(name: str, path: Path, *, manifest_version: str | None = None):
+def _git_identity(
+    name: str,
+    path: Path,
+    *,
+    manifest_version: str | None = None,
+    require_package_source: bool = False,
+):
     root = _git_root(path)
     if root is None:
+        return None
+    if require_package_source and not _is_package_source_checkout(path, root):
         return None
     sha = run_git(root, "rev-parse", "HEAD")
     if sha is None:
@@ -107,6 +115,13 @@ def _git_identity(name: str, path: Path, *, manifest_version: str | None = None)
     )
     release = run_git(root, "describe", "--tags", "--exact-match", "HEAD")
     return ComponentIdentity(name, version or manifest_version, release, sha, root, "git")
+
+
+def _is_package_source_checkout(package_path: Path, root: Path) -> bool:
+    package_path = package_path.resolve()
+    expected = (root / "src" / "hhru_bot").resolve()
+    legacy_expected = (root / "hhru_bot").resolve()
+    return package_path in {expected, legacy_expected}
 
 
 def _first_string(values: Iterable[Any]) -> str | None:
@@ -228,7 +243,7 @@ def cli_identity() -> ComponentIdentity:
 
     path = _package_location()
     package_root = path.parent
-    identity = _git_identity("installed CLI", package_root)
+    identity = _git_identity("installed CLI", package_root, require_package_source=True)
     if identity is not None:
         return identity
     try:

--- a/src/hhru_bot/provenance.py
+++ b/src/hhru_bot/provenance.py
@@ -1,0 +1,317 @@
+"""Build identity checks for the CLI and the Codex plugin lifecycle.
+
+The release job is the eventual source of the package/plugin identity (#673).
+Until that source lands, this module deliberately accepts the identity emitted
+by either git (editable/check-out installs) or a manifest/provenance file.  The
+doctor therefore does not silently turn a missing SHA into a successful check.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PLUGIN_NAME = "hhru-cc-plugin"
+MARKETPLACE_NAME = "hhru"
+RECOVERY_COMMAND = "codex plugin marketplace upgrade hhru --json"
+
+
+@dataclass(frozen=True)
+class ComponentIdentity:
+    """Version/provenance observed for one lifecycle component."""
+
+    name: str
+    version: str | None
+    release: str | None
+    commit_sha: str | None
+    location: Path | None = None
+    source: str | None = None
+
+    @property
+    def complete(self) -> bool:
+        # An untagged development checkout legitimately has no release tag;
+        # its full commit SHA is still a sufficient provenance anchor.
+        return bool(self.version and self.commit_sha)
+
+    def describe(self) -> str:
+        version = self.version or "неизвестна"
+        release = self.release or "неизвестен"
+        sha = self.commit_sha or "неизвестен"
+        return f"version={version}, release={release}, sha={sha}"
+
+
+@dataclass(frozen=True)
+class DoctorResult:
+    """Comparison result for the three lifecycle components."""
+
+    components: tuple[ComponentIdentity, ...]
+    drift: bool
+    reasons: tuple[str, ...]
+
+
+def run_git(path: Path, *args: str) -> str | None:
+    """Run a read-only git query, returning ``None`` outside a checkout."""
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _git_root(path: Path) -> Path | None:
+    root = run_git(path, "rev-parse", "--show-toplevel")
+    return Path(root).resolve() if root else None
+
+
+def _git_identity(name: str, path: Path, *, manifest_version: str | None = None):
+    root = _git_root(path)
+    if root is None:
+        return None
+    sha = run_git(root, "rev-parse", "HEAD")
+    if sha is None:
+        return None
+    # An editable install has no reliable wheel metadata.  Its version is the
+    # git description, as opposed to importlib.metadata.version().  This also
+    # makes a checkout copied into the plugin cache comparable to the CLI.
+    version = run_git(root, "describe", "--tags", "--always", "HEAD")
+    release = run_git(root, "describe", "--tags", "--exact-match", "HEAD")
+    return ComponentIdentity(name, version or manifest_version, release, sha, root, "git")
+
+
+def _first_string(values: Iterable[Any]) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _provenance_values(*objects: Any) -> tuple[str | None, str | None]:
+    """Extract release/tag and SHA from current and future manifest shapes."""
+
+    release_values: list[Any] = []
+    sha_values: list[Any] = []
+    pending = list(objects)
+    while pending:
+        obj = pending.pop(0)
+        if not isinstance(obj, dict):
+            continue
+        nested = obj.get("provenance")
+        if isinstance(nested, dict):
+            pending.append(nested)
+        release_values.extend(obj.get(key) for key in ("release", "tag", "release_tag"))
+        sha_values.extend(obj.get(key) for key in ("commit_sha", "git_commit_sha", "commit", "sha"))
+        vcs_info = obj.get("vcs_info")
+        if isinstance(vcs_info, dict):
+            release_values.append(vcs_info.get("requested_revision"))
+            sha_values.append(vcs_info.get("commit_id"))
+        source = obj.get("source")
+        if isinstance(source, dict):
+            release_values.extend(source.get(key) for key in ("release", "tag"))
+            sha_values.extend(
+                source.get(key) for key in ("commit_sha", "git_commit_sha", "commit", "sha")
+            )
+    return _first_string(release_values), _first_string(sha_values)
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _manifest_identity(name: str, root: Path, manifest: Path) -> ComponentIdentity:
+    payload = _load_json(manifest) or {}
+    plugin: dict[str, Any] = {}
+    plugins = payload.get("plugins")
+    if isinstance(plugins, list):
+        plugin = next(
+            (
+                item
+                for item in plugins
+                if isinstance(item, dict) and item.get("name") == PLUGIN_NAME
+            ),
+            {},
+        )
+    version = _first_string(
+        (
+            plugin.get("version"),
+            payload.get("version"),
+            (payload.get("metadata") or {}).get("version")
+            if isinstance(payload.get("metadata"), dict)
+            else None,
+        )
+    )
+    release, sha = _provenance_values(
+        payload, plugin, payload.get("metadata"), plugin.get("source")
+    )
+    return ComponentIdentity(name, version, release, sha, root, "manifest")
+
+
+def _manifest_for(root: Path, *, marketplace: bool = False) -> Path | None:
+    candidates = (
+        (
+            root / ".claude-plugin" / "marketplace.json",
+            root / ".agents" / "plugins" / "marketplace.json",
+            root / ".codex-plugin" / "plugin.json",
+        )
+        if marketplace
+        else (root / ".codex-plugin" / "plugin.json",)
+    )
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def _identity_from_root(name: str, root: Path, *, marketplace: bool = False) -> ComponentIdentity:
+    manifest = _manifest_for(root, marketplace=marketplace)
+    manifest_identity = _manifest_identity(name, root, manifest) if manifest else None
+    identity = _git_identity(
+        name, root, manifest_version=manifest_identity.version if manifest_identity else None
+    )
+    if identity is not None:
+        return identity
+    if manifest_identity is not None:
+        return manifest_identity
+    return ComponentIdentity(name, None, None, None, root, "missing")
+
+
+def _package_location() -> Path:
+    # __file__ is in the actual imported package, including an editable install.
+    return Path(__file__).resolve()
+
+
+def cli_identity() -> ComponentIdentity:
+    """Inspect the installed CLI, preferring its checkout when editable."""
+
+    path = _package_location()
+    package_root = path.parent
+    identity = _git_identity("installed CLI", package_root)
+    if identity is not None:
+        return identity
+    try:
+        version = importlib.metadata.version("hhru-bot")
+        distribution = importlib.metadata.distribution("hhru-bot")
+        direct_url = _load_json(Path(distribution.locate_file("direct_url.json")))
+        release, sha = _provenance_values(direct_url)
+    except importlib.metadata.PackageNotFoundError:
+        version, release, sha = None, None, None
+    # #673 can replace this module's generated values without changing the
+    # doctor.  Keep the names permissive so both a generated ``__tag__`` and a
+    # generated ``__release__`` remain valid inputs during the transition.
+    try:
+        from . import _version as source_version
+
+        version = version or _first_string((getattr(source_version, "__version__", None),))
+        release = release or _first_string(
+            (getattr(source_version, "__release__", None), getattr(source_version, "__tag__", None))
+        )
+        sha = sha or _first_string(
+            (
+                getattr(source_version, "__commit_sha__", None),
+                getattr(source_version, "__git_commit_sha__", None),
+            )
+        )
+    except ImportError:
+        pass
+    return ComponentIdentity("installed CLI", version, release, sha, package_root, "package")
+
+
+def _default_marketplace_path() -> Path | None:
+    codex_home = Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+    candidates = [
+        codex_home / "plugins" / "marketplaces" / MARKETPLACE_NAME,
+        Path("~/.claude/plugins/marketplaces/hhru").expanduser(),
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def marketplace_identity(path: Path | None = None) -> ComponentIdentity:
+    path = path.expanduser() if path else _default_marketplace_path()
+    if path is None:
+        return ComponentIdentity("marketplace snapshot", None, None, None, None, "missing")
+    if path.is_file():
+        return _manifest_identity("marketplace snapshot", path.parent.parent, path)
+    return _identity_from_root("marketplace snapshot", path, marketplace=True)
+
+
+def _plugin_cache_candidate(cache: Path) -> Path | None:
+    if cache.is_file():
+        return cache.parent.parent if cache.name == "plugin.json" else None
+    if (cache / ".codex-plugin" / "plugin.json").is_file():
+        return cache
+    candidates = sorted(
+        (path.parent.parent for path in cache.glob("*/.codex-plugin/plugin.json")),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _default_plugin_cache_path() -> Path:
+    codex_home = Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+    return codex_home / "plugins" / "cache" / "hhru" / PLUGIN_NAME
+
+
+def plugin_cache_identity(path: Path | None = None) -> ComponentIdentity:
+    cache = path.expanduser() if path else _default_plugin_cache_path()
+    candidate = _plugin_cache_candidate(cache) if cache.exists() else None
+    if candidate is None:
+        return ComponentIdentity("installed plugin cache", None, None, None, cache, "missing")
+    return _identity_from_root("installed plugin cache", candidate)
+
+
+def collect_identities(
+    *, marketplace: Path | None = None, plugin_cache: Path | None = None
+) -> tuple[ComponentIdentity, ...]:
+    """Collect the three states compared by ``hhru diagnostics doctor``."""
+
+    return (cli_identity(), marketplace_identity(marketplace), plugin_cache_identity(plugin_cache))
+
+
+def compare_identities(components: Iterable[ComponentIdentity]) -> DoctorResult:
+    components = tuple(components)
+    reasons: list[str] = []
+    for component in components:
+        if not component.complete:
+            reasons.append(f"{component.name}: provenance неполная ({component.describe()})")
+    if components:
+        for field, label in (
+            ("version", "version"),
+            ("release", "release/tag"),
+            ("commit_sha", "commit SHA"),
+        ):
+            values = {getattr(component, field) for component in components}
+            if len(values) > 1:
+                reasons.append(
+                    f"разный {label}: "
+                    + "; ".join(f"{c.name}={getattr(c, field) or 'неизвестен'}" for c in components)
+                )
+    return DoctorResult(components, bool(reasons), tuple(reasons))
+
+
+def run_doctor(
+    *, marketplace: Path | None = None, plugin_cache: Path | None = None
+) -> DoctorResult:
+    return compare_identities(
+        collect_identities(marketplace=marketplace, plugin_cache=plugin_cache)
+    )

--- a/src/hhru_bot/provenance.py
+++ b/src/hhru_bot/provenance.py
@@ -12,6 +12,7 @@ import importlib.metadata
 import json
 import os
 import subprocess
+import tomllib
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -77,6 +78,17 @@ def _git_root(path: Path) -> Path | None:
     return Path(root).resolve() if root else None
 
 
+def _source_version(root: Path) -> str | None:
+    """Read the checkout's declared version without using installed metadata."""
+
+    try:
+        payload = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    project = payload.get("project")
+    return _first_string((project.get("version"),)) if isinstance(project, dict) else None
+
+
 def _git_identity(name: str, path: Path, *, manifest_version: str | None = None):
     root = _git_root(path)
     if root is None:
@@ -84,10 +96,15 @@ def _git_identity(name: str, path: Path, *, manifest_version: str | None = None)
     sha = run_git(root, "rev-parse", "HEAD")
     if sha is None:
         return None
-    # An editable install has no reliable wheel metadata.  Its version is the
-    # git description, as opposed to importlib.metadata.version().  This also
-    # makes a checkout copied into the plugin cache comparable to the CLI.
-    version = run_git(root, "describe", "--tags", "--always", "HEAD")
+    # An editable install has no reliable wheel metadata.  Read its declared
+    # source version, then use git for release/SHA provenance.  A git
+    # description is only a last-resort version for a checkout without a
+    # pyproject, never a replacement for a semantic package version.
+    version = (
+        manifest_version
+        or _source_version(root)
+        or run_git(root, "describe", "--tags", "--always", "HEAD")
+    )
     release = run_git(root, "describe", "--tags", "--exact-match", "HEAD")
     return ComponentIdentity(name, version or manifest_version, release, sha, root, "git")
 
@@ -116,7 +133,6 @@ def _provenance_values(*objects: Any) -> tuple[str | None, str | None]:
         sha_values.extend(obj.get(key) for key in ("commit_sha", "git_commit_sha", "commit", "sha"))
         vcs_info = obj.get("vcs_info")
         if isinstance(vcs_info, dict):
-            release_values.append(vcs_info.get("requested_revision"))
             sha_values.append(vcs_info.get("commit_id"))
         source = obj.get("source")
         if isinstance(source, dict):
@@ -131,6 +147,16 @@ def _load_json(path: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _load_json_text(text: str | None) -> dict[str, Any] | None:
+    if text is None:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
 
@@ -208,7 +234,7 @@ def cli_identity() -> ComponentIdentity:
     try:
         version = importlib.metadata.version("hhru-bot")
         distribution = importlib.metadata.distribution("hhru-bot")
-        direct_url = _load_json(Path(distribution.locate_file("direct_url.json")))
+        direct_url = _load_json_text(distribution.read_text("direct_url.json"))
         release, sha = _provenance_values(direct_url)
     except importlib.metadata.PackageNotFoundError:
         version, release, sha = None, None, None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -110,6 +110,20 @@ def test_direct_url_vcs_info_provides_commit_sha():
     assert sha == "d" * 40
 
 
+def test_noneditable_package_inside_checkout_does_not_inherit_checkout_sha(tmp_path: Path):
+    root = tmp_path / "project"
+    package = root / ".venv" / "lib" / "python3.12" / "site-packages" / "hhru_bot"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
+
+    assert _git_identity("installed CLI", package, require_package_source=True) is None
+
+
 def test_manifest_provenance_is_used_when_cache_has_no_git_directory(tmp_path: Path):
     root = tmp_path / "cache" / "0.2.0" / ".codex-plugin"
     root.mkdir(parents=True)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -12,6 +12,9 @@ import pytest
 from hhru_bot.provenance import (
     ComponentIdentity,
     DoctorResult,
+    _git_identity,
+    _load_json_text,
+    _provenance_values,
     compare_identities,
     plugin_cache_identity,
 )
@@ -56,16 +59,17 @@ def test_editable_checkout_uses_git_identity_not_manifest_version(tmp_path: Path
     (root / ".codex-plugin" / "plugin.json").write_text(
         json.dumps({"name": "hhru-cc-plugin", "version": "0.1.0"}), encoding="utf-8"
     )
+    (root / "pyproject.toml").write_text("[project]\nversion = '0.1.0'\n", encoding="utf-8")
     subprocess.run(["git", "init", "-q", str(root)], check=True)
     subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
     subprocess.run(["git", "-C", str(root), "add", "."], check=True)
     subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
 
-    identity = plugin_cache_identity(root)
+    identity = _git_identity("installed CLI", root)
 
     assert identity.source == "git"
-    assert identity.version != "0.1.0"
+    assert identity.version == "0.1.0"
     assert (
         identity.commit_sha
         == subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
@@ -84,6 +88,26 @@ def test_plugin_cache_reports_missing_provenance(tmp_path: Path):
     assert identity.version == "0.1.0"
     assert identity.commit_sha is None
     assert identity.complete is False
+
+
+def test_direct_url_vcs_info_provides_commit_sha():
+    direct_url = _load_json_text(
+        json.dumps(
+            {
+                "url": "https://github.com/axisrow/hhru",
+                "vcs_info": {
+                    "vcs": "git",
+                    "requested_revision": "main",
+                    "commit_id": "d" * 40,
+                },
+            }
+        )
+    )
+
+    assert direct_url is not None
+    release, sha = _provenance_values(direct_url)
+    assert release is None
+    assert sha == "d" * 40
 
 
 def test_manifest_provenance_is_used_when_cache_has_no_git_directory(tmp_path: Path):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,124 @@
+"""Checks for the CLI/plugin lifecycle provenance doctor (#674)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hhru_bot.provenance import (
+    ComponentIdentity,
+    DoctorResult,
+    compare_identities,
+    plugin_cache_identity,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _identity(name: str, *, version: str = "0.1.0", sha: str = "a" * 40):
+    return ComponentIdentity(name, version, "v0.1.0", sha)
+
+
+def test_doctor_detects_different_sha_even_when_versions_match():
+    result = compare_identities(
+        (
+            _identity("installed CLI", sha="a" * 40),
+            _identity("marketplace snapshot", sha="b" * 40),
+            _identity("installed plugin cache", sha="a" * 40),
+        )
+    )
+
+    assert result.drift is True
+    assert any("commit SHA" in reason for reason in result.reasons)
+
+
+def test_doctor_detects_different_version_and_sha():
+    result = compare_identities(
+        (
+            _identity("installed CLI"),
+            _identity("marketplace snapshot", version="0.2.0", sha="b" * 40),
+            _identity("installed plugin cache"),
+        )
+    )
+
+    assert result.drift is True
+    assert any("version" in reason for reason in result.reasons)
+    assert any("commit SHA" in reason for reason in result.reasons)
+
+
+def test_editable_checkout_uses_git_identity_not_manifest_version(tmp_path: Path):
+    root = tmp_path / "checkout"
+    (root / ".codex-plugin").mkdir(parents=True)
+    (root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "hhru-cc-plugin", "version": "0.1.0"}), encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
+
+    identity = plugin_cache_identity(root)
+
+    assert identity.source == "git"
+    assert identity.version != "0.1.0"
+    assert (
+        identity.commit_sha
+        == subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+    )
+
+
+def test_plugin_cache_reports_missing_provenance(tmp_path: Path):
+    root = tmp_path / "cache" / "0.1.0" / ".codex-plugin"
+    root.mkdir(parents=True)
+    (root / "plugin.json").write_text(
+        json.dumps({"name": "hhru-cc-plugin", "version": "0.1.0"}), encoding="utf-8"
+    )
+
+    identity = plugin_cache_identity(root.parent)
+
+    assert identity.version == "0.1.0"
+    assert identity.commit_sha is None
+    assert identity.complete is False
+
+
+def test_manifest_provenance_is_used_when_cache_has_no_git_directory(tmp_path: Path):
+    root = tmp_path / "cache" / "0.2.0" / ".codex-plugin"
+    root.mkdir(parents=True)
+    (root / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "hhru-cc-plugin",
+                "version": "0.2.0",
+                "provenance": {"release": "v0.2.0", "commit_sha": "c" * 40},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    identity = plugin_cache_identity(root.parent)
+
+    assert identity.complete is True
+    assert identity.release == "v0.2.0"
+    assert identity.commit_sha == "c" * 40
+
+
+def test_doctor_prints_one_recovery_command(capsys, monkeypatch):
+    from hhru_bot.commands import diagnostics
+
+    components = (_identity("installed CLI"), _identity("marketplace snapshot", sha="b" * 40))
+    monkeypatch.setattr(
+        diagnostics,
+        "run_doctor",
+        lambda **_: DoctorResult(components, True, ("different commit SHA",)),
+    )
+
+    assert (
+        diagnostics.run_doctor_command(SimpleNamespace(marketplace=None, plugin_cache=None)) is True
+    )
+    output = capsys.readouterr().out
+    assert output.count("codex plugin marketplace upgrade hhru --json") == 1


### PR DESCRIPTION
## Summary
- add `hhru diagnostics doctor` to compare version, release/tag, and commit SHA across CLI, marketplace snapshot, and Codex plugin cache
- support editable checkouts via git identity and manifest provenance for packaged installs
- report one recovery command on drift and add adversarial provenance tests

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `python3 scripts/gen_cli_docs.py --check`
- `pytest`

## Dependency
Issue #673 remains open; the collector has a seam for its generated provenance source and currently falls back to git/manifest metadata.

Closes #674