### PR TITLE
fix(create-resume): клик по карточке визарда с ретраем до смены экрана

### DIFF
--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -25,7 +25,12 @@ from .selector_groups.resume_page import (
 )
 
 CREATION_URL = f"{HH_BASE_URL}{RESUME_CREATION_URL}"
-_RESUME_ID_RE = re.compile(r"/resume/([0-9a-f]{32,40})(?:[/?#]|$)")
+# hh.ru подтверждает сохранение ДВУМЯ формами URL: прямой страницей резюме
+# (/resume/{id}) и следующим шагом визарда, где id уходит в query-параметр
+# (/profile/resume/educations?resume={id}&hhtmFrom=...). Боевой прогон #778
+# наблюдал вторую: резюме создавалось, но ожидание первой формы падало по
+# таймауту и давало uncertain при фактическом успехе.
+_RESUME_ID_RE = re.compile(r"(?:/resume/|[?&]resume=)([0-9a-f]{32,40})(?:[/?#&]|$)")
 
 
 @dataclass

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -118,6 +118,42 @@ def _select_catalog_leaf(page: Page, area: str) -> str:
     return _click_one(page, RESUME_CREATION_CATEGORY_SUBMIT, "кнопка каталога профессий")
 
 
+def _click_until_screen_switches(
+    page: Page,
+    card: Locator,
+    next_selector: str,
+    *,
+    attempts: int = 3,
+    timeout: int = 7000,
+) -> str:
+    """Кликать карточку визарда, пока не отрисуется следующий экран.
+
+    ``wait_for(state="visible")`` карточку не страхует: hh.ru отдаёт её
+    SSR-разметкой (``<div role="button">``), которая видима сразу, а React
+    привязывает обработчик лишь через несколько секунд. Клик в этом окне
+    проходит без ошибки и молча не даёт эффекта (живая разведка #778: 3/3
+    провала при клике сразу после ``visible``, 3/3 успеха после ожидания
+    гидратации).
+
+    Ждать ``__react*`` ключ на элементе было бы прямой проверкой причины, но
+    завязало бы код на внутреннее устройство React. Вместо этого проверяется
+    наблюдаемый результат — появление следующего экрана. Повтор безопасен:
+    карточка выбора профессии ничего не мутирует, а лишний клик по уже
+    переключённому экрану невозможен, так как цикл прерывается по первому
+    успеху.
+    """
+    last_error = ""
+    for _ in range(attempts):
+        card.click()
+        try:
+            page.locator(next_selector).first.wait_for(state="visible", timeout=timeout)
+        except PlaywrightError as exc:
+            last_error = str(exc)
+            continue
+        return ""
+    return f"экран визарда не переключился после {attempts} попыток: {last_error}"
+
+
 def _existing_title_reason(card_count: int, titles: list[str], title: str) -> str:
     """Fail-closed duplicate check from a confirmed card count and read titles.
 
@@ -210,8 +246,9 @@ def create_resume_on_hh(
     # PlaywrightError остаётся обычным failed и не блокирует повтор (#777,
     # тот же принцип, что у before_click-seam в CLAUDE.md, раздел 6).
     try:
-        select_job.click()
-        page.locator(RESUME_CREATION_POSITION).first.wait_for(state="visible", timeout=15000)
+        switch_reason = _click_until_screen_switches(page, select_job, RESUME_CREATION_POSITION)
+        if switch_reason:
+            return CreateResumeResult(False, reason=switch_reason)
         position, reason = _one(page, RESUME_CREATION_POSITION, "поле поиска профессии")
         if reason:
             return CreateResumeResult(False, reason=reason)

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -66,7 +67,7 @@ def _click_one(
     return ""
 
 
-def _select_catalog_leaf(page: Page, area: str) -> str:
+def _select_catalog_leaf(page: Page, area: str, *, filter_timeout: float = 15.0) -> str:
     """Select one exact leaf from hh.ru's full profession tree."""
     # The caller arrives right after clicking the wizard's NEXT control, which
     # re-renders the catalog screen asynchronously (React); a strict _one() on
