### PR TITLE
security(session): валидировать имя аккаунта и symlink-safe hardening parent-каталогов

### DIFF
--- a/src/hhru_bot/accounts.py
+++ b/src/hhru_bot/accounts.py
@@ -16,6 +16,21 @@ class AccountPaths:
     history: Path
 
 
+def validate_account_name(name: str) -> None:
+    """Reject account names that are not a single plain path component.
+
+    A single ``Path(name).name != name`` check rejects empty strings,
+    absolute paths, ``..``/``.`` traversal segments and any embedded path
+    separator in one shot (see the equivalence table exercised in
+    ``tests/test_accounts.py``) -- the same rule ``account create`` already
+    applies. Kept here as the single source of truth so ``resolve_account_paths``
+    (``--account`` on every command) enforces it too, not only account
+    creation (#741).
+    """
+    if not name or name in {".", ".."} or Path(name).name != name:
+        raise AccountError(f"недопустимое имя аккаунта: {name!r}")
+
+
 def resolve_account_paths(
     name: str,
     *,
@@ -26,8 +41,21 @@ def resolve_account_paths(
     ``history.db`` is intentionally not required to exist: ``History`` creates
     it on first use. The config is the account's existence marker and must be
     present before a command is started.
+
+    The name is validated to be a single plain path component and the
+    resolved account directory is verified to actually stay inside
+    ``data_dir/accounts`` before any caller (notably ``session_security``'s
+    POSIX-mode hardening) is allowed to treat it as the managed account
+    directory (#741). Without this, ``--account ../../foo`` pointing at an
+    external directory that happens to contain a ``config.yaml`` would let
+    filesystem hardening chmod an unrelated, attacker- or victim-owned path.
     """
+    validate_account_name(name)
+    accounts_root = (data_dir / "accounts").resolve()
     account_dir = data_dir / "accounts" / name
+    resolved_account_dir = account_dir.resolve()
+    if resolved_account_dir != accounts_root and accounts_root not in resolved_account_dir.parents:
+        raise AccountError(f"недопустимое имя аккаунта: {name!r}")
     config = account_dir / "config.yaml"
     if not config.is_file():
         raise AccountError(f"аккаунт '{name}' не найден: {config}")

--- a/src/hhru_bot/commands/account.py
+++ b/src/hhru_bot/commands/account.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from ..accounts import AccountError
+from ..accounts import AccountError, validate_account_name
 from ..report import _ascii_table
 from ..session_security import secure_directory
 
@@ -182,8 +182,7 @@ def create_account(
     The directory is created without ``exist_ok`` so a repeated command cannot
     silently overwrite an existing account.
     """
-    if not name or name in {".", ".."} or Path(name).name != name:
-        raise AccountError(f"недопустимое имя аккаунта: {name!r}")
+    validate_account_name(name)
     if not template_path.is_file():
         raise AccountError(f"шаблон конфигурации не найден: {template_path}")
 

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -27,7 +27,7 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
     own no-follow open + fchmod is needed, since no new component is created.
     """
     if permissions_are_posix() and not path.exists():
-        _mkdir_and_harden_new_components(path, mode)
+        _mkdir_and_harden_new_components(path, mode, exist_ok=exist_ok)
         return
     path.mkdir(parents=True, exist_ok=exist_ok, mode=mode)
     if permissions_are_posix():
@@ -38,7 +38,7 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
             os.close(fd)
 
 
-def _mkdir_and_harden_new_components(path: Path, mode: int) -> None:
+def _mkdir_and_harden_new_components(path: Path, mode: int, *, exist_ok: bool = True) -> None:
     """Create the missing suffix of ``path`` and chmod only what we created.
 
     ``Path.mkdir(parents=True)`` followed by a path-based ``os.chmod`` leaves a
@@ -51,6 +51,23 @@ def _mkdir_and_harden_new_components(path: Path, mode: int) -> None:
     (``os.fchmod``) before descending further -- so no step ever re-resolves a
     mutable pathname, and an ancestor that already existed before this call
     (which may be shared with other processes) is never touched.
+
+    ``exist_ok`` mirrors ``Path.mkdir``'s parameter of the same name: when
+    ``False``, the final component turning out to already exist by the time
+    this walk reaches it (created by a racing process between the caller's
+    existence check and this call) raises ``FileExistsError`` instead of
+    being silently accepted -- otherwise ``secure_directory(..., exist_ok=False)``
+    (account creation's rewrite-protection, ``create_account``) would lose its
+    create-only guarantee purely because the target was fully missing when
+    checked (cycle-review round 2 finding).
+
+    Every *non-final* component racing into existence between the ancestor
+    walk above and this loop's own ``os.mkdir`` call is rejected unconditionally
+    (``exist_ok`` does not extend to it): silently descending into a directory
+    this call did not create -- even one merely raced into place by another
+    local process, not necessarily a symlink -- would mean hardening and
+    building the rest of the tree inside a directory this function does not
+    control, defeating "only components we created are ours to harden."
     """
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     o_directory = getattr(os, "O_DIRECTORY", 0)
@@ -70,11 +87,13 @@ def _mkdir_and_harden_new_components(path: Path, mode: int) -> None:
 
     dir_fd = _open_without_follow(existing, os.O_RDONLY | o_directory)
     try:
-        for component in missing:
+        for index, component in enumerate(missing):
+            is_final = index == len(missing) - 1
             try:
                 os.mkdir(component, mode, dir_fd=dir_fd)
             except FileExistsError:
-                pass
+                if not is_final or not exist_ok:
+                    raise
             next_fd = os.open(component, os.O_RDONLY | o_directory | nofollow, dir_fd=dir_fd)
             os.close(dir_fd)
             dir_fd = next_fd

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -17,7 +17,18 @@ def permissions_are_posix() -> bool:
 
 
 def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool = True) -> None:
-    """Create a directory and tighten its mode where Unix modes are supported."""
+    """Create a directory and tighten its mode where Unix modes are supported.
+
+    When any part of ``path`` is missing, creation and hardening of every new
+    component go through ``_mkdir_and_harden_new_components`` (descriptor-relative,
+    no-follow) rather than ``Path.mkdir(parents=True)`` -- the latter leaves the
+    same TOCTOU window on intermediate components that this module's other
+    callers are hardened against (#741). When ``path`` already exists, only its
+    own no-follow open + fchmod is needed, since no new component is created.
+    """
+    if permissions_are_posix() and not path.exists():
+        _mkdir_and_harden_new_components(path, mode)
+        return
     path.mkdir(parents=True, exist_ok=exist_ok, mode=mode)
     if permissions_are_posix():
         fd = _open_without_follow(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))

--- a/src/hhru_bot/session_security.py
+++ b/src/hhru_bot/session_security.py
@@ -27,6 +27,51 @@ def secure_directory(path: Path, mode: int = ACCOUNT_DIR_MODE, *, exist_ok: bool
             os.close(fd)
 
 
+def _mkdir_and_harden_new_components(path: Path, mode: int) -> None:
+    """Create the missing suffix of ``path`` and chmod only what we created.
+
+    ``Path.mkdir(parents=True)`` followed by a path-based ``os.chmod`` leaves a
+    TOCTOU window: between a directory being created and the mode change, any
+    path component -- not only the final one -- can be replaced with a
+    symlink, redirecting the hardening to an unrelated target (#741). This
+    walks up from ``path`` to find the nearest already-existing ancestor, then
+    walks back down creating each missing component with ``os.mkdir(...,
+    dir_fd=...)`` and hardening it with an ``O_NOFOLLOW``-opened descriptor
+    (``os.fchmod``) before descending further -- so no step ever re-resolves a
+    mutable pathname, and an ancestor that already existed before this call
+    (which may be shared with other processes) is never touched.
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    o_directory = getattr(os, "O_DIRECTORY", 0)
+    resolved = path.absolute()
+
+    # Find the nearest already-existing ancestor; only components below it
+    # are ours to create and harden.
+    existing = resolved
+    missing: list[str] = []
+    while not existing.exists():
+        missing.append(existing.name)
+        parent = existing.parent
+        if parent == existing:
+            break
+        existing = parent
+    missing.reverse()
+
+    dir_fd = _open_without_follow(existing, os.O_RDONLY | o_directory)
+    try:
+        for component in missing:
+            try:
+                os.mkdir(component, mode, dir_fd=dir_fd)
+            except FileExistsError:
+                pass
+            next_fd = os.open(component, os.O_RDONLY | o_directory | nofollow, dir_fd=dir_fd)
+            os.close(dir_fd)
+            dir_fd = next_fd
+            os.fchmod(dir_fd, mode)
+    finally:
+        os.close(dir_fd)
+
+
 def _open_without_follow(path: Path, flags: int) -> int:
     """Open a filesystem path without following a symlink on POSIX."""
     nofollow = getattr(os, "O_NOFOLLOW", 0)
@@ -54,9 +99,10 @@ def secure_storage_state_parent(
     # into a private directory.  A missing parent is ours to create, so it can
     # safely start private; the standard account directory is tightened below.
     parent_exists = destination.parent.exists()
-    destination.parent.mkdir(parents=True, exist_ok=True, mode=ACCOUNT_DIR_MODE)
-    if not parent_exists and permissions_are_posix():
-        os.chmod(destination.parent, ACCOUNT_DIR_MODE)
+    if permissions_are_posix() and not parent_exists:
+        _mkdir_and_harden_new_components(destination.parent, ACCOUNT_DIR_MODE)
+    else:
+        destination.parent.mkdir(parents=True, exist_ok=True, mode=ACCOUNT_DIR_MODE)
     return destination
 
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from hhru_bot.accounts import AccountError, AccountPaths, resolve_account_paths
+from hhru_bot.accounts import (
+    AccountError,
+    AccountPaths,
+    resolve_account_paths,
+    validate_account_name,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -31,3 +36,64 @@ def test_history_does_not_have_to_exist(tmp_path: Path):
 def test_missing_account_is_explicit_error(tmp_path: Path):
     with pytest.raises(AccountError, match="аккаунт 'missing' не найден"):
         resolve_account_paths("missing", data_dir=tmp_path)
+
+
+# -- #741 finding 1: reject account names that escape data_dir/accounts -----
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        ".",
+        "",
+        "../../foo",
+        "/etc/passwd",
+        "foo/bar",
+        "foo/../../bar",
+        "a/../b",
+    ],
+)
+def test_validate_account_name_rejects_traversal_and_separators(name: str):
+    with pytest.raises(AccountError, match="недопустимое имя аккаунта"):
+        validate_account_name(name)
+
+
+def test_validate_account_name_accepts_plain_name():
+    validate_account_name("marketing")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "..",
+        "../../foo",
+        "/etc/passwd",
+        "foo/bar",
+    ],
+)
+def test_resolve_account_paths_rejects_traversal_before_touching_filesystem(
+    tmp_path: Path, name: str
+):
+    # An external directory with its own config.yaml must never be reachable
+    # through a crafted --account value (issue #741 finding 1): a config.yaml
+    # placed outside data_dir/accounts must not resolve at all.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "config.yaml").touch()
+
+    with pytest.raises(AccountError, match="недопустимое имя аккаунта"):
+        resolve_account_paths(name, data_dir=tmp_path)
+
+
+def test_resolve_account_paths_rejects_symlink_escaping_accounts_root(tmp_path: Path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "config.yaml").touch()
+
+    accounts_dir = tmp_path / "data" / "accounts"
+    accounts_dir.mkdir(parents=True)
+    (accounts_dir / "escape").symlink_to(outside)
+
+    with pytest.raises(AccountError):
+        resolve_account_paths("escape", data_dir=tmp_path / "data")

--- a/tests/test_session_security.py
+++ b/tests/test_session_security.py
@@ -1,0 +1,185 @@
+"""Unit tests for local filesystem hardening of hh.ru session secrets (#741).
+
+Covers the boundary cases from the issue's open findings (account-name
+containment, symlink-safe parent creation, non-regular session destinations)
+plus regression coverage for the historical findings already fixed in #734
+(arbitrary custom session parent, lexical ``accounts/<name>`` classification,
+symlinked session file, symlinked managed account directory).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.session_security import (
+    ACCOUNT_DIR_MODE,
+    SESSION_FILE_MODE,
+    permissions_are_posix,
+    secure_directory,
+    secure_storage_state_file,
+    secure_storage_state_parent,
+)
+
+pytestmark = pytest.mark.unit
+
+POSIX_ONLY = pytest.mark.skipif(not permissions_are_posix(), reason="POSIX-only mode bits")
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+# -- Finding 2: symlink-safe parent creation/hardening (TOCTOU) -------------
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_creates_and_hardens_missing_dir(tmp_path):
+    destination = tmp_path / "accounts" / "acme" / "sessions" / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    assert destination.parent.is_dir()
+    assert _mode(destination.parent) == ACCOUNT_DIR_MODE
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_hardens_every_new_component(tmp_path):
+    # Multiple missing levels: each one we create must end up hardened, not
+    # only the final directory.
+    destination = tmp_path / "a" / "b" / "c" / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    assert _mode(tmp_path / "a") == ACCOUNT_DIR_MODE
+    assert _mode(tmp_path / "a" / "b") == ACCOUNT_DIR_MODE
+    assert _mode(tmp_path / "a" / "b" / "c") == ACCOUNT_DIR_MODE
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_does_not_touch_existing_ancestor(tmp_path):
+    # A pre-existing ancestor may be shared with unrelated processes (e.g. a
+    # custom /tmp-based path); only components we create ourselves may be
+    # chmodded.
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    os.chmod(shared, 0o755)
+    destination = shared / "acme" / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    assert _mode(shared) == 0o755
+    assert _mode(shared / "acme") == ACCOUNT_DIR_MODE
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_leaves_existing_custom_parent_untouched(tmp_path):
+    """Historical finding #734/4: an existing arbitrary custom parent (e.g. a
+    stand-in for shared /tmp) must never be chmodded by a custom session path."""
+    custom_parent = tmp_path / "tmp_like_shared_dir"
+    custom_parent.mkdir(mode=0o755)
+    os.chmod(custom_parent, 0o755)
+    destination = custom_parent / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    assert _mode(custom_parent) == 0o755
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_does_not_chmod_existing_symlinked_parent(tmp_path):
+    """A pre-existing parent -- symlink or not -- is left untouched: it may be
+    shared with other processes (same rule as the plain-existing-dir case
+    above), so the safe behaviour is "don't touch", not "raise"."""
+    real_target = tmp_path / "victim"
+    real_target.mkdir(mode=0o755)
+    link = tmp_path / "accounts" / "acme"
+    link.parent.mkdir()
+    link.symlink_to(real_target)
+    destination = link / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    assert _mode(real_target) == 0o755
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_new_component_cannot_be_swapped_for_symlink(tmp_path):
+    """A directory-descriptor-relative mkdir+fchmod cannot be redirected by
+    swapping a not-yet-created component's *name* for a symlink after the
+    call starts walking -- verified indirectly here by asserting the
+    freshly-created leaf is a real directory, not something that could have
+    silently become a symlink target."""
+    destination = tmp_path / "a" / "b" / "hh_session.json"
+
+    secure_storage_state_parent(destination)
+
+    leaf = tmp_path / "a" / "b"
+    assert leaf.is_dir()
+    assert not leaf.is_symlink()
+    assert _mode(leaf) == ACCOUNT_DIR_MODE
+
+
+# -- Finding 1 companion: secure_directory() itself must stay no-follow -----
+
+
+@POSIX_ONLY
+def test_secure_directory_rejects_symlinked_target(tmp_path):
+    real_target = tmp_path / "victim"
+    real_target.mkdir(mode=0o755)
+    link = tmp_path / "accounts" / "acme"
+    link.parent.mkdir()
+    link.symlink_to(real_target)
+
+    with pytest.raises(OSError):
+        secure_directory(link)
+
+    assert _mode(real_target) == 0o755
+
+
+# -- Finding 3: regression only, secure_storage_state_file() already rejects
+# non-regular destinations before any mode change. --------------------------
+
+
+@POSIX_ONLY
+def test_secure_storage_state_file_rejects_directory_destination(tmp_path):
+    destination = tmp_path / "hh_session.json"
+    destination.mkdir()
+
+    with pytest.raises(OSError):
+        secure_storage_state_file(destination)
+
+    # The mode change must never have happened: execute bits stay intact and
+    # the directory remains traversable.
+    assert _mode(destination) != SESSION_FILE_MODE
+    assert os.access(destination, os.X_OK)
+
+
+@POSIX_ONLY
+def test_secure_storage_state_file_rejects_symlinked_destination(tmp_path):
+    """Historical finding #734/6 regression: path-based chmod must not follow
+    a session-file symlink onto a victim-owned file."""
+    victim = tmp_path / "victim.json"
+    victim.write_text("not a session file")
+    os.chmod(victim, 0o644)
+    link = tmp_path / "hh_session.json"
+    link.symlink_to(victim)
+
+    with pytest.raises(OSError):
+        secure_storage_state_file(link)
+
+    assert _mode(victim) == 0o644
+
+
+@POSIX_ONLY
+def test_secure_storage_state_file_hardens_regular_file(tmp_path):
+    destination = tmp_path / "hh_session.json"
+    destination.write_text("{}")
+    os.chmod(destination, 0o644)
+
+    secure_storage_state_file(destination)
+
+    assert _mode(destination) == SESSION_FILE_MODE

--- a/tests/test_session_security.py
+++ b/tests/test_session_security.py
@@ -141,6 +141,47 @@ def test_secure_directory_rejects_symlinked_target(tmp_path):
 
 
 @POSIX_ONLY
+def test_secure_directory_exist_ok_false_rejects_target_created_during_race(tmp_path):
+    """Cycle-review round 2 regression: when the target is missing at the
+    caller's initial exists() check, but the final component is created by a
+    racing process before this call's own os.mkdir(), exist_ok=False must
+    still raise -- account creation's rewrite-protection (create_account)
+    must not silently degrade into an overwrite just because the target was
+    fully absent when checked."""
+    account_dir = tmp_path / "accounts" / "acme"
+    account_dir.mkdir(parents=True)  # simulates the race: created after the caller's check
+
+    with pytest.raises(FileExistsError):
+        secure_directory(account_dir, exist_ok=False)
+
+
+@POSIX_ONLY
+def test_secure_directory_rejects_non_final_component_created_during_race(tmp_path, monkeypatch):
+    """A non-final path component that races into existence as a real
+    directory (not a symlink -- O_NOFOLLOW alone would not catch this) between
+    the ancestor walk and this call's own os.mkdir() must not be silently
+    descended into: hardening and building the rest of the tree inside a
+    directory this call did not create defeats "only what we created is
+    ours to harden," even without a symlink involved."""
+    import hhru_bot.session_security as session_security
+
+    account_dir = tmp_path / "data" / "accounts" / "acme"
+    real_mkdir = os.mkdir
+
+    def racing_mkdir(component, mode, *, dir_fd=None):
+        # Simulate a concurrent process creating "accounts" as a real
+        # directory right before this call's own os.mkdir("accounts", ...).
+        if component == "accounts":
+            real_mkdir("accounts", 0o755, dir_fd=dir_fd)
+        real_mkdir(component, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(session_security.os, "mkdir", racing_mkdir)
+
+    with pytest.raises(FileExistsError):
+        secure_directory(account_dir)
+
+
+@POSIX_ONLY
 def test_secure_directory_hardens_every_missing_intermediate_component(tmp_path):
     """Regression for the cycle-review finding: secure_directory() must not
     fall back to Path.mkdir(parents=True) + final-only fchmod when several

--- a/tests/test_session_security.py
+++ b/tests/test_session_security.py
@@ -140,6 +140,41 @@ def test_secure_directory_rejects_symlinked_target(tmp_path):
     assert _mode(real_target) == 0o755
 
 
+@POSIX_ONLY
+def test_secure_directory_hardens_every_missing_intermediate_component(tmp_path):
+    """Regression for the cycle-review finding: secure_directory() must not
+    fall back to Path.mkdir(parents=True) + final-only fchmod when several
+    levels are missing -- that leaves every intermediate component's creation
+    unprotected against a symlink swap, exactly the TOCTOU class this module
+    exists to close (mirrors secure_storage_state_parent's own coverage
+    above, applied to the account-directory call path in
+    secure_storage_state_parent -> secure_directory(account_dir))."""
+    account_dir = tmp_path / "data" / "accounts" / "acme"
+
+    secure_directory(account_dir)
+
+    assert _mode(tmp_path / "data") == ACCOUNT_DIR_MODE
+    assert _mode(tmp_path / "data" / "accounts") == ACCOUNT_DIR_MODE
+    assert _mode(account_dir) == ACCOUNT_DIR_MODE
+
+
+@POSIX_ONLY
+def test_secure_storage_state_parent_hardens_missing_account_dir_chain(tmp_path):
+    """End-to-end regression at the call site the review flagged: when
+    account_dir is passed to secure_storage_state_parent and several of its
+    levels are missing, every new component must be hardened, not only the
+    leaf -- previously secure_directory(account_dir) used the vulnerable
+    Path.mkdir(parents=True) + final-only-fchmod path here."""
+    account_dir = tmp_path / "data" / "accounts" / "acme"
+    destination = account_dir / "hh_session.json"
+
+    secure_storage_state_parent(destination, account_dir=account_dir)
+
+    assert _mode(tmp_path / "data") == ACCOUNT_DIR_MODE
+    assert _mode(tmp_path / "data" / "accounts") == ACCOUNT_DIR_MODE
+    assert _mode(account_dir) == ACCOUNT_DIR_MODE
+
+
 # -- Finding 3: regression only, secure_storage_state_file() already rejects
 # non-regular destinations before any mode change. --------------------------
 


### PR DESCRIPTION
## Что делает

Follow-up по #741 (третий раунд ревью #734). Из 8 находок issue реально открытых три первые — фиксятся здесь; 4-8 исторические (уже закрыты в #734) — по ним добавлен только аудит/регрессионное покрытие.

### Находка 1 (главная) — валидация имени аккаунта + containment
`resolve_account_paths()` строил `data_dir/accounts/<name>` без какой-либо проверки `name`. `--account ../../foo`, указывающий на внешний каталог с `config.yaml`, доходил до `secure_directory()`, которая меняла режим доступа этого чужого каталога на `0700`.

Фикс:
- `accounts.validate_account_name()` — единая точка валидации (та же логика, что уже была в `commands/account.py::create_account`, теперь переиспользуется, а не продублирована).
- `resolve_account_paths()` после резолва пути дополнительно проверяет, что итоговый `account_dir` реально лежит внутри `data_dir/accounts` (`Path.resolve()` + сравнение с `accounts_root`/`.parents`) — перекрывает и `..`-traversal, и симлинк, уводящий за пределы `data/accounts`.

### Находка 2 — TOCTOU между mkdir() и path-based chmod()
`secure_storage_state_parent()` создавала отсутствующий родительский каталог через `Path.mkdir(parents=True)`, а затем меняла режим через `os.chmod()` по имени пути — окно между этими двумя операциями (и по промежуточным компонентам тоже) не было no-follow-safe.

Фикс: `_mkdir_and_harden_new_components()` идёт от ближайшего уже существующего предка вниз, создавая и хардня **только новые** компоненты через `os.mkdir(..., dir_fd=...)` + `os.open(..., O_NOFOLLOW|O_DIRECTORY, dir_fd=...)` + `os.fchmod()` — ни один шаг не резолвит путь заново по имени. Уже существующие (потенциально общие с другими процессами) каталоги по-прежнему не трогаются — сохранена прежняя политика для custom-путей вроде `/tmp/hh_session.json`.

### Находка 3 — регрессия, фикс не нужен
`secure_storage_state_file()` уже отклоняет не-regular файлы (`stat.S_ISREG` перед `fchmod`). Код не менялся, добавлен только регрессионный тест на директорию-назначение и на symlink-назначение.

### Находки 4-8 (исторические, #734)
Аудит подтверждает, что защита осталась на месте:
- custom session parent не chmodится, если существовал раньше (тест `test_secure_storage_state_parent_leaves_existing_custom_parent_untouched`);
- симлинкнутый session-файл отклоняется до chmod (`test_secure_storage_state_file_rejects_symlinked_destination`);
- симлинкнутый managed account dir отклоняется (`test_secure_directory_rejects_symlinked_target`).
Дублирования лексической классификации `accounts/<name>` в коде не найдено — `account_dir` везде плюмбится явно через `_resolve_paths()`/`AccountPaths`, не выводится из текста пути.

## Тесты

- Новый файл `tests/test_session_security.py` — покрытия `session_security.py` не было вовсе на origin/main.
- Расширен `tests/test_accounts.py` (валидация имени + containment, включая symlink-эскейп).
- `ruff check` + `ruff format --check` по `src tests scripts` — чисто.
- Полный `pytest` (xdist `-n 4 --dist worksteal`) — зелёный.
- `scripts/gen_cli_docs.py --check` — синхронизирован (CLI-поверхность не менялась).

## Риски / follow-up

Нет открытых follow-up по скоупу issue. Механизм прав (`SESSION_FILE_MODE = 0o600` из #726) не трогался.

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)