### PR TITLE
fix(delete-resume): отличать удалённое резюме от незагрузившегося списка

### DIFF
--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -113,6 +113,20 @@ def delete_resume_on_hh(
         try:
             card.first.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
         except PlaywrightError:
+            # Различаем два исхода, которые раньше сливались в одну причину
+            # «не появилась после загрузки списка». Если в списке есть ДРУГИЕ
+            # карточки, значит он отрисован полностью и резюме просто не
+            # существует (удалено вручную или чужой id) — сообщаем это прямо.
+            # Пустой список по-прежнему неоднозначен: подтверждённого
+            # empty-state селектора в исследованном DOM нет (см. _wait_list_ready),
+            # поэтому там сохраняется прежняя формулировка про загрузку.
+            if page.locator(RESUME_LIST_CARD).count() > 0:
+                return DeleteResumeResult(
+                    resume_id,
+                    False,
+                    f"резюме resume_id={resume_id} не найдено в списке; возможно, оно уже удалено",
+                    False,
+                )
             return DeleteResumeResult(
                 resume_id,
                 False,

--- a/tests/test_delete_resume_browser.py
+++ b/tests/test_delete_resume_browser.py
@@ -270,3 +270,64 @@ def test_ambiguous_direct_action_does_not_fall_back_to_profile(monkeypatch):
     assert "неоднозначно" in result.reason
     assert page.profile_opened is False
     assert page.clicked is False
+
+
+class MissingResumePage(Page):
+    """Список резюме отрисован, но карточки с нужным resume_id в нём нет.
+
+    Живой прогон 2026-08-29: пользователь удалил черновик вручную, и
+    ``delete-resume`` по его id сообщил «карточка … не появилась после
+    загрузки списка» — формулировка про загрузку, хотя список загрузился
+    полностью, а резюме просто не существует. Страница такого резюме на
+    hh.ru отдаёт «Произошла ошибка» вместо 404 (проверено в Chrome), так что
+    отличить «не прогрузилось» от «удалено» пользователь по выводу не может.
+    """
+
+    def locator(self, selector):
+        if selector == RESUME_LIST_CARD:
+            # Список ЕСТЬ: другие резюме на странице отрисованы.
+            return Locator(self, selector, 5)
+        if ":has(" in selector:
+            # Карточки искомого резюме нет и не появится.
+            return Locator(self, selector, 0, detached_error=PlaywrightError("not attached"))
+        return super().locator(selector)
+
+
+def test_absent_resume_is_reported_as_missing_not_as_load_failure(monkeypatch):
+    """Отсутствующее резюме — отдельная причина, а не «список не загрузился»."""
+    _patch_navigation(monkeypatch)
+    page = MissingResumePage()
+
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+
+    assert result.success is False
+    assert result.uncertain is False
+    assert "не появилась после загрузки списка" not in result.reason, (
+        f"причина вводит в заблуждение: список загружен, резюме не существует — {result.reason}"
+    )
+    assert "не найдено" in result.reason or "не существует" in result.reason
+
+
+class EmptyListPage(Page):
+    """Список не отрисовался вовсе: ни одной карточки."""
+
+    def locator(self, selector):
+        if selector == RESUME_LIST_CARD or ":has(" in selector:
+            return Locator(self, selector, 0, detached_error=PlaywrightError("not attached"))
+        return super().locator(selector)
+
+
+def test_empty_list_keeps_load_failure_wording(monkeypatch):
+    """Пустой список остаётся неоднозначным — прежняя причина про загрузку.
+
+    Подтверждённого empty-state селектора в DOM нет (см. ``_wait_list_ready``),
+    поэтому «резюме не существует» здесь утверждать нельзя: список мог просто
+    не прогрузиться.
+    """
+    _patch_navigation(monkeypatch)
+    page = EmptyListPage()
+
+    result = delete.delete_resume_on_hh(cast(PlaywrightPage, page), RESUME, dry_run=False)
+
+    assert result.success is False
+    assert "не появилась после загрузки списка" in result.reason


### PR DESCRIPTION
Closes #783

## Что было

`delete-resume` по id уже удалённого резюме:

```
[FAIL] fb6ef122… — карточка resume_id=fb6ef122… не появилась после загрузки списка
```

Список при этом загружен полностью — резюме просто не существует, его удалили вручную через UI hh.ru. Формулировка указывает на проблему загрузки и уводит диагностику в сторону.

## Почему это дорого стоит

Внешние признаки подталкивают к неверному выводу:

- страница удалённого резюме отдаёт **HTTP 200 и красный баннер «Произошла ошибка. Возникли неполадки»**, а не 404 — проверено в реальном Chrome, не в headless;
- `title` пуст, SPA не рендерится, `networkidle` не наступает — симптомы неотличимы от настоящей гонки гидратации;
- `list-resumes` просто не показывает такие резюме, без объяснения.

В этой сессии совокупность признаков привела меня к ошибочному предварительному выводу «на стороне hh.ru сбой, черновики скорее всего целы» — тогда как их удалил пользователь. Правильную причину дал только его ответ.

## Что сделано

Если в списке присутствуют **другие** карточки — он отрисован, и отсутствие искомой означает, что резюме не существует:

```
[FAIL] резюме resume_id=… не найдено в списке; возможно, оно уже удалено
```

Пустой список сохраняет прежнюю формулировку: подтверждённого empty-state селектора в исследованном DOM нет (см. комментарий `_wait_list_ready`), там неопределённость реальна и утверждать «удалено» нельзя. Fail-closed сохранён.

## red → green

```
AssertionError: причина вводит в заблуждение: список загружен, резюме не существует
  — карточка resume_id=aaaa… не появилась после загрузки списка
```

После фикса — 14 зелёных в файле, включая страж `test_empty_list_keeps_load_failure_wording` на сохранение прежнего поведения для пустого списка.

Полная сюита: exit=0, ноль падений.

## Mutation

Убиты все 3 мутанта: снятие различения, инверсия условия, ослабление `> 0` до `>= 0`.

`ruff check` и `ruff format --check` по `src tests` чисты.

## Проверено на живом hh.ru

Два реально удалённых id (черновик пользователя и мой тестовый) — оба дают новую причину вместо прежней.

## Смежное

`edit-experience` (#782) на том же классе входа тоже не диагностируется — работает с несуществующим резюме и сообщает про add-триггер. Здесь не чинится, но стоит учесть при работе над #782.