### PR TITLE
fix(apply): stop on expired session before consuming limit

### DIFF
--- a/scripts/scheduled_run.sh
+++ b/scripts/scheduled_run.sh
@@ -53,6 +53,8 @@ LOG_FILE="${LOG_DIR}/scheduled.log"
 # python3, что и интерактивный run.sh (совместимость с ручным запуском).
 # Без PYTHONPATH=src: код резолвится из site-packages editable install.
 PYTHON_BIN="${HHRU_PYTHON:-python3}"
+# Keep synchronized with CommandExitCode.SESSION_EXPIRED in exit_codes.py.
+SESSION_EXPIRED_EXIT_CODE=78
 run_cli() {
   "${PYTHON_BIN}" -m hhru_bot.cli "$@" 2>&1 | tee -a "${LOG_FILE}"
   return "${PIPESTATUS[0]}"
@@ -63,4 +65,14 @@ if [[ -n "${HHRU_ACCOUNT:-}" ]]; then
   ACCOUNT_ARGS=(--account "${HHRU_ACCOUNT}")
 fi
 
+set +e
 run_cli "${ACCOUNT_ARGS[@]}" "$@"
+status=$?
+set -e
+
+if [[ "${status}" -eq "${SESSION_EXPIRED_EXIT_CODE}" ]]; then
+  echo "[SESSION_EXPIRED] Сессия hh.ru истекла; выполните: hhru login или hhru refresh-token" \
+    | tee -a "${LOG_FILE}"
+fi
+
+exit "${status}"

--- a/src/hhru_bot/apply/pipeline.py
+++ b/src/hhru_bot/apply/pipeline.py
@@ -20,7 +20,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from ..ai.questions import AIQuestionAnswerer, AnswerProposal, extract_questions
-from ..browser import goto_hh, has_login_form
+from ..browser import goto_hh, require_authenticated_page
 from ..history import SKIP_REASONS, History
 from ..search import VacancyCard
 from ..vacancy_refresh import VacancyBodyCache, refresh_card
@@ -443,8 +443,10 @@ def _run(ctx: ApplyContext) -> ApplyResult:
     _halt_if_antibot(ctx)
     # Reuse the already-open vacancy page; no second navigation is needed.
     ctx.vacancy = refresh_card(ctx.page, ctx.vacancy, cache=ctx.vacancy_body_cache)
-    if has_login_form(ctx.page):
-        return ctx.fail("Сессия недействительна: страница содержит форму входа. Выполните login.")
+    # Authentication is a terminal pre-submit invariant.  Do not turn this
+    # into an ApplyResult(uncertain=True): unlike a submit failure, no action
+    # could have reached hh.ru before the page passed this check.
+    require_authenticated_page(ctx.page)
     ctx.probe("vacancy_loaded", url=ctx.vacancy.url)
 
     apply_button_found = apply_steps.wait_apply_button(ctx.page)

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -157,6 +157,11 @@ def require_authenticated_page(
 
     This must be called after navigation: the login form is a server-rendered
     positive signal, while a cookie alone only proves that it remains in the jar.
+
+    ``NotAuthenticated`` is a terminal pre-action signal for callers that may
+    otherwise continue through a batch.  It must not be converted into the
+    post-click ``uncertain`` state: no irreversible action is possible before
+    this check succeeds.
     """
     if not (auth_cookie_check or has_auth_cookie)(page):
         raise NotAuthenticated(

--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -22,6 +22,7 @@ from ..apply.antibot import AntiBotChallengeDetected, raise_for_antibot
 from ..apply.letter import CoverLetterProvider
 from ..apply.verify import verify_response_in_negotiations
 from ..blacklist import match as blacklist_match
+from ..browser import NotAuthenticated
 from ..config import AppConfig, ResumeConfig, SearchFilters, is_resume_url_placeholder
 from ..config_sections.scoring import ScoringWeights
 from ..copy_resume import resolve_numeric_resume_ids
@@ -556,7 +557,7 @@ def run_supervised_command(
     command: str,
     history: History,
     requested_limit: int | None,
-    body: Callable[[ApplyProgress], bool],
+    body: Callable[[ApplyProgress], bool | CommandExitCode],
     reconcile: Callable[[ApplyProgress, History, str], None] | None = None,
     print_summary: bool = True,
 ) -> bool | CommandExitCode:
@@ -616,15 +617,22 @@ def run_supervised_command(
     result: bool | CommandExitCode = True
     try:
         failed = body(progress)
-        final_status = (
-            "partial"
-            if failed and progress.attempted_count
-            else "failed"
-            if failed
-            else "completed"
-        )
-        exit_code = 1 if failed else 0
-        result = bool(failed)
+        if isinstance(failed, CommandExitCode):
+            # Typed terminal outcomes (currently expired authentication) must
+            # reach the CLI unchanged instead of becoming generic exit 1.
+            final_status = "failed"
+            exit_code = failed.value
+            result = failed
+        else:
+            final_status = (
+                "partial"
+                if failed and progress.attempted_count
+                else "failed"
+                if failed
+                else "completed"
+            )
+            exit_code = 1 if failed else 0
+            result = bool(failed)
     except KeyboardInterrupt:
         final_status = "interrupted"
         exit_code = CommandExitCode.SIGINT.value
@@ -635,6 +643,20 @@ def run_supervised_command(
         exit_code = 128 + exc.signum
         detail = f"signal={exc.signum}"
         result = CommandExitCode.SIGTERM
+    except NotAuthenticated as exc:
+        # A confirmed unauthenticated page is terminal before any action.  It
+        # is intentionally not recorded as an uncertain action: that state is
+        # reserved for the post-click grey zone where hh.ru may have accepted
+        # the request.  Keep the reason in the command ledger and expose a
+        # dedicated status for schedulers/automation.
+        final_status = "failed"
+        exit_code = CommandExitCode.SESSION_EXPIRED.value
+        detail = f"{type(exc).__name__}: {exc}"
+        print(
+            f"[FAIL] Сессия hh.ru недействительна: {exc}. "
+            "Выполните `hhru login` или `hhru refresh-token`, затем повторите."
+        )
+        result = CommandExitCode.SESSION_EXPIRED
     except BaseException as exc:
         detail = f"{type(exc).__name__}: {exc}"
         raise

--- a/src/hhru_bot/exit_codes.py
+++ b/src/hhru_bot/exit_codes.py
@@ -7,6 +7,11 @@ class CommandExitCode(Enum):
     """A command-level status that must be handled by :mod:`hhru_bot.cli`."""
 
     PERSISTENCE_FAILED = 2
+    # The command reached a confirmed unauthenticated page before any
+    # irreversible action.  Keep this distinct from the generic fail-closed
+    # status (1), persistence failures, and POSIX signal statuses so scheduled
+    # callers can stop retrying and surface the required manual remediation.
+    SESSION_EXPIRED = 78
     SIGHUP = 129
     SIGINT = 130
     SIGTERM = 143

--- a/tests/test_apply_letter_integration.py
+++ b/tests/test_apply_letter_integration.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
@@ -71,6 +72,9 @@ class _ApplyFakePage:
 
     def __init__(self):
         self.goto_calls: list[str] = []
+        self.context = SimpleNamespace(
+            cookies=lambda: [{"name": "hhtoken", "value": "test-session"}]
+        )
 
     def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)

--- a/tests/test_apply_pipeline.py
+++ b/tests/test_apply_pipeline.py
@@ -14,6 +14,7 @@ import pytest
 import hhru_bot.apply.pipeline as pipeline_module
 from hhru_bot.apply import ProbeHook, apply_to_vacancy
 from hhru_bot.apply.antibot import AntiBotChallengeDetected, AntiBotDetection
+from hhru_bot.browser import NotAuthenticated
 from hhru_bot.history import SKIP_REASONS
 from hhru_bot.search import VacancyCard
 
@@ -119,6 +120,9 @@ class FakePage:
         submit_click_error: Exception | None = None,
     ):
         self.url = ""
+        self.context = SimpleNamespace(
+            cookies=lambda: [{"name": "hhtoken", "value": "test-session"}]
+        )
         self.goto_calls: list[str] = []
         self._apply_button = apply_button
         self._already_responded = already_responded
@@ -224,20 +228,20 @@ def test_apply_login_form_is_checked_after_navigation(monkeypatch):
         events.append("goto")
         p.goto(url)
 
-    def fake_has_login_form(_page):
+    def fake_require_authenticated_page(_page):
         events.append("auth")
         assert events == ["goto", "auth"]
-        return True
+        raise NotAuthenticated("сессия истекла")
 
     monkeypatch.setattr(pipeline_module, "goto_hh", fake_goto)
-    monkeypatch.setattr(pipeline_module, "has_login_form", fake_has_login_form)
+    monkeypatch.setattr(
+        pipeline_module, "require_authenticated_page", fake_require_authenticated_page
+    )
 
-    result = apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
+    with pytest.raises(NotAuthenticated, match="сессия истекла"):
+        apply_to_vacancy(page, _vacancy(), "RID", "x", dry_run=True)
 
-    assert result.success is False
-    assert "Сессия недействительна" in result.reason
     assert events == ["goto", "auth"]
-    assert result.acted is False  # #163: провал до submit — без паузы и записи
 
 
 def test_antibot_detection_terminates_pipeline_before_per_vacancy_work(monkeypatch):

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -775,6 +775,9 @@ class _ApplyPipelineFakePage:
 
     def __init__(self):
         self.goto_calls: list[str] = []
+        self.context = SimpleNamespace(
+            cookies=lambda: [{"name": "hhtoken", "value": "test-session"}]
+        )
 
     def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)

--- a/tests/test_common_run_context.py
+++ b/tests/test_common_run_context.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from hhru_bot.browser import NotAuthenticated
 from hhru_bot.commands._common import ApplyProgress, SignalTermination, run_supervised_command
 from hhru_bot.exit_codes import CommandExitCode
 from hhru_bot.history import LEGACY_LEASE_GRACE, CommandRunBusy, History
@@ -211,6 +212,31 @@ def test_generic_exception_persists_failed_status_with_detail(tmp_path: Path) ->
     assert row["status"] == "failed"
     assert row["exit_code"] == 1
     assert row["detail"] == "RuntimeError: boom"
+
+
+def test_expired_session_has_dedicated_exit_code_and_no_uncertain_count(
+    tmp_path: Path, capsys
+) -> None:
+    """A pre-action auth failure stops the batch and remains outside grey-zone accounting."""
+    history = History(tmp_path / "history.db")
+    seen: list[int] = []
+
+    def body(_progress: ApplyProgress) -> bool:
+        seen.append(1)
+        raise NotAuthenticated("cookie hhtoken не найден")
+
+    result = run_supervised_command(command="apply", history=history, requested_limit=5, body=body)
+
+    assert result is CommandExitCode.SESSION_EXPIRED
+    assert seen == [1]
+    row = history.command_runs()[-1]
+    assert row["status"] == "failed"
+    assert row["exit_code"] == CommandExitCode.SESSION_EXPIRED.value
+    assert row["attempted"] == 0
+    assert row["uncertain"] == 0
+    output = capsys.readouterr().out
+    assert "hhru login" in output
+    assert "hhru refresh-token" in output
 
 
 def test_nested_call_restores_outer_handler_lifo(tmp_path: Path) -> None:

--- a/tests/test_history_key_consistency.py
+++ b/tests/test_history_key_consistency.py
@@ -20,6 +20,7 @@ bump — под ``resume.resume_id`` (``AAA111``) → ключи расходя�
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 
@@ -90,6 +91,9 @@ class _ApplyFakePage:
 
     def __init__(self):
         self.goto_calls: list[str] = []
+        self.context = SimpleNamespace(
+            cookies=lambda: [{"name": "hhtoken", "value": "test-session"}]
+        )
 
     def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
         self.goto_calls.append(url)

--- a/tests/test_schedule_command.py
+++ b/tests/test_schedule_command.py
@@ -266,3 +266,13 @@ def test_shipped_scheduler_configs_have_one_persistent_log_writer(path):
         parsed = plistlib.loads(text.encode())
         assert parsed["StandardOutPath"] == "/dev/null"
         assert parsed["StandardErrorPath"] == "/dev/null"
+
+
+def test_scheduled_wrapper_surfaces_expired_session():
+    script = (Path(__file__).parents[1] / "scripts" / "scheduled_run.sh").read_text()
+
+    assert "SESSION_EXPIRED_EXIT_CODE=78" in script
+    assert 'if [[ "${status}" -eq "${SESSION_EXPIRED_EXIT_CODE}" ]]' in script
+    assert "[SESSION_EXPIRED]" in script
+    assert "hhru login или hhru refresh-token" in script
+    assert 'tee -a "${LOG_FILE}"' in script


### PR DESCRIPTION
Closes #720

## Summary
- stop apply immediately on confirmed terminal NotAuthenticated before any submit action
- preserve post-click uncertain fail-closed behavior
- expose dedicated session-expired exit code and scheduled-run remediation

## Verification
- ruff check src tests scripts
- ruff format --check src tests scripts
- python scripts/selector_contracts.py check
- pytest -q

No hh.ru login or WRITE operations were performed.