### PR TITLE
fix(history): ручная reconciliation больше не игнорируется, кулдаун не обходится

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,15 @@ python3 -m playwright install chromium
         ```sql
         INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at)
         VALUES ('<resume_id>', '<resume_id>', 'delete_resume', 'success',
-                'manual reconciliation: confirmed via hh.ru UI', datetime('now'));
+                'manual reconciliation: confirmed via hh.ru UI',
+                strftime('%Y-%m-%dT%H:%M:%f', 'now', 'localtime'));
         ```
+     `created_at` пишется в том же формате, что и код (`datetime.now().isoformat()`):
+     локальное время с разделителем `T`. Голый `datetime('now')` даёт UTC с пробелом —
+     `_parse_recorded_at` такую строку понимает, но однородность формата в таблице
+     дешевле, чем разбор разнобоя. Порядок «резолюция позже uncertain» определяется
+     по `id` (см. `has_unresolved_uncertain`), а не по `created_at`, поэтому опечатка
+     в дате не заблокирует команду навсегда.
      Писать `success` вручную можно **только** после подтверждения на hh.ru —
      тот же fail-closed принцип, что и у самого `uncertain`: ложный `success`
      хуже постоянной блокировки.

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -773,8 +773,11 @@ def _parse_recorded_at(value: str) -> datetime:
     parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is not None:
         return parsed.astimezone().replace(tzinfo=None)
-    if "T" not in value:
-        # Форма SQLite ``datetime('now')``: UTC без указания зоны.
+    if " " in value:
+        # Форма SQLite ``datetime('now')``: UTC без указания зоны. Проверяется
+        # именно пробел-разделитель, а не отсутствие ``'T'``: под второе условие
+        # попала бы и date-only строка (``date('now')``), для которой полночь
+        # сдвинулась бы на величину смещения зоны вместо начала суток.
         return parsed.replace(tzinfo=UTC).astimezone().replace(tzinfo=None)
     return parsed
 

--- a/src/hhru_bot/history.py
+++ b/src/hhru_bot/history.py
@@ -10,7 +10,7 @@ import secrets
 import sqlite3
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -760,6 +760,25 @@ def _row_is_live(row: sqlite3.Row, *, now: datetime) -> bool:
     return started_at > now - LEGACY_LEASE_GRACE
 
 
+def _parse_recorded_at(value: str) -> datetime:
+    """Разобрать ``created_at`` из ``actions``, приведя его к локальному времени.
+
+    Код пишет ``datetime.now().isoformat()`` — локальное время с разделителем
+    ``'T'``. Но ручная reconciliation (CLAUDE.md, раздел 6) вставляет строку
+    напрямую через SQL ``datetime('now')``, а SQLite отдаёт для него UTC с
+    пробелом-разделителем. Naive-разбор такой строки выглядел бы старше на
+    величину смещения таймзоны и обходил кулдаун (``bump`` — 4 часа), поэтому
+    UTC-форма распознаётся по разделителю и переводится в локальное время.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        return parsed.astimezone().replace(tzinfo=None)
+    if "T" not in value:
+        # Форма SQLite ``datetime('now')``: UTC без указания зоны.
+        return parsed.replace(tzinfo=UTC).astimezone().replace(tzinfo=None)
+    return parsed
+
+
 class History:
     # Feedback is deliberately bounded: it is prompt context, not an archive
     # of potentially sensitive letters.
@@ -1499,7 +1518,7 @@ class History:
                 """,
                 (resume_id, action),
             ).fetchone()
-            return datetime.fromisoformat(row["created_at"]) if row else None
+            return _parse_recorded_at(row["created_at"]) if row else None
 
     def time_since_last(self, resume_id: str, action: str) -> timedelta | None:
         last = self.last_action_at(resume_id, action)
@@ -1519,20 +1538,28 @@ class History:
         "the earlier uncertain was resolved".
         """
         with self._connect() as conn:
+            # Порядок берётся по ``id`` (монотонный rowid), а НЕ по ``created_at``.
+            # Форматы ``created_at`` в таблице смешаны: код пишет
+            # ``datetime.now().isoformat()`` (локальное время, разделитель 'T'),
+            # а ручная reconciliation (CLAUDE.md, раздел 6) — SQL
+            # ``datetime('now')`` (UTC, разделитель ' '). Строковое сравнение
+            # ``created_at > ?`` считало документированную резолюцию НЕ более
+            # поздней (0x20 < 0x54) и не снимало блокировку никогда; сравнение
+            # же разобранными датами спотыкалось о секундную точность
+            # ``datetime('now')``. ``id`` свободен от обеих проблем: он отражает
+            # фактический порядок вставки и не зависит от формата и таймзоны.
             last_success = conn.execute(
                 """
