### PR TITLE
test(cli): red test — сетевой сбой goto_hh печатает голый traceback (#747)

### DIFF
--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -16,6 +16,8 @@ import pkgutil
 import sys
 from pathlib import Path
 
+from playwright.sync_api import Error as PlaywrightError
+
 from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
 from .apply.antibot import AntiBotChallengeDetected
@@ -318,6 +320,28 @@ def _resolve_paths(args: argparse.Namespace) -> None:
     args.account_dir = str(account_paths.config.parent) if account_paths else None
 
 
+def _log_unhandled_to_file(command: str, message: str) -> None:
+    """Write an unhandled-exception record to the hhru_bot FileHandler only.
+
+    Shared by the generic ``except Exception`` path (#179) and the #747
+    PlaywrightError branch below: both re-raise afterwards, letting Python's
+    own excepthook print the traceback to stderr exactly once. Duplicating the
+    console output here would print it twice.
+    """
+    record = logging.getLogger("hhru_bot").makeRecord(
+        "hhru_bot",
+        logging.ERROR,
+        __file__,
+        0,
+        message,
+        (command,),
+        sys.exc_info(),
+    )
+    for handler in logging.getLogger("hhru_bot").handlers:
+        if isinstance(handler, logging.FileHandler):
+            handler.handle(record)
+
+
 def _execute(args: argparse.Namespace) -> None:
     # READ-команда `log` намеренно минует setup_logging: FileHandler создал бы
     # data/logs/hhru_bot.log на запись до run(), что нарушает READ-контракт «не меняет
@@ -348,6 +372,31 @@ def _execute(args: argparse.Namespace) -> None:
     except BrowserLaunchError as exc:
         print(f"[ENVIRONMENT] {exc}", file=sys.stderr)
         sys.exit(1)
+    except PlaywrightError as exc:
+        # #747: goto_hh (browser.py) пробрасывает PlaywrightTimeoutError/
+        # PlaywrightError одинаково для любой причины — сеть недоступна вовсе
+        # (DNS/connect timeout), анти-бот hh.ru или дрейф селектора/медленный
+        # рендер. Различаем только то, что можно различить достоверно:
+        # net::ERR_* — код уровня сетевого стека Chromium (Playwright не
+        # добрался до ответа сервера вообще), а не таймаут рендера/анти-бота.
+        if "net::ERR_" in str(exc):
+            print(
+                f"[ENVIRONMENT] похоже на отсутствие сети/соединения с hh.ru: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        # Остальные PlaywrightError (в т.ч. "чистый" TimeoutError без net::ERR_*
+        # в сообщении — страница не отрисовалась, возможен анти-бот) НЕ
+        # переквалифицируем: причина неизвестна, и по fail-closed инварианту
+        # (CLAUDE.md §5) остаётся неопределённой. Тот же путь логирования в файл
+        # + traceback, что и в except Exception ниже (#179).
+        if logging_enabled:
+            _log_unhandled_to_file(
+                args.command,
+                "Необработанное исключение в команде '%s' "
+                "(страница не отрисовалась / возможен анти-бот)",
+            )
+        raise
     except AntiBotChallengeDetected as exc:
         # #344: terminal apply/run state.  Do not render a traceback or continue
         # with another vacancy/resume (or bump in the combined ``run`` command).
@@ -371,18 +420,7 @@ def _execute(args: argparse.Namespace) -> None:
             # через excepthook — пользователь видел бы его дважды. Пишем запись
             # только в FileHandler напрямую, консоль получает traceback один раз
             # от самого Python (стандартное поведение необработанного исключения).
-            record = logging.getLogger("hhru_bot").makeRecord(
-                "hhru_bot",
-                logging.ERROR,
-                __file__,
-                0,
-                "Необработанное исключение в команде '%s'",
-                (args.command,),
-                sys.exc_info(),
-            )
-            for handler in logging.getLogger("hhru_bot").handlers:
-                if isinstance(handler, logging.FileHandler):
-                    handler.handle(record)
+            _log_unhandled_to_file(args.command, "Необработанное исключение в команде '%s'")
         raise
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -628,3 +628,32 @@ def test_antibot_terminal_state_prints_fail_without_traceback(monkeypatch, capsy
     assert "решите её вручную" in stderr
     assert "Traceback" not in stderr
     logging.getLogger("hhru_bot").handlers.clear()
+
+
+def test_network_connection_failure_prints_environment_without_traceback(monkeypatch, capsys):
+    """#747: сетевой сбой соединения (нет доступа до hh.ru — прокси/GFW/etc,
+    причина не устанавливается) должен получать тот же структурированный
+    контракт, что и BrowserLaunchError/AntiBotChallengeDetected (см. соседние
+    тесты выше в этом файле), а не падать в общий except Exception с голым
+    Python-traceback.
+
+    RED: сейчас cli.py::_execute не классифицирует net::ERR_* отдельно —
+    Playwright Error из goto_hh улетает в generic except Exception → raise,
+    печатая traceback в stderr вместо "[ENVIRONMENT] ...".
+    """
+    from playwright.sync_api import Error as PlaywrightError
+
+    def _network_down(_args: argparse.Namespace) -> bool:
+        raise PlaywrightError("Page.goto: net::ERR_TIMED_OUT at https://hh.ru/applicant/my_resumes")
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _network_down)
+    with pytest.raises(SystemExit) as exc_info:
+        main(["whoami"])
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "[ENVIRONMENT]" in stderr
+    assert "Traceback" not in stderr
+    logging.getLogger("hhru_bot").handlers.clear()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -657,3 +657,43 @@ def test_network_connection_failure_prints_environment_without_traceback(monkeyp
     assert "[ENVIRONMENT]" in stderr
     assert "Traceback" not in stderr
     logging.getLogger("hhru_bot").handlers.clear()
+
+
+def test_plain_timeout_without_net_err_stays_unclassified(monkeypatch, capsys):
+    """#747 (граница скоупа): throttled-канал — TCP/TLS-хендшейк проходит,
+    страница просто не успевает докачаться за GOTO_TIMEOUT_MS. Playwright в
+    этом случае бросает "чистый" PlaywrightTimeoutError БЕЗ net::ERR_* в
+    сообщении (как и в первой попытке из живого лога issue #747 — net::ERR_*
+    появился только на второй попытке goto).
+
+    Такой сбой НЕ должен переквалифицироваться в "[ENVIRONMENT]": причина
+    неизвестна (может быть анти-бот, может быть медленный/задушенный канал —
+    не отличить программно), и по fail-closed инварианту (CLAUDE.md §5)
+    остаётся неопределённой. Контракт — тот же, что и до #747: traceback
+    в консоли + запись в hhru_bot.log (#179), НЕ "[ENVIRONMENT]".
+    """
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    from hhru_bot.logging_setup import LOG_DIR
+
+    def _render_timeout(_args: argparse.Namespace) -> bool:
+        raise PlaywrightTimeoutError("Page.goto: Timeout 90000ms exceeded.")
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _render_timeout)
+
+    try:
+        with pytest.raises(PlaywrightTimeoutError, match="Timeout 90000ms exceeded"):
+            main(["whoami"])
+
+        stderr = capsys.readouterr().err
+        assert "[ENVIRONMENT]" not in stderr
+
+        log_file = LOG_DIR / "hhru_bot.log"
+        assert log_file.exists()
+        content = log_file.read_text(encoding="utf-8")
+        assert "Необработанное исключение в команде 'whoami'" in content
+        assert "страница не отрисовалась / возможен анти-бот" in content
+    finally:
+        logging.getLogger("hhru_bot").handlers.clear()


### PR DESCRIPTION
## Что это

Фикс для issue #747: `goto_hh()` (`src/hhru_bot/browser.py`) ретраит на любую
`PlaywrightTimeoutError`/`PlaywrightError` одинаково — сетевой сбой соединения
(`net::ERR_TIMED_OUT`, `net::ERR_NAME_NOT_RESOLVED` и т.п.) неотличим от
анти-бота hh.ru или дрейфа селектора. После исчерпания попыток исключение
пробрасывалось в `cli.py::_execute`, падало в общий `except Exception` и
пользователь получал сырой Python-traceback вместо структурированного
сообщения по контракту `docs/cli-spec.md`.

Closes #747

## Фикс

`_execute()` теперь распознаёт маркер `net::ERR_*` в тексте `PlaywrightError`
как сбой сетевого стека Chromium (соединение не установлено вовсе, до ответа
сервера дело не дошло) и репортит его как `[ENVIRONMENT]`, по аналогии с уже
существующей веткой `BrowserLaunchError`.

Любая другая `PlaywrightError` (включая «чистый» `TimeoutError` без
`net::ERR_*` — страница не отрисовалась, возможен анти-бот) НЕ
переквалифицируется: причина неизвестна, и по fail-closed инварианту проекта
(CLAUDE.md §5) остаётся неопределённой — тот же путь логирования в файл +
traceback, что был раньше в общем `except Exception`. Дублирование между
этой веткой и `except Exception` устранено общим хелпером
`_log_unhandled_to_file()`.

Retry-логика `goto_hh` не тронута — классификация происходит только на
границе CLI (`cli.py::_execute`), как и требовал явный скоуп задачи.

## Red → Green

`tests/test_cli_commands.py::test_network_connection_failure_prints_environment_without_traceback`
(написан заранее, коммит 098f7dc) теперь зелёный:

```
$ python3 -m pytest tests/test_cli_commands.py -v
43 passed in 0.82s
```

Полный набор:

```
$ python3 -m pytest -n 4 --dist worksteal
2698 passed, 2 skipped in 35.74s
```

`ruff check` / `ruff format --check` по `src tests scripts` — чисто.
`scripts/gen_cli_docs.py --check` — синхронизирован (CLI-контракт не менялся).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
