### PR TITLE
fix: close selector provenance audit gap

### DIFF
--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -974,6 +974,12 @@ def _ensure_extra_contracts(catalog: dict[str, Any], evidence: dict[str, Any]) -
             "decision": decision,
             "sources": {},
             "live_matches": live_matches,
+            **_audit_metadata(
+                logical_id,
+                sources={},
+                live_matches=live_matches,
+                declared_at=contract["declared_at"],
+            ),
         }
         if decision in {"documented_live", "workflow_live"}:
             row["evidence"] = {
@@ -992,11 +998,15 @@ def _audit_metadata(
     today: str | None = None,
 ) -> dict[str, Any]:
     """Return deterministic bootstrap provenance for audited selector groups."""
-    if not logical_id.startswith(AUDITED_SELECTOR_GROUP_PREFIXES):
-        return {}
     verified_at = today or date.today().isoformat()
     reference_count = len(sources)
-    if reference_count >= 2:
+    if reference_count >= 3:
+        origin = "reference_exact"
+        status = "reference_binding"
+        verification = "contract_tested"
+        flow = "reference_selector_scan_and_contract_check"
+        note = "Exact selector value is bound to all three approved reference sources."
+    elif reference_count >= 2:
         origin = "reference_consensus"
         status = "reference_binding"
         verification = "contract_tested"

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -52,7 +52,23 @@ REFERENCE_CONFIG = {
     },
 }
 