-                SELECT created_at FROM actions
+                SELECT MAX(id) AS id FROM actions
                 WHERE resume_id = ? AND action = ? AND status = 'success'
-                ORDER BY created_at DESC
-                LIMIT 1
                 """,
                 (resume_id, action),
             ).fetchone()
             params: tuple = (resume_id, action)
             since_clause = ""
-            if last_success:
-                since_clause = "AND created_at > ?"
-                params = (*params, last_success["created_at"])
+            if last_success and last_success["id"] is not None:
+                since_clause = "AND id > ?"
+                params = (*params, last_success["id"])
             row = conn.execute(
                 f"""
                 SELECT 1 FROM actions

--- a/tests/test_history_created_at_format.py
+++ b/tests/test_history_created_at_format.py
@@ -176,3 +176,14 @@ def test_documented_sql_snippet_matches_code_format(tmp_path):
     assert abs(_parse_recorded_at(doc_written) - _parse_recorded_at(code_written)) < timedelta(
         minutes=5
     )
+
+
+def test_date_only_value_is_not_shifted_by_timezone(tmp_path):
+    """Date-only строка — полночь локального дня, а не полночь UTC.
+
+    ``_parse_recorded_at`` распознаёт UTC по форме SQLite ``datetime('now')``
+    ('YYYY-MM-DD HH:MM:SS'). Более широкая эвристика «нет 'T' — значит UTC»
+    сдвигала бы и ``date('now')`` на смещение зоны, превращая начало суток в
+    произвольный час (для UTC+8 — 08:00 того же дня).
+    """
+    assert _parse_recorded_at("2026-08-29") == datetime(2026, 8, 29, 0, 0, 0)

