### PR TITLE
fix(about): fail fast when about button is missing (#790)

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -121,8 +121,19 @@ def _fallback_about(existing: str, profile: AIProfile | None, mode: str) -> Abou
 
 
 def open_about_editor(page: Page, resume: ResumeConfig) -> str:
-    """Open the confirmed inline editor and return its current textarea value."""
-    goto_hh(page, resume.resume_url, ready_selector=resume_page.RESUME_EDIT_ABOUT_BUTTON)
+    """Open the confirmed inline editor and return its current textarea value.
+
+    The trigger button is absent on empty resumes. Navigate without
+    ``ready_selector`` so the command does not hang for 2+ minutes when
+    the selector is missing; verify the button explicitly afterwards.
+    """
+    goto_hh(page, resume.resume_url)
+    trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
+    if trigger.count() != 1:
+        raise AboutGenerationError(
+            "кнопка редактирования «Обо мне» не найдена однозначно "
+            "(резюме, вероятно, пустое — раздел ещё не создан)"
+        )
     try:
         field = open_hydrated_resume_editor(
             page,

--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -126,9 +126,19 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     The trigger button is absent on empty resumes. Navigate without
     ``ready_selector`` so the command does not hang for 2+ minutes when
     the selector is missing; verify the button explicitly afterwards.
+
+    ``goto_hh`` only guarantees URL commit, not rendered DOM, so wait for
+    the trigger to become visible before the strict count check.
     """
     goto_hh(page, resume.resume_url)
     trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
+    try:
+        trigger.wait_for(state="visible", timeout=10_000)
+    except PlaywrightError as exc:
+        raise AboutGenerationError(
+            "кнопка редактирования «Обо мне» не появилась после навигации "
+            f"(резюме, вероятно, пустое — раздел ещё не создан): {exc}"
+        ) from exc
     if trigger.count() != 1:
         raise AboutGenerationError(
             "кнопка редактирования «Обо мне» не найдена однозначно "

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -200,16 +200,20 @@ def test_open_about_editor_fails_fast_when_button_missing(monkeypatch):
     page.url = "https://hh.ru/resume/resume-id"
     trigger = MagicMock(name="trigger")
     trigger.count.return_value = 0
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    trigger.wait_for.side_effect = PlaywrightTimeoutError("not visible")
 
     page.locator.side_effect = lambda selector: {
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
     }[selector]
     monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
 
-    with pytest.raises(AboutGenerationError, match="не найдена однозначно"):
+    with pytest.raises(AboutGenerationError, match="не появилась после навигации"):
         open_about_editor(page, bare_resume("resume-id"))
 
-    trigger.count.assert_called_once()
+    trigger.wait_for.assert_called_once()
+    trigger.count.assert_not_called()
     trigger.click.assert_not_called()
 
 
@@ -219,6 +223,7 @@ def test_open_about_editor_fails_fast_when_button_ambiguous(monkeypatch):
     page.url = "https://hh.ru/resume/resume-id"
     trigger = MagicMock(name="trigger")
     trigger.count.return_value = 2
+    trigger.wait_for.return_value = None
 
     page.locator.side_effect = lambda selector: {
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
@@ -228,5 +233,6 @@ def test_open_about_editor_fails_fast_when_button_ambiguous(monkeypatch):
     with pytest.raises(AboutGenerationError, match="не найдена однозначно"):
         open_about_editor(page, bare_resume("resume-id"))
 
+    trigger.wait_for.assert_called_once()
     trigger.count.assert_called_once()
     trigger.click.assert_not_called()

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -191,3 +191,42 @@ def test_open_about_editor_still_fails_closed_on_unexpected_route(monkeypatch):
 
     with pytest.raises(AboutGenerationError):
         open_about_editor(page, bare_resume("resume-id"))
+
+
+def test_open_about_editor_fails_fast_when_button_missing(monkeypatch):
+    """An empty resume has no about button; the command must fail immediately
+    instead of hanging for 2+ minutes on ready_selector timeout (#790)."""
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock(name="trigger")
+    trigger.count.return_value = 0
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AboutGenerationError, match="не найдена однозначно"):
+        open_about_editor(page, bare_resume("resume-id"))
+
+    trigger.count.assert_called_once()
+    trigger.click.assert_not_called()
+
+
+def test_open_about_editor_fails_fast_when_button_ambiguous(monkeypatch):
+    """Multiple about buttons must also fail fast, not enter the editor flow."""
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock(name="trigger")
+    trigger.count.return_value = 2
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AboutGenerationError, match="не найдена однозначно"):
+        open_about_editor(page, bare_resume("resume-id"))
+
+    trigger.count.assert_called_once()
+    trigger.click.assert_not_called()


### PR DESCRIPTION
## Что починил

Аспект 2 из #790: команда \`about\` висела 2+ минуты и не писала в \`history.db\`, когда кнопка редактирования «Обо мне» отсутствовала на пустом резюме.

### Причина
\`open_about_editor\` передавал отсутствующий \`ready_selector\` в \`goto_hh\`, который ретраил навигацию до \`_GOTO_MAX_ATTEMPTS=3\` с таймаутом 90с — итого до 270с зависания без записи в историю.

### Исправление
Убрал \`ready_selector\` из \`goto_hh\`, добавил явную проверку \`count() != 1\` после навигации. Теперь команда:
- проходит навигацию быстро;
- сразу падает с понятной ошибкой, если кнопка отсутствует или неоднозначна;
- не зависает на 2+ минуты.

### Доказательство
- Юнит-тесты: \`test_open_about_editor_fails_fast_when_button_missing\` и \`test_open_about_editor_fails_fast_when_button_ambiguous\`.
- Лайв dry-run на существующем резюме завершился за секунды с \`[DRY-RUN]\`, без зависаний.

Refs #790