### PR TITLE
ci: lint and format scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
         run: python -m playwright install chromium
 
       - name: Ruff check
-        run: ruff check src tests
+        run: ruff check src tests scripts
 
       - name: Ruff format check
-        run: ruff format --check src tests
+        run: ruff format --check src tests scripts
 
       - name: Plugin manifests in sync with package version
         run: python3 scripts/sync_plugin_manifests.py --check

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -1035,10 +1035,10 @@ def _reconcile_audit_metadata(catalog: dict[str, Any]) -> None:
         previous_origin = row.get("origin")
         if sources:
             reference_count = len(sources)
-            lost_consensus = (
-                reference_count < 2
-                and previous_origin in {"reference_exact", "reference_consensus"}
-            )
+            lost_consensus = reference_count < 2 and previous_origin in {
+                "reference_exact",
+                "reference_consensus",
+            }
             row["coverage_status"] = "reference_binding"
             row["origin"] = (
                 "reference_exact"


### PR DESCRIPTION
## Summary
- Format scripts/selector_contracts.py with Ruff.
- Run Ruff check and format coverage across src tests scripts in CI.

## Tests
- ruff check src tests scripts
- ruff format --check src tests scripts
- ruff check src tests
- ruff format --check src tests
- pytest --deselect tests/test_plugin_metadata.py::test_plugin_manifests_are_currently_generated_from_pyproject (2586 passed, 4 deselected)
- Full pytest: 1 known failure in tests/test_plugin_metadata.py::test_plugin_manifests_are_currently_generated_from_pyproject due to the unrelated #687 marketplace manifest mismatch.

Closes #686
