### PR TITLE
feat(config): структурированные факты кандидата в конфиге (#751)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -163,6 +163,44 @@ resumes:
     #       organization: "Школа данных"
     #       specialty: "SQL"
     #       year: "2020"
+    # Опционально (#751): машинно-читаемые факты о кандидате — фундамент
+    # адаптивных резюме под кластеры вакансий (#750). Пока НЕ подключено ни к
+    # одному генератору разделов (about/experience/skills/...) — это #753/#754.
+    # Каждый факт несёт tags: список тегов релевантности, по которым будущий
+    # отбор решит, показывать ли факт под конкретный кластер. Пустой tags =
+    # факт релевантен всем кластерам (или кластеризация ещё не проведена).
+    # Правдивость обязательна (#750): даты/компании/образование не выдумываются,
+    # только отбираются/скрываются под кластер.
+    # candidate_facts:
+    #   work_experience:
+    #     - company: "ООО Пример"
+    #       position: "Backend-разработчик"
+    #       period_from: "2021-03"
+    #       period_to: "2024-06"
+    #       description: "Разработка высоконагруженного API на Python/Django."
+    #       skills: ["python", "django", "postgresql"]
+    #       tags: ["backend", "python"]
+    #     - company: "ИП Пример"
+    #       position: "Data Analyst"
+    #       period_from: "2019-01"
+    #       period_to: "2021-02"
+    #       description: "Аналитика продаж, дашборды в Superset."
+    #       skills: ["sql", "python", "superset"]
+    #       tags: ["analytics", "sql"]
+    #   education:
+    #     - institution: "МГУ"
+    #       specialty: "Физика"
+    #       year: "2015"
+    #       tags: ["general"]
+    #   languages:
+    #     - name: "Английский"
+    #       level: "B2"
+    #       tags: ["general"]
+    #   projects:
+    #     - name: "Пет-проект: трекер вакансий"
+    #       description: "CLI на Playwright для автопоиска вакансий."
+    #       skills: ["python", "playwright"]
+    #       tags: ["backend", "automation"]
     cover_letter: null
 
   - id: "resume-name-2"

--- a/src/hhru_bot/config.py
+++ b/src/hhru_bot/config.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     # Только для статического анализа; реальный импорт был бы циклическим
     # (config_sections.ai импортирует ConfigError из config).
     from .config_sections.ai import AiConfig
+    from .config_sections.candidate_facts import CandidateFacts
     from .config_sections.questionnaires import QuestionnairesConfig
 
 
@@ -72,6 +73,12 @@ class ResumeConfig:
     ai_profile: object | None = None
     resume_sections: object | None = None
     education: object | None = None
+    # #751: структурированные факты о кандидате (места работы/образование/языки/
+    # проекты) под отбор в адаптивных резюме (#750). В отличие от полей выше —
+    # типизировано явно, а не через object|None (issue #751 "Заодно исправить":
+    # новая секция не должна тащить тот же дефект типизации; потребителям не
+    # нужен cast(), см. commands/about.py:73-76 для контраста).
+    candidate_facts: CandidateFacts | None = None
 
     @property
     def resume_id(self) -> str:

--- a/src/hhru_bot/config_sections/__init__.py
+++ b/src/hhru_bot/config_sections/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from . import (  # noqa: F401
     account,
     ai_profile,
+    candidate_facts,
     education,
     resume_sections,
     scoring,

--- a/src/hhru_bot/config_sections/candidate_facts.py
+++ b/src/hhru_bot/config_sections/candidate_facts.py
@@ -1,0 +1,208 @@
+"""Парсер опциональной resume-секции candidate_facts -> CandidateFacts (issue #751).
+
+Фундамент эпика #750 (адаптивные резюме: пул под кластеры). `AIProfile`
+(#17, ``ai_profile.py``) покрывает только генерацию сопроводительных писем и
+не описывает структурированные факты о кандидате — места работы с датами,
+образование, языки, проекты. Без них отбор фактов под кластер вакансий
+(глубина адаптации, выбранная в #750) реализовать не из чего.
+
+Секция опциональна: при отсутствии load_config оставит
+ResumeConfig.candidate_facts = None (обратная совместимость — код,
+написанный до #751, продолжает работать без изменений).
+
+**Каждый факт (место работы, образование, язык, проект) несёт список
+`tags: list[str]` — теги релевантности.** Это единственный контракт, ради
+которого существует эта секция: без тегов sub-issue отбора (#753/#754) не
+сможет решить, какой факт показывать под какой кластер вакансий. Пустой
+список `tags` — валидное значение (факт релевантен всем кластерам или
+кластеризация ещё не проведена), но поле обязано присутствовать в датаклассе.
+
+Эта секция НЕ подключена ни к одному генератору разделов резюме (about.py,
+experience.py, ...) — это осознанно оставлено sub-issue #753. #751 — только
+машинно-читаемое описание фактов.
+
+Секция типизирована явно (`CandidateFacts | None`), а не через нейтральный
+`object | None` (в отличие от `ResumeConfig.ai_profile`/`scoring`/
+`resume_sections`/`education` — те заведены раньше и их дефект типизации не
+в скоупе этого issue, см. CLAUDE.md и тело #751 "Заодно исправить" /
+"Чего НЕ делать"). Новый код так не делает.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..config import ConfigError
+from ._registry import register
+
+
+def _require_str(raw: dict, key: str, context: str) -> str:
+    value = raw.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ConfigError(f"Поле '{key}' в '{context}' должно быть строкой, получено: {value!r}")
+    return value
+
+
+def _require_str_list(raw: dict, key: str, context: str) -> list[str]:
+    value = raw.get(key, [])
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        raise ConfigError(f"Поле '{key}' в '{context}' должно быть списком строк")
+    return value
+
+
+@dataclass(frozen=True)
+class WorkExperienceFact:
+    """Одно место работы. Правдивость обязательна (#750): даты/компания/должность
+    не выдумываются, только отбираются под кластер через `tags`."""
+
+    company: str = ""
+    position: str = ""
+    period_from: str = ""
+    period_to: str = ""
+    description: str = ""
+    skills: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EducationFact:
+    institution: str = ""
+    specialty: str = ""
+    year: str = ""
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class LanguageFact:
+    name: str = ""
+    level: str = ""
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ProjectFact:
+    name: str = ""
+    description: str = ""
+    skills: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CandidateFacts:
+    """Машинно-читаемые факты о кандидате. Все поля опциональны/списки могут
+    быть пустыми — секция подключается постепенно, по мере заполнения."""
+
+    work_experience: list[WorkExperienceFact] = field(default_factory=list)
+    education: list[EducationFact] = field(default_factory=list)
+    languages: list[LanguageFact] = field(default_factory=list)
+    projects: list[ProjectFact] = field(default_factory=list)
+
+
+def _parse_work_experience(raw, context: str) -> list[WorkExperienceFact]:
+    value = raw.get("work_experience", [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ConfigError(f"Поле '{context}.work_experience' должно быть списком")
+    result = []
+    for i, item in enumerate(value):
+        item_context = f"{context}.work_experience[{i}]"
+        if not isinstance(item, dict):
+            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
+        result.append(
+            WorkExperienceFact(
+                company=_require_str(item, "company", item_context),
+                position=_require_str(item, "position", item_context),
+                period_from=_require_str(item, "period_from", item_context),
+                period_to=_require_str(item, "period_to", item_context),
+                description=_require_str(item, "description", item_context),
+                skills=_require_str_list(item, "skills", item_context),
+                tags=_require_str_list(item, "tags", item_context),
+            )
+        )
+    return result
+
+
+def _parse_education(raw, context: str) -> list[EducationFact]:
+    value = raw.get("education", [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ConfigError(f"Поле '{context}.education' должно быть списком")
+    result = []
+    for i, item in enumerate(value):
+        item_context = f"{context}.education[{i}]"
+        if not isinstance(item, dict):
+            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
+        result.append(
+            EducationFact(
+                institution=_require_str(item, "institution", item_context),
+                specialty=_require_str(item, "specialty", item_context),
+                year=_require_str(item, "year", item_context),
+                tags=_require_str_list(item, "tags", item_context),
+            )
+        )
+    return result
+
+
+def _parse_languages(raw, context: str) -> list[LanguageFact]:
+    value = raw.get("languages", [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ConfigError(f"Поле '{context}.languages' должно быть списком")
+    result = []
+    for i, item in enumerate(value):
+        item_context = f"{context}.languages[{i}]"
+        if not isinstance(item, dict):
+            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
+        result.append(
+            LanguageFact(
+                name=_require_str(item, "name", item_context),
+                level=_require_str(item, "level", item_context),
+                tags=_require_str_list(item, "tags", item_context),
+            )
+        )
+    return result
+
+
+def _parse_projects(raw, context: str) -> list[ProjectFact]:
+    value = raw.get("projects", [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ConfigError(f"Поле '{context}.projects' должно быть списком")
+    result = []
+    for i, item in enumerate(value):
+        item_context = f"{context}.projects[{i}]"
+        if not isinstance(item, dict):
+            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
+        result.append(
+            ProjectFact(
+                name=_require_str(item, "name", item_context),
+                description=_require_str(item, "description", item_context),
+                skills=_require_str_list(item, "skills", item_context),
+                tags=_require_str_list(item, "tags", item_context),
+            )
+        )
+    return result
+
+
+@register("candidate_facts")
+def parse_candidate_facts(raw, context: str) -> CandidateFacts | None:
+    """raw — подсекция candidate_facts (может быть None/отсутствовать/{})."""
+    if not raw:
+        return None
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Секция '{context}' должна быть отображением")
+
+    return CandidateFacts(
+        work_experience=_parse_work_experience(raw, context),
+        education=_parse_education(raw, context),
+        languages=_parse_languages(raw, context),
+        projects=_parse_projects(raw, context),
+    )

--- a/src/hhru_bot/config_sections/candidate_facts.py
+++ b/src/hhru_bot/config_sections/candidate_facts.py
@@ -30,19 +30,27 @@ experience.py, ...) — это осознанно оставлено sub-issue #
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass, field
 
 from ..config import ConfigError
 from ._registry import register
+
+# Поля-даты (year, period_from, period_to) естественно писать в YAML без
+# кавычек ("2015", "2021-03-01") — PyYAML парсит их как int/date, не str.
+# Соседняя секция education.py уже терпит int для year (isinstance(value,
+# (str, int))); здесь то же самое расширено на date/datetime ради
+# period_from/period_to (полный ISO-вид тоже валиден без кавычек в YAML).
+_SCALAR_TYPES = (str, int, datetime.date, datetime.datetime)
 
 
 def _require_str(raw: dict, key: str, context: str) -> str:
     value = raw.get(key, "")
     if value is None:
         return ""
-    if not isinstance(value, str):
+    if not isinstance(value, _SCALAR_TYPES):
         raise ConfigError(f"Поле '{key}' в '{context}' должно быть строкой, получено: {value!r}")
-    return value
+    return str(value).strip() if not isinstance(value, str) else value
 
 
 def _require_str_list(raw: dict, key: str, context: str) -> list[str]:
@@ -102,93 +110,40 @@ class CandidateFacts:
     projects: list[ProjectFact] = field(default_factory=list)
 
 
-def _parse_work_experience(raw, context: str) -> list[WorkExperienceFact]:
-    value = raw.get("work_experience", [])
+# (dataclass, поля-строки, поля-списки-строк) на каждую подсекцию — параметризует
+# generic-парсер ниже вместо четырёх механически идентичных функций (все четыре
+# отличались только именем секции/полей, ту же форму уже обобщает
+# education.py::_records() для одной записи).
+_FACT_SPECS: dict[str, tuple[type, tuple[str, ...], tuple[str, ...]]] = {
+    "work_experience": (
+        WorkExperienceFact,
+        ("company", "position", "period_from", "period_to", "description"),
+        ("skills", "tags"),
+    ),
+    "education": (EducationFact, ("institution", "specialty", "year"), ("tags",)),
+    "languages": (LanguageFact, ("name", "level"), ("tags",)),
+    "projects": (ProjectFact, ("name", "description"), ("skills", "tags")),
+}
+
+
+def _parse_fact_list(raw: dict, section: str, context: str) -> list:
+    fact_cls, str_fields, list_fields = _FACT_SPECS[section]
+    value = raw.get(section, [])
     if value is None:
         return []
     if not isinstance(value, list):
-        raise ConfigError(f"Поле '{context}.work_experience' должно быть списком")
+        raise ConfigError(f"Поле '{context}.{section}' должно быть списком")
     result = []
     for i, item in enumerate(value):
-        item_context = f"{context}.work_experience[{i}]"
+        item_context = f"{context}.{section}[{i}]"
         if not isinstance(item, dict):
             raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
-        result.append(
-            WorkExperienceFact(
-                company=_require_str(item, "company", item_context),
-                position=_require_str(item, "position", item_context),
-                period_from=_require_str(item, "period_from", item_context),
-                period_to=_require_str(item, "period_to", item_context),
-                description=_require_str(item, "description", item_context),
-                skills=_require_str_list(item, "skills", item_context),
-                tags=_require_str_list(item, "tags", item_context),
-            )
-        )
-    return result
-
-
-def _parse_education(raw, context: str) -> list[EducationFact]:
-    value = raw.get("education", [])
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        raise ConfigError(f"Поле '{context}.education' должно быть списком")
-    result = []
-    for i, item in enumerate(value):
-        item_context = f"{context}.education[{i}]"
-        if not isinstance(item, dict):
-            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
-        result.append(
-            EducationFact(
-                institution=_require_str(item, "institution", item_context),
-                specialty=_require_str(item, "specialty", item_context),
-                year=_require_str(item, "year", item_context),
-                tags=_require_str_list(item, "tags", item_context),
-            )
-        )
-    return result
-
-
-def _parse_languages(raw, context: str) -> list[LanguageFact]:
-    value = raw.get("languages", [])
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        raise ConfigError(f"Поле '{context}.languages' должно быть списком")
-    result = []
-    for i, item in enumerate(value):
-        item_context = f"{context}.languages[{i}]"
-        if not isinstance(item, dict):
-            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
-        result.append(
-            LanguageFact(
-                name=_require_str(item, "name", item_context),
-                level=_require_str(item, "level", item_context),
-                tags=_require_str_list(item, "tags", item_context),
-            )
-        )
-    return result
-
-
-def _parse_projects(raw, context: str) -> list[ProjectFact]:
-    value = raw.get("projects", [])
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        raise ConfigError(f"Поле '{context}.projects' должно быть списком")
-    result = []
-    for i, item in enumerate(value):
-        item_context = f"{context}.projects[{i}]"
-        if not isinstance(item, dict):
-            raise ConfigError(f"Элемент '{item_context}' должен быть отображением")
-        result.append(
-            ProjectFact(
-                name=_require_str(item, "name", item_context),
-                description=_require_str(item, "description", item_context),
-                skills=_require_str_list(item, "skills", item_context),
-                tags=_require_str_list(item, "tags", item_context),
-            )
-        )
+        kwargs: dict[str, str | list[str]] = {}
+        for name in str_fields:
+            kwargs[name] = _require_str(item, name, item_context)
+        for name in list_fields:
+            kwargs[name] = _require_str_list(item, name, item_context)
+        result.append(fact_cls(**kwargs))
     return result
 
 
@@ -201,8 +156,8 @@ def parse_candidate_facts(raw, context: str) -> CandidateFacts | None:
         raise ConfigError(f"Секция '{context}' должна быть отображением")
 
     return CandidateFacts(
-        work_experience=_parse_work_experience(raw, context),
-        education=_parse_education(raw, context),
-        languages=_parse_languages(raw, context),
-        projects=_parse_projects(raw, context),
+        work_experience=_parse_fact_list(raw, "work_experience", context),
+        education=_parse_fact_list(raw, "education", context),
+        languages=_parse_fact_list(raw, "languages", context),
+        projects=_parse_fact_list(raw, "projects", context),
     )

--- a/tests/test_candidate_facts.py
+++ b/tests/test_candidate_facts.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import datetime
 import textwrap
 
 import pytest
@@ -141,6 +142,54 @@ def test_parse_candidate_facts_tags_default_empty_list():
     )
     assert facts is not None
     assert facts.work_experience[0].tags == []
+
+
+def test_parse_candidate_facts_unquoted_year_and_date_coerced_to_str():
+    # "year: 2015" и "period_from: 2021-03-01" без кавычек — естественный
+    # способ написать их в YAML; PyYAML парсит их как int/datetime.date, не
+    # str. Соседняя education.py секция уже терпит int для year — здесь то
+    # же самое, иначе load_config аварийно падает на самом обычном вводе.
+    facts = parse_candidate_facts(
+        {
+            "education": [{"institution": "МГУ", "year": 2015}],
+            "work_experience": [
+                {
+                    "company": "X",
+                    "period_from": datetime.date(2021, 3, 1),
+                    "period_to": datetime.date(2024, 6, 1),
+                }
+            ],
+        },
+        "resumes[0].candidate_facts",
+    )
+    assert facts is not None
+    assert facts.education[0].year == "2015"
+    assert facts.work_experience[0].period_from == "2021-03-01"
+    assert facts.work_experience[0].period_to == "2024-06-01"
+
+
+def test_load_config_candidate_facts_unquoted_year_does_not_raise(tmp_path):
+    # Integration-регрессия: тот же кейс через полный load_config с реальным
+    # YAML-парсингом (не dict, собранный вручную в тесте выше).
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/CF500"
+            search:
+              text: "x"
+            candidate_facts:
+              education:
+                - institution: "МГУ"
+                  year: 2015
+        """,
+    )
+    facts = load_config(path).resumes[0].candidate_facts
+    assert facts is not None
+    assert facts.education[0].year == "2015"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_candidate_facts.py
+++ b/tests/test_candidate_facts.py
@@ -1,0 +1,288 @@
+"""Тесты resume-секции candidate_facts (issue #751).
+
+Фундамент эпика #750: структурированные факты о кандидате с тегами
+релевантности. Секция опциональна, обратная совместимость обязательна.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from hhru_bot.config import ConfigError, load_config
+from hhru_bot.config_sections.candidate_facts import (
+    CandidateFacts,
+    EducationFact,
+    LanguageFact,
+    ProjectFact,
+    WorkExperienceFact,
+    parse_candidate_facts,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_config(tmp_path, body: str):
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def _minimal_config() -> str:
+    return """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/AAA111"
+            search:
+              text: "python developer"
+    """
+
+
+# --- parse_candidate_facts: unit-тесты чистой функции ---
+
+
+def test_parse_candidate_facts_none_when_raw_is_none():
+    assert parse_candidate_facts(None, "resumes[0].candidate_facts") is None
+
+
+def test_parse_candidate_facts_none_when_raw_is_empty_dict():
+    # Консистентно с ai_profile/scoring: {} трактуется как отсутствие секции.
+    assert parse_candidate_facts({}, "resumes[0].candidate_facts") is None
+
+
+def test_parse_candidate_facts_wrong_type_raises():
+    with pytest.raises(ConfigError, match="отображением"):
+        parse_candidate_facts("not-a-dict", "resumes[0].candidate_facts")
+
+
+def test_parse_candidate_facts_full():
+    raw = {
+        "work_experience": [
+            {
+                "company": "ООО Пример",
+                "position": "Backend-разработчик",
+                "period_from": "2021-03",
+                "period_to": "2024-06",
+                "description": "Разработка API на Python/Django.",
+                "skills": ["python", "django"],
+                "tags": ["backend", "python"],
+            }
+        ],
+        "education": [
+            {
+                "institution": "МГУ",
+                "specialty": "Физика",
+                "year": "2015",
+                "tags": ["general"],
+            }
+        ],
+        "languages": [
+            {"name": "Английский", "level": "B2", "tags": ["general"]},
+        ],
+        "projects": [
+            {
+                "name": "Трекер вакансий",
+                "description": "CLI на Playwright",
+                "skills": ["python", "playwright"],
+                "tags": ["backend", "automation"],
+            }
+        ],
+    }
+    facts = parse_candidate_facts(raw, "resumes[0].candidate_facts")
+    assert facts == CandidateFacts(
+        work_experience=[
+            WorkExperienceFact(
+                company="ООО Пример",
+                position="Backend-разработчик",
+                period_from="2021-03",
+                period_to="2024-06",
+                description="Разработка API на Python/Django.",
+                skills=["python", "django"],
+                tags=["backend", "python"],
+            )
+        ],
+        education=[
+            EducationFact(institution="МГУ", specialty="Физика", year="2015", tags=["general"])
+        ],
+        languages=[LanguageFact(name="Английский", level="B2", tags=["general"])],
+        projects=[
+            ProjectFact(
+                name="Трекер вакансий",
+                description="CLI на Playwright",
+                skills=["python", "playwright"],
+                tags=["backend", "automation"],
+            )
+        ],
+    )
+
+
+def test_parse_candidate_facts_partial_sections_default_empty():
+    # Указана только одна подсекция — остальные дефолтятся в пустые списки.
+    facts = parse_candidate_facts(
+        {"languages": [{"name": "Английский", "level": "B2"}]},
+        "resumes[0].candidate_facts",
+    )
+    assert facts is not None
+    assert facts.work_experience == []
+    assert facts.education == []
+    assert facts.projects == []
+    assert facts.languages == [LanguageFact(name="Английский", level="B2", tags=[])]
+
+
+def test_parse_candidate_facts_tags_default_empty_list():
+    # tags опционален на уровне отдельного факта: пустой список — валидное
+    # значение (факт релевантен всем кластерам / кластеризация не проведена).
+    facts = parse_candidate_facts(
+        {"work_experience": [{"company": "ООО Пример", "position": "Dev"}]},
+        "resumes[0].candidate_facts",
+    )
+    assert facts is not None
+    assert facts.work_experience[0].tags == []
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["work_experience", "education", "languages", "projects"],
+)
+def test_parse_candidate_facts_section_wrong_type_raises(section):
+    with pytest.raises(ConfigError, match=section):
+        parse_candidate_facts({section: "not-a-list"}, "resumes[0].candidate_facts")
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["work_experience", "education", "languages", "projects"],
+)
+def test_parse_candidate_facts_section_item_wrong_type_raises(section):
+    with pytest.raises(ConfigError, match="отображением"):
+        parse_candidate_facts({section: ["not-a-dict"]}, "resumes[0].candidate_facts")
+
+
+def test_parse_candidate_facts_tags_wrong_type_raises():
+    with pytest.raises(ConfigError, match="tags"):
+        parse_candidate_facts(
+            {"work_experience": [{"company": "X", "tags": "not-a-list"}]},
+            "resumes[0].candidate_facts",
+        )
+
+
+def test_parse_candidate_facts_skills_wrong_type_raises():
+    with pytest.raises(ConfigError, match="skills"):
+        parse_candidate_facts(
+            {"projects": [{"name": "X", "skills": "python"}]},
+            "resumes[0].candidate_facts",
+        )
+
+
+# --- load_config integration: обратная совместимость + полный конфиг ---
+
+
+def test_load_config_candidate_facts_none_when_absent(tmp_path):
+    config = load_config(_write_config(tmp_path, _minimal_config()))
+    assert config.resumes[0].candidate_facts is None
+
+
+def test_load_config_candidate_facts_full(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/CF100"
+            search:
+              text: "python developer"
+            candidate_facts:
+              work_experience:
+                - company: "ООО Пример"
+                  position: "Backend-разработчик"
+                  period_from: "2021-03"
+                  period_to: "2024-06"
+                  description: "API на Python/Django"
+                  skills: ["python", "django"]
+                  tags: ["backend", "python"]
+              education:
+                - institution: "МГУ"
+                  specialty: "Физика"
+                  year: "2015"
+                  tags: ["general"]
+              languages:
+                - name: "Английский"
+                  level: "B2"
+                  tags: ["general"]
+              projects:
+                - name: "Трекер вакансий"
+                  description: "CLI на Playwright"
+                  skills: ["python"]
+                  tags: ["automation"]
+        """,
+    )
+    facts = load_config(path).resumes[0].candidate_facts
+    assert facts is not None
+    assert facts.work_experience[0].company == "ООО Пример"
+    assert facts.work_experience[0].tags == ["backend", "python"]
+    assert facts.education[0].institution == "МГУ"
+    assert facts.languages[0].name == "Английский"
+    assert facts.projects[0].name == "Трекер вакансий"
+
+
+def test_load_config_candidate_facts_empty_dict_is_none(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/CF200"
+            search:
+              text: "x"
+            candidate_facts: {}
+        """,
+    )
+    assert load_config(path).resumes[0].candidate_facts is None
+
+
+def test_load_config_candidate_facts_invalid_type_raises(tmp_path):
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/CF300"
+            search:
+              text: "x"
+            candidate_facts:
+              work_experience: "not-a-list"
+        """,
+    )
+    with pytest.raises(ConfigError, match="work_experience"):
+        load_config(path)
+
+
+def test_load_config_without_candidate_facts_still_loads_other_sections(tmp_path):
+    # Обратная совместимость: конфиг с ai_profile, но без candidate_facts,
+    # продолжает грузиться (секции независимы).
+    path = _write_config(
+        tmp_path,
+        """
+        account:
+          storage_state_file: data/storage_state/hh_session.json
+        resumes:
+          - id: r1
+            resume_url: "https://hh.ru/resume/CF400"
+            search:
+              text: "x"
+            ai_profile:
+              summary: "Кратко о себе"
+        """,
+    )
+    resume = load_config(path).resumes[0]
+    assert resume.candidate_facts is None
+    assert resume.ai_profile is not None


### PR DESCRIPTION
## Что сделано

Фундамент эпика #750 (адаптивные резюме: пул под кластеры). `AIProfile` (#17)
объявлен узко — только для генерации сопроводительных писем; структурированных
фактов о кандидате (места работы, образование, языки, проекты) не было.
Без них отбор фактов под кластер (выбранная в #750 глубина адаптации:
«формулировки + отбор фактов») реализовать не из чего.

- Новая опциональная resume-секция `candidate_facts` в `config_sections/`
  через `@register("candidate_facts")` — реестр не тронут, `ResumeConfig`
  расширен одним нейтральным полем.
- Структура: `work_experience`, `education`, `languages`, `projects`.
  **Каждый факт несёт `tags: list[str]`** — теги релевантности, без которых
  будущий отбор под кластер (#753/#754) невозможен.
- Валидация через `ConfigError` по образцу существующих парсеров
  (`ai_profile.py`, `education.py`).
- Секция опциональна: отсутствие → `None`, поведение не меняется
  (обратная совместимость).
- `config/config.example.yaml` дополнен закомментированным примером формата.
- Новая секция типизирована честно — `CandidateFacts | None`, а не
  `object | None`. В отличие от `ai_profile`/`scoring`/`resume_sections`/
  `education` (заведены раньше, их дефект типизации вне скоупа этого issue —
  см. тело #751 "Чего НЕ делать"), потребителям не понадобится `cast()`
  (см. `commands/about.py:73-76` для контраста).

## Чего сознательно НЕ сделано (по ТЗ issue)

- Секция **не подключена** ни к одному генератору разделов резюме
  (`about.py`, `experience.py`, ...) — это отдельные sub-issue #753/#754.
- Существующий `object | None` в `ai_profile`/`scoring`/`resume_sections`/
  `education` не тронут — не в скоупе.

## Проверки

- `ruff check` + `ruff format --check` по `src tests scripts` — чисто.
- Полный `pytest` (xdist `-n 4 --dist worksteal`) — зелёный.
- `scripts/gen_cli_docs.py --check` — синхронизирован (новых CLI-команд нет).
- Новые unit-тесты (`tests/test_candidate_facts.py`, 21 тест): чистый парсер +
  integration через `load_config`, обратная совместимость, невалидные типы.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)