### PR TITLE
fix: regenerate plugin marketplace manifest

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -19,11 +19,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity",
-      "version": "0.1.0"
+      "category": "Productivity"
     }
-  ],
-  "metadata": {
-    "version": "0.1.0"
-  }
+  ]
 }


### PR DESCRIPTION
Closes #687

## Summary
- Regenerate `.agents/plugins/marketplace.json` with `scripts/sync_plugin_manifests.py`.
- Remove duplicate manifest entries introduced by the merge collision.
- Confirm the existing CI `sync --check` guard covers future drift.

## Tests
- `python3 scripts/sync_plugin_manifests.py --check`
- duplicate-key validation with `json.load(..., object_pairs_hook=...)`
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`