### PR TITLE
feat(security): protect account session files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ config/
 Дампы `probe` содержат HTML и скриншот формы отклика залогиненного
 пользователя — это такие же приватные данные, как сессия.
 
+Каждый локальный аккаунт — это отдельный набор секретов: его `hh_session.json`
+содержит доступ к hh.ru. Хранилище `data/` нельзя коммитить или включать в
+Docker-образ; передавайте его контейнеру только как приватный mount.
+
 ## Первый запуск: вход в аккаунт
 
 ```bash
@@ -651,7 +655,7 @@ READ hh.ru: competitors collect --text QUERY [--search-in SCOPE] [--max-pages N]
 
 #### `diagnostics doctor`
 
-Сравнивает версию, release/tag и commit SHA установленного CLI, marketplace snapshot и загруженного Codex plugin.
+Сравнивает версию, release/tag и commit SHA установленного CLI, marketplace snapshot и загруженного Codex plugin; проверяет права каталогов аккаунтов и файлов сессий.
 
 - `--marketplace-path, --marketplace MARKETPLACE` — Путь к marketplace snapshot (для диагностики нестандартной установки)
 - `--plugin-cache PLUGIN_CACHE` — Путь к Codex plugin cache (для диагностики нестандартной установки)

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -17,7 +18,7 @@ from .browser import (
 )
 from .config import AppConfig
 from .session_security import (
-    prepare_storage_state_file,
+    create_storage_state_temp,
     secure_storage_state_file,
     secure_storage_state_parent,
 )
@@ -25,7 +26,11 @@ from .session_security import (
 logger = logging.getLogger("hhru_bot.auth")
 
 
-def login(config: AppConfig, history_path: str | Path = Path("data/history.db")) -> None:
+def login(
+    config: AppConfig,
+    history_path: str | Path = Path("data/history.db"),
+    account_dir: str | Path | None = None,
+) -> None:
     """
     Открывает hh.ru в headed-браузере и ждёт, пока пользователь вручную войдёт
     в аккаунт (логин/пароль, СМС-код, капча — всё, что попросит hh.ru).
@@ -38,7 +43,7 @@ def login(config: AppConfig, history_path: str | Path = Path("data/history.db"))
     timeout_seconds = 300
     progress_interval_seconds = 15
     storage_state_file = config.storage_state_file
-    secure_storage_state_parent(storage_state_file)
+    secure_storage_state_parent(storage_state_file, account_dir=account_dir)
 
     with sync_playwright() as p:
         browser = launch_browser(p, headless=False)
@@ -98,13 +103,14 @@ def login(config: AppConfig, history_path: str | Path = Path("data/history.db"))
         # Цикл выше выходит сюда только через `break` на строке успеха
         # (has_auth_cookie(page) and not has_login_form(page)) — повторная
         # проверка cookie здесь была бы недостижимым дублированием.
-        placeholder_created = prepare_storage_state_file(storage_state_file)
+        fd, temporary_state = create_storage_state_temp(storage_state_file, account_dir=account_dir)
+        os.close(fd)
         try:
-            context.storage_state(path=str(storage_state_file))
-            secure_storage_state_file(storage_state_file)
+            context.storage_state(path=str(temporary_state))
+            secure_storage_state_file(temporary_state)
+            os.replace(temporary_state, storage_state_file)
         except BaseException:
-            if placeholder_created:
-                storage_state_file.unlink(missing_ok=True)
+            temporary_state.unlink(missing_ok=True)
             raise
         logger.info("Сессия сохранена: %s", storage_state_file)
         read_account_profile(page, history_path)

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -16,6 +16,11 @@ from .browser import (
     launch_browser,
 )
 from .config import AppConfig
+from .session_security import (
+    prepare_storage_state_file,
+    secure_storage_state_file,
+    secure_storage_state_parent,
+)
 
 logger = logging.getLogger("hhru_bot.auth")
 
@@ -33,7 +38,7 @@ def login(config: AppConfig, history_path: str | Path = Path("data/history.db"))
     timeout_seconds = 300
     progress_interval_seconds = 15
     storage_state_file = config.storage_state_file
-    storage_state_file.parent.mkdir(parents=True, exist_ok=True)
+    secure_storage_state_parent(storage_state_file)
 
     with sync_playwright() as p:
         browser = launch_browser(p, headless=False)
@@ -93,7 +98,14 @@ def login(config: AppConfig, history_path: str | Path = Path("data/history.db"))
         # Цикл выше выходит сюда только через `break` на строке успеха
         # (has_auth_cookie(page) and not has_login_form(page)) — повторная
         # проверка cookie здесь была бы недостижимым дублированием.
-        context.storage_state(path=str(storage_state_file))
+        placeholder_created = prepare_storage_state_file(storage_state_file)
+        try:
+            context.storage_state(path=str(storage_state_file))
+            secure_storage_state_file(storage_state_file)
+        except BaseException:
+            if placeholder_created:
+                storage_state_file.unlink(missing_ok=True)
+            raise
         logger.info("Сессия сохранена: %s", storage_state_file)
         read_account_profile(page, history_path)
 

--- a/src/hhru_bot/auth.py
+++ b/src/hhru_bot/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -19,7 +20,6 @@ from .browser import (
 from .config import AppConfig
 from .session_security import (
     create_storage_state_temp,
-    secure_storage_state_file,
     secure_storage_state_parent,
 )
 
@@ -104,12 +104,21 @@ def login(
         # (has_auth_cookie(page) and not has_login_form(page)) — повторная
         # проверка cookie здесь была бы недостижимым дублированием.
         fd, temporary_state = create_storage_state_temp(storage_state_file, account_dir=account_dir)
-        os.close(fd)
         try:
-            context.storage_state(path=str(temporary_state))
-            secure_storage_state_file(temporary_state)
+            # Ask Playwright for the state in memory, then serialize it through
+            # the already-open 0600 descriptor.  Reopening the temporary path
+            # by name would let a writer of a shared custom parent redirect
+            # bearer-token contents through a symlink (Codex review).
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
+                json.dump(context.storage_state(), handle, ensure_ascii=False)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
             os.replace(temporary_state, storage_state_file)
         except BaseException:
+            if fd >= 0:
+                os.close(fd)
             temporary_state.unlink(missing_ok=True)
             raise
         logger.info("Сессия сохранена: %s", storage_state_file)

--- a/src/hhru_bot/auth_code.py
+++ b/src/hhru_bot/auth_code.py
@@ -114,6 +114,7 @@ def login_with_code(
     *,
     code_file: Path | None = None,
     timeout_seconds: int = CODE_TIMEOUT_SECONDS,
+    account_dir: str | Path | None = None,
 ) -> None:
     """Complete login in one browser process and save only confirmed state."""
     if not login.strip():
@@ -156,7 +157,9 @@ def login_with_code(
             code = _read_code(code_file, timeout_seconds)
             code_field.fill(code)
             _wait_for_authenticated_page(page, timeout_seconds)
-            write_storage_state(context.storage_state(), config.storage_state_file)
+            write_storage_state(
+                context.storage_state(), config.storage_state_file, account_dir=account_dir
+            )
     except (PlaywrightError, PlaywrightTimeoutError) as exc:
         raise RuntimeError("Ошибка браузера при входе; сессия не сохранена") from exc
     finally:

--- a/src/hhru_bot/auth_code.py
+++ b/src/hhru_bot/auth_code.py
@@ -29,6 +29,7 @@ from .selectors import (
     LOGIN_EMAIL_TYPE,
     LOGIN_PHONE_INPUT,
 )
+from .session_security import secure_storage_state_parent
 
 logger = logging.getLogger("hhru_bot.auth_code")
 
@@ -121,7 +122,7 @@ def login_with_code(
         raise ValueError("Логин не должен быть пустым")
     if timeout_seconds <= 0:
         raise ValueError("Таймаут должен быть положительным")
-    config.storage_state_file.parent.mkdir(parents=True, exist_ok=True)
+    secure_storage_state_parent(config.storage_state_file, account_dir=account_dir)
     temporary_state = config.storage_state_file.with_name(
         config.storage_state_file.name + ".login-code.tmp.json"
     )

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -309,6 +309,10 @@ def _resolve_paths(args: argparse.Namespace) -> None:
         if account_paths is not None
         else DEFAULT_HISTORY_PATH
     )
+    # Keep the managed account directory separate from the user-controlled
+    # config path.  A caller may combine --account with an explicit --config;
+    # that config's parent must never be chmodded as if it were an account.
+    args.account_dir = str(account_paths.config.parent) if account_paths else None
 
 
 def _execute(args: argparse.Namespace) -> None:

--- a/src/hhru_bot/commands/account.py
+++ b/src/hhru_bot/commands/account.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from ..accounts import AccountError
 from ..report import _ascii_table
+from ..session_security import secure_directory
 
 DEFAULT_DATA_DIR = Path("data")
 DEFAULT_TEMPLATE_PATH = Path("config") / "config.example.yaml"
@@ -188,7 +189,7 @@ def create_account(
 
     account_dir = data_dir / "accounts" / name
     try:
-        account_dir.mkdir(parents=True)
+        secure_directory(account_dir, exist_ok=False)
     except FileExistsError as exc:
         raise AccountError(
             f"аккаунт '{name}' уже существует: {account_dir} (перезапись запрещена)"

--- a/src/hhru_bot/commands/diagnostics.py
+++ b/src/hhru_bot/commands/diagnostics.py
@@ -1,10 +1,118 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 
+from ..config import load_config
 from ..diagnostics import _same_path, export_bundle
 from ..provenance import RECOVERY_COMMAND, run_doctor
+from ..session_security import ACCOUNT_DIR_MODE, SESSION_FILE_MODE, permissions_are_posix
+from .account import scan_accounts
+
+
+@dataclass(frozen=True)
+class SessionPermission:
+    """Permission facts for one configured local account."""
+
+    name: str
+    account_dir: Path
+    session_file: Path | None
+    account_mode: int | None = None
+    session_mode: int | None = None
+    error: str | None = None
+
+    @property
+    def weak(self) -> bool:
+        if self.error or not permissions_are_posix():
+            return False
+        return bool(
+            (self.account_mode is not None and self.account_mode & 0o077)
+            or (self.session_mode is not None and self.session_mode & 0o077)
+        )
+
+
+def check_session_permissions(data_dir: Path = Path("data")) -> tuple[SessionPermission, ...]:
+    """Inspect every named account without opening or reading session files."""
+    result: list[SessionPermission] = []
+    for account in scan_accounts(data_dir):
+        if not permissions_are_posix():
+            result.append(
+                SessionPermission(
+                    account.name,
+                    account.config_path.parent,
+                    None,
+                    error="Windows ACL не представлены POSIX-режимом",
+                )
+            )
+            continue
+
+        try:
+            config = load_config(account.config_path)
+            session_file = config.storage_state_file
+            account_mode = account.config_path.parent.stat().st_mode & 0o777
+            session_mode = session_file.stat().st_mode & 0o777 if session_file.exists() else None
+        except Exception:
+            # Config errors must not expose arbitrary values from a malformed
+            # file, and a diagnostics command must remain useful for the other
+            # accounts.
+            result.append(
+                SessionPermission(
+                    account.name,
+                    account.config_path.parent,
+                    None,
+                    error="не удалось прочитать конфигурацию или права",
+                )
+            )
+            continue
+        result.append(
+            SessionPermission(
+                account.name,
+                account.config_path.parent,
+                session_file,
+                account_mode,
+                session_mode,
+            )
+        )
+    return tuple(result)
+
+
+def _format_mode(mode: int | None) -> str:
+    return "отсутствует" if mode is None else f"{mode:04o}"
+
+
+def _print_session_permissions() -> bool:
+    entries = check_session_permissions()
+    if not entries:
+        return False
+
+    weak = False
+    if not permissions_are_posix():
+        print(
+            "[WARN] Проверка прав сессий пропущена: Windows ACL нельзя достоверно "
+            "представить POSIX-режимом; проверьте ACL вручную."
+        )
+    for entry in entries:
+        if entry.error:
+            print(f"[WARN] [SESSION] {entry.name}: {entry.error}.")
+            continue
+        session = str(entry.session_file) if entry.session_file else "неизвестен"
+        print(
+            f"[SESSION] {entry.name}: каталог аккаунта "
+            f"{_format_mode(entry.account_mode)}, сессия {session} "
+            f"({_format_mode(entry.session_mode)}; ожидается {SESSION_FILE_MODE:04o}), "
+            f"ожидаемый каталог {ACCOUNT_DIR_MODE:04o}."
+        )
+        if entry.weak:
+            weak = True
+            print(
+                f"[WARN] [SESSION] {entry.name}: права слабее ожидаемых. "
+                f"Рекомендация: chmod {ACCOUNT_DIR_MODE:03o} {entry.account_dir}; "
+                f"chmod {SESSION_FILE_MODE:03o} {session}."
+            )
+        elif entry.session_mode is None:
+            print(f"[INFO] [SESSION] {entry.name}: файл сессии ещё не создан.")
+    return weak
 
 
 def register(subparsers) -> None:
@@ -18,10 +126,11 @@ def register(subparsers) -> None:
     e.set_defaults(func=run)
     d = sub.add_parser(
         "doctor",
-        help="Проверить согласованность CLI, marketplace snapshot и plugin cache",
+        help="Проверить установку и права локальных сессий",
         description=(
             "Сравнивает версию, release/tag и commit SHA установленного CLI, "
-            "marketplace snapshot и загруженного Codex plugin."
+            "marketplace snapshot и загруженного Codex plugin; проверяет права "
+            "каталогов аккаунтов и файлов сессий."
         ),
     )
     d.add_argument(
@@ -66,11 +175,13 @@ def run_doctor_command(args: argparse.Namespace) -> bool:
     result = run_doctor(marketplace=args.marketplace, plugin_cache=args.plugin_cache)
     for component in result.components:
         print(f"[{component.name}] {component.describe()}")
-    if not result.drift:
+    permission_drift = _print_session_permissions()
+    if not result.drift and not permission_drift:
         print("[OK] CLI, marketplace snapshot и plugin cache согласованы.")
         return False
-    print("[DRIFT] CLI, marketplace snapshot и plugin cache рассинхронизированы.")
-    for reason in result.reasons:
-        print(f"[DETAIL] {reason}")
-    print(f"[FIX] Выполните одну команду: {RECOVERY_COMMAND}")
-    return True
+    if result.drift:
+        print("[DRIFT] CLI, marketplace snapshot и plugin cache рассинхронизированы.")
+        for reason in result.reasons:
+            print(f"[DETAIL] {reason}")
+        print(f"[FIX] Выполните одну команду: {RECOVERY_COMMAND}")
+    return result.drift or permission_drift

--- a/src/hhru_bot/commands/import_cookies.py
+++ b/src/hhru_bot/commands/import_cookies.py
@@ -46,7 +46,11 @@ def run(args: argparse.Namespace) -> bool:
         if not hhtoken:
             print("[FAIL] Cookie hhtoken не найден; текущая сессия не изменена.")
             return True
-        backup = write_storage_state(state, config.storage_state_file)
+        backup = write_storage_state(
+            state,
+            config.storage_state_file,
+            account_dir=getattr(args, "account_dir", None),
+        )
     except (OSError, RuntimeError, ValueError, browser_cookie3.BrowserCookieError) as exc:
         print(f"[FAIL] Не удалось импортировать куки Chrome: {exc}")
         return True

--- a/src/hhru_bot/commands/login.py
+++ b/src/hhru_bot/commands/login.py
@@ -15,4 +15,8 @@ def run(args: argparse.Namespace) -> None:
     from ..config import load_config_or_exit
 
     config = load_config_or_exit(args.config)
-    login(config, history_path=args.history)
+    login(
+        config,
+        history_path=args.history,
+        account_dir=getattr(args, "account_dir", None),
+    )

--- a/src/hhru_bot/commands/login_code.py
+++ b/src/hhru_bot/commands/login_code.py
@@ -22,5 +22,10 @@ def run(args: argparse.Namespace) -> None:
     from ..config import load_config_or_exit
 
     config = load_config_or_exit(args.config)
-    login_with_code(config, args.login, code_file=args.code_file)
+    login_with_code(
+        config,
+        args.login,
+        code_file=args.code_file,
+        account_dir=getattr(args, "account_dir", None),
+    )
     print("[OK] Сессия сохранена")

--- a/src/hhru_bot/commands/refresh_token.py
+++ b/src/hhru_bot/commands/refresh_token.py
@@ -50,6 +50,7 @@ def run(args: argparse.Namespace) -> bool:
                 write_storage_state(
                     context.storage_state(),
                     config.storage_state_file,
+                    account_dir=getattr(args, "account_dir", None),
                 )
                 print(f"[OK] Сессия пересохранена в {config.storage_state_file}")
             else:

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -10,6 +10,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from .session_security import secure_storage_state_file, secure_storage_state_parent
+
 CHROME_EPOCH_OFFSET = 11_644_473_600
 MAX_PLAYWRIGHT_EXPIRES = 253_402_300_799  # 9999-12-31T23:59:59Z
 SAMESITE = {-1: "Lax", 0: "None", 1: "Lax", 2: "Strict"}
@@ -141,8 +143,12 @@ def read_chrome_cookies(cookie_file: Path | str) -> list[dict[str, Any]]:
 def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path | None:
     """Write state, preserving existing state and an existing backup."""
     destination = Path(destination)
+    secure_storage_state_parent(destination)
+    destination_exists = destination.exists()
+    if destination_exists:
+        secure_storage_state_file(destination)
     backup: Path | None = None
-    if destination.exists():
+    if destination_exists:
         # Exclusive create (O_CREAT|O_EXCL), not candidate.exists(): a
         # pre-planted symlink at the guessable `<destination>.bak` name can be
         # *dangling*, so exists() (which follows symlinks) reports False and
@@ -199,7 +205,6 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
             candidate.unlink(missing_ok=True)
             raise
         backup = candidate
-    destination.parent.mkdir(parents=True, exist_ok=True)
     # Write-then-rename: an interrupted/failed write must never leave the
     # active session truncated (Codex review, PR #168) — the backup above
     # already preserves the old session, but only a temp write + atomic
@@ -233,4 +238,5 @@ def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path 
         tmp.unlink(missing_ok=True)
         raise
     os.replace(tmp, destination)
+    secure_storage_state_file(destination)
     return backup

--- a/src/hhru_bot/cookie_import.py
+++ b/src/hhru_bot/cookie_import.py
@@ -140,10 +140,15 @@ def read_chrome_cookies(cookie_file: Path | str) -> list[dict[str, Any]]:
     return rows
 
 
-def write_storage_state(state: dict[str, Any], destination: Path | str) -> Path | None:
+def write_storage_state(
+    state: dict[str, Any],
+    destination: Path | str,
+    *,
+    account_dir: Path | str | None = None,
+) -> Path | None:
     """Write state, preserving existing state and an existing backup."""
     destination = Path(destination)
-    secure_storage_state_parent(destination)
+    secure_storage_state_parent(destination, account_dir=account_dir)
     destination_exists = destination.exists()
     if destination_exists:
         secure_storage_state_file(destination)

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -32,12 +32,19 @@ def secure_storage_state_parent(destination: Path | str) -> Path:
     """Prepare private directories surrounding a storage-state file.
 
     The account directory is tightened when the destination belongs to the
-    standard ``data/accounts/<name>`` layout.  The immediate storage directory
-    is private too, including for custom paths, so a session cannot be listed
-    by another local user while it is being written.
+    standard ``data/accounts/<name>`` layout.  A missing storage directory is
+    created privately; existing custom directories are left untouched because
+    the caller may share them with unrelated processes.
     """
     destination = Path(destination)
-    secure_directory(destination.parent)
+    # Do not chmod an arbitrary existing path supplied by a user.  For
+    # example, a custom ``/tmp/hh_session.json`` must not turn shared /tmp
+    # into a private directory.  A missing parent is ours to create, so it can
+    # safely start private; the standard account directory is tightened below.
+    parent_exists = destination.parent.exists()
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=ACCOUNT_DIR_MODE)
+    if not parent_exists and permissions_are_posix():
+        os.chmod(destination.parent, ACCOUNT_DIR_MODE)
     account_directory = _account_directory(destination)
     if account_directory is not None:
         secure_directory(account_directory)

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -64,6 +65,8 @@ def secure_storage_state_file(destination: Path | str) -> None:
     if permissions_are_posix():
         fd = _open_without_follow(Path(destination), os.O_RDONLY)
         try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise OSError(f"файл сессии не является обычным файлом: {destination}")
             os.fchmod(fd, SESSION_FILE_MODE)
         finally:
             os.close(fd)

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -23,9 +23,20 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
 
 def _account_directory(path: Path) -> Path | None:
     for parent in (path.parent, *path.parent.parents):
-        if parent.parent.name == "accounts":
+        # Only the repository's standard ``data/accounts/<name>`` layout is
+        # managed here.  A user may intentionally configure a custom path
+        # such as ``/srv/accounts/shared``; chmod must not lock that directory.
+        if parent.parent.name == "accounts" and parent.parent.parent.name == "data":
             return parent
     return None
+
+
+def _open_without_follow(path: Path, flags: int) -> int:
+    """Open a session path without following a symlink on POSIX."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow and path.is_symlink():
+        raise OSError(f"путь сессии является символической ссылкой: {path}")
+    return os.open(path, flags | nofollow)
 
 
 def secure_storage_state_parent(destination: Path | str) -> Path:
@@ -65,20 +76,31 @@ def prepare_storage_state_file(destination: Path | str) -> bool:
         return False
 
     try:
-        os.chmod(destination, SESSION_FILE_MODE)
+        fd = _open_without_follow(destination, os.O_RDONLY)
     except FileNotFoundError:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags = os.O_WRONLY | os.O_CREAT
         try:
-            fd = os.open(destination, flags, SESSION_FILE_MODE)
+            fd = _open_without_follow(destination, flags | os.O_EXCL)
         except FileExistsError:
-            os.chmod(destination, SESSION_FILE_MODE)
+            fd = _open_without_follow(destination, os.O_RDONLY)
         else:
-            os.close(fd)
+            try:
+                os.fchmod(fd, SESSION_FILE_MODE)
+            finally:
+                os.close(fd)
             return True
+    try:
+        os.fchmod(fd, SESSION_FILE_MODE)
+    finally:
+        os.close(fd)
     return False
 
 
 def secure_storage_state_file(destination: Path | str) -> None:
     """Tighten an existing session file after a writer has populated it."""
     if permissions_are_posix():
-        os.chmod(Path(destination), SESSION_FILE_MODE)
+        fd = _open_without_follow(Path(destination), os.O_RDONLY)
+        try:
+            os.fchmod(fd, SESSION_FILE_MODE)
+        finally:
+            os.close(fd)

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -1,0 +1,77 @@
+"""Local filesystem protections for hh.ru session secrets."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+SESSION_FILE_MODE = 0o600
+ACCOUNT_DIR_MODE = 0o700
+
+
+def permissions_are_posix() -> bool:
+    """Return whether Unix mode bits are meaningful for this process."""
+    return os.name != "nt"
+
+
+def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool = True) -> None:
+    """Create a directory and tighten its mode where Unix modes are supported."""
+    path.mkdir(parents=True, exist_ok=exist_ok, mode=mode)
+    if permissions_are_posix():
+        os.chmod(path, mode)
+
+
+def _account_directory(path: Path) -> Path | None:
+    for parent in (path.parent, *path.parent.parents):
+        if parent.parent.name == "accounts":
+            return parent
+    return None
+
+
+def secure_storage_state_parent(destination: Path | str) -> Path:
+    """Prepare private directories surrounding a storage-state file.
+
+    The account directory is tightened when the destination belongs to the
+    standard ``data/accounts/<name>`` layout.  The immediate storage directory
+    is private too, including for custom paths, so a session cannot be listed
+    by another local user while it is being written.
+    """
+    destination = Path(destination)
+    secure_directory(destination.parent)
+    account_directory = _account_directory(destination)
+    if account_directory is not None:
+        secure_directory(account_directory)
+    return destination
+
+
+def prepare_storage_state_file(destination: Path | str) -> bool:
+    """Ensure a session destination exists with owner-only mode.
+
+    Returning whether this call created the file lets callers remove an empty
+    placeholder if the subsequent browser write fails.  On Windows the mode
+    argument and ``chmod`` do not represent ACLs; directory preparation still
+    succeeds, while diagnostics explicitly reports that ACL inspection is not
+    available.
+    """
+    destination = secure_storage_state_parent(destination)
+    if not permissions_are_posix():
+        return False
+
+    try:
+        os.chmod(destination, SESSION_FILE_MODE)
+    except FileNotFoundError:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        try:
+            fd = os.open(destination, flags, SESSION_FILE_MODE)
+        except FileExistsError:
+            os.chmod(destination, SESSION_FILE_MODE)
+        else:
+            os.close(fd)
+            return True
+    return False
+
+
+def secure_storage_state_file(destination: Path | str) -> None:
+    """Tighten an existing session file after a writer has populated it."""
+    if permissions_are_posix():
+        os.chmod(Path(destination), SESSION_FILE_MODE)

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -19,11 +19,15 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
     """Create a directory and tighten its mode where Unix modes are supported."""
     path.mkdir(parents=True, exist_ok=exist_ok, mode=mode)
     if permissions_are_posix():
-        os.chmod(path, mode)
+        fd = _open_without_follow(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fchmod(fd, mode)
+        finally:
+            os.close(fd)
 
 
 def _open_without_follow(path: Path, flags: int) -> int:
-    """Open a session path without following a symlink on POSIX."""
+    """Open a filesystem path without following a symlink on POSIX."""
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     if not nofollow and path.is_symlink():
         raise OSError(f"путь сессии является символической ссылкой: {path}")
@@ -41,6 +45,9 @@ def secure_storage_state_parent(
     because the caller may share them with unrelated processes.
     """
     destination = Path(destination)
+    if account_dir is not None:
+        secure_directory(Path(account_dir))
+
     # Do not chmod an arbitrary existing path supplied by a user.  For
     # example, a custom ``/tmp/hh_session.json`` must not turn shared /tmp
     # into a private directory.  A missing parent is ours to create, so it can
@@ -49,8 +56,6 @@ def secure_storage_state_parent(
     destination.parent.mkdir(parents=True, exist_ok=True, mode=ACCOUNT_DIR_MODE)
     if not parent_exists and permissions_are_posix():
         os.chmod(destination.parent, ACCOUNT_DIR_MODE)
-    if account_dir is not None:
-        secure_directory(Path(account_dir))
     return destination
 
 

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 SESSION_FILE_MODE = 0o600
@@ -21,16 +22,6 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
         os.chmod(path, mode)
 
 
-def _account_directory(path: Path) -> Path | None:
-    for parent in (path.parent, *path.parent.parents):
-        # Only the repository's standard ``data/accounts/<name>`` layout is
-        # managed here.  A user may intentionally configure a custom path
-        # such as ``/srv/accounts/shared``; chmod must not lock that directory.
-        if parent.parent.name == "accounts" and parent.parent.parent.name == "data":
-            return parent
-    return None
-
-
 def _open_without_follow(path: Path, flags: int) -> int:
     """Open a session path without following a symlink on POSIX."""
     nofollow = getattr(os, "O_NOFOLLOW", 0)
@@ -39,13 +30,15 @@ def _open_without_follow(path: Path, flags: int) -> int:
     return os.open(path, flags | nofollow)
 
 
-def secure_storage_state_parent(destination: Path | str) -> Path:
+def secure_storage_state_parent(
+    destination: Path | str, *, account_dir: Path | str | None = None
+) -> Path:
     """Prepare private directories surrounding a storage-state file.
 
-    The account directory is tightened when the destination belongs to the
-    standard ``data/accounts/<name>`` layout.  A missing storage directory is
-    created privately; existing custom directories are left untouched because
-    the caller may share them with unrelated processes.
+    ``account_dir`` is supplied by the account-aware CLI path, rather than
+    inferred from a user-controlled session path.  A missing storage directory
+    is created privately; existing custom directories are left untouched
+    because the caller may share them with unrelated processes.
     """
     destination = Path(destination)
     # Do not chmod an arbitrary existing path supplied by a user.  For
@@ -56,44 +49,9 @@ def secure_storage_state_parent(destination: Path | str) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True, mode=ACCOUNT_DIR_MODE)
     if not parent_exists and permissions_are_posix():
         os.chmod(destination.parent, ACCOUNT_DIR_MODE)
-    account_directory = _account_directory(destination)
-    if account_directory is not None:
-        secure_directory(account_directory)
+    if account_dir is not None:
+        secure_directory(Path(account_dir))
     return destination
-
-
-def prepare_storage_state_file(destination: Path | str) -> bool:
-    """Ensure a session destination exists with owner-only mode.
-
-    Returning whether this call created the file lets callers remove an empty
-    placeholder if the subsequent browser write fails.  On Windows the mode
-    argument and ``chmod`` do not represent ACLs; directory preparation still
-    succeeds, while diagnostics explicitly reports that ACL inspection is not
-    available.
-    """
-    destination = secure_storage_state_parent(destination)
-    if not permissions_are_posix():
-        return False
-
-    try:
-        fd = _open_without_follow(destination, os.O_RDONLY)
-    except FileNotFoundError:
-        flags = os.O_WRONLY | os.O_CREAT
-        try:
-            fd = _open_without_follow(destination, flags | os.O_EXCL)
-        except FileExistsError:
-            fd = _open_without_follow(destination, os.O_RDONLY)
-        else:
-            try:
-                os.fchmod(fd, SESSION_FILE_MODE)
-            finally:
-                os.close(fd)
-            return True
-    try:
-        os.fchmod(fd, SESSION_FILE_MODE)
-    finally:
-        os.close(fd)
-    return False
 
 
 def secure_storage_state_file(destination: Path | str) -> None:
@@ -104,3 +62,21 @@ def secure_storage_state_file(destination: Path | str) -> None:
             os.fchmod(fd, SESSION_FILE_MODE)
         finally:
             os.close(fd)
+
+
+def create_storage_state_temp(
+    destination: Path | str, *, account_dir: Path | str | None = None
+) -> tuple[int, Path]:
+    """Create a private temporary path for a browser state export."""
+    destination = secure_storage_state_parent(destination, account_dir=account_dir)
+    fd, name = tempfile.mkstemp(
+        dir=destination.parent, prefix=destination.name + ".", suffix=".tmp"
+    )
+    if permissions_are_posix():
+        try:
+            os.fchmod(fd, SESSION_FILE_MODE)
+        except BaseException:
+            os.close(fd)
+            Path(name).unlink(missing_ok=True)
+            raise
+    return fd, Path(name)

--- a/tests/test_account_command.py
+++ b/tests/test_account_command.py
@@ -31,6 +31,8 @@ def test_create_copies_template(tmp_path, monkeypatch, capsys):
     created = tmp_path / "data" / "accounts" / "marketing" / "config.yaml"
     assert created.read_text(encoding="utf-8") == template.read_text(encoding="utf-8")
     assert 'Аккаунт "marketing" создан' in capsys.readouterr().out
+    if os.name != "nt":
+        assert (created.parent.stat().st_mode & 0o777) == 0o700
 
 
 def test_create_does_not_overwrite_existing_account(tmp_path, monkeypatch, capsys):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -63,6 +64,26 @@ def test_login_succeeds_when_auth_confirmed_on_third_poll(monkeypatch, tmp_path)
 
     context.storage_state.assert_called_once_with(path=str(config.storage_state_file))
     read_profile.assert_called_once_with(context.new_page.return_value, Path("data/history.db"))
+
+
+def test_login_creates_private_account_session_path(monkeypatch, tmp_path):
+    context = _make_playwright(monkeypatch)
+    monkeypatch.setattr(auth, "has_auth_cookie", lambda p: True)
+    monkeypatch.setattr(auth, "has_login_form", lambda p: False)
+    monkeypatch.setattr(time, "monotonic", iter([0, 0]).__next__)
+    context.storage_state.side_effect = lambda path: Path(path).write_text(
+        '{"cookies": [], "origins": []}\n', encoding="utf-8"
+    )
+
+    session = tmp_path / "data" / "accounts" / "work" / "storage_state" / "hh_session.json"
+    config = MagicMock(storage_state_file=session, user_agent=None)
+
+    auth.login(config)
+
+    if os.name != "nt":
+        assert (session.stat().st_mode & 0o777) == 0o600
+        assert (session.parent.stat().st_mode & 0o777) == 0o700
+        assert (session.parents[1].stat().st_mode & 0o777) == 0o700
 
 
 def test_login_times_out_when_login_form_never_disappears(monkeypatch, tmp_path):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,6 +17,7 @@ def _make_playwright(monkeypatch):
     """Собирает моки sync_playwright()/browser/context/page для login(); возвращает context."""
     context = MagicMock()
     context.new_page.return_value = MagicMock()
+    context.storage_state.return_value = {"cookies": [], "origins": []}
     browser = MagicMock()
     browser.new_context.return_value = context
 
@@ -62,11 +63,8 @@ def test_login_succeeds_when_auth_confirmed_on_third_poll(monkeypatch, tmp_path)
 
     auth.login(config)
 
-    context.storage_state.assert_called_once()
-    temporary_path = Path(context.storage_state.call_args.kwargs["path"])
-    assert temporary_path != config.storage_state_file
-    assert temporary_path.name.startswith("session.json.")
-    assert not temporary_path.exists()
+    context.storage_state.assert_called_once_with()
+    assert config.storage_state_file.exists()
     read_profile.assert_called_once_with(context.new_page.return_value, Path("data/history.db"))
 
 
@@ -75,9 +73,7 @@ def test_login_creates_private_account_session_path(monkeypatch, tmp_path):
     monkeypatch.setattr(auth, "has_auth_cookie", lambda p: True)
     monkeypatch.setattr(auth, "has_login_form", lambda p: False)
     monkeypatch.setattr(time, "monotonic", iter([0, 0]).__next__)
-    context.storage_state.side_effect = lambda path: Path(path).write_text(
-        '{"cookies": [], "origins": []}\n', encoding="utf-8"
-    )
+    context.storage_state.return_value = {"cookies": [], "origins": []}
 
     session = tmp_path / "data" / "accounts" / "work" / "storage_state" / "hh_session.json"
     config = MagicMock(storage_state_file=session, user_agent=None)
@@ -118,8 +114,5 @@ def test_login_never_calls_input_in_non_tty(monkeypatch, tmp_path):
         auth.login(config)
 
     mocked_input.assert_not_called()
-    context.storage_state.assert_called_once()
-    temporary_path = Path(context.storage_state.call_args.kwargs["path"])
-    assert temporary_path != config.storage_state_file
-    assert temporary_path.name.startswith("session.json.")
-    assert not temporary_path.exists()
+    context.storage_state.assert_called_once_with()
+    assert config.storage_state_file.exists()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -62,7 +62,11 @@ def test_login_succeeds_when_auth_confirmed_on_third_poll(monkeypatch, tmp_path)
 
     auth.login(config)
 
-    context.storage_state.assert_called_once_with(path=str(config.storage_state_file))
+    context.storage_state.assert_called_once()
+    temporary_path = Path(context.storage_state.call_args.kwargs["path"])
+    assert temporary_path != config.storage_state_file
+    assert temporary_path.name.startswith("session.json.")
+    assert not temporary_path.exists()
     read_profile.assert_called_once_with(context.new_page.return_value, Path("data/history.db"))
 
 
@@ -78,7 +82,7 @@ def test_login_creates_private_account_session_path(monkeypatch, tmp_path):
     session = tmp_path / "data" / "accounts" / "work" / "storage_state" / "hh_session.json"
     config = MagicMock(storage_state_file=session, user_agent=None)
 
-    auth.login(config)
+    auth.login(config, account_dir=session.parents[1])
 
     if os.name != "nt":
         assert (session.stat().st_mode & 0o777) == 0o600
@@ -114,4 +118,8 @@ def test_login_never_calls_input_in_non_tty(monkeypatch, tmp_path):
         auth.login(config)
 
     mocked_input.assert_not_called()
-    context.storage_state.assert_called_once_with(path=str(config.storage_state_file))
+    context.storage_state.assert_called_once()
+    temporary_path = Path(context.storage_state.call_args.kwargs["path"])
+    assert temporary_path != config.storage_state_file
+    assert temporary_path.name.startswith("session.json.")
+    assert not temporary_path.exists()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -42,6 +42,7 @@ def test_account_paths_are_defaults_but_explicit_paths_win(tmp_path, monkeypatch
     _resolve_paths(args)
     assert Path(args.config).resolve() == account / "config.yaml"
     assert Path(args.history).resolve() == account / "history.db"
+    assert Path(args.account_dir).resolve() == account
 
     args = parser.parse_args(
         [
@@ -59,6 +60,7 @@ def test_account_paths_are_defaults_but_explicit_paths_win(tmp_path, monkeypatch
     _resolve_paths(args)
     assert Path(args.config) == tmp_path / "custom.yaml"
     assert Path(args.history) == tmp_path / "custom.db"
+    assert args.account_dir is None
     assert DEFAULT_CONFIG_PATH == Path("data/config.yaml")
     assert DEFAULT_HISTORY_PATH == Path("data/history.db")
 

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -151,6 +151,22 @@ def test_custom_existing_session_parent_is_not_rechmodded(tmp_path: Path):
     assert (destination.stat().st_mode & 0o777) == 0o600
 
 
+def test_custom_accounts_path_is_not_treated_as_managed_account(tmp_path: Path):
+    account_dir = tmp_path / "srv" / "accounts" / "shared"
+    parent = account_dir / "storage_state"
+    parent.mkdir(parents=True)
+    destination = parent / "hh_session.json"
+    if os.name == "nt":
+        pytest.skip("POSIX directory modes are not available on Windows")
+    account_dir.chmod(0o755)
+    parent.chmod(0o755)
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert (account_dir.stat().st_mode & 0o777) == 0o755
+    assert (parent.stat().st_mode & 0o777) == 0o755
+
+
 def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeypatch):
     # Codex + /review re-review (PR #168): a previous fix called
     # tmp.chmod(0o600) AFTER tmp.write_text() had already created the file

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -127,6 +127,16 @@ def test_write_does_not_widen_session_file_permissions(tmp_path: Path):
     assert mode == 0o600, f"storage_state_file permissions widened to {oct(mode)}"
 
 
+def test_new_account_session_and_directories_are_private(tmp_path: Path):
+    destination = tmp_path / "data" / "accounts" / "work" / "storage_state" / "hh_session.json"
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    if os.name != "nt":
+        assert (destination.stat().st_mode & 0o777) == 0o600
+        assert (destination.parent.stat().st_mode & 0o777) == 0o700
+        assert (destination.parents[1].stat().st_mode & 0o777) == 0o700
+
+
 def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeypatch):
     # Codex + /review re-review (PR #168): a previous fix called
     # tmp.chmod(0o600) AFTER tmp.write_text() had already created the file

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -169,6 +169,26 @@ def test_custom_accounts_path_is_not_treated_as_managed_account(tmp_path: Path):
     assert (parent.stat().st_mode & 0o777) == 0o755
 
 
+def test_managed_account_symlink_is_rejected_without_touching_target(tmp_path: Path):
+    if os.name == "nt":
+        pytest.skip("POSIX symlink and directory modes are not available on Windows")
+
+    accounts = tmp_path / "data" / "accounts"
+    accounts.mkdir(parents=True)
+    external = tmp_path / "external"
+    external.mkdir()
+    external.chmod(0o755)
+    account_link = accounts / "work"
+    account_link.symlink_to(external, target_is_directory=True)
+
+    destination = account_link / "storage_state" / "hh_session.json"
+    with pytest.raises(OSError):
+        write_storage_state({"cookies": [], "origins": []}, destination, account_dir=account_link)
+
+    assert external.stat().st_mode & 0o777 == 0o755
+    assert not (external / "storage_state").exists()
+
+
 def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeypatch):
     # Codex + /review re-review (PR #168): a previous fix called
     # tmp.chmod(0o600) AFTER tmp.write_text() had already created the file

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -189,6 +189,20 @@ def test_managed_account_symlink_is_rejected_without_touching_target(tmp_path: P
     assert not (external / "storage_state").exists()
 
 
+def test_existing_directory_destination_is_rejected_without_chmod(tmp_path: Path):
+    if os.name == "nt":
+        pytest.skip("POSIX directory modes are not available on Windows")
+
+    destination = tmp_path / "project"
+    destination.mkdir()
+    destination.chmod(0o755)
+
+    with pytest.raises(OSError, match="обычным файлом"):
+        write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert destination.stat().st_mode & 0o777 == 0o755
+
+
 def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeypatch):
     # Codex + /review re-review (PR #168): a previous fix called
     # tmp.chmod(0o600) AFTER tmp.write_text() had already created the file

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -129,7 +129,9 @@ def test_write_does_not_widen_session_file_permissions(tmp_path: Path):
 
 def test_new_account_session_and_directories_are_private(tmp_path: Path):
     destination = tmp_path / "data" / "accounts" / "work" / "storage_state" / "hh_session.json"
-    write_storage_state({"cookies": [], "origins": []}, destination)
+    write_storage_state(
+        {"cookies": [], "origins": []}, destination, account_dir=destination.parents[1]
+    )
 
     if os.name != "nt":
         assert (destination.stat().st_mode & 0o777) == 0o600

--- a/tests/test_cookie_import.py
+++ b/tests/test_cookie_import.py
@@ -137,6 +137,20 @@ def test_new_account_session_and_directories_are_private(tmp_path: Path):
         assert (destination.parents[1].stat().st_mode & 0o777) == 0o700
 
 
+def test_custom_existing_session_parent_is_not_rechmodded(tmp_path: Path):
+    parent = tmp_path / "shared"
+    parent.mkdir()
+    destination = parent / "hh_session.json"
+    if os.name == "nt":
+        pytest.skip("POSIX directory modes are not available on Windows")
+    parent.chmod(0o755)
+
+    write_storage_state({"cookies": [], "origins": []}, destination)
+
+    assert (parent.stat().st_mode & 0o777) == 0o755
+    assert (destination.stat().st_mode & 0o777) == 0o600
+
+
 def test_temp_file_is_never_world_readable_while_written(tmp_path: Path, monkeypatch):
     # Codex + /review re-review (PR #168): a previous fix called
     # tmp.chmod(0o600) AFTER tmp.write_text() had already created the file

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,14 +1,69 @@
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from hhru_bot import __version__
 from hhru_bot import _version as version_module
+from hhru_bot.commands import diagnostics as diagnostics_command
 from hhru_bot.diagnostics import _same_path, build_bundle, redact
 
 pytestmark = pytest.mark.unit
+
+
+def _write_account(tmp_path: Path, *, session: bool = True) -> tuple[Path, Path]:
+    account_dir = tmp_path / "data" / "accounts" / "work"
+    (account_dir / "storage_state").mkdir(parents=True)
+    (account_dir / "config.yaml").write_text(
+        "account:\n  storage_state_file: storage_state/hh_session.json\n", encoding="utf-8"
+    )
+    session_path = account_dir / "storage_state" / "hh_session.json"
+    if session:
+        session_path.write_text('{"token":"do-not-print"}', encoding="utf-8")
+    return account_dir, session_path
+
+
+def test_diagnostics_reports_weak_session_permissions_without_reading_secret(
+    tmp_path, monkeypatch, capsys
+):
+    account_dir, session_path = _write_account(tmp_path)
+    account_dir.chmod(0o755)
+    session_path.chmod(0o644)
+    monkeypatch.chdir(tmp_path)
+
+    entries = diagnostics_command.check_session_permissions()
+    assert len(entries) == 1
+    assert entries[0].weak is True
+
+    monkeypatch.setattr(
+        diagnostics_command,
+        "run_doctor",
+        lambda **_: SimpleNamespace(components=(), drift=False, reasons=()),
+    )
+    assert (
+        diagnostics_command.run_doctor_command(SimpleNamespace(marketplace=None, plugin_cache=None))
+        is True
+    )
+    output = capsys.readouterr().out
+    assert "0755" in output and "0644" in output
+    assert "chmod 700" in output and "chmod 600" in output
+    assert "do-not-print" not in output
+
+
+def test_diagnostics_does_not_fake_posix_modes_on_windows(tmp_path, monkeypatch):
+    _write_account(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(diagnostics_command, "permissions_are_posix", lambda: False)
+
+    entries = diagnostics_command.check_session_permissions()
+
+    assert len(entries) == 1
+    assert entries[0].error is not None
+    assert entries[0].account_mode is None
+    assert entries[0].session_mode is None
+    assert entries[0].weak is False
 
 
 def test_redaction_adversarial():


### PR DESCRIPTION
## Summary
- enforce owner-only session files and private account directories on POSIX systems
- report session/account permissions for every named account in diagnostics, with explicit Windows ACL fallback
- document session-secret handling and add regression coverage

Closes #726

## Tests
- ruff check src tests scripts
- ruff format --check src tests scripts
- python scripts/selector_contracts.py check
- python scripts/gen_cli_docs.py --check
- pytest -q

## Risks
Windows cannot represent POSIX mode bits; diagnostics warns and asks for manual ACL verification.