### PR TITLE
fix(diagnostics): recommend unified hhru update

### DIFF
--- a/src/hhru_bot/provenance.py
+++ b/src/hhru_bot/provenance.py
@@ -20,7 +20,7 @@ from typing import Any
 
 PLUGIN_NAME = "hhru-cc-plugin"
 MARKETPLACE_NAME = "hhru"
-RECOVERY_COMMAND = "codex plugin marketplace upgrade hhru --json"
+RECOVERY_COMMAND = "hhru update"
 
 
 @dataclass(frozen=True)

--- a/src/hhru_bot/provenance.py
+++ b/src/hhru_bot/provenance.py
@@ -342,6 +342,11 @@ def compare_identities(components: Iterable[ComponentIdentity]) -> DoctorResult:
             ("commit_sha", "commit SHA"),
         ):
             values = {getattr(component, field) for component in components}
+            # A wheel installed from an immutable commit has PEP 610 commit
+            # provenance but no release tag. Matching commit provenance is the
+            # stronger identity check; an absent tag alone is not drift.
+            if field == "release" and None in values:
+                continue
             if len(values) > 1:
                 reasons.append(
                     f"разный {label}: "

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -152,7 +152,7 @@ def test_doctor_recovery_action_clears_drift(capsys, monkeypatch):
 
     state = {
         "components": (
-            _identity("installed CLI", sha="a" * 40),
+            ComponentIdentity("installed CLI", "0.1.0", None, "a" * 40),
             _identity("marketplace snapshot", sha="b" * 40),
             _identity("installed plugin cache", sha="b" * 40),
         )
@@ -165,7 +165,8 @@ def test_doctor_recovery_action_clears_drift(capsys, monkeypatch):
 
     def unified_update(**_kwargs):
         state["components"] = tuple(
-            _identity(component.name, sha="c" * 40) for component in state["components"]
+            ComponentIdentity(component.name, component.version, component.release, "c" * 40)
+            for component in state["components"]
         )
         return SimpleNamespace(
             release=SimpleNamespace(version="0.1.0", commit="c" * 40),

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,7 +12,6 @@ import pytest
 
 from hhru_bot.provenance import (
     ComponentIdentity,
-    DoctorResult,
     _git_identity,
     _load_json_text,
     _provenance_values,
@@ -145,18 +145,52 @@ def test_manifest_provenance_is_used_when_cache_has_no_git_directory(tmp_path: P
     assert identity.commit_sha == "c" * 40
 
 
-def test_doctor_prints_one_recovery_command(capsys, monkeypatch):
+def test_doctor_recovery_action_clears_drift(capsys, monkeypatch):
+    from hhru_bot.cli import build_parser
     from hhru_bot.commands import diagnostics
+    from hhru_bot.commands import update as update_command
 
-    components = (_identity("installed CLI"), _identity("marketplace snapshot", sha="b" * 40))
+    state = {
+        "components": (
+            _identity("installed CLI", sha="a" * 40),
+            _identity("marketplace snapshot", sha="b" * 40),
+            _identity("installed plugin cache", sha="b" * 40),
+        )
+    }
     monkeypatch.setattr(
         diagnostics,
         "run_doctor",
-        lambda **_: DoctorResult(components, True, ("different commit SHA",)),
+        lambda **_: compare_identities(state["components"]),
     )
 
-    assert (
-        diagnostics.run_doctor_command(SimpleNamespace(marketplace=None, plugin_cache=None)) is True
-    )
+    def unified_update(**_kwargs):
+        state["components"] = tuple(
+            _identity(component.name, sha="c" * 40) for component in state["components"]
+        )
+        return SimpleNamespace(
+            release=SimpleNamespace(version="0.1.0", commit="c" * 40),
+            cli_source="test-cli",
+            plugin_source="test-plugin",
+        )
+
+    monkeypatch.setattr(update_command, "update", unified_update)
+
+    assert diagnostics.run_doctor_command(SimpleNamespace(marketplace=None, plugin_cache=None))
     output = capsys.readouterr().out
-    assert output.count("codex plugin marketplace upgrade hhru --json") == 1
+    fix_line = next(line for line in output.splitlines() if line.startswith("[FIX] "))
+    recommended_argv = shlex.split(fix_line.split(": ", 1)[1])
+
+    # Execute the action advertised by doctor through the real CLI parser. This
+    # rejects plugin-only commands and verifies that the recommendation reaches
+    # the unified update command rather than merely matching a string literal.
+    args = build_parser().parse_args(recommended_argv[1:])
+    assert args.func is update_command.run
+    assert args.func(args) is None
+    capsys.readouterr()
+
+    assert not compare_identities(state["components"]).drift
+    assert (
+        diagnostics.run_doctor_command(SimpleNamespace(marketplace=None, plugin_cache=None))
+        is False
+    )
+    assert "[OK]" in capsys.readouterr().out


### PR DESCRIPTION
Closes #694

## Summary
- point doctor drift recovery at the unified `hhru update` flow from #675/#685
- treat a missing release tag as non-drift when immutable commit provenance agrees (the normal non-editable pip install shape)
- replace the literal-only provenance test with a behavioral contract test that executes the advertised CLI action and verifies doctor returns `[OK]` with CLI, marketplace, and plugin aligned

## Dependency
- Stacked on open PR #685; it is not merged yet. This PR intentionally targets its update command.
- Does not change the unrelated ref/tag implementation in #693/#695.

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest tests/test_provenance.py` (8 passed)
- `pytest` (2606 passed, 1 skipped, 3 deselected; 2 release-packaging fixture failures because the now-existing local `v0.1.0` tag points at `c7d8f36` while those fixtures use a synthetic SHA; unrelated to this change and covered by open #695)