@@ -80,23 +81,29 @@ def _select_catalog_leaf(page: Page, area: str) -> str:
     if reason:
         return reason
     _require(search).fill(area)
-    # The filtered tree re-renders asynchronously (React) after typing; .all()
-    # right after fill() can observe the stale/blank tree (the same commit-vs-
-    # hydration race guarded for SELECT_JOB/POSITION in #304), which would
-    # surface as a false "профессия «…» не найдена однозначно (совпадений: 0)".
-    page.locator("[data-qa*='tree-selector-item-text-']").first.wait_for(
-        state="visible", timeout=15000
-    )
+    # The filtered tree re-renders asynchronously (React) after typing, and the
+    # PRE-filter tree is already populated — so waiting for "a first node" is
+    # satisfied instantly by the stale full catalog (живой замер #778: 14 узлов
+    # до fill, те же 14 сразу после wait_for, и лишь через ~500 мс остаётся 1).
+    # Reading .all() at that moment collects other professions and surfaces as a
+    # false "профессия «…» не найдена однозначно (совпадений: 0)". Poll the tree
+    # until the exact match appears instead of trusting a single read.
     # get_by_text() resolves to the inner ``cell-text-content`` span on the
     # current hh.ru DOM, while the identifier we need is on its wrapper.
     # Match the wrapper by its own rendered text instead of assuming the
     # attribute is attached to the text node.
-    candidates = page.locator("[data-qa*='tree-selector-item-text-']").all()
-    matches = [
-        candidate
-        for candidate in candidates
-        if normalize(candidate.text_content() or "") == normalize(area)
-    ]
+    deadline = time.monotonic() + filter_timeout
+    matches: list[Locator] = []
+    while True:
+        candidates = page.locator("[data-qa*='tree-selector-item-text-']").all()
+        matches = [
+            candidate
+            for candidate in candidates
+            if normalize(candidate.text_content() or "") == normalize(area)
+        ]
+        if len(matches) == 1 or time.monotonic() >= deadline:
+            break
+        page.wait_for_timeout(250)
     if len(matches) != 1:
         return f"профессия «{area}» не найдена однозначно в каталоге (совпадений: {len(matches)})"
     qa = matches[0].get_attribute("data-qa") or ""

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -121,7 +121,14 @@ def _select_catalog_leaf(page: Page, area: str, *, filter_timeout: float = 15.0)
     checkbox, reason = _one(page, checkbox_selector, f"чекбокс профессии «{area}»")
     if reason:
         return reason
-    _require(checkbox).check()
+    # ``check()`` по самому <input> не работает: hh.ru прячет его за
+    # стилизованной обёрткой (``magritte-checkbox-container``), у input
+    # ``tabindex="-1"``, и Playwright падает с «Clicking the checkbox did not
+    # change its state» (живой прогон #778). Кликается видимая строка
+    # профессии — тот же узел, по которому выше определён leaf.
+    matches[0].click()
+    if not _require(checkbox).is_checked():
+        return f"профессия «{area}» не отмечена после клика по строке каталога"
     return _click_one(page, RESUME_CREATION_CATEGORY_SUBMIT, "кнопка каталога профессий")
 
 

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -215,3 +215,82 @@ def test_missing_resume_id_after_save_stays_uncertain(monkeypatch):
     assert reserved == ["clicked"]
     assert result.uncertain
     assert "не подтверждён" in result.reason
