### PR TITLE
fix(release): validate marketplace release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Plugin manifests in sync with package version
         run: python3 scripts/sync_plugin_manifests.py --check
 
+      - name: Plugin marketplace refs resolve
+        run: python3 scripts/check_plugin_refs.py
+
       - name: Pytest suite budget (Linux)
         if: runner.os == 'Linux'
         run: python scripts/check_pytest_budget.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         run: python3 scripts/sync_plugin_manifests.py --check
 
       - name: Plugin marketplace refs resolve
+        # A version-bump PR is allowed to introduce its future release tag;
+        # the push checks below validate it before/when release publication runs.
+        if: github.event_name != 'pull_request'
         run: python3 scripts/check_plugin_refs.py
 
       - name: Pytest suite budget (Linux)

--- a/docs/plugin-packaging.md
+++ b/docs/plugin-packaging.md
@@ -20,6 +20,16 @@ different version. It updates these fields:
 - `.agents/plugins/marketplace.json:metadata.version` and
   `plugins[0].version`.
 
+## Release refs
+
+The Codex marketplace uses the release model introduced by #676 and merged in
+#681: its Git source must point to the version tag (`v` plus
+`pyproject.toml`'s version), rather than to a floating branch. CI runs
+`python3 scripts/check_plugin_refs.py`, which resolves every URL source with
+`git ls-remote` and fails if the referenced tag is absent. The first release
+therefore requires publishing `v0.1.0`; subsequent version bumps require a
+corresponding tag before their marketplace manifest can pass CI.
+
 The marketplace files are both needed. `.claude-plugin/marketplace.json` is
 the Claude Code local marketplace entry (`source: "./"`), while
 `.agents/plugins/marketplace.json` is the Codex team marketplace entry (a Git

--- a/docs/plugin-packaging.md
+++ b/docs/plugin-packaging.md
@@ -26,9 +26,11 @@ The Codex marketplace uses the release model introduced by #676 and merged in
 #681: its Git source must point to the version tag (`v` plus
 `pyproject.toml`'s version), rather than to a floating branch. CI runs
 `python3 scripts/check_plugin_refs.py`, which resolves every URL source with
-`git ls-remote` and fails if the referenced tag is absent. The first release
-therefore requires publishing `v0.1.0`; subsequent version bumps require a
-corresponding tag before their marketplace manifest can pass CI.
+`git ls-remote` and fails if the referenced tag is absent. The check runs on
+pushes (including the tag-triggered release workflow), not on pull requests:
+the first release therefore requires publishing `v0.1.0` after its release
+commit is selected, and subsequent version bumps require a corresponding tag
+before the resulting push can pass CI.
 
 The marketplace files are both needed. `.claude-plugin/marketplace.json` is
 the Claude Code local marketplace entry (`source: "./"`), while

--- a/scripts/check_plugin_refs.py
+++ b/scripts/check_plugin_refs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Check that release tags in the checked-in plugin marketplaces resolve remotely.
+
+Manifest synchronization proves that generated version fields are current. It
+does not prove that an installation can resolve the Git tag used by the
+marketplace. This check closes that gap without changing the install-time
+manifest: every URL source is queried with ``git ls-remote``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+MARKETPLACE_PATHS = (Path(".agents/plugins/marketplace.json"),)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read marketplace manifest {path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"marketplace manifest must be a JSON object: {path}")
+    return value
+
+
+def _tag_exists(url: str, ref: str) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--exit-code", "--refs", url, f"refs/tags/{ref}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc)
+    if result.returncode == 0 and result.stdout.strip():
+        return True, ""
+    detail = result.stderr.strip() or "remote ref was not found"
+    return False, detail
+
+
+def check_refs(root: Path) -> list[str]:
+    """Return human-readable errors for URL refs missing from their remotes."""
+
+    errors: list[str] = []
+    for relative_path in MARKETPLACE_PATHS:
+        path = root / relative_path
+        try:
+            manifest = _load(path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        plugins = manifest.get("plugins")
+        if not isinstance(plugins, list):
+            errors.append(f"marketplace manifest has no plugins list: {relative_path}")
+            continue
+        for index, plugin in enumerate(plugins):
+            if not isinstance(plugin, dict):
+                errors.append(f"plugin entry {index} is not an object: {relative_path}")
+                continue
+            source = plugin.get("source")
+            if not isinstance(source, dict) or source.get("source") != "url":
+                continue
+            url = source.get("url")
+            ref = source.get("ref")
+            label = f"{relative_path} plugins[{index}]"
+            if not isinstance(url, str) or not url:
+                errors.append(f"{label} has no Git URL")
+                continue
+            if not isinstance(ref, str) or not ref:
+                errors.append(f"{label} has no Git ref")
+                continue
+            exists, detail = _tag_exists(url, ref)
+            if not exists:
+                errors.append(f"{label} tag {ref!r} does not resolve in {url}: {detail}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+
+    errors = check_refs(args.root.resolve())
+    if errors:
+        print("Plugin marketplace refs are invalid:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("Plugin marketplace refs resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_plugin_refs.py
+++ b/scripts/check_plugin_refs.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,17 @@ def _load(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"marketplace manifest must be a JSON object: {path}")
     return value
+
+
+def _expected_tag(root: Path) -> str:
+    try:
+        with (root / "pyproject.toml").open("rb") as stream:
+            version = tomllib.load(stream)["project"]["version"]
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"cannot read project.version from {root / 'pyproject.toml'}") from exc
+    if not isinstance(version, str) or not version:
+        raise ValueError("project.version must be a non-empty string")
+    return f"v{version}"
 
 
 def _tag_exists(url: str, ref: str) -> tuple[bool, str]:
@@ -50,6 +62,10 @@ def check_refs(root: Path) -> list[str]:
     """Return human-readable errors for URL refs missing from their remotes."""
 
     errors: list[str] = []
+    try:
+        expected_tag = _expected_tag(root)
+    except ValueError as exc:
+        return [str(exc)]
     for relative_path in MARKETPLACE_PATHS:
         path = root / relative_path
         try:
@@ -77,6 +93,11 @@ def check_refs(root: Path) -> list[str]:
                 continue
             if not isinstance(ref, str) or not ref:
                 errors.append(f"{label} has no Git ref")
+                continue
+            if ref != expected_tag:
+                errors.append(
+                    f"{label} tag {ref!r} does not match project version; expected {expected_tag!r}"
+                )
                 continue
             exists, detail = _tag_exists(url, ref)
             if not exists:

--- a/tests/test_plugin_refs.py
+++ b/tests/test_plugin_refs.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.smoke
 
 
 def _write_marketplace(root: Path, *, url: str, ref: str) -> None:
+    (root / "pyproject.toml").write_text('[project]\nversion = "0.1.0"\n', encoding="utf-8")
     path = root / ".agents/plugins/marketplace.json"
     path.parent.mkdir(parents=True)
     path.write_text(
@@ -66,3 +67,19 @@ def test_check_refs_rejects_a_missing_remote_ref(tmp_path, monkeypatch):
     errors = check_plugin_refs.check_refs(tmp_path)
     assert len(errors) == 1
     assert "tag 'v0.1.0' does not resolve" in errors[0]
+
+
+def test_check_refs_rejects_a_tag_for_another_project_version(tmp_path, monkeypatch):
+    _write_marketplace(tmp_path, url="https://github.com/axisrow/hhru.git", ref="v0.1.0")
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.2.0"\n', encoding="utf-8")
+
+    def fail_if_called(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("a mismatched tag must not be queried")
+
+    monkeypatch.setattr(check_plugin_refs.subprocess, "run", fail_if_called)
+
+    errors = check_plugin_refs.check_refs(tmp_path)
+    assert errors == [
+        ".agents/plugins/marketplace.json plugins[0] tag 'v0.1.0' does not match "
+        "project version; expected 'v0.2.0'"
+    ]

--- a/tests/test_plugin_refs.py
+++ b/tests/test_plugin_refs.py
@@ -1,0 +1,68 @@
+"""Regression tests for installable plugin marketplace refs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from scripts import check_plugin_refs  # noqa: E402
+
+pytestmark = pytest.mark.smoke
+
+
+def _write_marketplace(root: Path, *, url: str, ref: str) -> None:
+    path = root / ".agents/plugins/marketplace.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "plugins": [
+                    {"name": "hhru-cc-plugin", "source": {"source": "url", "url": url, "ref": ref}}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_check_refs_accepts_a_remote_ref(tmp_path, monkeypatch):
+    _write_marketplace(tmp_path, url="https://github.com/axisrow/hhru.git", ref="v0.1.0")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):  # noqa: ANN001
+        calls.append(command)
+        assert kwargs["timeout"] == 30
+        return subprocess.CompletedProcess(command, 0, "0123 refs/tags/v0.1.0\n", "")
+
+    monkeypatch.setattr(check_plugin_refs.subprocess, "run", fake_run)
+
+    assert check_plugin_refs.check_refs(tmp_path) == []
+    assert calls == [
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--refs",
+            "https://github.com/axisrow/hhru.git",
+            "refs/tags/v0.1.0",
+        ]
+    ]
+
+
+def test_check_refs_rejects_a_missing_remote_ref(tmp_path, monkeypatch):
+    _write_marketplace(tmp_path, url="https://github.com/axisrow/hhru.git", ref="v0.1.0")
+
+    def fake_run(command, **kwargs):  # noqa: ANN001
+        return subprocess.CompletedProcess(command, 2, "", "fatal: ref not found\n")
+
+    monkeypatch.setattr(check_plugin_refs.subprocess, "run", fake_run)
+
+    errors = check_plugin_refs.check_refs(tmp_path)
+    assert len(errors) == 1
+    assert "tag 'v0.1.0' does not resolve" in errors[0]

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 import tarfile
 from pathlib import Path
@@ -18,8 +19,18 @@ pytestmark = pytest.mark.smoke
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
 
 
+def _tagless_source(tmp_path: Path) -> Path:
+    """Build from a checkout without the repository's real release tags."""
+    source = Path(__file__).parents[1]
+    return shutil.copytree(
+        source,
+        tmp_path / "source",
+        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+    )
+
+
 def test_release_bundle_stamps_every_manifest_and_contains_installed_skill(tmp_path):
-    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+    archive = build_release(_tagless_source(tmp_path), tmp_path, "v0.1.0", COMMIT)
 
     with tarfile.open(archive, "r:gz") as opened:
         opened.extractall(tmp_path / "installed", filter="data")
@@ -42,7 +53,7 @@ def test_release_bundle_stamps_every_manifest_and_contains_installed_skill(tmp_p
 
 
 def test_release_validation_rejects_manifest_from_another_commit(tmp_path):
-    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+    archive = build_release(_tagless_source(tmp_path), tmp_path, "v0.1.0", COMMIT)
     with tarfile.open(archive, "r:gz") as opened:
         opened.extractall(tmp_path / "installed", filter="data")
     bundle = next((tmp_path / "installed").iterdir())


### PR DESCRIPTION
Closes #693

## Summary

- Choose release model (A): keep the marketplace on `v0.1.0` because #681 (squash `e6a47deb`) already introduced one-tag CLI/plugin releases and tag-triggered publication.
- Add an automated push-time check that resolves every URL source as a remote Git tag, catching missing or stale install refs outside manual installation. Pull requests are intentionally not blocked on a future release tag; pushes and tag-triggered release workflows validate it.
- Add regression coverage and document that every version bump requires its corresponding release tag.

The annotated `v0.1.0` tag was explicitly authorized and published at the then-current `origin/main` release commit `c7d8f36`. The marketplace upgrade was verified locally with `codex plugin marketplace upgrade hhru --json` and returned `errors: []`.

## Tests

- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `pytest` (2598 passed, 1 skipped, 3 deselected)

## Known risk

Release tags remain a deliberate release operation: each package version bump must publish its matching `v<version>` tag so the marketplace ref and tag-triggered release stay resolvable.