### PR TITLE
feat(browser): различать throttled-канал от анти-бота в goto_hh (#749)

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -87,6 +87,46 @@ class NotAuthenticated(PageStateIndeterminate):
     """The current page does not prove that the hh.ru session is valid."""
 
 
+class ThrottledChannelDetected(PlaywrightTimeoutError):
+    """goto_hh timed out AFTER the server answered the navigation request.
+
+    #749: a distinct third class of goto_hh failure, next to net::ERR_* (#748,
+    connection never established) and "чистый" TimeoutError with no other
+    signal (rendering/anti-bot, stays intentionally unclassified). Here the
+    main-document response was observed with an OK status (TCP connect + TLS
+    handshake + HTTP headers all succeeded — server is alive and reachable),
+    yet the body never finished downloading before GOTO_TIMEOUT_MS. This is
+    the structural signature of a throttled/degraded network channel (e.g. a
+    dying VPN tunnel), not an anti-bot challenge or selector drift — both of
+    which would still leave goto without any observed response at all.
+
+    Subclasses PlaywrightTimeoutError so it keeps flowing through every
+    existing `except PlaywrightError`/`except PlaywrightTimeoutError` call
+    site unchanged; only cli.py's classification branch inspects it directly.
+    Fail-closed (CLAUDE.md §5): this only relabels the failure, it never
+    turns it into a success — goto_hh still raises.
+    """
+
+
+def _is_navigation_response(response, url: str) -> bool:
+    """Whether ``response`` answers the navigation request for ``url``.
+
+    Compares without the query string: hh.ru's own redirects/tracking params
+    can differ between the requested URL and the response URL that reports
+    them, and only the path identifies "this is the document we asked for".
+    """
+    try:
+        response_url = response.url
+        status = response.status
+    except PlaywrightError:
+        return False
+    return (
+        urlsplit(response_url).path == urlsplit(url).path
+        and isinstance(status, int)
+        and status < 400
+    )
+
+
 def open_hydrated_resume_editor(
     page: Page,
     *,
@@ -220,29 +260,61 @@ def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
     2. ``ready_selector`` (опц.) — после удачного goto дождаться конкретного
        ``data-qa`` маркера страницы (короткий GOTO_TIMEOUT_MS, если не задан
        context-timeout), вместо ненадёжного networkidle. None — не ждать.
+    3. (#749) Если попытка провалилась таймаутом, но за это время пришёл
+       response навигационного запроса со статусом < 400 — сервер живой,
+       узкое место в скорости передачи тела. Такую ошибку оборачиваем в
+       ``ThrottledChannelDetected`` вместо проброса как есть.
 
     domcontentloaded НЕ меняем (рекомендация референсов #80: DDoS-Guard держит
     сеть активной, networkidle может не сработать).
     """
     last_error: Exception | None = None
     for attempt in range(1, _GOTO_MAX_ATTEMPTS + 1):
+        # #749: слушаем response ТОЛЬКО чтобы отличить "сервер ответил, но
+        # тело не докачалось" (throttled-канал) от "goto не увидел ответ
+        # вообще" (анти-бот/дрейф селектора/сеть недоступна) — сигнал уже
+        # идущего page.goto(), НЕ отдельный сетевой запрос (запрет CLAUDE.md/#747).
+        response_observed = False
+
+        def _on_response(response, _url=url) -> None:
+            nonlocal response_observed
+            if _is_navigation_response(response, _url):
+                response_observed = True
+
+        # Best-effort: unit test doubles for Page (bump/apply/etc.) commonly
+        # implement only goto/locator, not the full event-emitter surface.
+        # The throttled-channel signal is a diagnostic nicety layered on top
+        # of retry — its absence must not break goto_hh for callers whose
+        # fake Page has no .on/.remove_listener.
+        listener_attached = hasattr(page, "on")
+        if listener_attached:
+            page.on("response", _on_response)
         try:
-            page.goto(url, wait_until="domcontentloaded")
-            if ready_selector:
-                page.locator(ready_selector).wait_for(timeout=GOTO_TIMEOUT_MS)
-            return
-        except (PlaywrightTimeoutError, PlaywrightError) as exc:
-            last_error = exc
-            if attempt < _GOTO_MAX_ATTEMPTS:
-                wait = _GOTO_BACKOFF_SECONDS * attempt
-                logger.warning(
-                    "goto не прошёл (попытка %d/%d): %s — повтор через %.1fs",
-                    attempt,
-                    _GOTO_MAX_ATTEMPTS,
-                    exc,
-                    wait,
-                )
-                time.sleep(wait)
+            try:
+                page.goto(url, wait_until="domcontentloaded")
+                if ready_selector:
+                    page.locator(ready_selector).wait_for(timeout=GOTO_TIMEOUT_MS)
+                return
+            except (PlaywrightTimeoutError, PlaywrightError) as exc:
+                if response_observed and "net::ERR_" not in str(exc):
+                    exc = ThrottledChannelDetected(str(exc))
+                last_error = exc
+                if attempt < _GOTO_MAX_ATTEMPTS:
+                    wait = _GOTO_BACKOFF_SECONDS * attempt
+                    logger.warning(
+                        "goto не прошёл (попытка %d/%d): %s — повтор через %.1fs",
+                        attempt,
+                        _GOTO_MAX_ATTEMPTS,
+                        exc,
+                        wait,
+                    )
+                    time.sleep(wait)
+        finally:
+            if listener_attached:
+                try:
+                    page.remove_listener("response", _on_response)
+                except PlaywrightError:
+                    pass
     # Последняя попытка провалилась — пробрасываем, как обычный goto.
     assert last_error is not None
     raise last_error

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -320,7 +320,20 @@ def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
                     # её таймаут НЕ должен попадать в эту ветку: это дрейф
                     # селектора/анти-бот на уже докачанной странице, канал
                     # тут ни при чём.
-                    if response_observed and "net::ERR_" not in str(exc):
+                    #
+                    # Cycle-review PR #760, Codex finding: ThrottledChannelDetected
+                    # документирован как "timed out AFTER" (docstring выше) — узкое
+                    # место строго в скорости докачки тела. Не-timeout PlaywrightError
+                    # (напр. "Navigation interrupted by another navigation" —
+                    # конкурирующая JS-навигация) с наблюдённым response — не
+                    # throttling, а другая причина; переквалификация тут была бы
+                    # недостоверной диагностикой. Поэтому isinstance проверяем ДО
+                    # response_observed, а не полагаемся на общий PlaywrightError.
+                    if (
+                        isinstance(exc, PlaywrightTimeoutError)
+                        and response_observed
+                        and "net::ERR_" not in str(exc)
+                    ):
                         raise ThrottledChannelDetected(str(exc)) from exc
                     raise
                 if ready_selector:

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -96,35 +96,47 @@ class ThrottledChannelDetected(PlaywrightTimeoutError):
     main-document response was observed with an OK status (TCP connect + TLS
     handshake + HTTP headers all succeeded — server is alive and reachable),
     yet the body never finished downloading before GOTO_TIMEOUT_MS. This is
-    the structural signature of a throttled/degraded network channel (e.g. a
-    dying VPN tunnel), not an anti-bot challenge or selector drift — both of
-    which would still leave goto without any observed response at all.
+    the typical signature of a throttled/degraded network channel (e.g. a
+    dying VPN tunnel).
+
+    Known limit (code-review round 1): it is not a proof. hh.ru's DDoS-Guard
+    can serve a challenge interstitial as a 200 document on the same path,
+    producing the same signature. The verdict is therefore diagnostic only —
+    it never changes control flow, and goto_hh still raises (CLAUDE.md §5,
+    fail-closed).
 
     Subclasses PlaywrightTimeoutError so it keeps flowing through every
     existing `except PlaywrightError`/`except PlaywrightTimeoutError` call
     site unchanged; only cli.py's classification branch inspects it directly.
-    Fail-closed (CLAUDE.md §5): this only relabels the failure, it never
-    turns it into a success — goto_hh still raises.
     """
 
 
 def _is_navigation_response(response, url: str) -> bool:
-    """Whether ``response`` answers the navigation request for ``url``.
+    """Whether ``response`` answers the navigation (document) request for ``url``.
 
-    Compares without the query string: hh.ru's own redirects/tracking params
-    can differ between the requested URL and the response URL that reports
-    them, and only the path identifies "this is the document we asked for".
+    Navigation-ness is taken from Playwright's own structural signal
+    (``request.is_navigation_request()`` + ``resource_type == "document"``),
+    not guessed from the URL (code-review round 1): hh.ru's SPA issues
+    xhr/fetch/prefetch requests against the very same path, and counting
+    those as "the server answered the document" would misclassify an
+    unanswered navigation as a live channel.
+
+    The path is still compared (without the query string: hh.ru's own
+    redirects/tracking params can differ between the requested URL and the
+    response URL that reports them), so a document response for a
+    *different* page does not count either.
     """
     try:
+        request = response.request
+        if not request.is_navigation_request():
+            return False
+        if request.resource_type != "document":
+            return False
         response_url = response.url
         status = response.status
-    except PlaywrightError:
+    except (PlaywrightError, AttributeError):
         return False
-    return (
-        urlsplit(response_url).path == urlsplit(url).path
-        and isinstance(status, int)
-        and status < 400
-    )
+    return urlsplit(response_url).path == urlsplit(url).path and status < 400
 
 
 def open_hydrated_resume_editor(
@@ -260,10 +272,14 @@ def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
     2. ``ready_selector`` (опц.) — после удачного goto дождаться конкретного
        ``data-qa`` маркера страницы (короткий GOTO_TIMEOUT_MS, если не задан
        context-timeout), вместо ненадёжного networkidle. None — не ждать.
-    3. (#749) Если попытка провалилась таймаутом, но за это время пришёл
-       response навигационного запроса со статусом < 400 — сервер живой,
-       узкое место в скорости передачи тела. Такую ошибку оборачиваем в
-       ``ThrottledChannelDetected`` вместо проброса как есть.
+    3. (#749) Если сам ``page.goto`` (не ``ready_selector``) провалился
+       таймаутом, но за это время пришёл response навигационного document-
+       запроса со статусом < 400 — сервер живой, узкое место в скорости
+       передачи тела. Такую ошибку оборачиваем в ``ThrottledChannelDetected``
+       вместо проброса как есть. ``ready_selector`` — отдельная проверка ПОСЛЕ
+       успешного goto; её таймаут classification'у не подлежит (code-review
+       round 1: канал там уже доказано живой, причина — дрейф селектора или
+       анти-бот интерстишл, и должна остаться неопределённой, см. #748).
 
     domcontentloaded НЕ меняем (рекомендация референсов #80: DDoS-Guard держит
     сеть активной, networkidle может не сработать).
@@ -285,19 +301,32 @@ def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
         # implement only goto/locator, not the full event-emitter surface.
         # The throttled-channel signal is a diagnostic nicety layered on top
         # of retry — its absence must not break goto_hh for callers whose
-        # fake Page has no .on/.remove_listener.
-        listener_attached = hasattr(page, "on")
+        # fake Page has no .on/.remove_listener. Require BOTH methods: a
+        # double with .on but no .remove_listener (test_copy_resume_browser.py
+        # StubPage, code-review round 1) would register the listener fine and
+        # then blow up in `finally` with an uncaught AttributeError — on the
+        # success path too, not just on error, since `return` still runs it.
+        listener_attached = hasattr(page, "on") and hasattr(page, "remove_listener")
         if listener_attached:
             page.on("response", _on_response)
         try:
             try:
-                page.goto(url, wait_until="domcontentloaded")
+                try:
+                    page.goto(url, wait_until="domcontentloaded")
+                except (PlaywrightTimeoutError, PlaywrightError) as exc:
+                    # #749 code-review round 1: throttled-классификация
+                    # применима ТОЛЬКО к самому goto() (докачке тела
+                    # документа). ready_selector — отдельная проверка ниже,
+                    # её таймаут НЕ должен попадать в эту ветку: это дрейф
+                    # селектора/анти-бот на уже докачанной странице, канал
+                    # тут ни при чём.
+                    if response_observed and "net::ERR_" not in str(exc):
+                        raise ThrottledChannelDetected(str(exc)) from exc
+                    raise
                 if ready_selector:
                     page.locator(ready_selector).wait_for(timeout=GOTO_TIMEOUT_MS)
                 return
             except (PlaywrightTimeoutError, PlaywrightError) as exc:
-                if response_observed and "net::ERR_" not in str(exc):
-                    exc = ThrottledChannelDetected(str(exc))
                 last_error = exc
                 if attempt < _GOTO_MAX_ATTEMPTS:
                     wait = _GOTO_BACKOFF_SECONDS * attempt
@@ -313,7 +342,7 @@ def goto_hh(page: Page, url: str, *, ready_selector: str | None = None) -> None:
             if listener_attached:
                 try:
                     page.remove_listener("response", _on_response)
-                except PlaywrightError:
+                except (PlaywrightError, AttributeError):
                     pass
     # Последняя попытка провалилась — пробрасываем, как обычный goto.
     assert last_error is not None

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -21,7 +21,7 @@ from playwright.sync_api import Error as PlaywrightError
 from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
 from .apply.antibot import AntiBotChallengeDetected
-from .browser import BrowserLaunchError
+from .browser import BrowserLaunchError, ThrottledChannelDetected
 from .exit_codes import CommandExitCode
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
@@ -382,6 +382,19 @@ def _execute(args: argparse.Namespace) -> None:
         if "net::ERR_" in str(exc):
             print(
                 f"[ENVIRONMENT] похоже на отсутствие сети/соединения с hh.ru: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        # #749: третий класс — throttled-канал. goto_hh уже подтвердил (по
+        # response навигационного запроса, полученному ДО таймаута), что
+        # сервер ответил — TCP/TLS/заголовки прошли, узкое место строго в
+        # скорости докачки тела. Отличается и от net::ERR_* (нет вовсе), и
+        # от "чистого" TimeoutError без наблюдаемого response (там причина
+        # остаётся неопределённой намеренно, см. ветку ниже).
+        if isinstance(exc, ThrottledChannelDetected):
+            print(
+                f"[ENVIRONMENT] похоже на медленный/задушенный канал до hh.ru "
+                f"(сервер ответил, но страница не докачалась): {exc}",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -19,6 +19,7 @@ from hhru_bot import browser
 from hhru_bot.browser import (
     GOTO_TIMEOUT_MS,
     NotAuthenticated,
+    ThrottledChannelDetected,
     goto_hh,
     open_confirmed_resume,
     require_authenticated_page,
@@ -377,3 +378,115 @@ def test_goto_hh_ready_selector_absent_retries_then_raises(monkeypatch):
 
     # retry сработал: 3 goto-попытки (ready_selector проверяется после каждой)
     assert page.goto.call_count == 3
+
+
+def _page_with_response_listener(monkeypatch):
+    """Мок Page, эмулирующий page.on('response', handler)/remove_listener.
+
+    goto_hh регистрирует ровно один response-listener за попытку; тест
+    вызывает его вручную (эмулируя приход HTTP-ответа сервера ДО таймаута),
+    затем поднимает page.goto из PlaywrightTimeoutError, как реальный
+    Playwright делает при таймауте после уже полученных заголовков.
+    """
+    monkeypatch.setattr(browser.time, "sleep", lambda _: None)
+    listeners: list = []
+    page = MagicMock(name="Page")
+    page.on.side_effect = lambda _event, handler: listeners.append(handler)
+    return page, listeners
+
+
+def _fake_response(url: str, status: int):
+    response = MagicMock(name="Response")
+    response.url = url
+    response.status = status
+    return response
+
+
+def test_goto_hh_wraps_timeout_as_throttled_when_response_observed(monkeypatch):
+    """#749: сервер ответил (status 200 на навигационный URL), но тело не
+    успело докачаться — PlaywrightTimeoutError без net::ERR_*.  goto_hh
+    должен переквалифицировать это в ThrottledChannelDetected — throttled-
+    канал, а не анти-бот/дрейф селектора.
+    """
+    url = "https://hh.ru/search/vacancy"
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        # Сервер успел ответить до того, как истёк таймаут рендера.
+        for handler in listeners:
+            handler(_fake_response(url, 200))
+        raise PlaywrightTimeoutError("Page.goto: Timeout 90000ms exceeded.")
+
+    page.goto.side_effect = _goto
+
+    with pytest.raises(ThrottledChannelDetected):
+        goto_hh(page, url)
+
+    assert page.goto.call_count == 3  # ретраится и на последней пробрасывает
+
+
+def test_goto_hh_no_response_stays_unclassified_timeout(monkeypatch):
+    """Симметричный случай: response вообще не пришёл (анти-бот/дрейф
+    селектора/сеть недоступна) — ошибка НЕ должна переквалифицироваться.
+    """
+    page, _listeners = _page_with_response_listener(monkeypatch)
+    page.goto.side_effect = PlaywrightTimeoutError("Page.goto: Timeout 90000ms exceeded.")
+
+    with pytest.raises(PlaywrightTimeoutError) as excinfo:
+        goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+
+
+def test_goto_hh_net_err_not_reclassified_as_throttled(monkeypatch):
+    """net::ERR_* остаётся в своём классе (#748) даже если listener успел
+    увидеть какой-то response до обрыва соединения — net::ERR_* в тексте
+    ошибки приоритетнее throttled-эвристики.
+    """
+    url = "https://hh.ru/search/vacancy"
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        for handler in listeners:
+            handler(_fake_response(url, 200))
+        raise PlaywrightError("Page.goto: net::ERR_CONNECTION_RESET")
+
+    page.goto.side_effect = _goto
+
+    with pytest.raises(PlaywrightError) as excinfo:
+        goto_hh(page, url)
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+    assert "net::ERR_" in str(excinfo.value)
+
+
+def test_goto_hh_response_for_unrelated_url_ignored(monkeypatch):
+    """Response для другого URL (напр. аналитика/трекер) не должен
+    засчитываться как подтверждение навигационного запроса.
+    """
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        for handler in listeners:
+            handler(_fake_response("https://hh.ru/analytics/beacon", 200))
+        raise PlaywrightTimeoutError("Page.goto: Timeout 90000ms exceeded.")
+
+    page.goto.side_effect = _goto
+
+    with pytest.raises(PlaywrightTimeoutError) as excinfo:
+        goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+
+
+def test_goto_hh_removes_response_listener_after_each_attempt(monkeypatch):
+    """Listener не должен копиться между попытками/вызовами (утечка памяти)."""
+    page, listeners = _page_with_response_listener(monkeypatch)
+    removed: list = []
+    page.remove_listener.side_effect = lambda _event, handler: removed.append(handler)
+    page.goto.return_value = None
+
+    goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert len(listeners) == 1
+    assert removed == listeners

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -468,6 +468,32 @@ def test_goto_hh_net_err_not_reclassified_as_throttled(monkeypatch):
     assert "net::ERR_" in str(excinfo.value)
 
 
+def test_goto_hh_non_timeout_error_not_reclassified_as_throttled(monkeypatch):
+    """Cycle-review PR #760, Codex finding: throttled-классификация обёрнута
+    вокруг ЛЮБОГО ``PlaywrightError`` без ``net::ERR_*``, а не только вокруг
+    ``PlaywrightTimeoutError``, хотя ``ThrottledChannelDetected`` документирован
+    именно как "timed out AFTER" (docstring, browser.py). Не-timeout ошибка
+    (напр. "Navigation interrupted by another navigation" — конкурирующая
+    JS-навигация, а не throttling) с наблюдённым response не должна
+    переквалифицироваться в throttled: это меняет смысл диагностики на
+    неверный без всякого основания.
+    """
+    url = "https://hh.ru/search/vacancy"
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        for handler in listeners:
+            handler(_fake_response(url, 200))
+        raise PlaywrightError("Navigation interrupted by another navigation")
+
+    page.goto.side_effect = _goto
+
+    with pytest.raises(PlaywrightError) as excinfo:
+        goto_hh(page, url)
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+
+
 def test_goto_hh_response_for_unrelated_url_ignored(monkeypatch):
     """Response для другого URL (напр. аналитика/трекер) не должен
     засчитываться как подтверждение навигационного запроса.

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -395,10 +395,18 @@ def _page_with_response_listener(monkeypatch):
     return page, listeners
 
 
-def _fake_response(url: str, status: int):
+def _fake_response(url: str, status: int, *, navigation: bool = True):
+    """Мок Response с настраиваемым структурным признаком навигации.
+
+    navigation=False эмулирует SPA-субресурс (xhr/fetch/prefetch) — code-review
+    round 1: совпадение URL само по себе не доказывает, что это ответ на
+    document-запрос, а не побочный запрос по тому же пути.
+    """
     response = MagicMock(name="Response")
     response.url = url
     response.status = status
+    response.request.is_navigation_request.return_value = navigation
+    response.request.resource_type = "document" if navigation else "xhr"
     return response
 
 
@@ -475,6 +483,52 @@ def test_goto_hh_response_for_unrelated_url_ignored(monkeypatch):
 
     with pytest.raises(PlaywrightTimeoutError) as excinfo:
         goto_hh(page, "https://hh.ru/search/vacancy")
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+
+
+def test_goto_hh_non_navigation_response_same_path_ignored(monkeypatch):
+    """Code-review round 1, finding #2: субресурс (xhr/fetch) по ТОМУ ЖЕ
+    пути — не доказательство того, что сервер отдал документ. Навигационность
+    берётся из структурного признака Playwright, а не из совпадения URL.
+    """
+    url = "https://hh.ru/search/vacancy"
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        for handler in listeners:
+            handler(_fake_response(url, 200, navigation=False))
+        raise PlaywrightTimeoutError("Page.goto: Timeout 90000ms exceeded.")
+
+    page.goto.side_effect = _goto
+
+    with pytest.raises(PlaywrightTimeoutError) as excinfo:
+        goto_hh(page, url)
+
+    assert not isinstance(excinfo.value, ThrottledChannelDetected)
+
+
+def test_goto_hh_ready_selector_timeout_not_throttled(monkeypatch):
+    """Code-review round 1, finding #1 (блокер): goto прошёл (канал доказано
+    живой, ответ 200 наблюдён), но ready_selector не появился — дрейф
+    селектора/анти-бот интерстишл на уже докачанной странице. Причина
+    остаётся неопределённой (#748) — это НЕ throttled-канал.
+    """
+    url = "https://hh.ru/resume/abc"
+    page, listeners = _page_with_response_listener(monkeypatch)
+
+    def _goto(_url, **_kwargs):
+        for handler in listeners:
+            handler(_fake_response(url, 200))
+        return None  # goto успешен — канал доказано живой
+
+    page.goto.side_effect = _goto
+    page.locator.return_value.wait_for.side_effect = PlaywrightTimeoutError(
+        "Locator.wait_for: Timeout 90000ms exceeded."
+    )
+
+    with pytest.raises(PlaywrightTimeoutError) as excinfo:
+        goto_hh(page, url, ready_selector="[data-qa='resume-update-button']")
 
     assert not isinstance(excinfo.value, ThrottledChannelDetected)
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -697,3 +697,33 @@ def test_plain_timeout_without_net_err_stays_unclassified(monkeypatch, capsys):
         assert "страница не отрисовалась / возможен анти-бот" in content
     finally:
         logging.getLogger("hhru_bot").handlers.clear()
+
+
+def test_throttled_channel_prints_environment_without_traceback(monkeypatch, capsys):
+    """#749: goto_hh уже подтвердил (по response навигационного запроса,
+    полученному до таймаута), что сервер живой — узкое место строго в
+    скорости докачки тела (throttled/задушенный канал, напр. умирающий VPN).
+
+    Это третий класс, отдельный от net::ERR_* (#748, соединение не
+    установлено вовсе) и от "чистого" TimeoutError без наблюдаемого response
+    (#747, остаётся неопределённым намеренно) — должен получить тот же
+    структурированный [ENVIRONMENT]-контракт, что и net::ERR_*, но с текстом,
+    отличающим причину.
+    """
+    from hhru_bot.browser import ThrottledChannelDetected
+
+    def _throttled(_args: argparse.Namespace) -> bool:
+        raise ThrottledChannelDetected("Page.goto: Timeout 90000ms exceeded.")
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _throttled)
+    with pytest.raises(SystemExit) as exc_info:
+        main(["whoami"])
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "[ENVIRONMENT]" in stderr
+    assert "медленный" in stderr or "задушенный" in stderr
+    assert "Traceback" not in stderr
+    logging.getLogger("hhru_bot").handlers.clear()

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -201,6 +201,16 @@ class StubPage:
     def on(self, event, handler):
         self._event_handlers.setdefault(event, []).append(handler)
 
+    def remove_listener(self, event, handler):
+        # #749 code-review round 1, finding #3: goto_hh registers a
+        # response-listener per attempt and always removes it in a
+        # `finally` (including the success path). A Page double with `on`
+        # but no `remove_listener` blows up with an uncaught AttributeError
+        # the first time a test exercises the real goto_hh through it.
+        handlers = self._event_handlers.get(event, [])
+        if handler in handlers:
+            handlers.remove(handler)
+
     def emit(self, event, value):
         for handler in self._event_handlers.get(event, []):
             handler(value)
@@ -214,6 +224,29 @@ class StubPage:
         self.reloads.append(wait_until)
         if self.reload_action is not None:
             self.reload_action()
+
+
+def test_real_goto_hh_survives_stub_page_without_remove_listener_bug(monkeypatch):
+    """#749 code-review round 1, finding #3 (regression guard).
+
+    StubPage is the one Page double in this suite that defines ``on`` for
+    transient-overlay wiring without also defining ``remove_listener``.
+    Every other test in this file bypasses this by having ``_patch_env``
+    replace ``cr.goto_hh`` with a fake BEFORE any ``original_goto = cr.goto_hh``
+    capture runs, so the real ``goto_hh`` never actually touches StubPage in
+    those tests. This test calls the real ``browser.goto_hh`` directly,
+    closing that gap: StubPage must expose a working ``remove_listener`` (see
+    the method above) or this raises AttributeError from goto_hh's `finally`
+    on the ordinary success path.
+    """
+    from hhru_bot.browser import goto_hh
+
+    page = StubPage()
+    page.goto = lambda url, **kwargs: page.gotos.append(url)  # type: ignore[attr-defined]
+
+    goto_hh(page, "https://hh.ru/applicant/my_resumes")
+
+    assert page.gotos == ["https://hh.ru/applicant/my_resumes"]
 
 
 class StubConsoleMessage:


### PR DESCRIPTION
## Что

Третий класс причины сбоя `goto_hh`, поверх уже смерджённой классификации из #747/#748 (net::ERR_* vs "чистый" TimeoutError):

- **net::ERR_\*** (сеть недоступна вовсе) → `[ENVIRONMENT]` (#748, без изменений).
- **Throttled-канал** (этот PR): TCP/TLS-хендшейк проходит, сервер отвечает (response навигационного запроса со статусом < 400 подтверждён), но тело страницы не успевает докачаться за `GOTO_TIMEOUT_MS` — Playwright бросает "чистый" `PlaywrightTimeoutError` без `net::ERR_*` в сообщении, структурно неотличимый от анти-бота по одному тексту исключения. Теперь классифицируется отдельно.
- **"Чистый" TimeoutError без наблюдаемого response** (анти-бот/дрейф селектора) — остаётся неопределённым, fail-closed, без изменений.

## Как

`goto_hh` (`browser.py`) регистрирует `page.on("response", ...)` на каждую попытку goto — слушает уже идущий запрос, отдельных сетевых проб к hh.ru нет (запрет CLAUDE.md/#747). Если по URL навигационного запроса пришёл ответ со статусом < 400, а затем всё равно случился timeout без `net::ERR_*` — исключение оборачивается в новый `ThrottledChannelDetected(PlaywrightTimeoutError)`.

`ThrottledChannelDetected` — подкласс `PlaywrightTimeoutError`, поэтому проходит через все существующие `except PlaywrightError`/`except PlaywrightTimeoutError` без изменений; `cli.py::_execute` явно проверяет `isinstance` и печатает `[ENVIRONMENT]` с отдельным текстом ("похоже на медленный/задушенный канал..."), рядом с веткой net::ERR_*.

Регистрация listener'а — best-effort (`hasattr(page, "on")`): многие unit-тестовые Page-дублёры в проекте реализуют только `goto`/`locator`, не полный event-emitter API Playwright; при их отсутствии throttled-детекция просто не срабатывает, `goto_hh` работает как раньше.

## Инварианты

- Fail-closed (CLAUDE.md §5): throttled-детекция только делает причину видимой в тексте `[ENVIRONMENT]`, `goto_hh` продолжает бросать исключение как и раньше — сбой никогда не превращается в успех.
- Прямых HTTP-запросов (`page.request.*`) не добавлено — тест-страж на это не тронут.
- Retry-логика `goto_hh` не переписана — тот же `_GOTO_MAX_ATTEMPTS`/backoff, только классификация финальной ошибки.

## Тесты

- `tests/test_browser_navigation.py`: 5 новых тестов — throttled-обёртка при наблюдённом response, отсутствие переквалификации без response, приоритет net::ERR_* над throttled-эвристикой, игнор response для несвязанного URL, снятие listener'а после попытки.
- `tests/test_cli_commands.py`: новый тест `[ENVIRONMENT]`-контракта для `ThrottledChannelDetected` на CLI-границе.
- Полный `pytest -n 4 --dist worksteal`: 100% green, budget 35s/240s.
- `ruff check` + `ruff format --check` по `src tests scripts`: чисто.
- `scripts/gen_cli_docs.py --check`: синхронизирован (изменение не затрагивает CLI-команды).

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)