### PR TITLE
fix(docker): prevent compose schedule drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,10 @@ docker compose run --rm --entrypoint hhru hhru --headless --account default run
 ```
 
 Для непрерывного варианта `docker-compose.yml` содержит минимальный sleep-loop:
-он запускает `--account default run --headless`, ждёт 4 часа и повторяет. Запусти его так:
+он запускает `--account default run --headless`, затем ждёт остаток 4-часового
+интервала с момента начала прогона и повторяет. Поэтому длительность прогона не
+накапливает дрейф расписания. Контейнеру также выделен увеличенный `/dev/shm`
+(`shm_size: 1gb`) для Chromium. Запусти его так:
 
 ```bash
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     init: true
     restart: unless-stopped
+    shm_size: 1gb
     # The image entrypoint is hhru; this service command is a shell loop.
     entrypoint: []
     environment:
@@ -14,6 +15,9 @@ services:
       - -c
       - >-
         while true; do
+          started_at=$$(date +%s);
           hhru --account "$${HHRU_ACCOUNT:-default}" --headless run;
-          sleep 14400;
+          elapsed=$$(($$(date +%s) - started_at));
+          remaining=$$((14400 - elapsed));
+          if [ "$$remaining" -gt 0 ]; then sleep "$$remaining"; fi;
         done

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,29 @@
+"""Regression checks for the Docker Compose runner (#719)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.integration
+
+COMPOSE_FILE = Path(__file__).parents[1] / "docker-compose.yml"
+
+
+def _service() -> dict:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    return compose["services"]["hhru"]
+
+
+def test_chromium_has_a_larger_shared_memory_segment():
+    assert _service()["shm_size"] == "1gb"
+
+
+def test_compose_loop_sleeps_until_the_next_run_mark():
+    command = "\n".join(_service()["command"])
+
+    assert "started_at=$$(date +%s)" in command
+    assert "elapsed=$$(($$(date +%s) - started_at))" in command
+    assert "remaining=$$((14400 - elapsed))" in command
+    assert 'sleep "$$remaining"' in command
+    assert "sleep 14400" not in command


### PR DESCRIPTION
Closes #719

## Summary
- keep the Compose loop cadence anchored to each run start instead of sleeping four hours after completion
- allocate 1gb of shared memory to Chromium
- document the behavior and add regression checks

## Tests
- ruff check src tests scripts
- ruff format --check src tests scripts
- python scripts/selector_contracts.py check
- pytest (2621 passed, 2 skipped, 3 deselected)