-AUDITED_SELECTOR_GROUP_PREFIXES = ("search_page.", "vacancy_page.")
+# Keep this list aligned with ``src/hhru_bot/selector_groups``.  The login
+# module's catalog IDs retain the historical ``selectors.`` prefix, so it is
+# included here as the audit prefix for ``selector_groups/login.py``.
+AUDITED_SELECTOR_GROUP_PREFIXES = (
+    "account_profile.",
+    "apply_form.",
+    "competitor_resume.",
+    "negotiations.",
+    "resume_experience.",
+    "resume_list.",
+    "resume_page.",
+    "resume_rename.",
+    "resume_visibility.",
+    "search_page.",
+    "vacancy_page.",
+    "selectors.",
+)
 AUDIT_REQUIRED_FIELDS = (
     "coverage_status",
     "origin",
@@ -975,7 +991,7 @@ def _audit_metadata(
     declared_at: str,
     today: str | None = None,
 ) -> dict[str, Any]:
-    """Return deterministic bootstrap provenance for the audited page groups."""
+    """Return deterministic bootstrap provenance for audited selector groups."""
     if not logical_id.startswith(AUDITED_SELECTOR_GROUP_PREFIXES):
         return {}
     verified_at = today or date.today().isoformat()
@@ -1423,12 +1439,15 @@ def verify_catalog(catalog: dict[str, Any]) -> list[str]:
     if catalog.get("binding_definitions") != _binding_definitions():
         errors.append("semantic reference bindings are stale; run selector refresh")
     for logical_id, row in catalog.get("selectors", {}).items():
+        # coverage_status is the catalog-wide canonical provenance field.  Do
+        # this check before the group-specific audit so records outside the
+        # page-group list cannot silently omit or bypass it.
+        if row.get("coverage_status") not in AUDIT_STATUSES:
+            errors.append(f"{logical_id}: invalid coverage_status")
         if logical_id.startswith(AUDITED_SELECTOR_GROUP_PREFIXES):
             for field in AUDIT_REQUIRED_FIELDS:
                 if not row.get(field):
                     errors.append(f"{logical_id}: missing audit field {field}")
-            if row.get("coverage_status") not in AUDIT_STATUSES:
-                errors.append(f"{logical_id}: invalid coverage_status")
             if row.get("origin") not in AUDIT_ORIGINS:
                 errors.append(f"{logical_id}: invalid origin")
             if row.get("coverage_status") == "reference_binding":

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -1055,8 +1055,6 @@ def _reconcile_audit_metadata(catalog: dict[str, Any]) -> None:
     """Invalidate reference provenance when a refresh changes its bindings."""
     today = date.today().isoformat()
     for logical_id, row in catalog.get("selectors", {}).items():
-        if not logical_id.startswith(AUDITED_SELECTOR_GROUP_PREFIXES):
-            continue
         sources = row.get("sources", {})
         previous_origin = row.get("origin")
         if sources:
@@ -1112,8 +1110,6 @@ def _has_reviewed_runtime_evidence(logical_id: str, row: dict[str, Any]) -> bool
     """Do not let audit bookkeeping become activation evidence on refresh."""
     if not row.get("evidence"):
         return False
-    if not logical_id.startswith(AUDITED_SELECTOR_GROUP_PREFIXES):
-        return True
     if row["evidence"].get("runtime_authoritative") is False:
         return False
     return not (not row.get("active", True) and row.get("decision") == "unavailable")

--- a/scripts/selector_contracts.py
+++ b/scripts/selector_contracts.py
@@ -1057,6 +1057,13 @@ def _reconcile_audit_metadata(catalog: dict[str, Any]) -> None:
     for logical_id, row in catalog.get("selectors", {}).items():
         sources = row.get("sources", {})
         previous_origin = row.get("origin")
+        # A durable failure is stronger than any refreshed metadata. Keep the
+        # row unavailable even when the source set is empty and the audit
+        # fields need bootstrapping.
+        if row.get("verification") in {"unavailable", "failed"}:
+            row["decision"] = "unavailable"
+            row["active"] = False
+            continue
         if sources:
             reference_count = len(sources)
             lost_consensus = reference_count < 2 and previous_origin in {

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -30,10 +30,11 @@ selectors:
       source: src/hhru_bot/selector_groups/account_profile.py:30
       note: Account-level fields from the authenticated live DOM observed on 2026-08-18.
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_account_profile_read_only
     verified_by: codex
@@ -48,10 +49,11 @@ selectors:
       source: src/hhru_bot/selector_groups/account_profile.py:32
       note: Account-level fields from the authenticated live DOM observed on 2026-08-18.
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_account_profile_read_only
     verified_by: codex
@@ -66,10 +68,11 @@ selectors:
       source: src/hhru_bot/selector_groups/account_profile.py:28
       note: Account-level fields from the authenticated live DOM observed on 2026-08-18.
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_account_profile_read_only
     verified_by: codex
@@ -84,10 +87,11 @@ selectors:
       source: src/hhru_bot/selector_groups/account_profile.py:29
       note: Account-level fields from the authenticated live DOM observed on 2026-08-18.
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_account_profile_read_only
     verified_by: codex
@@ -102,10 +106,11 @@ selectors:
       source: src/hhru_bot/selector_groups/account_profile.py:31
       note: Account-level fields from the authenticated live DOM observed on 2026-08-18.
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_account_profile_read_only
     verified_by: codex
@@ -118,10 +123,11 @@ selectors:
     live_matches:
     - title
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/account_profile.py:23
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -138,10 +144,11 @@ selectors:
     live_matches:
     - resume-contact-email-value
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/account_profile.py:37
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -158,10 +165,11 @@ selectors:
     live_matches:
     - resume-contact-phone-value-preferred
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/account_profile.py:36
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -178,10 +186,11 @@ selectors:
     live_matches:
     - profile-activator-fullname
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/account_profile.py:41
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -201,7 +210,7 @@ selectors:
       note: fail-closed captcha detector; absence never authorizes a write
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -219,7 +228,7 @@ selectors:
       note: fail-closed captcha detector; absence never authorizes a write
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -237,7 +246,7 @@ selectors:
       note: fail-closed captcha detector; absence never authorizes a write
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -251,6 +260,7 @@ selectors:
     sources: {}
     live_matches: []
     active: false
+    coverage_status: needs_live_evidence
     bindings:
       tgeruzov:
       - file: script.js
@@ -307,8 +317,8 @@ selectors:
         line: 790
         key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form#0::0
         value: '[data-qa="vacancy-response-popup-form-letter-input"]'
-    coverage_status: reference binding
-    origin: browser_dom
+    coverage_status: reference_binding
+    origin: reference_single
     verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/apply_form.py:90
@@ -334,7 +344,7 @@ selectors:
       note: значением (сверено на вакансии с опциональным письмом на ПОЛНОЙ форме —
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: browser_observed
     last_verified_at: 2026-08-20
@@ -370,7 +380,7 @@ selectors:
         line: 769
         key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form.add_letter_btn#0::0
         value: '[data-qa="vacancy-response-letter-toggle"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_consensus
     verification: browser_observed
     evidence:
@@ -404,8 +414,8 @@ selectors:
         line: 71
         key: script.js::module.SELECTORS.attachCoverInModal#0::2
         value: '[data-qa="add-cover-letter"]'
-    coverage_status: reference binding
-    origin: browser_dom
+    coverage_status: reference_binding
+    origin: reference_single
     verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/apply_form.py:71
@@ -437,7 +447,7 @@ selectors:
         line: 510
         key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form.blocks#0::0
         value: '[data-qa="task-body"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     evidence:
@@ -458,7 +468,7 @@ selectors:
     - task-body
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: browser_observed
     evidence:
@@ -478,7 +488,7 @@ selectors:
     - task-question
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -497,7 +507,7 @@ selectors:
     - drop-base
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -523,7 +533,7 @@ selectors:
         line: 878
         key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form.first_resume#0::0
         value: '[data-qa="vacancy-response-popup-form-resume-option"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     evidence:
@@ -549,7 +559,7 @@ selectors:
         line: 873
         key: app/parsers/hh_playwright.py::module.HHPlaywright._fill_response_form.resume_select#0::0
         value: '[data-qa="vacancy-response-popup-form-resume-dropdown"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     evidence:
@@ -570,7 +580,7 @@ selectors:
     - resume-title
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -618,7 +628,7 @@ selectors:
         line: 366
         key: app/parsers/hh_playwright.py::module.HHPlaywright.apply_to_vacancy.submit_btn#0::0
         value: '[data-qa="vacancy-response-submit-popup"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_consensus
     verification: browser_observed
     evidence:
@@ -648,7 +658,7 @@ selectors:
       source: live browser run 2026-08-25
       note: Read-only navigation to https://hh.ru/account/login found one account-login-form marker in the rendered DOM; no
         account mutation performed.
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-25'
@@ -667,6 +677,7 @@ selectors:
       source: docs/research/issue-679-live-probe.md
       note: Read-only Chrome observation of the public resume city marker on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -686,6 +697,7 @@ selectors:
       note: Read-only Chrome observation of the public resume header paragraph containing city, relocation and business-trip
         text on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -704,6 +716,7 @@ selectors:
       source: docs/research/issue-679-live-probe.md
       note: Read-only Chrome observation of the public resume relocation marker on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -720,10 +733,11 @@ selectors:
       source: src/hhru_bot/selector_groups/competitor_resume.py:8
       note: read-only public-resume pagination fallback; cannot trigger a mutation
     active: true
+    coverage_status: not_implemented_upstream
     bindings: {}
     status: not implemented upstream
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: public_resume_search_read_only
     verified_by: codex
@@ -738,10 +752,11 @@ selectors:
       source: src/hhru_bot/selector_groups/competitor_resume.py:7
       note: read-only public-resume pagination fallback; cannot trigger a mutation
     active: true
+    coverage_status: not_implemented_upstream
     bindings: {}
     status: not implemented upstream
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: public_resume_search_read_only
     verified_by: codex
@@ -756,10 +771,11 @@ selectors:
       source: src/hhru_bot/selector_groups/competitor_resume.py:9
       note: read-only public-resume pagination fallback; cannot trigger a mutation
     active: true
+    coverage_status: not_implemented_upstream
     bindings: {}
     status: not implemented upstream
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: public_resume_search_read_only
     verified_by: codex
@@ -776,6 +792,7 @@ selectors:
       source: docs/research/issue-679-live-probe.md
       note: Read-only Chrome observation of combined area and business-trip field on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -794,6 +811,7 @@ selectors:
       source: docs/research/issue-679-live-probe.md
       note: Read-only Chrome observation of resume search cards on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -810,10 +828,11 @@ selectors:
       source: src/hhru_bot/selector_groups/competitor_resume.py:6
       note: read-only empty-state union; callers still require confirmed page state
     active: true
+    coverage_status: not_implemented_upstream
     bindings: {}
     status: not implemented upstream
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: public_resume_search_read_only
     verified_by: codex
@@ -830,6 +849,7 @@ selectors:
       source: docs/research/issue-679-live-probe.md
       note: Read-only Chrome observation of resume search card title links on 2026-08-27.
     active: true
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-27T00:00:00Z'
@@ -847,7 +867,7 @@ selectors:
       source: src/hhru_bot/create_resume.py:1
       note: reviewed existing runtime selector and its read-only/live workflow
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -865,10 +885,10 @@ selectors:
       source: src/hhru_bot/negotiations_chat.py:1
       note: reviewed existing runtime selector and its read-only/live workflow
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unverified
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations chat author attribution (not run)
     verified_by: human
   negotiations.CHAT_MESSAGE_INPUT:
@@ -890,7 +910,7 @@ selectors:
         line: 1374
         key: app/parsers/hh_playwright.py::module.HHPlaywright.send_thanks_via_clicks.input_selectors#0::0
         value: '[data-qa="chatik-new-message-text"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -908,10 +928,10 @@ selectors:
       source: src/hhru_bot/selector_groups/negotiations.py:1
       note: reviewed existing runtime selector and its read-only/live workflow
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unverified
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations chat message parsing (not run)
     verified_by: human
   negotiations.CHAT_MESSAGE_SEND:
@@ -933,7 +953,7 @@ selectors:
         line: 1409
         key: app/parsers/hh_playwright.py::module.HHPlaywright.send_thanks_via_clicks.send_selectors#0::0
         value: '[data-qa="chatik-do-send-message"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -1061,13 +1081,13 @@ selectors:
     - working-hours-text
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unverified
     evidence:
       source: src/hhru_bot/selector_groups/negotiations.py:74
       note: The saved live-match list contains unrelated *-text nodes; a scoped authenticated chat artifact is still required.
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations chat message parsing (not run)
     verified_by: human
   negotiations.LEGACY_NEGOTIATION_CHAT_LINK:
@@ -1082,7 +1102,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: contract_tested
     last_verified_at: 2026-08-16
@@ -1100,7 +1120,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: contract_tested
     last_verified_at: 2026-08-16
@@ -1118,7 +1138,7 @@ selectors:
       note: read-only compatibility with saved legacy markup
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: contract_tested
     last_verified_at: 2026-08-16
@@ -1136,7 +1156,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: contract_tested
     last_verified_at: 2026-08-16
@@ -1154,7 +1174,7 @@ selectors:
       note: read-only compatibility with saved legacy markup
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: manual
     verification: contract_tested
     last_verified_at: 2026-08-16
@@ -1172,7 +1192,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     last_verified_at: 2026-08-16
@@ -1190,7 +1210,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     last_verified_at: 2026-08-16
@@ -1208,7 +1228,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     last_verified_at: 2026-08-16
@@ -1226,7 +1246,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     last_verified_at: 2026-08-16
@@ -1244,7 +1264,7 @@ selectors:
       note: Страница откликов и переписки (/applicant/negotiations), сверенная 2026-08-16.
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     last_verified_at: 2026-08-16
@@ -1274,7 +1294,7 @@ selectors:
         line: 977
         key: app/parsers/hh_playwright.py::module.HHPlaywright._parse_negotiation_item.company_el#0::0
         value: '[data-qa="negotiations-item-company"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -1312,7 +1332,7 @@ selectors:
         line: 1030
         key: app/parsers/hh_playwright.py::module.HHPlaywright.check_negotiations_status#0::1
         value: '[data-qa="negotiations-item"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -1337,7 +1357,7 @@ selectors:
         line: 980
         key: app/parsers/hh_playwright.py::module.HHPlaywright._parse_negotiation_item.status_el#0::0
         value: '[data-qa="negotiations-item-status"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -1362,7 +1382,7 @@ selectors:
         line: 970
         key: app/parsers/hh_playwright.py::module.HHPlaywright._parse_negotiation_item.title_el#0::0
         value: '[data-qa="negotiations-item-title"]'
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -1377,13 +1397,13 @@ selectors:
     live_matches: []
     active: false
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unavailable
     evidence:
       source: src/hhru_bot/selector_groups/negotiations.py:52
       note: No authenticated withdrawal DOM snapshot or safe read-only flow was run; selector remains inactive and fail-closed.
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations withdrawal (not run; write path disabled)
     verified_by: human
     unavailable_reason: Read-only audit 2026-08-25 found no saved DOM snapshot and no approved reference source with a browser/UI
@@ -1397,13 +1417,13 @@ selectors:
     live_matches: []
     active: false
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unavailable
     evidence:
       source: src/hhru_bot/selector_groups/negotiations.py:52
       note: No authenticated withdrawal DOM snapshot or safe read-only flow was run; selector remains inactive and fail-closed.
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations withdrawal (not run; write path disabled)
     verified_by: human
     unavailable_reason: Read-only audit 2026-08-25 found no saved DOM snapshot and no approved reference source with a browser/UI
@@ -1417,13 +1437,13 @@ selectors:
     live_matches: []
     active: false
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: manual
     verification: unavailable
     evidence:
       source: src/hhru_bot/selector_groups/negotiations.py:52
       note: No authenticated withdrawal DOM snapshot or safe read-only flow was run; selector remains inactive and fail-closed.
-    last_verified_at: null
+    last_verified_at: '2026-08-25'
     verified_flow: negotiations withdrawal (not run; write path disabled)
     verified_by: human
     unavailable_reason: Read-only audit 2026-08-25 found no saved DOM snapshot and no approved reference source with a browser/UI
@@ -1442,7 +1462,7 @@ selectors:
         successfully.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-25'
@@ -1460,7 +1480,7 @@ selectors:
       source: src/hhru_bot/professional_roles.py:1
       note: reviewed existing runtime selector and its read-only/live workflow
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -1478,7 +1498,7 @@ selectors:
       source: src/hhru_bot/professional_roles.py:1
       note: reviewed existing runtime selector and its read-only/live workflow
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -1497,7 +1517,7 @@ selectors:
         successfully.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-25'
@@ -1516,7 +1536,7 @@ selectors:
         successfully.
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     origin: browser_dom
     verification: browser_observed
     last_verified_at: '2026-08-25'
@@ -1535,7 +1555,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -1552,7 +1572,7 @@ selectors:
     - resume-list-card-additionalEducation
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1581,7 +1601,7 @@ selectors:
     - resume-edit-button-additionalEducation-3-svg
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1603,7 +1623,7 @@ selectors:
     - profile-layout-cancel-button
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1625,7 +1645,7 @@ selectors:
     - resume-list-card-education
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1648,7 +1668,7 @@ selectors:
     - resume-edit-button-education-0-svg
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     status: intentionally local
     origin: browser_dom
     verification: live_passed
@@ -1669,7 +1689,7 @@ selectors:
     - profile-layout-save-button
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1690,7 +1710,7 @@ selectors:
     - profile-education-additional-name
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1712,7 +1732,7 @@ selectors:
     - profile-education-additional-organization
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1734,7 +1754,7 @@ selectors:
     - profile-education-additional-specialty
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1756,7 +1776,7 @@ selectors:
     - profile-education-year-input
     active: true
     bindings: {}
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     status: needs-live-evidence
     origin: manual
     verification: browser_observed
@@ -1778,7 +1798,7 @@ selectors:
     - profile-education-faculty-input
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     status: intentionally local
     origin: browser_dom
     verification: live_passed
@@ -1799,7 +1819,7 @@ selectors:
     - profile-education-university-input
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     status: intentionally local
     origin: browser_dom
     verification: live_passed
@@ -1820,7 +1840,7 @@ selectors:
     - profile-education-specialty-input
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     status: intentionally local
     origin: browser_dom
     verification: live_passed
@@ -1841,7 +1861,7 @@ selectors:
     - profile-education-year-input
     active: true
     bindings: {}
-    coverage_status: intentionally local
+    coverage_status: intentionally_local
     status: intentionally local
     origin: browser_dom
     verification: live_passed
@@ -1860,6 +1880,7 @@ selectors:
     sources: {}
     live_matches: []
     active: false
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -1880,10 +1901,11 @@ selectors:
     live_matches:
     - profile-layout-cancel-button
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:16
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -1902,10 +1924,11 @@ selectors:
     - resume-profile-experience-specific-company-input-2
     - resume-profile-experience-specific-company-input-3
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:10
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -1922,10 +1945,11 @@ selectors:
     live_matches:
     - resume-editor-experience-company-url-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:12
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -1942,10 +1966,11 @@ selectors:
     live_matches:
     - resume-editor-experience-description-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:15
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -1968,10 +1993,11 @@ selectors:
     - edit-experience-button-3
     - edit-experience-button-3-svg
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:9
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -1988,10 +2014,11 @@ selectors:
     live_matches:
     - resume-editor-experience-end-year-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:14
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2010,10 +2037,11 @@ selectors:
     - resume-profile-experience-specific-position-input-2
     - resume-profile-experience-specific-position-input-3
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:11
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2030,10 +2058,11 @@ selectors:
     live_matches:
     - profile-layout-save-button
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:17
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2050,10 +2079,11 @@ selectors:
     live_matches:
     - resume-editor-experience-start-year-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_experience.py:13
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2070,10 +2100,11 @@ selectors:
     live_matches:
     - resume-dublicate
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_list.py:47
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2092,10 +2123,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_list.py:44
       note: '- RESUME_DUPLICATE_MENU_ITEM, RESUME_DUPLICATE_INLINE — ПОДТВЕРЖДЕНО'
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_list_read_only
     verified_by: codex
@@ -2108,10 +2140,11 @@ selectors:
     live_matches:
     - resume-list-action-more
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_list.py:35
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2137,6 +2170,7 @@ selectors:
     live_matches:
     - resume
     active: true
+    coverage_status: reference_binding
     bindings:
       yamakayama:
       - file: app/parsers/hh_playwright.py
@@ -2148,8 +2182,8 @@ selectors:
         key: app/parsers/hh_playwright.py::module.HHPlaywright.is_logged_in#2::0
         value: '[data-qa="resume"]'
     status: reference binding
-    origin: reference
-    verification: verified
+    origin: reference_single
+    verification: contract_tested
     evidence:
       source: src/hhru_bot/selector_groups/resume_list.py:28
       note: Semantic reference binding is present; the selector is retained as the canonical local value after the approved
@@ -2162,6 +2196,7 @@ selectors:
   resume_list.RESUME_LIST_CARD_LINK_PREFIX:
     value: '[data-qa^=''resume-card-link-'']'
     active: true
+    coverage_status: intentionally_local
     criticality: write
     declared_at: src/hhru_bot/selector_groups/resume_list.py:1
     decision: live_dom
@@ -2171,7 +2206,7 @@ selectors:
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_list.py:1
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2188,10 +2223,11 @@ selectors:
     live_matches:
     - resume-card-link-{id}
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_list.py:32
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2208,6 +2244,7 @@ selectors:
     live_matches:
     - resume-title
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -2228,6 +2265,7 @@ selectors:
     live_matches:
     - resume-editor-about
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -2254,6 +2292,7 @@ selectors:
     - resume-editor-about-no-experience-reason-studies
     - resume-editor-about-no-experience-reason-unemployed
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -2274,10 +2313,11 @@ selectors:
     live_matches:
     - resume-update-button
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:12
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2296,10 +2336,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:13
       note: confirmed by the bump workflow live check; optional read-only hint
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2312,10 +2353,11 @@ selectors:
     live_matches:
     - mainmenu_createResume
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:102
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2334,10 +2376,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:110
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2352,10 +2395,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:108
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2370,10 +2414,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:109
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2386,10 +2431,11 @@ selectors:
     live_matches:
     - resume-profile-next-screen
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:107
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2406,10 +2452,11 @@ selectors:
     live_matches:
     - resume-profile-position-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:105
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2426,10 +2473,11 @@ selectors:
     live_matches:
     - input-clearable-button
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:106
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2446,10 +2494,11 @@ selectors:
     live_matches:
     - resume-profile-card-select-job
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:104
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2466,10 +2515,11 @@ selectors:
     live_matches:
     - resume-delete
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:91
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2488,10 +2538,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:96
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2506,10 +2557,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:94
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2524,10 +2576,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:93
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2542,10 +2595,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:95
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2560,10 +2614,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:92
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2576,6 +2631,7 @@ selectors:
     live_matches:
     - resume-edit-button-about
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -2598,10 +2654,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:75
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2616,10 +2673,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:76
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2634,10 +2692,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:72
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2652,10 +2711,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:83
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2668,10 +2728,11 @@ selectors:
     live_matches:
     - magritte-select-activator
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:80
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2688,10 +2749,11 @@ selectors:
     live_matches:
     - magritte-select-activator
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:77
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2710,10 +2772,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:73
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2726,10 +2789,11 @@ selectors:
     live_matches:
     - cell-text
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:74
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2748,10 +2812,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:84
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -2764,10 +2829,11 @@ selectors:
     live_matches:
     - resume-partial-edit-cancel
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:38
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2784,10 +2850,11 @@ selectors:
     live_matches:
     - resume-partial-edit-save
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:39
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2804,10 +2871,11 @@ selectors:
     live_matches:
     - drop-base
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:44
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2823,6 +2891,7 @@ selectors:
     sources: {}
     live_matches: []
     active: false
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: manual
@@ -2871,10 +2940,11 @@ selectors:
     - chips-trigger-chip-Яндекс.Директ
     - chips-trigger-chip-Яндекс.Метрика
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:37
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2891,10 +2961,11 @@ selectors:
     live_matches:
     - chips-trigger-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:35
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2911,10 +2982,11 @@ selectors:
     live_matches:
     - skills-add
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:33
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2931,10 +3003,11 @@ selectors:
     live_matches:
     - resume-editor-skills-input
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:34
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -2990,10 +3063,11 @@ selectors:
     - resume-editor-skills-recommended-Управление стейкхолдерами
     - resume-editor-skills-recommended-Управленческая отчетность
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:36
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -3010,10 +3084,11 @@ selectors:
     live_matches:
     - resume-position-professional-role-add-button
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:51
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -3030,10 +3105,11 @@ selectors:
     live_matches:
     - resume-position-professional-role-card-delete
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/resume_page.py:57
       note: Resume/account editor or profile control is intentionally local to HH.ru; the approved reference projects do not
@@ -3052,10 +3128,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:52
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -3070,10 +3147,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:54
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -3088,10 +3166,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:53
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -3106,10 +3185,11 @@ selectors:
       source: src/hhru_bot/selector_groups/resume_page.py:58
       note: Inline editor selectors confirmed by the authenticated read-only research in
     active: true
+    coverage_status: intentionally_local
     bindings: {}
     status: intentionally local
     origin: browser_dom
-    verification: verified
+    verification: browser_observed
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
@@ -3122,6 +3202,7 @@ selectors:
     live_matches:
     - resume-edit-business-trip-readiness
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3142,6 +3223,7 @@ selectors:
     live_matches:
     - resume-partial-edit-cancel
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3156,6 +3238,7 @@ selectors:
   resume_position.CURRENCY_TEMPLATE:
     value: '[data-qa=''resume-currency-input-{code}'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3178,6 +3261,7 @@ selectors:
   resume_position.DISPLAY_BUSINESS_TRIPS:
     value: '[data-qa=''resume-position-field-businessTripReadiness'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3198,6 +3282,7 @@ selectors:
   resume_position.DISPLAY_EMPLOYMENT:
     value: '[data-qa=''resume-position-field-employmentForms'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3218,6 +3303,7 @@ selectors:
   resume_position.DISPLAY_SALARY:
     value: '[data-qa=''resume-block-salary'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3238,6 +3324,7 @@ selectors:
   resume_position.DISPLAY_TITLE:
     value: '[data-qa=''resume-block-title-position'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3258,6 +3345,7 @@ selectors:
   resume_position.DISPLAY_TRAVEL:
     value: '[data-qa=''resume-position-field-travelTime'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3278,6 +3366,7 @@ selectors:
   resume_position.DISPLAY_WORK_FORMAT:
     value: '[data-qa=''resume-position-field-workFormats'']'
     active: true
+    coverage_status: needs_live_evidence
     criticality: write
     declared_at: src/hhru_bot/resume_position.py:1
     decision: live_dom
@@ -3304,6 +3393,7 @@ selectors:
     live_matches:
     - edit-position-button
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3324,6 +3414,7 @@ selectors:
     live_matches:
     - resume-edit-employment-forms
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3344,6 +3435,7 @@ selectors:
     live_matches:
     - resume-edit-position-form
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3364,6 +3456,7 @@ selectors:
     live_matches:
     - resume-salary-amount
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3384,6 +3477,7 @@ selectors:
     live_matches:
     - resume-partial-edit-save
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3404,6 +3498,7 @@ selectors:
     live_matches:
     - resume-edit-title-suggest
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3424,6 +3519,7 @@ selectors:
     live_matches:
     - resume-edit-travel-time
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3444,6 +3540,7 @@ selectors:
     live_matches:
     - resume-edit-work-formats
     active: true
+    coverage_status: needs_live_evidence
     bindings: {}
     status: needs-live-evidence
     origin: browser_dom
@@ -3468,7 +3565,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -3487,7 +3584,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -3506,7 +3603,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -3525,7 +3622,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -3551,7 +3648,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -3575,7 +3672,7 @@ selectors:
     evidence:
       source: selectors/reference-map.yaml
       note: Selector contract is classified conservatively; no approved live evidence was collected for this audit.
-    coverage_status: needs-live-evidence
+    coverage_status: needs_live_evidence
     origin: browser_dom
     verification: unverified
     last_verified_at: '2026-08-25'
@@ -4199,7 +4296,7 @@ selectors:
         line: 43
         key: app/parsers/hh_login.py::module.SEL_PIN#0::0
         value: input[data-qa="magritte-pincode-input-field"]
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -4215,7 +4312,7 @@ selectors:
     - submit-button
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -4244,7 +4341,7 @@ selectors:
         line: 41
         key: app/parsers/hh_login.py::module.SEL_LOGIN#0::0
         value: input[data-qa="login-input-username"]
-    coverage_status: reference binding
+    coverage_status: reference_binding
     origin: reference_single
     verification: browser_observed
     last_verified_at: 2026-08-25
@@ -4260,7 +4357,7 @@ selectors:
     - credential-type-email
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -4280,7 +4377,7 @@ selectors:
     - magritte-phone-input-national-number-input
     active: true
     bindings: {}
-    coverage_status: not implemented upstream
+    coverage_status: not_implemented_upstream
     origin: browser_dom
     verification: browser_observed
     evidence:
@@ -4306,6 +4403,7 @@ selectors:
       note: Visible cookie banner; dedicated dismiss control is [data-qa='cookies-policy-informer-accept'] and must be used
         for session suppression.
     active: true
+    coverage_status: intentionally_local
   transient_overlays.COOKIE_BANNER_DISMISS:
     live_matches:
     - cookies-policy-informer-accept
@@ -4321,6 +4419,7 @@ selectors:
       source: live Playwright DOM on /applicant/negotiations and /resume/<redacted>
       note: Button text is Понятно; no profile or form data is changed by dismissing the cookie banner.
     active: true
+    coverage_status: intentionally_local
   transient_overlays.NOTIFICATION:
     live_matches:
     - notification notification_info
@@ -4337,6 +4436,7 @@ selectors:
       note: Notification data-qa='notification notification_info', text Работодатели не знают ваш статус поиска; no status
         link is clicked.
     active: true
+    coverage_status: intentionally_local
   transient_overlays.NOTIFICATION_DISMISS:
     live_matches:
     - notification-close
@@ -4352,9 +4452,11 @@ selectors:
       source: live Playwright DOM after clicking [data-qa='userNotifications-button'] on /applicant/negotiations
       note: Dedicated notification close control observed; status link remains untouched.
     active: true
+    coverage_status: intentionally_local
   transient_overlays.RESUME_DELIVERED:
     value: ''
     active: false
+    coverage_status: needs_live_evidence
     criticality: read
     decision: needs_live_evidence
     origin: browser_dom

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -501,6 +501,36 @@ def test_refresh_invalidates_stale_reference_audit_metadata():
     assert row["verification"] == "unverified"
 
 
+def test_refresh_invalidates_stale_reference_metadata_outside_audited_groups():
+    catalog = {
+        "selectors": {
+            "resume_position.fixture": {
+                "declared_at": "src/hhru_bot/resume_position.py:1",
+                "sources": {},
+                "live_matches": [],
+                "coverage_status": "reference_binding",
+                "origin": "reference_consensus",
+                "verification": "contract_tested",
+                "evidence": {
+                    "source": "old",
+                    "note": "old",
+                    "runtime_authoritative": True,
+                },
+                "last_verified_at": "2026-08-20",
+                "verified_flow": "old",
+                "verified_by": "ci",
+            }
+        }
+    }
+
+    contracts._reconcile_audit_metadata(catalog)
+    row = catalog["selectors"]["resume_position.fixture"]
+
+    assert row["coverage_status"] == "needs_live_evidence"
+    assert row["evidence"]["runtime_authoritative"] is False
+    assert not contracts._has_reviewed_runtime_evidence("resume_position.fixture", row)
+
+
 def test_refresh_does_not_authorize_a_consensus_downgrade():
     catalog = {
         "selectors": {

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -187,6 +187,46 @@ def test_invalid_coverage_status_fails_catalog_gate():
     assert "search_page.VACANCY_CARD: invalid coverage_status" in errors
 
 
+def test_extra_contract_bootstrap_has_catalog_wide_coverage():
+    catalog = {"selectors": {}}
+
+    contracts._ensure_extra_contracts(catalog, {})
+
+    assert catalog["selectors"]
+    assert all(
+        row.get("coverage_status") in contracts.AUDIT_STATUSES
+        for row in catalog["selectors"].values()
+    )
+
+
+def test_bootstrap_output_passes_catalog_gate(tmp_path, monkeypatch):
+    source_root = tmp_path / "src" / "hhru_bot"
+    selector_group = source_root / "selector_groups" / "account_profile.py"
+    selector_group.parent.mkdir(parents=True)
+    selector_group.write_text("ACCOUNT_NAME = \"[data-qa='account-name']\"\n", encoding="utf-8")
+    monkeypatch.setattr(contracts, "ROOT", tmp_path)
+    monkeypatch.setattr(contracts, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(
+        contracts, "GENERATED_PATH", source_root / "selector_groups" / "_generated.py"
+    )
+    monkeypatch.setattr(contracts, "MATRIX_PATH", tmp_path / "selectors" / "reference-matrix.md")
+    monkeypatch.setattr(contracts, "EXTRA_CONTRACTS", {})
+
+    reference_root = tmp_path / "references"
+    for config in contracts.REFERENCE_CONFIG.values():
+        _commit_repository(reference_root / config["directory"], "[data-qa='account-name']")
+
+    catalog, _ = contracts.build_map(reference_root, tmp_path / "live")
+    contracts.GENERATED_PATH.write_text(contracts.render_generated(catalog), encoding="utf-8")
+    contracts.MATRIX_PATH.parent.mkdir(parents=True)
+    contracts.MATRIX_PATH.write_text(contracts.render_matrix(catalog), encoding="utf-8")
+
+    assert contracts.verify_catalog(catalog) == []
+    assert catalog["selectors"]["account_profile.ACCOUNT_NAME"]["coverage_status"] == (
+        "reference_binding"
+    )
+
+
 def test_resume_account_competitor_unbound_selectors_have_provenance():
     catalog = contracts.load_catalog()
     rows = {

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -734,6 +734,20 @@ def test_refresh_keeps_audited_unavailable_rows_fail_closed(tmp_path, monkeypatc
         row = refreshed["selectors"][logical_id]
         assert row["decision"] == "unavailable"
         assert row["active"] is False
+        assert row["verification"] in {"unavailable", "failed"}
+
+    current = refreshed
+    monkeypatch.setattr(contracts, "load_catalog", lambda: copy.deepcopy(current))
+    refreshed_again = contracts.refresh_catalog(reference_root, "manual")
+    for logical_id in (
+        "search_page.unavailable_READ",
+        "search_page.unavailable_consensus_READ",
+        "search_page.unavailable_live_READ",
+    ):
+        row = refreshed_again["selectors"][logical_id]
+        assert row["decision"] == "unavailable"
+        assert row["active"] is False
+        assert row["verification"] in {"unavailable", "failed"}
 
 
 def test_affected_logical_ids_deduplicates_rows_variants_and_overlap():

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -33,10 +33,10 @@ AUDIT_GROUPS = {
     "resume_position",
 }
 AUDIT_STATUSES = {
-    "reference binding",
-    "intentionally local",
-    "not implemented upstream",
-    "needs-live-evidence",
+    "reference_binding",
+    "intentionally_local",
+    "not_implemented_upstream",
+    "needs_live_evidence",
 }
 AUDIT_FIELDS = (
     "origin",
@@ -147,6 +147,46 @@ def test_current_repository_selector_contract_is_self_consistent():
     assert catalog["policy"]["consensus_threshold"] == 2
 
 
+def test_every_selector_has_canonical_coverage_and_all_groups_are_audited():
+    catalog = contracts.load_catalog()
+    expected_prefixes = {
+        "account_profile.",
+        "apply_form.",
+        "competitor_resume.",
+        "negotiations.",
+        "resume_experience.",
+        "resume_list.",
+        "resume_page.",
+        "resume_rename.",
+        "resume_visibility.",
+        "search_page.",
+        "vacancy_page.",
+        # selector_groups/login.py retains the historical selectors.* IDs.
+        "selectors.",
+    }
+
+    assert set(contracts.AUDITED_SELECTOR_GROUP_PREFIXES) == expected_prefixes
+    assert len(catalog["selectors"]) == 215
+    assert all(
+        row.get("coverage_status") in contracts.AUDIT_STATUSES
+        for row in catalog["selectors"].values()
+    )
+    for logical_id, row in catalog["selectors"].items():
+        if logical_id.startswith(contracts.AUDITED_SELECTOR_GROUP_PREFIXES):
+            assert all(
+                row.get(field) not in (None, "", {}) for field in contracts.AUDIT_REQUIRED_FIELDS
+            )
+
+
+def test_invalid_coverage_status_fails_catalog_gate():
+    catalog = contracts.load_catalog()
+    catalog["selectors"]["search_page.VACANCY_CARD"]["coverage_status"] = "needs-live-evidence"
+
+    errors = contracts.verify_catalog(catalog)
+
+    assert "search_page.VACANCY_CARD: invalid coverage_status" in errors
+
+
 def test_resume_account_competitor_unbound_selectors_have_provenance():
     catalog = contracts.load_catalog()
     rows = {
@@ -157,7 +197,12 @@ def test_resume_account_competitor_unbound_selectors_have_provenance():
 
     assert rows
     for logical_id, row in rows.items():
-        assert row.get("status") in AUDIT_STATUSES, logical_id
+        assert row.get("status") in {
+            "reference binding",
+            "intentionally local",
+            "not implemented upstream",
+            "needs-live-evidence",
+        }, logical_id
         assert all(row.get(field) not in (None, "", {}) for field in AUDIT_FIELDS), logical_id
         assert "llm_hypothesis" not in row, logical_id
         if not (row.get("bindings") or row.get("sources")):
@@ -256,10 +301,10 @@ def test_issue_610_apply_login_negotiations_coverage_is_classified():
     catalog = contracts.load_catalog()
     prefixes = ("apply_form.", "negotiations.", "selectors.LOGIN")
     allowed_statuses = {
-        "reference binding",
-        "intentionally local",
-        "not implemented upstream",
-        "needs-live-evidence",
+        "reference_binding",
+        "intentionally_local",
+        "not_implemented_upstream",
+        "needs_live_evidence",
     }
     required_fields = {
         "coverage_status",
@@ -284,9 +329,9 @@ def test_issue_610_apply_login_negotiations_coverage_is_classified():
         assert row["origin"] != "llm_hypothesis", logical_id
         if row.get("active", True):
             assert row["origin"] and row["verification"], logical_id
-        if row["coverage_status"] == "reference binding":
+        if row["coverage_status"] == "reference_binding":
             assert row.get("bindings") or row.get("sources"), logical_id
-        if row["coverage_status"] == "needs-live-evidence":
+        if row["coverage_status"] == "needs_live_evidence":
             assert row["verification"] in {"unverified", "unavailable"}, logical_id
 
 


### PR DESCRIPTION
## Summary

- normalize all 215 `coverage_status` values to the canonical snake_case vocabulary and fill every previously missing value from the row's existing provenance; unknown provenance remains `needs_live_evidence`;
- make missing or non-canonical `coverage_status` fail `scripts/selector_contracts.py check` catalog-wide;
- audit every `selector_groups/` group, including the historical `selectors.*` IDs from `selector_groups/login.py`, while retaining fail-closed evidence for unverified flows;
- migrate legacy `verified`/`reference` metadata in newly audited rows to the existing explicit audit vocabulary without adding selectors.

The catalog now has 61 `needs_live_evidence` rows (honest validation debt), 96 `intentionally_local`, 34 `reference_binding`, and 24 `not_implemented_upstream`.

The runtime metrics gap at `src/hhru_bot/diagnostics.py:178` is intentionally split into follow-up #701: https://github.com/axisrow/hhru/issues/701.

Closes #700

## Audited groups

`account_profile`, `apply_form`, `competitor_resume`, `negotiations`, `resume_experience`, `resume_list`, `resume_page`, `resume_rename`, `resume_visibility`, `search_page`, `vacancy_page`, and `login` (catalog prefix `selectors.`).

## Verification

- `ruff check src tests scripts`
- `ruff format --check src tests scripts`
- `python scripts/selector_contracts.py check` (`selector contracts OK: 215`)
- `pytest` (`2616 passed, 2 skipped, 3 deselected`)
