### PR TITLE
fix(run): propagate bump failures

### DIFF
--- a/src/hhru_bot/commands/run.py
+++ b/src/hhru_bot/commands/run.py
@@ -25,7 +25,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> bool:
+def run(args: argparse.Namespace) -> bool | CommandExitCode:
     print("=== Полный цикл: search -> apply -> bump ===")
     apply_failed = apply_cmd.run(args)
     # Apply and bump are independent actions: even if vacancy search is
@@ -33,5 +33,7 @@ def run(args: argparse.Namespace) -> bool:
     # Keep bump for the same resume and report apply's failure to the caller.
     if isinstance(apply_failed, CommandExitCode):
         return apply_failed
-    bump_cmd.run(args)
-    return bool(apply_failed)
+    bump_failed = bump_cmd.run(args)
+    if isinstance(bump_failed, CommandExitCode):
+        return bump_failed
+    return bool(apply_failed or bump_failed)

--- a/tests/test_reliability_bundle.py
+++ b/tests/test_reliability_bundle.py
@@ -326,3 +326,33 @@ def test_combined_run_does_not_bump_after_typed_interrupt(monkeypatch) -> None:
     )
 
     assert run_command.run(argparse.Namespace()) is CommandExitCode.SIGINT
+
+
+@pytest.mark.parametrize(
+    ("apply_failed", "bump_failed"),
+    [(False, True), (True, False), (True, True)],
+)
+def test_combined_run_fails_if_either_phase_fails(monkeypatch, apply_failed, bump_failed) -> None:
+    from hhru_bot.commands import run as run_command
+
+    bump_calls = []
+    monkeypatch.setattr(run_command.apply_cmd, "run", lambda _args: apply_failed)
+    monkeypatch.setattr(
+        run_command.bump_cmd,
+        "run",
+        lambda _args: bump_calls.append(True) or bump_failed,
+    )
+
+    assert run_command.run(argparse.Namespace()) is True
+    assert bump_calls == [True]
+
+
+def test_combined_run_propagates_bump_exit_code(monkeypatch) -> None:
+    from hhru_bot.commands import run as run_command
+
+    monkeypatch.setattr(run_command.apply_cmd, "run", lambda _args: False)
+    monkeypatch.setattr(
+        run_command.bump_cmd, "run", lambda _args: CommandExitCode.PERSISTENCE_FAILED
+    )
+
+    assert run_command.run(argparse.Namespace()) is CommandExitCode.PERSISTENCE_FAILED


### PR DESCRIPTION
Closes #718

## Summary
- propagate bump failures from the combined run command
- preserve bump execution after ordinary apply failures
- preserve typed CommandExitCode propagation

## Tests
- ruff check src tests scripts
- ruff format --check src tests scripts
- python scripts/selector_contracts.py check
- pytest