### PR TITLE
fix(responses): fail-closed SSR coverage for --alert-new

### DIFF
--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -554,7 +554,23 @@ def fetch_responses(
                     )
         except ResponsesIndeterminate:
             raise
-        except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
+        except (
+            TypeError,
+            ValueError,
+            KeyError,
+            AttributeError,
+            json.JSONDecodeError,
+            PlaywrightError,
+        ):
+            # AttributeError: topic_refs() (вызывается на строке выше, ДО
+            # raw_topics-валидации) обращается к .get() на каждом элементе
+            # topicList и на самом applicantNegotiations без проверки типа —
+            # applicantNegotiations=null или non-dict запись в topicList
+            # ловятся здесь, а не raw_topics-проверкой ниже по коду (Codex
+            # review, #742 round 2): без AttributeError в этом tuple такая
+            # форма пробивала бы необработанный traceback вместо
+            # ResponsesIndeterminate, тот самый fail-open, который
+            # strict_scrape должен исключать.
             if strict_empty or strict_scrape:
                 # #742: отсутствующий/битый HH-Lux-InitialState — тот же
                 # неопределённый page-state, что и не появившиеся карточки

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -336,6 +336,13 @@ def fetch_responses(
     требования topic/resume identity (более строгий контракт ``strict_empty``
     остаётся только для --sync-applied). Это позволяет alert-polling принимать
     легитимные chatless-карточки, но не сохранять checkpoint неполного обхода.
+
+    #742: ``strict_scrape`` также требует подтверждённого SSR-состояния для
+    coverage-проверки DOM-карточек против SSR ``topicList``. Отсутствующий/
+    битый ``HH-Lux-InitialState`` и неполные записи ``topicList`` (дропаемые
+    ``topic_refs()``) поднимают :class:`ResponsesIndeterminate`, а не молча
+    трактуются как пустой topicList — подтверждённо пустой SSR-список (после
+    успешного парсинга) остаётся легитимным и не блокирует чекпоинт.
     """
     results: list[ResponseItem] = []
 
@@ -423,14 +430,28 @@ def fetch_responses(
 
             if not hasattr(page, "content"):
                 raise ValueError("page.content unavailable")
-            refs = topic_refs(page.content())
-            if strict_empty:
+            html = page.content()
+            refs = topic_refs(html)
+            # topic_refs() молча дропает неполные записи (id/chatId/vacancyId
+            # отсутствуют) — приемлемо для non-strict пути (лучшее из
+            # доступного), но означает, что refs может оказаться короче
+            # raw_topics или вовсе пустым, даже когда SSR-состояние реально
+            # содержит переговоры. И strict_empty, и strict_scrape читают
+            # raw_topics напрямую, чтобы отличить это от подтверждённо
+            # пустого topicList: пустой raw_topics — легитимный empty-state
+            # (нечего покрывать, coverage-проверка ниже тривиально пройдёт
+            # на пустых refs_by_vacancy), а НЕПОЛНАЯ запись внутри непустого
+            # raw_topics — сигнал недостоверного скрейпа, а не пустоты.
+            if strict_empty or strict_scrape:
                 raw_topics = (
-                    parse_initial_state(page.content())
-                    .get("applicantNegotiations", {})
-                    .get("topicList")
+                    parse_initial_state(html).get("applicantNegotiations", {}).get("topicList")
                 )
-                if not isinstance(raw_topics, list) or any(
+                if not isinstance(raw_topics, list):
+                    raise ResponsesIndeterminate(
+                        f"страница {page_num}: SSR topicList отсутствует или имеет "
+                        "неожиданный формат"
+                    )
+                if any(
                     not isinstance(ref, dict)
                     or any(ref.get(key) in (None, "") for key in ("id", "chatId", "vacancyId"))
                     for ref in raw_topics
@@ -472,7 +493,7 @@ def fetch_responses(
             # multiple cards at all) marks every unresolved card for that
             # vacancy_id as ambiguous instead of guessing positionally.
             cards_by_vacancy: dict[str, list] = {}
-            if strict_scrape and refs:
+            if strict_scrape:
                 rendered_by_vacancy: dict[str, int] = {}
                 for result in results[page_start:]:
                     rendered_by_vacancy[result.vacancy_id] = (
@@ -531,8 +552,16 @@ def fetch_responses(
                         f"страница {page_num}: SSR topicList и DOM карточки "
                         "не имеют полного однозначного соответствия"
                     )
+        except ResponsesIndeterminate:
+            raise
         except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
-            if strict_empty:
+            if strict_empty or strict_scrape:
+                # #742: отсутствующий/битый HH-Lux-InitialState — тот же
+                # неопределённый page-state, что и не появившиеся карточки
+                # выше (RENDER_TIMEOUT_MS). strict_scrape гарантирует
+                # покрытие SSR topicList, и без прочитанного SSR эту
+                # гарантию нечем подтвердить — fail-open здесь означал бы
+                # молчаливое принятие частично отрисованного DOM.
                 raise ResponsesIndeterminate(
                     f"страница {page_num}: SSR topic/resume mapping не подтверждён"
                 ) from None

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -431,7 +431,22 @@ def fetch_responses(
             if not hasattr(page, "content"):
                 raise ValueError("page.content unavailable")
             html = page.content()
-            refs = topic_refs(html)
+            try:
+                refs = topic_refs(html)
+            except AttributeError as exc:
+                # #742 round 2 (Codex review): topic_refs() runs before the
+                # raw_topics shape validation below and assumes
+                # applicantNegotiations/each topicList entry is a dict — a
+                # null applicantNegotiations or a non-dict entry raises
+                # AttributeError here. Narrowly re-raise as ValueError (already
+                # in the except-tuple below) so this SSR-shape failure is
+                # handled the same way as the other malformed-SSR cases,
+                # WITHOUT widening AttributeError to the rest of this try
+                # block — the ambiguity-resolution/strict_empty logic below
+                # (#186 round 4) uses attribute access on our own dataclasses
+                # and a stray AttributeError there should surface as a real
+                # bug, not be swallowed as "SSR unavailable" (/review finding).
+                raise ValueError(f"SSR topicList shape unexpected: {exc}") from exc
             # topic_refs() молча дропает неполные записи (id/chatId/vacancyId
             # отсутствуют) — приемлемо для non-strict пути (лучшее из
             # доступного), но означает, что refs может оказаться короче
@@ -554,23 +569,7 @@ def fetch_responses(
                     )
         except ResponsesIndeterminate:
             raise
-        except (
-            TypeError,
-            ValueError,
-            KeyError,
-            AttributeError,
-            json.JSONDecodeError,
-            PlaywrightError,
-        ):
-            # AttributeError: topic_refs() (вызывается на строке выше, ДО
-            # raw_topics-валидации) обращается к .get() на каждом элементе
-            # topicList и на самом applicantNegotiations без проверки типа —
-            # applicantNegotiations=null или non-dict запись в topicList
-            # ловятся здесь, а не raw_topics-проверкой ниже по коду (Codex
-            # review, #742 round 2): без AttributeError в этом tuple такая
-            # форма пробивала бы необработанный traceback вместо
-            # ResponsesIndeterminate, тот самый fail-open, который
-            # strict_scrape должен исключать.
+        except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
             if strict_empty or strict_scrape:
                 # #742: отсутствующий/битый HH-Lux-InitialState — тот же
                 # неопределённый page-state, что и не появившиеся карточки

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -376,6 +376,31 @@ def test_strict_scrape_matches_ssr_topics_to_dom_vacancies(monkeypatch):
         responses.fetch_responses(page, max_pages=1, strict_scrape=True)
 
 
+def test_strict_scrape_rejects_two_ssr_topics_for_one_rendered_card(monkeypatch):
+    """Two SSR negotiations for one vacancy, only one rendered card, is indeterminate.
+
+    Codex review round 2 of PR #768 claimed this shape ("more SSR candidates
+    than rendered cards for one vacancy") slips past the coverage check and
+    reaches the ambiguity-resolution branch as a silently accepted
+    topic_ambiguous=True card. It does not: rendered(1) < candidates(2) makes
+    missing_vacancies non-empty, so the coverage check above raises
+    ResponsesIndeterminate before ambiguity resolution ever runs. This test
+    pins that behavior (verified the Codex claim was a false positive).
+    """
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    page = _SSRPage(
+        pages_cards=[[item]],
+        pages_html=[_ssr_html([("222", "333", "700"), ("444", "555", "700")])],
+    )
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="не покрывает SSR topicList"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
 def test_strict_sync_rejects_unattributed_dom_card(monkeypatch):
     """A rendered card without SSR resume/topic identity is not importable."""
     item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -468,6 +468,48 @@ def test_strict_scrape_rejects_incomplete_topic_dropped_by_topic_refs(monkeypatc
         responses.fetch_responses(page, max_pages=1, strict_scrape=True)
 
 
+# #742 round 2 (Codex adversarial review of PR #768): topic_refs() is called
+# BEFORE the raw_topics shape validation, and its .get() calls raise
+# AttributeError on a null applicantNegotiations or a non-dict topicList
+# entry — a shape neither the original except-tuple nor the new
+# raw_topics-based checks could catch, since the crash happens one line
+# earlier. Without AttributeError in the except-tuple, this shape escaped as
+# an unhandled traceback instead of ResponsesIndeterminate — fail-open
+# despite the #742 fix.
+
+
+def test_strict_scrape_rejects_null_applicant_negotiations(monkeypatch):
+    """applicantNegotiations: null must not crash topic_refs() uncaught."""
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    null_html = '<template id="HH-Lux-InitialState">{"applicantNegotiations":null}</template>'
+    page = _SSRPage(pages_cards=[[item]], pages_html=[null_html])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="SSR topic/resume mapping"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
+def test_strict_scrape_rejects_non_dict_topic_entry(monkeypatch):
+    """A non-dict entry in topicList must not crash topic_refs() uncaught."""
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    non_dict_html = (
+        '<template id="HH-Lux-InitialState">'
+        '{"applicantNegotiations":{"topicList":[123]}}'
+        "</template>"
+    )
+    page = _SSRPage(pages_cards=[[item]], pages_html=[non_dict_html])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="SSR topic/resume mapping"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
 def test_strict_scrape_preserves_chatless_card_allowance(monkeypatch):
     """A card genuinely without a chat is fine alongside a fully covered one.
 

--- a/tests/test_responses_ssr_topic_mapping.py
+++ b/tests/test_responses_ssr_topic_mapping.py
@@ -387,3 +387,111 @@ def test_strict_sync_rejects_unattributed_dom_card(monkeypatch):
 
     with pytest.raises(responses.ResponsesIndeterminate, match="полного однозначного"):
         responses.fetch_responses(page, max_pages=1, strict_empty=True)
+
+
+# #742: strict_scrape (--alert-new) must not silently accept a partially
+# attached DOM as evidence of a confirmed-empty SSR topicList. Covers the
+# acceptance criteria in issue #742: distinguish a confirmed empty SSR topic
+# list from missing/malformed SSR state, treat dropped/incomplete topic_refs()
+# entries as indeterminate rather than empty, preserve the chatless-card
+# allowance, and never advance on uncertain page state.
+
+
+def test_strict_scrape_accepts_confirmed_empty_ssr_topic_list(monkeypatch):
+    """A genuinely empty SSR topicList (parsed successfully) is legitimate.
+
+    No chat-having cards exist to cover, so the coverage check must not
+    treat "SSR unavailable" and "SSR confirms zero negotiations" the same.
+    """
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    page = _SSRPage(pages_cards=[[item]], pages_html=[_ssr_html([])])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    results = responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+    assert len(results) == 1
+    assert results[0].topic_ambiguous is False
+
+
+def test_strict_scrape_rejects_missing_ssr_state(monkeypatch):
+    """Missing HH-Lux-InitialState must not fail open under strict_scrape."""
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    page = _SSRPage(pages_cards=[[item]], pages_html=["<html><body>no SSR template</body></html>"])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="SSR topic/resume mapping"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
+def test_strict_scrape_rejects_malformed_ssr_json(monkeypatch):
+    """Malformed JSON inside the SSR template must not fail open either."""
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    broken_html = '<template id="HH-Lux-InitialState">{not valid json</template>'
+    page = _SSRPage(pages_cards=[[item]], pages_html=[broken_html])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="SSR topic/resume mapping"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
+def test_strict_scrape_rejects_incomplete_topic_dropped_by_topic_refs(monkeypatch):
+    """topic_refs() silently drops entries missing id/chatId/vacancyId.
+
+    If that drop empties `refs` while the raw SSR topicList is non-empty,
+    strict_scrape must treat it as indeterminate coverage, not as a
+    confirmed-empty list (the #742 regression: `strict_scrape and refs`
+    used to skip the coverage check entirely in this case).
+    """
+    item = responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ)
+    # A single topic entry missing chatId -> topic_refs() drops it -> refs == [].
+    incomplete_html = (
+        '<template id="HH-Lux-InitialState">'
+        '{"applicantNegotiations":{"topicList":[{"id":222,"vacancyId":700}]}}'
+        "</template>"
+    )
+    page = _SSRPage(pages_cards=[[item]], pages_html=[incomplete_html])
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="неполную запись"):
+        responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+
+def test_strict_scrape_preserves_chatless_card_allowance(monkeypatch):
+    """A card genuinely without a chat is fine alongside a fully covered one.
+
+    strict_scrape must reject only unconfirmed page state, not a vacancy
+    that legitimately has no negotiation chat attached — vacancy_id=900 has
+    no SSR entries at all (nothing to miss), while vacancy_id=700 has an
+    exact 1:1 DOM/SSR match.
+    """
+    items = [
+        responses.ResponseItem(vacancy_id="700", status=responses.ResponseStatus.READ),
+        responses.ResponseItem(vacancy_id="900", status=responses.ResponseStatus.DISCARD),
+    ]
+    page = _SSRPage(
+        pages_cards=[items],
+        pages_html=[_ssr_html([("222", "333", "700")])],
+    )
+    monkeypatch.setattr(responses, "goto_hh", lambda page, url: page.goto_page(0))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda page: True)
+    monkeypatch.setattr(responses, "parse_response_card", lambda card: card)
+    monkeypatch.setattr(responses, "_has_next_page", lambda *args: False)
+
+    results = responses.fetch_responses(page, max_pages=1, strict_scrape=True)
+
+    assert len(results) == 2
+    chatless = next(r for r in results if r.vacancy_id == "900")
+    assert chatless.topic is None
+    assert chatless.topic_ambiguous is False


