### PR TITLE
fix: education route-guard for query-based resumeFrom + tests

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -12,7 +12,7 @@ import re
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
 from playwright.sync_api import Browser, BrowserContext, Locator, Page, sync_playwright
 from playwright.sync_api import Error as PlaywrightError
@@ -151,6 +151,7 @@ def open_hydrated_resume_editor(
     trigger_error: str = "кнопка редактирования не подтверждена",
     open_error: str = "форма редактирования не открылась",
     wrong_route_error: str = "форма редактирования открыта не для того резюме",
+    expected_query: dict[str, str] | None = None,
 ):
     """Open a resume editor only after its hydrated DOM marker appears.
 
@@ -158,7 +159,7 @@ def open_hydrated_resume_editor(
     click can therefore succeed at the DOM level while doing nothing. Retry
     only while still on the profile page and require the editor marker as the
     positive result; callers may additionally bind the editor to a dedicated
-    edit route.
+    edit route and/or expected query parameters.
     """
     editor = page.locator(editor_selector)
 
@@ -196,6 +197,15 @@ def open_hydrated_resume_editor(
     )
     if not route_matches:
         raise RuntimeError(wrong_route_error)
+    if expected_query is not None:
+        page_url = page.url
+        if not isinstance(page_url, str):
+            raise RuntimeError(wrong_route_error)
+        current_query = parse_qs(urlsplit(page_url).query)
+        for key, expected_value in expected_query.items():
+            actual_values = current_query.get(key, [])
+            if expected_value not in actual_values:
+                raise RuntimeError(wrong_route_error)
     return editor
 
 

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -35,7 +35,7 @@ ADDITIONAL_TRIGGER = "[data-qa='resume-edit-button-additionalEducation-{index}']
 # the form; they do not persist anything until SAVE_BUTTON is clicked.
 PRIMARY_ADD = "[data-qa='resume-list-card-education'] [data-qa='link']"
 ADDITIONAL_ADD = "[data-qa='resume-list-card-additionalEducation'] [data-qa='link']"
-PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation/[^/?#]+")
+PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)")
 ADDITIONAL_ROUTE = re.compile(r"/profile/edit/additionalEducation/[^/?#]+")
 CANCEL_BUTTON = "[data-qa='profile-layout-cancel-button']"
 SAVE_BUTTON = "[data-qa='profile-layout-save-button']"
@@ -208,6 +208,7 @@ def _edit_block(
                 trigger_error=f"триггер образования {index} не найден однозначно",
                 open_error=f"форма образования {index} не открылась",
                 wrong_route_error=f"форма образования {index} открыта не для того резюме",
+                expected_query={"resumeFrom": resume_id} if not additional else None,
             )
             for name, selector in fields.items():
                 value = getattr(record, name)

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -167,6 +167,55 @@ def test_open_about_editor_accepts_draft_edit_route(monkeypatch):
     assert open_about_editor(page, bare_resume("resume-id")) == ""
 
 
+def test_open_about_editor_accepts_draft_edit_route_with_query(monkeypatch):
+    """Query parameters on the edit route must not break the route guard (#788 follow-up)."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    field.count.return_value = 0
+    field.input_value.return_value = ""
+    field.wait_for.return_value = None
+
+    def click_side_effect():
+        page.url = "https://hh.ru/resume/edit/resume-id/about?foo=bar"
+
+    trigger.click.side_effect = click_side_effect
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    assert open_about_editor(page, bare_resume("resume-id")) == ""
+
+
+def test_open_about_editor_rejects_wrong_route_with_empty_resume_id(monkeypatch):
+    """An empty resume_id must not accidentally match a different edit route."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    field = MagicMock()
+    field.count.return_value = 0
+    field.input_value.return_value = ""
+    field.wait_for.return_value = None
+
+    def click_side_effect():
+        page.url = "https://hh.ru/resume/edit/other-id/about"
+
+    trigger.click.side_effect = click_side_effect
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AboutGenerationError):
+        open_about_editor(page, bare_resume(""))
+
+
 def test_open_about_editor_still_fails_closed_on_unexpected_route(monkeypatch):
     """The route guard must not be weakened: an unexpected editor route still
     fails closed instead of silently editing the wrong resume (#527)."""

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -8,6 +8,7 @@ DDoS-Guard грузится 33с+ против дефолта Playwright 30с, �
 
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
@@ -22,6 +23,7 @@ from hhru_bot.browser import (
     ThrottledChannelDetected,
     goto_hh,
     open_confirmed_resume,
+    open_hydrated_resume_editor,
     require_authenticated_page,
 )
 
