### PR TITLE
fix(resume-position): кликать label-чип валюты, а не button/radio напрямую

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -761,19 +761,26 @@ def apply_position(page: Page, plan: PositionValues) -> None:
     if plan.salary is not None:
         page.locator(SALARY).fill(str(plan.salary))
     if plan.currency is not None:
-        # The data-qa input is a hidden radio behind the visible Magritte
-        # button. Clicking it directly is intercepted by the button content.
-        # Use the confirmed accessible button instead of force-clicking the
-        # hidden input (which would bypass Playwright's hit-target checks).
+        # The data-qa element is a visible (not hidden) radio input inside a
+        # Magritte chip <label>; its accessible name comes from the label's
+        # Russian text (#785 live probe), not from the currency code, and the
+        # role is "radio", not "button" — matching against role="button" or
+        # against the currency code always misses. The radio is absolutely
+        # positioned under the chip's <span> content, so clicking the radio
+        # itself is intercepted by that span (confirmed live, #785); the
+        # actual hit target is the wrapping <label> chip, which is the same
+        # element get_by_role("radio", ...) resolves its accessible name
+        # from, so its bounding box is used to click through the label.
         currency_input = page.locator(CURRENCY[plan.currency])
         if currency_input.count() != 1:
             raise RuntimeError(f"селектор валюты не подтверждён: {plan.currency}")
-        currency_button = page.get_by_role(
-            "button", name=CURRENCY_LABELS[plan.currency], exact=True
-        )
-        if currency_button.count() != 1:
-            raise RuntimeError(f"кнопка валюты не подтверждена: {plan.currency}")
-        currency_button.click()
+        currency_radio = page.get_by_role("radio", name=CURRENCY_LABELS[plan.currency], exact=True)
+        if currency_radio.count() != 1:
+            raise RuntimeError(f"переключатель валюты не подтверждён: {plan.currency}")
+        currency_chip = currency_radio.locator("xpath=ancestor::label[1]")
+        if currency_chip.count() != 1:
+            raise RuntimeError(f"чип валюты не подтверждён: {plan.currency}")
+        currency_chip.click()
     if plan.employment:
         for value in plan.employment:
             _set_control(page, EMPLOYMENT, value, EMPLOYMENT_LABELS)

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -386,20 +386,28 @@ def test_apply_position_rejects_multiple_work_format_values():
     page.locator.assert_not_called()
 
 
-def test_apply_position_clicks_visible_currency_button_not_hidden_input():
+def test_apply_position_clicks_currency_chip_label_not_radio_input():
+    # #785: the data-qa element is a visible role="radio" input whose click
+    # target is intercepted by its chip <span>; the real hit target is the
+    # wrapping <label> chip, resolved from the confirmed radio via xpath.
     page = MagicMock()
     currency_input = MagicMock()
     currency_input.count.return_value = 1
-    currency_button = MagicMock()
-    currency_button.count.return_value = 1
+    currency_radio = MagicMock()
+    currency_radio.count.return_value = 1
+    currency_chip = MagicMock()
+    currency_chip.count.return_value = 1
+    currency_radio.locator.return_value = currency_chip
     page.locator.return_value = currency_input
-    page.get_by_role.return_value = currency_button
+    page.get_by_role.return_value = currency_radio
 
     resume_position.apply_position(page, PositionValues(currency="RUR"))
 
     currency_input.click.assert_not_called()
-    page.get_by_role.assert_called_once_with("button", name="Рубли", exact=True)
-    currency_button.click.assert_called_once_with()
+    currency_radio.click.assert_not_called()
+    page.get_by_role.assert_called_once_with("radio", name="Рубли", exact=True)
+    currency_radio.locator.assert_called_once_with("xpath=ancestor::label[1]")
+    currency_chip.click.assert_called_once_with()
 
 
 def test_set_control_reopens_dropdown_for_each_value():


### PR DESCRIPTION
## Проблема

`resume-position --currency RUR|EUR|USD` падал:
```
[FAIL] кнопка валюты не подтверждена: RUR
```

Код искал `page.get_by_role("button", name=CURRENCY_LABELS[plan.currency])` —
но элемент имеет `role="radio"`, а не `role="button"`.

## Живое исследование (read-only, resume `ab465fcfff1100a7700039ed1f733654436452`)

Открыл `/resume/edit/{id}/position` headless-браузером через существующий
`open_hydrated_resume_editor` из `browser.py` и снял живой DOM:

```html
<label class="magritte-chip..." data-qa="chip" data-interactive="true">
  <input name="currency" data-qa="resume-currency-input-RUR" type="radio" value="RUR" checked>
  <span class="magritte-content...">
    <span class="magritte-label...">Рубли</span>
  </span>
</label>
```

Ключевые находки:
- Элемент — `<input type="radio" data-qa="resume-currency-input-{code}">`, обёрнутый в `<label>`.
- **Accessible name radio — русский текст label** ("Рубли"/"Евро"/"Доллары"), а НЕ код валюты (в отличие от предположения в issue #785 про `role=radio name=RUR`). Живая проверка:
  - `get_by_role("radio", name="RUR")` → count=0
  - `get_by_role("radio", name="Рубли")` → count=1 ✅
- Radio `position: absolute`, `opacity: 1`, `visible`, но **клик по самому radio перехватывается `<span>`** чипа (`intercepts pointer events`, подтверждено живым retry-логом Playwright) — старый комментарий в коде про "hidden radio" был неточным по причине, но верным по симптому.
- Реальный hit target — обёртка `<label>` (сам чип). Клик по `label`, найденному через `currency_radio.locator("xpath=ancestor::label[1]")` от уже подтверждённого radio, проходит без перехвата.

## Живое подтверждение фикса (read-only, без Save)

Тем же headless-скриптом кликнул через новый локатор:
```
fixed chip locator count for RUR label: 1
click on RUR chip <label> succeeded (no PlaywrightError)
checked after click: True

after clicking EUR chip:
  RUR checked: False
  EUR checked: True
after clicking back to RUR chip:
  RUR checked: True
  EUR checked: False
```

Переключение RUR → EUR → RUR реально меняет `checked`-состояние DOM без
ошибок Playwright. Save-кнопка не нажималась, изменение не сохранено на hh.ru
(проверено — резюме осталось в исходном состоянии RUR).

## Фикс

`get_by_role("button", name=CURRENCY_LABELS[...])` →
`get_by_role("radio", name=CURRENCY_LABELS[...])`, клик — по `xpath=ancestor::label[1]`
от найденного radio (реальный hit target), а не по radio напрямую.

## Тесты

- Обновлён `test_apply_position_clicks_visible_currency_button_not_hidden_input`
  → `test_apply_position_clicks_currency_chip_label_not_radio_input`, проверяет
  новую цепочку локаторов (`get_by_role("radio", ...)` → `.locator("xpath=ancestor::label[1]")` → `.click()`).
- `ruff check` / `ruff format --check` — чисто.
- `pytest -n 4 --dist worksteal` — 2889 passed, 2 skipped.
- `scripts/gen_cli_docs.py --check` — синхронизирован (сигнатура CLI не менялась).

Closes #785