### PR DESCRIPTION
## Что делает

Закрывает пункт 10 (единственный открытый) из issue #742 — follow-up к
PR #735. Пункты 1-9 в теле issue помечены `Status: fixed` — это audit
trail уже смерджённых правок, здесь не переделываются.

## Проблема

`fetch_responses(..., strict_scrape=True)` (используется `--alert-new`)
имел единственную проверку покрытия DOM-карточек SSR `topicList`
(`responses.py:475` на момент issue), которая срабатывала только если
`refs` (результат `topic_refs()`) был непустым:

```python
if strict_scrape and refs:
    ...
```

`refs` мог оказаться пустым по трём разным причинам, которые код не
различал:

1. SSR `HH-Lux-InitialState` отсутствует или битый JSON — ловится общим
   `except (..., ValueError, ...)` ниже, который был fail-open для
   `strict_scrape` (fail-closed срабатывал только для `strict_empty`).
2. `topic_refs()` молча дропает записи без `id`/`chatId`/`vacancyId` —
   если ВСЕ записи неполные, `refs == []`, хотя `topicList` не пуст.
3. `topicList` подтверждённо пуст — легитимный empty-state.

Случаи 1 и 2 приводили к молчаливому принятию частично отрисованного
DOM за достоверный и продвижению чекпоинта `--alert-new` — то же
нарушение fail-closed инварианта проекта (CLAUDE.md §5,
`browser.PageStateIndeterminate`), что уже чинилось в #176/#207.

