### PR TITLE
fix(hhru-live): re-detect overlay after hide->show, add behavioral test

### DIFF
--- a/extensions/hhru-live/content.js
+++ b/extensions/hhru-live/content.js
@@ -21,23 +21,38 @@ function report(element) {
   chrome.runtime.sendMessage(report);
 }
 
+function isVisible(element) {
+  return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+}
+
+// `seen` gates a report only while the element stays visible: once it goes
+// hidden it is dropped from the set, so a later show (same DOM node, same
+// attribute toggle) is treated as a fresh detection instead of being
+// permanently blocked. This is what makes the `attributes: true` observer
+// (added for hide/show toggles) actually useful across repeat show events.
+function reportIfNewlyVisible(node, seen) {
+  if (!isVisible(node)) {
+    seen.delete(node);
+    return;
+  }
+  if (seen.has(node)) return;
+  seen.add(node);
+  report(node);
+}
+
 function inspect(node, seen) {
   if (!(node instanceof Element)) return;
-  if (OVERLAY_SELECTORS.some((selector) => node.matches(selector)) && !seen.has(node)) {
-    seen.add(node);
-    report(node);
+  if (OVERLAY_SELECTORS.some((selector) => node.matches(selector))) {
+    reportIfNewlyVisible(node, seen);
   }
   node.querySelectorAll(OVERLAY_SELECTORS.join(',')).forEach((el) => {
-    if (seen.has(el)) return;
-    seen.add(el);
-    report(el);
+    reportIfNewlyVisible(el, seen);
   });
 }
 
 const seen = new WeakSet();
 document.querySelectorAll(OVERLAY_SELECTORS.join(',')).forEach((el) => {
-  seen.add(el);
-  report(el);
+  reportIfNewlyVisible(el, seen);
 });
 const observer = new MutationObserver((mutations) => {
   mutations.forEach(({ type, target, addedNodes }) => {

--- a/extensions/hhru-live/content.js
+++ b/extensions/hhru-live/content.js
@@ -7,7 +7,19 @@ const OVERLAY_SELECTORS = [
 ];
 
 function isVisible(element) {
-  return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+  // offsetWidth/offsetHeight/getClientRects() only react to display:none —
+  // a visibility:hidden element still reports non-zero layout metrics, so it
+  // would be treated as "visible" here (Codex round-3 review of #767: this
+  // silently defeats the hide->show re-detect gate for that CSS pattern).
+  // checkVisibility() (Chrome 105+) covers visibility/display/content-visibility
+  // in one call; fall back to the layout check + an explicit visibility read
+  // for older Chrome (MV3's floor is Chrome 88).
+  if (typeof element.checkVisibility === 'function') {
+    return element.checkVisibility({ checkOpacity: false, checkVisibilityCSS: true });
+  }
+  const hasLayout = !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+  if (!hasLayout) return false;
+  return getComputedStyle(element).visibility !== 'hidden';
 }
 
 function classify(element) {

--- a/extensions/hhru-live/content.js
+++ b/extensions/hhru-live/content.js
@@ -6,6 +6,10 @@ const OVERLAY_SELECTORS = [
   '[class*="notification"]', '[class*="cookie"]'
 ];
 
+function isVisible(element) {
+  return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+}
+
 function classify(element) {
   const text = (element.innerText || element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 500);
   const role = element.getAttribute('role');
@@ -13,16 +17,12 @@ function classify(element) {
   const type = /cookie/i.test(className + text)
     ? 'cookie_banner' : role === 'dialog' || role === 'alertdialog' || /modal|popup/i.test(className)
     ? 'modal' : /toast|notification/i.test(className) ? 'notification' : 'overlay';
-  return { type, text, role, className: className.slice(0, 200), visible: !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length) };
+  return { type, text, role, className: className.slice(0, 200), visible: isVisible(element) };
 }
 
 function report(element) {
   const report = { kind: 'overlay_detected', observedAt: new Date().toISOString(), overlay: classify(element) };
   chrome.runtime.sendMessage(report);
-}
-
-function isVisible(element) {
-  return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
 }
 
 // `seen` gates a report only while the element stays visible: once it goes

--- a/tests/js_harness/dom_stub.js
+++ b/tests/js_harness/dom_stub.js
@@ -1,0 +1,198 @@
+// Minimal, dependency-free DOM + chrome.* stub for behaviorally executing
+// extensions/hhru-live/content.js under Node's `vm` module (see
+// tests/test_hhru_live_behavior.py). Implements exactly the surface content.js
+// touches: Element (matches/getAttribute/setAttribute/classList/querySelectorAll/
+// offsetWidth/offsetHeight/getClientRects), a documentElement-rooted tree, and a
+// synchronous-batch MutationObserver whose callback semantics mirror the real
+// spec closely enough for this content script (one microtask-flushed batch per
+// group of synchronous mutations, delivered as {type, target, addedNodes}).
+//
+// No third-party dependency (jsdom/linkedom) is introduced: the project has no
+// npm/package.json footprint at all, and content.js's actual DOM usage is a
+// handful of primitives that are cheap and low-risk to hand-roll here, per the
+// project's "maximum simplicity, do not add dependencies without justification"
+// principle (see CLAUDE.md).
+
+'use strict';
+
+function matchesSimpleSelector(el, selector) {
+  // Supports exactly the selector shapes content.js's OVERLAY_SELECTORS uses:
+  // [attr="value"], [attr*="value"], [attr]
+  const attrMatch = selector.match(/^\[([a-zA-Z-]+)(?:([*])?=("([^"]*)"|'([^']*)'))?\]$/);
+  if (!attrMatch) throw new Error(`unsupported selector in stub: ${selector}`);
+  const [, attr, op, , dq, sq] = attrMatch;
+  const value = dq ?? sq;
+  const actual = el.getAttribute(attr);
+  if (actual === null) return false;
+  if (value === undefined) return true;
+  if (op === '*') return actual.includes(value);
+  return actual === value;
+}
+
+class ClassList {
+  constructor(el) {
+    this._el = el;
+  }
+  add(...names) {
+    const cur = new Set((this._el.getAttribute('class') || '').split(/\s+/).filter(Boolean));
+    names.forEach((n) => cur.add(n));
+    this._el.setAttribute('class', [...cur].join(' '));
+  }
+  remove(...names) {
+    const cur = new Set((this._el.getAttribute('class') || '').split(/\s+/).filter(Boolean));
+    names.forEach((n) => cur.delete(n));
+    this._el.setAttribute('class', [...cur].join(' '));
+  }
+}
+
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this._attrs = new Map();
+    this.children = [];
+    this.parentNode = null;
+    this.innerText = '';
+    this.textContent = '';
+    this._offsetWidth = 0;
+    this._offsetHeight = 0;
+    this._clientRects = [];
+    this.classList = new ClassList(this);
+  }
+
+  get offsetWidth() {
+    return this._offsetWidth;
+  }
+  get offsetHeight() {
+    return this._offsetHeight;
+  }
+  getClientRects() {
+    return this._clientRects;
+  }
+
+  // Test-only helper: flips the visibility signals content.js's isVisible()
+  // reads (offsetWidth/offsetHeight/getClientRects().length), simulating a
+  // real browser's post-layout state after a class/style toggle.
+  _setVisible(visible) {
+    this._offsetWidth = visible ? 100 : 0;
+    this._offsetHeight = visible ? 40 : 0;
+    this._clientRects = visible ? [{ width: 100, height: 40 }] : [];
+  }
+
+  getAttribute(name) {
+    return this._attrs.has(name) ? this._attrs.get(name) : null;
+  }
+
+  setAttribute(name, value) {
+    const root = this._ownerDocument();
+    this._attrs.set(name, String(value));
+    if (root) root._recordMutation({ type: 'attributes', target: this, addedNodes: [] });
+  }
+
+  matches(selector) {
+    return matchesSimpleSelector(this, selector);
+  }
+
+  querySelectorAll(selectorList) {
+    const selectors = selectorList.split(',').map((s) => s.trim());
+    const out = [];
+    const visit = (node) => {
+      node.children.forEach((child) => {
+        if (selectors.some((s) => matchesSimpleSelector(child, s))) out.push(child);
+        visit(child);
+      });
+    };
+    visit(this);
+    return out;
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    const root = this._ownerDocument();
+    if (root) root._recordMutation({ type: 'childList', target: this, addedNodes: [child] });
+    return child;
+  }
+
+  _ownerDocument() {
+    let node = this;
+    while (node.parentNode) node = node.parentNode;
+    return node._isDocumentRoot ? node : null;
+  }
+}
+
+class DocumentElement extends Element {
+  constructor() {
+    super('html');
+    this._isDocumentRoot = true;
+    this._observers = [];
+    this._pendingRecords = [];
+    this._flushScheduled = false;
+  }
+
+  _recordMutation(record) {
+    this._pendingRecords.push(record);
+    if (this._flushScheduled) return;
+    this._flushScheduled = true;
+    // Real MutationObserver delivers a batch per microtask checkpoint, after
+    // the current synchronous script (or task) finishes. queueMicrotask
+    // mirrors that closely enough for this test harness.
+    queueMicrotask(() => this._flush());
+  }
+
+  _flush() {
+    const records = this._pendingRecords;
+    this._pendingRecords = [];
+    this._flushScheduled = false;
+    if (records.length === 0) return;
+    this._observers.forEach((cb) => cb(records));
+  }
+}
+
+function makeChrome(sentMessages) {
+  const listeners = [];
+  return {
+    runtime: {
+      sendMessage(message) {
+        sentMessages.push(message);
+      },
+      onMessage: {
+        addListener(fn) {
+          listeners.push(fn);
+        },
+      },
+      _listeners: listeners,
+    },
+  };
+}
+
+function createEnvironment() {
+  const documentElement = new DocumentElement();
+  const document = {
+    documentElement,
+    querySelectorAll: (sel) => documentElement.querySelectorAll(sel),
+    createElement: (tag) => new Element(tag),
+  };
+  const sentMessages = [];
+  const chrome = makeChrome(sentMessages);
+
+  class MutationObserver {
+    constructor(callback) {
+      this._callback = callback;
+    }
+    observe(target, _options) {
+      target._observers.push((records) => this._callback(records));
+    }
+  }
+
+  return {
+    document,
+    chrome,
+    sentMessages,
+    MutationObserver,
+    Element,
+    location: { href: 'https://hh.ru/vacancy/1' },
+    flush: () => documentElement._flush(),
+  };
+}
+
+module.exports = { createEnvironment, Element };

--- a/tests/js_harness/dom_stub.js
+++ b/tests/js_harness/dom_stub.js
@@ -56,6 +56,7 @@ class Element {
     this._offsetWidth = 0;
     this._offsetHeight = 0;
     this._clientRects = [];
+    this._visibilityHidden = false;
     this.classList = new ClassList(this);
   }
 
@@ -71,11 +72,36 @@ class Element {
 
   // Test-only helper: flips the visibility signals content.js's isVisible()
   // reads (offsetWidth/offsetHeight/getClientRects().length), simulating a
-  // real browser's post-layout state after a class/style toggle.
+  // real browser's post-layout state after a class/style toggle. This models
+  // display:none (all layout signals zeroed) — NOT visibility:hidden, which
+  // in a real browser keeps non-zero layout metrics. Use _setCssVisibility()
+  // to model that case instead.
   _setVisible(visible) {
     this._offsetWidth = visible ? 100 : 0;
     this._offsetHeight = visible ? 40 : 0;
     this._clientRects = visible ? [{ width: 100, height: 40 }] : [];
+    this._visibilityHidden = false;
+  }
+
+  // Test-only helper: models CSS `visibility:hidden` specifically — layout
+  // metrics stay non-zero (unlike display:none) but the element is not
+  // actually visible. Exercises the checkVisibility()/getComputedStyle()
+  // branch of content.js's isVisible() (issue #743 / PR #767 Codex round 3).
+  _setCssVisibility(hidden) {
+    this._offsetWidth = 100;
+    this._offsetHeight = 40;
+    this._clientRects = [{ width: 100, height: 40 }];
+    this._visibilityHidden = hidden;
+  }
+
+  // Mirrors the real Element.checkVisibility({checkOpacity, checkVisibilityCSS})
+  // contract closely enough for content.js's usage: false when display:none
+  // (zero layout) or visibility:hidden; true otherwise. Ignores checkOpacity
+  // (content.js always passes checkOpacity: false).
+  checkVisibility(_opts) {
+    const hasLayout = !!(this._offsetWidth || this._offsetHeight || this._clientRects.length);
+    if (!hasLayout) return false;
+    return !this._visibilityHidden;
   }
 
   getAttribute(name) {
@@ -184,12 +210,20 @@ function createEnvironment() {
     }
   }
 
+  // Fallback branch coverage for isVisible() on engines without
+  // checkVisibility(): getComputedStyle(el).visibility. Only `.visibility`
+  // is read by content.js, so that's all this stub needs to provide.
+  function getComputedStyle(element) {
+    return { visibility: element._visibilityHidden ? 'hidden' : 'visible' };
+  }
+
   return {
     document,
     chrome,
     sentMessages,
     MutationObserver,
     Element,
+    getComputedStyle,
     location: { href: 'https://hh.ru/vacancy/1' },
     flush: () => documentElement._flush(),
   };

--- a/tests/js_harness/run_content_scenario.js
+++ b/tests/js_harness/run_content_scenario.js
@@ -1,0 +1,70 @@
+// Executes extensions/hhru-live/content.js inside a vm context wired to
+// tests/js_harness/dom_stub.js, runs the hide->show->re-detect scenario for
+// issue #743 finding 1, and prints the sequence of reported overlay `kind`s
+// as JSON so tests/test_hhru_live_behavior.py can assert on real execution
+// instead of grepping source text.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { createEnvironment } = require('./dom_stub');
+
+const contentJsPath = path.join(__dirname, '..', '..', 'extensions', 'hhru-live', 'content.js');
+const source = fs.readFileSync(contentJsPath, 'utf8');
+
+const env = createEnvironment();
+const context = vm.createContext({
+  document: env.document,
+  chrome: env.chrome,
+  MutationObserver: env.MutationObserver,
+  Element: env.Element,
+  location: env.location,
+  console,
+});
+
+// Build a cookie-consent banner already present in the DOM before content.js
+// runs, matching the OVERLAY_SELECTORS `[class*="cookie"]` rule, and started
+// hidden — content.js's initial scan (document.querySelectorAll(...)) must
+// not report it while hidden.
+const banner = env.document.createElement('div');
+banner.setAttribute('class', 'cookie-banner');
+banner._setVisible(false);
+env.document.documentElement.appendChild(banner);
+env.flush();
+
+vm.runInContext(source, context);
+
+async function run() {
+  await Promise.resolve(); // flush the initial-scan microtask, if any queued
+
+  // Step 1: show the banner (attribute toggle a real site would use to
+  // reveal a pre-mounted cookie banner) -> should report once.
+  banner.classList.add('cookie-banner--visible');
+  banner._setVisible(true);
+  banner.setAttribute('class', banner.getAttribute('class')); // re-trigger attributes record
+  env.flush();
+  await Promise.resolve();
+
+  // Step 2: hide it again (dismissed) -> no report expected for a hide.
+  banner._setVisible(false);
+  banner.setAttribute('class', 'cookie-banner');
+  env.flush();
+  await Promise.resolve();
+
+  // Step 3: show it again via the same toggle -> must report a SECOND time.
+  // This is exactly the regression from issue #743 finding 1: a permanent
+  // WeakSet would silently swallow this second report.
+  banner._setVisible(true);
+  banner.setAttribute('class', 'cookie-banner cookie-banner--visible');
+  env.flush();
+  await Promise.resolve();
+
+  const kinds = env.sentMessages.map((m) => m.kind);
+  process.stdout.write(JSON.stringify({ kinds, messages: env.sentMessages }));
+}
+
+run().catch((err) => {
+  process.stderr.write(String((err && err.stack) || err));
+  process.exit(1);
+});

--- a/tests/js_harness/run_content_scenario.js
+++ b/tests/js_harness/run_content_scenario.js
@@ -19,6 +19,7 @@ const context = vm.createContext({
   chrome: env.chrome,
   MutationObserver: env.MutationObserver,
   Element: env.Element,
+  getComputedStyle: env.getComputedStyle,
   location: env.location,
   console,
 });

--- a/tests/js_harness/run_visibility_hidden_scenario.js
+++ b/tests/js_harness/run_visibility_hidden_scenario.js
@@ -1,0 +1,70 @@
+// Executes extensions/hhru-live/content.js against a scenario where an
+// overlay starts CSS `visibility:hidden` (non-zero layout metrics, unlike
+// display:none) and is later revealed by clearing that property. Regression
+// coverage for PR #767 Codex round-3 finding 1: offsetWidth/offsetHeight/
+// getClientRects() alone don't react to visibility:hidden, so isVisible()
+// must also check computed visibility (via checkVisibility() or
+// getComputedStyle().visibility) or the initial scan would treat the
+// still-hidden overlay as already "seen", permanently suppressing the real
+// reveal that follows.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { createEnvironment } = require('./dom_stub');
+
+const contentJsPath = path.join(__dirname, '..', '..', 'extensions', 'hhru-live', 'content.js');
+const source = fs.readFileSync(contentJsPath, 'utf8');
+
+const env = createEnvironment();
+const context = vm.createContext({
+  document: env.document,
+  chrome: env.chrome,
+  MutationObserver: env.MutationObserver,
+  Element: env.Element,
+  getComputedStyle: env.getComputedStyle,
+  location: env.location,
+  console,
+});
+
+// Modal already in the DOM before content.js runs, laid out (non-zero
+// offsetWidth/offsetHeight/getClientRects) but CSS visibility:hidden --
+// the initial scan must NOT report it while hidden this way.
+const modal = env.document.createElement('div');
+modal.setAttribute('class', 'modal');
+modal._setCssVisibility(true); // visibility:hidden
+env.document.documentElement.appendChild(modal);
+env.flush();
+
+vm.runInContext(source, context);
+
+async function run() {
+  await Promise.resolve(); // flush the initial-scan microtask
+
+  // The initial scan must NOT report the modal while it is still
+  // visibility:hidden -- this is exactly the bug: offsetWidth/offsetHeight/
+  // getClientRects() alone don't react to visibility:hidden, so without a
+  // real visibility check, the still-hidden modal would be misreported here.
+  const reportsBeforeReveal = env.sentMessages.filter((m) => m.kind === 'overlay_detected').length;
+
+  // Reveal it by clearing visibility:hidden (a style mutation, observed via
+  // the attributeFilter's 'style' entry) -> must report exactly once, and
+  // only now.
+  modal._setCssVisibility(false);
+  modal.setAttribute('style', 'visibility:visible');
+  env.flush();
+  await Promise.resolve();
+
+  const overlayReports = env.sentMessages.filter((m) => m.kind === 'overlay_detected');
+  process.stdout.write(JSON.stringify({
+    reportsBeforeReveal,
+    overlayReportCount: overlayReports.length,
+    messages: overlayReports,
+  }));
+}
+
+run().catch((err) => {
+  process.stderr.write(String((err && err.stack) || err));
+  process.exit(1);
+});

--- a/tests/test_hhru_live_behavior.py
+++ b/tests/test_hhru_live_behavior.py
@@ -29,14 +29,15 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).parents[1]
 RUNNER = REPO_ROOT / "tests" / "js_harness" / "run_content_scenario.js"
+VISIBILITY_RUNNER = REPO_ROOT / "tests" / "js_harness" / "run_visibility_hidden_scenario.js"
 
 
-def _run_scenario() -> dict:
+def _run_node_scenario(runner: Path) -> dict:
     node = shutil.which("node")
     if node is None:
         pytest.skip("node не найден в PATH — поведенческий тест content.js пропущен")
     result = subprocess.run(
-        [node, str(RUNNER)],
+        [node, str(runner)],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -46,6 +47,10 @@ def _run_scenario() -> dict:
         f"node harness завершился с ошибкой:\nstdout={result.stdout}\nstderr={result.stderr}"
     )
     return json.loads(result.stdout)
+
+
+def _run_scenario() -> dict:
+    return _run_node_scenario(RUNNER)
 
 
 def test_hhru_live_content_script_re_detects_overlay_after_hide_then_show():
@@ -78,3 +83,28 @@ def test_hhru_live_content_script_reports_connected_on_load():
     """
     scenario = _run_scenario()
     assert "connected" in scenario["kinds"]
+
+
+def test_hhru_live_content_script_does_not_misreport_css_visibility_hidden_as_shown():
+    """PR #767 Codex round-3 review, finding 1 (confidence 0.9): offsetWidth/
+    offsetHeight/getClientRects() alone react only to display:none, not to
+    CSS `visibility:hidden` -- an element with visibility:hidden still has
+    non-zero layout metrics. Without an explicit visibility check, an overlay
+    that starts visibility:hidden would be misreported as already-visible on
+    the initial DOM scan (and added to `seen`), permanently suppressing the
+    real reveal that follows -- silently defeating the issue #743 finding 1
+    hide->show re-detect fix for this specific CSS pattern.
+
+    Scenario in tests/js_harness/run_visibility_hidden_scenario.js: a modal
+    already in the DOM, laid out but visibility:hidden -> revealed by
+    clearing that property. Expects zero reports before the reveal and
+    exactly one report after.
+    """
+    scenario = _run_node_scenario(VISIBILITY_RUNNER)
+    assert scenario["reportsBeforeReveal"] == 0, (
+        "overlay must not be reported while still visibility:hidden "
+        f"(offsetWidth/offsetHeight/getClientRects alone would wrongly see it as visible): {scenario}"
+    )
+    assert scenario["overlayReportCount"] == 1, (
+        f"expected exactly one overlay_detected after the reveal, got: {scenario}"
+    )

--- a/tests/test_hhru_live_behavior.py
+++ b/tests/test_hhru_live_behavior.py
@@ -1,0 +1,80 @@
+"""Поведенческий тест extensions/hhru-live/content.js (issue #743).
+
+Существующие тесты в tests/test_page_state.py проверяют исходник content.js
+текстовым grep'ом — они умеют убедиться, что нужная строка присутствует, но
+не умеют исполнить код и проверить реальное поведение. Именно поэтому round 2
+(PR #644) дал регрессию находки 1 (permanent WeakSet блокирует повторный
+report после hide -> show): grep видел "WeakSet" в файле и был доволен, хотя
+семантика WeakSet стала неверной.
+
+Здесь content.js исполняется по-настоящему в Node (`node --check`-совместимый
+ES5/ES2020 синтаксис, без сборки) через vm.createContext с минимальным
+DOM/`chrome.*`-стабом (tests/js_harness/dom_stub.js). Зависимость выбрана
+намеренно: проект не имеет npm/package.json вообще, а jsdom/linkedom как
+devDependency потребовали бы заводить такой footprint ради нескольких
+DOM-примитивов, которые content.js реально использует. Системный `node`
+уже присутствует на GitHub Actions ubuntu-latest раннере (используется самим
+Actions рантаймом), поэтому здесь не требуется новый CI setup-шаг — тест
+пропускается (skip, не fail), если `node` недоступен локально.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).parents[1]
+RUNNER = REPO_ROOT / "tests" / "js_harness" / "run_content_scenario.js"
+
+
+def _run_scenario() -> dict:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node не найден в PATH — поведенческий тест content.js пропущен")
+    result = subprocess.run(
+        [node, str(RUNNER)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"node harness завершился с ошибкой:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def test_hhru_live_content_script_re_detects_overlay_after_hide_then_show():
+    """Issue #743 finding 1: permanent WeakSet блокировал повторный report
+    того же DOM-узла, если overlay скрылся и снова показался через тот же
+    attribute-toggle (класс/aria-hidden). Сценарий в
+    tests/js_harness/run_content_scenario.js: cookie-баннер уже в DOM
+    (скрыт) -> показан (toggle класса) -> скрыт -> показан снова тем же
+    узлом. Ожидается ровно ДВА overlay_detected report'а — по одному на
+    каждый show, ни один hide не репортится, а второй show не должен быть
+    молча проглочен permanent-блокировкой.
+    """
+    scenario = _run_scenario()
+    overlay_reports = [m for m in scenario["messages"] if m["kind"] == "overlay_detected"]
+    assert len(overlay_reports) == 2, (
+        "ожидались 2 overlay_detected (после первого и второго show того же узла), "
+        f"получено {len(overlay_reports)}: {overlay_reports}"
+    )
+    assert all(r["overlay"]["visible"] for r in overlay_reports), (
+        "report() должен вызываться только когда overlay реально видим "
+        f"(offsetWidth/offsetHeight/getClientRects); got {overlay_reports}"
+    )
+    assert all(r["overlay"]["type"] == "cookie_banner" for r in overlay_reports)
+
+
+def test_hhru_live_content_script_reports_connected_on_load():
+    """Сценарий должен по-прежнему отправлять `connected` при загрузке
+    content.js — регресс-проверка, что harness не сломал остальную
+    инициализацию, пока проверяет узкий hide/show сценарий выше.
+    """
+    scenario = _run_scenario()
+    assert "connected" in scenario["kinds"]


### PR DESCRIPTION
## Что сделано

Issue #743 (round-3 находки для extensions/hhru-live/), сверено с фактическим
состоянием origin/main из шапки issue: находки 2 и 4 уже закрыты в PR #744,
находка 3 (`onConnectExternal`) осознанно не трогается — нет потребителя,
`externally_connectable` в манифест не добавлялся.

### Находка 1 (permanent WeakSet) — исправлена

`content.js`: module-level `seen` WeakSet (добавлен в PR #644 round 2 для
персистентного dedup между batch'ами мутаций) навсегда блокировал `report()`
для узла, даже после того как overlay скрылся и снова показался через тот же
attribute-toggle — то есть ломал именно ту фичу (`attributes: true` observer),
ради которой добавлялся в round 1.

Фикс: `reportIfNewlyVisible()` удаляет узел из `seen`, когда он перестаёт быть
видимым (`offsetWidth`/`offsetHeight`/`getClientRects().length`), поэтому
следующий показ того же узла снова репортится, а повторные mutation-записи
уже видимого узла по-прежнему дедуплицируются.

### Поведенческий тест

`tests/test_page_state.py` проверяет `content.js` только текстовым grep —
поэтому регрессия round 2→3 не была поймана: grep видел `"WeakSet"` в файле и
был доволен, хотя семантика WeakSet стала неверной.

Добавлен `tests/test_hhru_live_behavior.py` + `tests/js_harness/`:
исполняет реальный `content.js` через Node `vm.createContext` против
минимального hand-rolled DOM/`chrome.*`-стаба (`dom_stub.js`) и прогоняет
сценарий hide → show → hide → show на cookie-баннере, проверяя ровно два
`overlay_detected` (без фикса — один, регрессия воспроизведена и
зафиксирована перед фиксом, затем перепроверена после).

**Почему без jsdom/linkedom:** в проекте вообще нет `package.json`/npm
footprint — заводить его ради нескольких DOM-примитивов, которые реально
использует `content.js` (`matches`/`getAttribute`/`querySelectorAll`/
`classList`/`offsetWidth`/`getClientRects`/синхронно-батчевый
`MutationObserver`), было бы оверинжинирингом по принципу проекта
(«максимальная простота»). Системный `node` уже есть на GitHub Actions
`ubuntu-latest` (нужен самому Actions-рантайму) — новый CI setup-шаг не
требуется. Тест **скипается**, если `node` не найден в PATH локально, а не
падает.

## Проверено

- `ruff check src tests scripts` — чисто
- `ruff format --check src tests scripts` — чисто
- `pytest -n 4 --dist worksteal` — 2774 passed, 2 skipped, 30.6s (бюджет 60s)
- `scripts/gen_cli_docs.py --check` — синхронизирован (новых CLI-команд нет)
- Ручная проверка регрессии: откат фикса на исходный `content.js` из round 2
  даёт 1 `overlay_detected` вместо 2 на том же сценарии — тест ловит именно
  ту регрессию, из-за которой заведена issue.

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)