@@ -570,3 +572,80 @@ def test_goto_hh_removes_response_listener_after_each_attempt(monkeypatch):
 
     assert len(listeners) == 1
     assert removed == listeners
+
+
+def test_open_hydrated_resume_editor_accepts_matching_path_and_query(monkeypatch):
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/profile/edit/primaryEducation?resumeFrom=abc123&hhtmFrom=resume"
+    editor = MagicMock(name="editor")
+    editor.count.return_value = 1
+    page.locator.return_value = editor
+
+    result = open_hydrated_resume_editor(
+        page,
+        trigger_selector="[data-qa='x']",
+        editor_selector="[data-qa='y']",
+        profile_path="/resume/abc123",
+        edit_path=re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)"),
+        expected_query={"resumeFrom": "abc123"},
+        click_trigger=False,
+    )
+
+    assert result is editor
+
+
+def test_open_hydrated_resume_editor_rejects_mismatched_query(monkeypatch):
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/profile/edit/primaryEducation?resumeFrom=wrong&hhtmFrom=resume"
+    editor = MagicMock(name="editor")
+    editor.count.return_value = 1
+    page.locator.return_value = editor
+
+    with pytest.raises(RuntimeError, match="открыта не для того резюме"):
+        open_hydrated_resume_editor(
+            page,
+            trigger_selector="[data-qa='x']",
+            editor_selector="[data-qa='y']",
+            profile_path="/resume/abc123",
+            edit_path=re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)"),
+            expected_query={"resumeFrom": "abc123"},
+            click_trigger=False,
+        )
+
+
+def test_open_hydrated_resume_editor_rejects_mismatched_path_with_query(monkeypatch):
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/profile/edit/additionalEducation?resumeFrom=abc123&hhtmFrom=resume"
+    editor = MagicMock(name="editor")
+    editor.count.return_value = 1
+    page.locator.return_value = editor
+
+    with pytest.raises(RuntimeError, match="открыта не для того резюме"):
+        open_hydrated_resume_editor(
+            page,
+            trigger_selector="[data-qa='x']",
+            editor_selector="[data-qa='y']",
+            profile_path="/resume/abc123",
+            edit_path=re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)"),
+            expected_query={"resumeFrom": "abc123"},
+            click_trigger=False,
+        )
+
+
+def test_open_hydrated_resume_editor_omits_query_check_when_not_expected(monkeypatch):
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/edit/resume-id/keySkills?foo=bar"
+    editor = MagicMock(name="editor")
+    editor.count.return_value = 1
+    page.locator.return_value = editor
+
+    result = open_hydrated_resume_editor(
+        page,
+        trigger_selector="[data-qa='x']",
+        editor_selector="[data-qa='y']",
+        profile_path="/resume/resume-id",
+        edit_path="/resume/edit/resume-id/keySkills",
+        click_trigger=False,
+    )
+
+    assert result is editor

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -108,3 +108,28 @@ def test_hydration_runtime_error_after_prior_save_is_reported_not_raised(monkeyp
     assert result.saved == 1
     assert result.uncertain is True
     assert "ошибка UI" in result.reason
+
+
+def test_edit_block_passes_expected_query_to_open_hydrated_resume_editor(monkeypatch):
+    """#788: the education editor must bind the opened form to the requested
+    resume_id via the `resumeFrom` query parameter, not only via the path."""
+    page = FakePage(trigger_count=1, resume_id="resume-id")
+    captured: dict = {}
+
+    def fake_open_hydrated_resume_editor(page_arg, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return page.locator(next(iter(kwargs.get("editor_selector", "") or "x")))
+
+    monkeypatch.setattr(
+        resume_education, "open_hydrated_resume_editor", fake_open_hydrated_resume_editor
+    )
+
+    records = [
+        EducationRecord(
+            institution="A", level="", faculty="", organization="", specialty="", year="2020"
+        ),
+    ]
+
+    _edit_block(page, records, additional=False, dry_run=False, resume_id="resume-id")
+
+    assert captured.get("expected_query") == {"resumeFrom": "resume-id"}

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -753,6 +753,71 @@ def test_verify_wizard_save_polls_until_resume_card_title_matches(monkeypatch):
     page.wait_for_timeout.assert_called_once_with(resume_position.WIZARD_VERIFY_POLL_MS)
 
 
+def test_open_position_form_accepts_edit_route_with_query(monkeypatch):
+    """Query parameters on the edit route must not break the route guard."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/position?foo=bar"
+    edit = MagicMock()
+    edit.count.return_value = 1
+    form = MagicMock()
+    form.count.return_value = 0
+    form.wait_for.return_value = None
+    page.locator.side_effect = lambda selector: {
+        resume_position.EDIT: edit,
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
+    monkeypatch.setattr(
+        resume_position,
+        "parse_resume_state",
+        lambda *_args: ResumeState(status="new", is_searchable=True),
+    )
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", lambda _page: PositionValues())
+
+    flow = resume_position.open_position_form(page, resume)
+
+    assert flow.kind == "editor"
+    assert edit.click.call_count == 1
+    assert form.wait_for.call_count == 1
+
+
+def test_open_position_form_rejects_wrong_route_with_empty_resume_id(monkeypatch):
+    """An empty resume_id must not accidentally match a different edit route."""
+    resume = bare_resume("")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/other-resume-id/position"
+    edit = MagicMock()
+    edit.count.return_value = 1
+    form = MagicMock()
+    form.count.return_value = 0
+    form.wait_for.return_value = None
+    page.locator.side_effect = lambda selector: {
+        resume_position.EDIT: edit,
+        resume_position.FORM: form,
+    }[selector]
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
+    monkeypatch.setattr(
+        resume_position,
+        "parse_resume_state",
+        lambda *_args: ResumeState(status="new", is_searchable=True),
+    )
+    monkeypatch.setattr(resume_position, "read_display_position", lambda _page: PositionValues())
+    read_position = MagicMock(return_value=PositionValues())
+    monkeypatch.setattr(resume_position, "read_position", read_position)
+
+    with pytest.raises(
+        RuntimeError, match="форма редактирования позиции открыта не для того резюме"
+    ):
+        resume_position.open_position_form(page, resume)
+    read_position.assert_not_called()
+
+
 def test_verify_wizard_save_never_accepts_persistent_professional_role(monkeypatch):
     resume = bare_resume("resume-id")
     page = MagicMock()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -353,6 +353,66 @@ def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatc
     assert result.added == ("Machine  Learning",)
 
 
+def test_edit_skills_accepts_edit_route_with_query(monkeypatch) -> None:
+    """Query parameters on the edit route must not break the route guard."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/keySkills?foo=bar"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    cancel = MagicMock()
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "read_skills", lambda _page: ())
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is True
+    assert trigger.click.call_count == 1
+    assert editor.wait_for.call_count == 1
+
+
+def test_edit_skills_rejects_wrong_route_with_empty_resume_id(monkeypatch) -> None:
+    """An empty resume_id must not accidentally match a different edit route."""
+    resume = bare_resume("")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/other-resume-id/keySkills"
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    cancel = MagicMock()
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    read_skills = MagicMock(return_value=())
+    monkeypatch.setattr(skills_module, "read_skills", read_skills)
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Python", "advanced"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is False
+    assert result.reason == "форма навыков открыта не для того резюме"
+    read_skills.assert_not_called()
+    cancel.click.assert_not_called()
+
+
 def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) -> None:
     """An existing chip rendered with double internal whitespace must dedup the
     same skill from the plan, not be treated as a new addition.


### PR DESCRIPTION
Closes #788

## Что починил
- PRIMARY_ROUTE теперь матчит `/profile/edit/primaryEducation` без лишнего path-сегмента (resume_id живёт в query `resumeFrom`)
- `open_hydrated_resume_editor` получил `expected_query` и валидирует `resumeFrom` в фактическом URL
- `resume_education` передаёт `expected_query={'resumeFrom': resume_id}` для primary education

## Защита от класса #787
Route-guard теперь проверяет query `resumeFrom` — без этого сохранение может уйти в общий профиль мимо целевого резюме.

## Установленный факт по разведке #787
- **primary education**: resume-specific роут `/resume/edit/{resume_id}/primaryEducation` **не найден**. Единственный подтверждённый путь — общий `/profile/edit/primaryEducation?resumeFrom=<id>&hhtmFrom=resume`. Поэтому query-guard здесь является корректным фикcом.
- **additional education**: подтверждён resume-specific роут `/resume/edit/{resume_id}/additionalEducation` (live-дамп 2026-08-29). В этом PR additional education **не трогается** — вынесен в отдельный follow-up, чтобы не расширять scope.

## Доказательства
- unit: 292 insertions, targeted tests for query-aware route guard
- live dry-run на marketing (read-only, без Save): команда проходит через form-open путь без падения
- regex verification: реальные URL из ишью матчатся корректно

## CI
ruff check + ruff format --check + полный pytest — зелёный.