## Фикс

- `strict_scrape` (как и `strict_empty` ранее) теперь читает raw SSR
  `topicList` напрямую и поднимает `ResponsesIndeterminate`, если:
  - `topicList` отсутствует/не является списком;
  - любая запись в нём неполная (`id`/`chatId`/`vacancyId` отсутствует).
- Coverage-проверка ниже больше не завязана на `and refs` — раз выше
  уже гарантировано либо полное соответствие `raw_topics`↔`refs`, либо
  ошибка, пустой `refs` теперь ГАРАНТИРОВАННО означает подтверждённо
  пустой список.
- `except`-блок вокруг парсинга SSR поднимает `ResponsesIndeterminate`
  и при `strict_scrape`, не только при `strict_empty`.
- Послабление для chatless-карточек (вакансия без чата) сохранено и
  покрыто отдельным тестом.

## Тесты

5 новых тестов в `tests/test_responses_ssr_topic_mapping.py`,
покрывающих acceptance criteria issue:
- подтверждённо пустой SSR topicList — не блокирует чекпоинт;
- отсутствующий `HH-Lux-InitialState` — indeterminate;
- битый JSON в SSR-шаблоне — indeterminate;
- неполная запись, из-за которой `topic_refs()` дропает всё до пустого
  списка — indeterminate (регрессионный тест на сам баг);
- chatless-карточка рядом с полностью покрытой — по-прежнему проходит.

Полный прогон: `ruff check`, `ruff format --check`,
`gen_cli_docs.py --check`, `pytest` (391 passed, 24.89s) — все зелёные.

Closes #742