--- a/tests/test_history_created_at_format.py
+++ b/tests/test_history_created_at_format.py
@@ -1,0 +1,178 @@
+"""Ручная reconciliation из CLAUDE.md должна реально сниматься кодом.
+
+CLAUDE.md (раздел 6) предписывает единственный способ разрешить зависший
+``uncertain`` — вставить ``success``-строку в ``actions`` напрямую через SQL с
+``datetime('now')``. SQLite отдаёт для него ``'YYYY-MM-DD HH:MM:SS'`` в UTC, а
+сам код пишет ``datetime.now().isoformat()`` — локальное время с разделителем
+``'T'``. Расхождение ломает два независимых потребителя ``created_at``:
+
+1. ``has_unresolved_uncertain`` сравнивает даты СТРОКОЙ (``created_at > ?``).
+   ``' '`` (0x20) < ``'T'`` (0x54), поэтому при равной календарной дате
+   документированная резолюция не «позже» uncertain-строки, и блокировка
+   остаётся навсегда.
+2. ``last_action_at``/``time_since_last`` парсят строку как naive datetime и
+   вычитают из локального ``datetime.now()``: UTC-строка выглядит на величину
+   смещения таймзоны старше, обходя кулдаун (``bump`` — 4 часа).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.history import History, _parse_recorded_at
+
+pytestmark = pytest.mark.unit
+
+
+def _insert_documented_resolution(db_path, resume_id: str, action: str) -> None:
+    """Ровно тот INSERT, что предписан CLAUDE.md для ручной reconciliation."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO actions (resume_id, vacancy_id, action, status, reason, created_at)
+            VALUES (?, ?, ?, 'success', 'manual reconciliation: confirmed via hh.ru UI',
+                    datetime('now'))
+            """,
+            (resume_id, resume_id, action),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_documented_reconciliation_clears_unresolved_uncertain(tmp_path):
+    """Резолюция по инструкции обязана снимать блокировку повторного запуска."""
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    history.record_action("account", "account", "create_resume", "uncertain", "click sent")
+    assert history.has_unresolved_uncertain("account", "create_resume")
+
+    _insert_documented_resolution(db, "account", "create_resume")
+
+    assert not history.has_unresolved_uncertain("account", "create_resume")
+
+
+def test_utc_written_row_is_not_seen_as_hours_old(tmp_path):
+    """Действие, записанное «сейчас», не должно выглядеть старым для кулдауна."""
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    _insert_documented_resolution(db, "r1", "bump")
+
+    elapsed = history.time_since_last("r1", "bump")
+
+    assert elapsed is not None
+    # Запись сделана только что; любой заметный сдвиг означает неверный разбор
+    # таймзоны и обход 4-часового кулдауна bump.
+    assert elapsed < timedelta(minutes=5), f"свежая запись выглядит как {elapsed} назад"
+
+
+def test_uncertain_after_resolution_still_blocks(tmp_path):
+    """Секундное округление резолюции не должно скрывать НОВЫЙ uncertain."""
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    history.record_action("account", "account", "create_resume", "uncertain", "first")
+    _insert_documented_resolution(db, "account", "create_resume")
+    assert not history.has_unresolved_uncertain("account", "create_resume")
+
+    # Новая неподтверждённая попытка после резолюции обязана снова блокировать.
+    history.record_action("account", "account", "create_resume", "uncertain", "second")
+
+    assert history.has_unresolved_uncertain("account", "create_resume")
+
+
+def test_isoformat_resolution_still_clears(tmp_path):
+    """Штатный путь (success записан кодом) продолжает снимать блокировку."""
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    history.record_action("r1", "r1", "delete_resume", "uncertain", "click sent")
+    history.record_action("r1", "r1", "delete_resume", "success", "confirmed")
+
+    assert not history.has_unresolved_uncertain("r1", "delete_resume")
+
+
+def test_later_resolution_wins_over_earlier_one(tmp_path):
+    """Учитывается ПОСЛЕДНЯЯ резолюция, а не первая: MIN(id) вместо MAX(id)
+    признал бы более раннюю success разрешающей и пропустил бы uncertain,
+    записанный между двумя резолюциями."""
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    history.record_action("r2", "r2", "copy_resume", "success", "first ok")
+    history.record_action("r2", "r2", "copy_resume", "uncertain", "click sent")
+    history.record_action("r2", "r2", "copy_resume", "success", "second ok")
+    assert not history.has_unresolved_uncertain("r2", "copy_resume")
+
+    # Ещё один uncertain — уже после последней резолюции.
+    history.record_action("r2", "r2", "copy_resume", "uncertain", "later click")
+
+    assert history.has_unresolved_uncertain("r2", "copy_resume")
+
+
+def test_resolution_row_itself_does_not_count_as_uncertain(tmp_path):
+    """Граница строгая: uncertain засчитывается строго ПОЗЖЕ резолюции.
+
+    При нестрогом сравнении (``id >= ?``) сама success-строка попадала бы в
+    окно поиска uncertain-строк, а uncertain с тем же id не существует —
+    поэтому страж проверяет, что разрешённый uncertain не «воскресает».
+    """
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    uncertain_id = history.record_action("r3", "r3", "publish_resume", "uncertain", "click")
+    success_id = history.record_action("r3", "r3", "publish_resume", "success", "confirmed")
+    assert success_id == uncertain_id + 1
+
+    assert not history.has_unresolved_uncertain("r3", "publish_resume")
+
+
+def test_parse_recorded_at_normalizes_all_three_shapes():
+    """Три формы ``created_at`` приводятся к одному локальному моменту.
+
+    Код пишет ISO с 'T' (локальное время), ручная reconciliation — SQLite
+    ``datetime('now')`` (UTC с пробелом), а строка со смещением может прийти из
+    внешнего дампа/восстановления. Все три обязаны разбираться согласованно.
+    """
+    local = _parse_recorded_at("2026-08-29T16:03:10.556350")
+    assert local == datetime(2026, 8, 29, 16, 3, 10, 556350)
+
+    utc_space = _parse_recorded_at("2026-08-29 08:03:10")
+    aware_offset = _parse_recorded_at("2026-08-29T08:03:10+00:00")
+    # Обе описывают один момент UTC, значит и локальное представление одно.
+    assert utc_space == aware_offset
+    # Результат naive и в локальной зоне — его сравнивают с datetime.now().
+    assert utc_space.tzinfo is None
+    expected = datetime.fromisoformat("2026-08-29T08:03:10+00:00").astimezone()
+    assert utc_space == expected.replace(tzinfo=None)
+
+
+def test_documented_sql_snippet_matches_code_format(tmp_path):
+    """SQL из CLAUDE.md обязан писать тот же формат, что и ``record_action``.
+
+    Страж от повторения бага: раньше документация предписывала
+    ``datetime('now')`` (UTC с пробелом), расходившийся с
+    ``datetime.now().isoformat()`` кода.
+    """
+    claude_md = Path(__file__).resolve().parents[1] / "CLAUDE.md"
+    snippet = "strftime('%Y-%m-%dT%H:%M:%f', 'now', 'localtime')"
+    assert snippet in claude_md.read_text(encoding="utf-8"), (
+        "CLAUDE.md должен рекомендовать локальное время с разделителем 'T'"
+    )
+
+    db = tmp_path / "history.db"
+    history = History(str(db))
+    history.record_action("r4", "r4", "bump", "success", "written by code")
+    conn = sqlite3.connect(db)
+    try:
+        code_written = conn.execute("SELECT created_at FROM actions").fetchone()[0]
+        doc_written = conn.execute(f"SELECT {snippet}").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert "T" in code_written and "T" in doc_written
+    # Обе формы разбираются одинаково и дают локальное время.
+    assert abs(_parse_recorded_at(doc_written) - _parse_recorded_at(code_written)) < timedelta(
+        minutes=5
+    )


### PR DESCRIPTION
Closes #771

## Что было

Два дефекта из одного корня — расхождение формата `created_at` между кодом и документированной процедурой ручной reconciliation.

Код пишет `datetime.now().isoformat()` (локальное время, разделитель `T`), а CLAUDE.md раздел 6 предписывает SQL `datetime('now')` (UTC, разделитель — пробел).

1. **Блокировка не снималась никогда.** `has_unresolved_uncertain` сравнивал даты строкой (`created_at > ?`); `' '` (0x20) < `'T'` (0x54), поэтому документированная резолюция не признавалась более поздней. `create-resume`/`delete-resume`/`publish-resume`/`copy-resume` оставались заблокированными без способа разблокировать.
2. **Обход кулдауна.** `last_action_at` парсил UTC-строку как naive и вычитал из локального `datetime.now()` — запись, сделанная «сейчас», выглядела на смещение таймзоны старше. Для `bump` с 4-часовым кулдауном: свежая запись читалась как «8 часов назад» (зона UTC+8).

Найдено на живых данных: `create-resume` был заблокирован `uncertain`-строкой от 2026-08-18.

## Что сделано

- `has_unresolved_uncertain` определяет порядок по `id` (монотонный rowid) вместо `created_at` — не зависит ни от формата, ни от таймзоны. Промежуточный вариант со сравнением разобранными датами отвергнут: `datetime('now')` не имеет субсекундной точности, из-за чего резолюция в ту же секунду проигрывала uncertain, а округление вверх ослабляло fail-closed (проверено тестом).
- `_parse_recorded_at` нормализует все три формы `created_at` при чтении. Существующие строки не мигрируются — читаются обе формы.
- CLAUDE.md рекомендует `strftime('%Y-%m-%dT%H:%M:%f','now','localtime')` — формат кода; тест-страж следит за согласованностью документации и кода.

## red → green

`tests/test_history_created_at_format.py`, 2 красных теста воспроизводили оба бага:

```
AssertionError: assert not True      # блокировка не снята документированной резолюцией
AssertionError: свежая запись выглядит как 8:00:00.317486 назад
```

После фикса — 8 зелёных. Полная сюита: 2871 passed (было 2867; единственное падение `test_provenance.py::test_doctor_recovery_action_clears_drift` предсуществует на чистом main — про права доступа к каталогу сессии, к фиксу отношения не имеет).

## Mutation

Целевая проверка по ключевым элементам фикса: убиты `MAX(id)→MIN(id)`, обе ветки нормализации (`tzinfo`, разделитель), отключение `since_clause`. Выжил один эквивалентный мутант `id > ?` → `id >= ?`: `id` уникален (PK), а строка с равным `id` имеет `status='success'` и под условие поиска `status='uncertain'` не подпадает — поведение не меняется.

`ruff check` и `ruff format --check` по `src tests` чисты.