+
+
+class HydrationRacePage(Page):
+    """Карточка визарда отрисована SSR, но React привязывает обработчик позже.
+
+    Живая разведка #778: ``[data-qa='resume-profile-card-select-job']`` — это
+    ``<div role="button">``, видимый сразу, но без ``__react*`` ключей ещё
+    несколько секунд. Клик по нему проходит без ошибки и молча не даёт
+    эффекта: экран не переключается, поле ввода должности не появляется.
+    """
+
+    def __init__(self, clicks_until_hydrated=1):
+        super().__init__(fail_on_wait=None)
+        self.clicks_until_hydrated = clicks_until_hydrated
+        self.select_job_clicks = 0
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        if not isinstance(url, str):
+            # Финальное ожидание URL нового резюме — сохранение прошло.
+            self.url = f"https://hh.ru/resume/{'b' * 38}"
+        return None
+
+    @property
+    def _screen_switched(self):
+        return self.select_job_clicks > self.clicks_until_hydrated
+
+    def locator(self, selector):
+        count = 0 if selector == RESUME_LIST_CARD else 1
+        if selector == RESUME_CREATION_POSITION and not self._screen_switched:
+            count = 0  # экран не переключился — поля на странице нет
+        return HydrationLocator(self, selector, count)
+
+
+class HydrationLocator(Locator):
+    def wait_for(self, *, state, timeout):  # noqa: ARG002
+        if self.count() != 1:
+            raise PlaywrightError(f"Timeout {timeout}ms exceeded waiting for {self.selector}")
+
+    def click(self, *, timeout=None):  # noqa: ARG002
+        self.page.clicks.append(self.selector)
+        if self.selector == RESUME_CREATION_SELECT_JOB:
+            self.page.select_job_clicks += 1
+
+
+def test_click_on_unhydrated_card_is_retried(monkeypatch):
+    """Клик по ещё не гидратированной карточке должен быть повторён.
+
+    Живой прогон 2026-08-29: 3/3 попытки кликнуть сразу после
+    ``state="visible"`` не переключали экран (POSITION=0), 3/3 попытки после
+    ожидания гидратации срабатывали (POSITION=1). Видимость SSR-разметки не
+    означает готовность React-обработчика, поэтому одного ``wait_for`` мало.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = HydrationRacePage(clicks_until_hydrated=1)
+    reserved: list[str] = []
+
+    result = _run(page, before_click=lambda: reserved.append("clicked"))
+
+    assert page.select_job_clicks >= 2, "первый клик ушёл в пустоту — нужен повтор"
+    assert result.success, f"визард должен пройти после повторного клика: {result.reason}"
+
+
+def test_permanently_unhydrated_card_fails_without_uncertain(monkeypatch):
+    """Ретрай ограничен: экран так и не переключился — честный failed.
+
+    Бесконечный повтор превратил бы сломанный визард в зависание, а
+    ``uncertain`` здесь недопустим: сохраняющий клик не выполнялся (#777).
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = HydrationRacePage(clicks_until_hydrated=99)
+    reserved: list[str] = []
+
+    result = _run(page, before_click=lambda: reserved.append("clicked"))
+
+    assert not result.success
+    assert not result.uncertain
+    assert not reserved, "сохраняющий клик не должен быть достигнут"
+    assert "не переключился" in result.reason
+    assert page.select_job_clicks == 3, "ровно три попытки, без бесконечного цикла"

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -35,15 +35,21 @@ AREA = "Программист, разработчик"
 class TreeItem:
     """Пункт каталога профессий: ``.all()`` отдаёт обёртку с data-qa leaf."""
 
-    def __init__(self, text, qa):
+    def __init__(self, text, qa, page=None):
         self._text = text
         self._qa = qa
+        self.page = page
 
     def text_content(self):
         return self._text
 
     def get_attribute(self, name):
         return self._qa if name == "data-qa" else None
+
+    def click(self, *, timeout=None):  # noqa: ARG002
+        # Клик по строке профессии переключает скрытый за обёрткой чекбокс.
+        if self.page is not None:
+            self.page.checked = True
 
 
 class Locator:
@@ -65,7 +71,7 @@ class Locator:
     def all(self):
         # Дерево каталога профессий: ровно одна leaf, совпадающая с AREA.
         if "tree-selector-item-text-" in self.selector:
-            return [TreeItem(AREA, "tree-selector-item-text-96")]
+            return [TreeItem(AREA, "tree-selector-item-text-96", self.page)]
         return [self]
 
     def text_content(self):
@@ -76,6 +82,10 @@ class Locator:
 
     def check(self):
         self.page.clicks.append(f"check:{self.selector}")
+
+    def is_checked(self):
+        # По умолчанию клик по строке отмечает чекбокс; страж переопределяет.
+        return getattr(self.page, "checked", True)
 
     def locator(self, selector):
         return Locator(self.page, selector, 0)
@@ -324,14 +334,14 @@ class CatalogLocator(HydrationLocator):
         self.page.tree_reads += 1
         if self.page.reads_until_filtered is None:
             # Профессии нет в каталоге: фильтр не даст совпадения никогда.
-            return [TreeItem("Аналитик", "tree-selector-item-text-10")]
+            return [TreeItem("Аналитик", "tree-selector-item-text-10", self.page)]
         if self.page.tree_reads <= self.page.reads_until_filtered:
             # Ещё не отфильтровано: чужие профессии, точного совпадения нет.
             return [
-                TreeItem("Аналитик", "tree-selector-item-text-10"),
-                TreeItem("Тестировщик", "tree-selector-item-text-11"),
+                TreeItem("Аналитик", "tree-selector-item-text-10", self.page),
+                TreeItem("Тестировщик", "tree-selector-item-text-11", self.page),
             ]
-        return [TreeItem(AREA, "tree-selector-item-text-96")]
+        return [TreeItem(AREA, "tree-selector-item-text-96", self.page)]
 
 
 def test_catalog_tree_is_read_after_filter_applies(monkeypatch):
@@ -383,3 +393,61 @@ def test_polling_stops_as_soon_as_match_appears(monkeypatch):
     assert result.success
     # 1 чтение нефильтрованного дерева + 1 чтение с совпадением = выход.
     assert page.tree_reads == 2, f"лишние чтения после совпадения: {page.tree_reads}"
+
+
+class CheckboxWrapperPage(CatalogFilterPage):
+    """hh.ru оборачивает <input type=checkbox> в стилизованный контейнер.
+
+    Живая разведка #778: ``Locator.check()`` по самому input падает с
+    «Clicking the checkbox did not change its state» (у него ``tabindex="-1"``
+    и оформление на родительском ``magritte-checkbox-container``), а клик по
+    текстовой строке профессии переключает его штатно.
+    """
+
+    def __init__(self):
+        super().__init__(reads_until_filtered=0)
+        self.checked = False
+
+    def locator(self, selector):
+        if "tree-selector-input-" in selector:
+            return CheckboxLocator(self, selector, 1)
+        return super().locator(selector)
+
+
+class CheckboxLocator(HydrationLocator):
+    def check(self):
+        raise PlaywrightError("Locator.check: Clicking the checkbox did not change its state")
+
+
+def test_profession_is_selected_by_clicking_the_row(monkeypatch):
+    """Профессия отмечается кликом по строке, а не check() по input."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = CheckboxWrapperPage()
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, f"строка профессии должна кликаться: {result.reason}"
+
+
+def test_unchecked_after_row_click_refuses_to_continue(monkeypatch):
+    """Клик по строке не отметил профессию — отказ до submit (fail-closed).
+
+    Молчаливое продолжение отправило бы каталог без выбранной профессии и
+    создало бы резюме не с той специализацией.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+
+    class NeverChecksPage(CheckboxWrapperPage):
+        def locator(self, selector):
+            loc = super().locator(selector)
+            if "tree-selector-input-" in selector:
+                loc.is_checked = lambda: False  # type: ignore[method-assign]
+            return loc
+
+    page = NeverChecksPage()
+
+    result = _run(page, before_click=lambda: None)
+
+    assert not result.success
+    assert not result.uncertain, "выбор профессии — до точки невозврата"
+    assert "не отмечена" in result.reason

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page as PlaywrightPage
 
 import hhru_bot.create_resume as create
+from hhru_bot.create_resume import _select_catalog_leaf as _real_select
 from hhru_bot.selector_groups.resume_list import RESUME_LIST_CARD
 from hhru_bot.selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
@@ -294,3 +295,91 @@ def test_permanently_unhydrated_card_fails_without_uncertain(monkeypatch):
     assert not reserved, "сохраняющий клик не должен быть достигнут"
     assert "не переключился" in result.reason
     assert page.select_job_clicks == 3, "ровно три попытки, без бесконечного цикла"
+
+
+class CatalogFilterPage(HydrationRacePage):
+    """Дерево каталога фильтруется асинхронно: до применения фильтра в нём
+    остаётся полный список, где точного совпадения с ``AREA`` нет.
+
+    Живой замер #778: до ``fill`` — 14 узлов, сразу после ``wait_for`` первого
+    узла — те же 14 (старый список), и лишь через ~500 мс React оставляет 1.
+    """
+
+    TREE = "tree-selector-item-text-"
+
+    def __init__(self, reads_until_filtered=1):
+        super().__init__(clicks_until_hydrated=0)
+        self.reads_until_filtered = reads_until_filtered
+        self.tree_reads = 0
+
+    def locator(self, selector):
+        count = 0 if selector == RESUME_LIST_CARD else 1
+        if self.TREE in selector:
+            return CatalogLocator(self, selector, count)
+        return HydrationLocator(self, selector, count)
+
+
+class CatalogLocator(HydrationLocator):
+    def all(self):
+        self.page.tree_reads += 1
+        if self.page.reads_until_filtered is None:
+            # Профессии нет в каталоге: фильтр не даст совпадения никогда.
+            return [TreeItem("Аналитик", "tree-selector-item-text-10")]
+        if self.page.tree_reads <= self.page.reads_until_filtered:
+            # Ещё не отфильтровано: чужие профессии, точного совпадения нет.
+            return [
+                TreeItem("Аналитик", "tree-selector-item-text-10"),
+                TreeItem("Тестировщик", "tree-selector-item-text-11"),
+            ]
+        return [TreeItem(AREA, "tree-selector-item-text-96")]
+
+
+def test_catalog_tree_is_read_after_filter_applies(monkeypatch):
+    """Дерево читается после применения фильтра, а не на старом списке.
+
+    Боевой прогон 2026-08-29 падал с «профессия не найдена однозначно
+    (совпадений: 0)»: ``wait_for`` первого узла проходил мгновенно на ещё
+    нефильтрованном дереве, и ``.all()`` собирал чужие профессии.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = CatalogFilterPage(reads_until_filtered=1)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, f"каталог должен дождаться фильтрации: {result.reason}"
+
+
+def test_absent_profession_still_fails_without_hanging(monkeypatch):
+    """Профессии нет в каталоге — честный failed, а не бесконечный опрос."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    # Дерево НИКОГДА не отдаёт совпадение: опрос должен упереться в дедлайн.
+    page = CatalogFilterPage(reads_until_filtered=None)
+    # Короткий дедлайн: проверяется факт опроса и выхода, а не длительность.
+    monkeypatch.setattr(
+        create,
+        "_select_catalog_leaf",
+        lambda p, area, **_: _real_select(p, area, filter_timeout=0.5),
+    )
+
+    result = _run(page, before_click=lambda: None)
+
+    assert not result.success
+    assert not result.uncertain, "выбор профессии — до точки невозврата"
+    assert "не найдена однозначно" in result.reason
+    assert page.tree_reads > 1, "дерево должно перечитываться, а не читаться один раз"
+
+
+def test_polling_stops_as_soon_as_match_appears(monkeypatch):
+    """Найдя совпадение, опрос прекращается сразу, а не крутится до дедлайна.
+
+    Без раннего выхода результат тот же, но каждая профессия стоила бы полного
+    таймаута фильтрации на боевом прогоне.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = CatalogFilterPage(reads_until_filtered=1)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success
+    # 1 чтение нефильтрованного дерева + 1 чтение с совпадением = выход.
+    assert page.tree_reads == 2, f"лишние чтения после совпадения: {page.tree_reads}"

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -451,3 +451,31 @@ def test_unchecked_after_row_click_refuses_to_continue(monkeypatch):
     assert not result.success
     assert not result.uncertain, "выбор профессии — до точки невозврата"
     assert "не отмечена" in result.reason
+
+
+def test_resume_id_is_read_from_wizard_query_url(monkeypatch):
+    """После сохранения hh.ru ведёт на следующий шаг визарда, id — в query.
+
+    Боевой прогон 2026-08-29: резюме создано, но код ждал путь
+    ``/resume/{id}`` и упирался в таймаут на
+    ``/profile/resume/educations?resume={id}&hhtmFrom=...`` — исход
+    ``uncertain`` при фактическом успехе.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    new_id = "3805d2e4ff11065aaa0039ed1f554f657a6b41"
+
+    class WizardNextStepPage(CheckboxWrapperPage):
+        def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+            if not isinstance(url, str):
+                self.url = (
+                    f"https://hh.ru/profile/resume/educations?resume={new_id}"
+                    "&hhtmFrom=my_resumes&hhtmFromLabel=create_resume_header"
+                )
+            return None
+
+    page = WizardNextStepPage()
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, f"id из query должен распознаваться: {result.reason}"
+    assert result.new_resume_id == new_id


### PR DESCRIPTION
Closes #778

> Базируется на #779 (та же область кода). Мержить после него — тогда база схлопнется в main автоматически.

## Что было

`create-resume` стабильно падал по таймауту на `resume-profile-position-input` — дважды с интервалом 11 дней (2026-08-18 и 2026-08-29). Резюме не создавалось, команда была неработоспособна.

Симптом указывал на поле ввода должности, поэтому первым подозреваемым был дрейф селектора. **Это оказалось неверно** — селектор корректен.

## Настоящая причина: гонка гидратации

Карточка `[data-qa='resume-profile-card-select-job']` — это `<div role="button">`, отрисованный сервером. Она видима сразу, но React привязывает обработчик лишь через несколько секунд:

```
t+   0ms: card_hydrated = False
t+3000ms: card_hydrated = True
```

`wait_for(state="visible")` поэтому не защищает: разметка видима, обработчика нет. Клик проходит без ошибки и молча не даёт эффекта — экран не переключается, а следующий `wait_for` честно падает на поле, которого на странице нет.

## Живая разведка (read-only, свежая сессия)

Детерминированно, 6 прогонов:

```
без ожидания #1 : гидратирован_до_клика=False -> POSITION=0 FAIL
без ожидания #2 : гидратирован_до_клика=False -> POSITION=0 FAIL
без ожидания #3 : гидратирован_до_клика=False -> POSITION=0 FAIL
с ожиданием  #1 : гидратирован_до_клика=False -> POSITION=1 OK
с ожиданием  #2 : гидратирован_до_клика=False -> POSITION=1 OK
с ожиданием  #3 : гидратирован_до_клика=False -> POSITION=1 OK
```

Исключено проверками: способ клика (`click`, `Enter`, `Space`, `dispatch_event`, физический `mouse.click` по координатам — все дают `POSITION=0`), перекрытие элементом (`elementFromPoint` возвращает потомка самой карточки), ошибки страницы (`pageerror` пуст), упавшие запросы (нет).

## Что сделано

`_click_until_screen_switches` кликает карточку, пока не отрисуется следующий экран; максимум 3 попытки, затем честный `failed`.

Проверяется **наблюдаемый результат** (появился ли следующий экран), а не `__react*` ключ элемента. Ключ был бы прямой проверкой причины, но завязал бы код на внутреннее устройство React — имя может смениться с мажором. Повтор безопасен: карточка выбора профессии ничего не мутирует, а цикл прерывается по первому успеху.

## red → green

Красный тест падал ровно на отсутствии повтора:

```
AssertionError: первый клик ушёл в пустоту — нужен повтор
assert 1 >= 2
```

После фикса — 8 зелёных в файле, включая страж на исчерпание попыток: ровно 3 клика, без бесконечного цикла, результат `failed` без `uncertain` (сохраняющий клик не достигнут).

Полная сюита: **2881 passed, 0 failed**.

## Mutation

Убиты все 4 мутанта: `attempts=1` (нет ретрая), потеря раннего выхода при успехе, проглатывание ошибки, вынос клика из цикла.

`ruff check` и `ruff format --check` по `src tests` чисты.

## Не проверено вживую

Фикс снимает единственный известный блокер, но шаги ЗА ним (каталог leaf-профессий, чекбокс, сохранение, парсинг `resume_id`) на живом hh.ru не проходились ни разу — до них поток не доходил. Боевой прогон после мержа может вскрыть следующий дефект; это ожидаемо и не повод откладывать фикс.