### PR TITLE
fix(resume-position): исправить тексты опций панели "Тип занятости"

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -47,7 +47,7 @@ def register(subparsers) -> None:
     p.add_argument(
         "--employment",
         action="append",
-        choices=("full_time", "part_time", "project", "internship", "volunteer"),
+        choices=("full_time", "part_time", "internship", "volunteer"),
         help="Тип занятости (пока только одно значение — #526)",
     )
     p.add_argument(

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -94,10 +94,15 @@ WIZARD_TRANSITION_POLL_MS = 1_000
 WIZARD_VERIFY_TIMEOUT_MS = 30_000
 WIZARD_VERIFY_POLL_MS = 500
 
+# Панель "Тип занятости" на hh.ru показывает ровно эти 4 опции (confirmed live
+# DOM, #799): нет отдельных "Частичная занятость"/"Проектная работа" — hh.ru
+# объединил их в общую панель, а "full_time" отображается и кликается как
+# "Постоянная работа", не "Полная занятость". Единый словарь используется и
+# для клика по опции (_set_control), и для read_display_position — расхождение
+# между ними (#799) было первопричиной "вариант формы не найден".
 EMPLOYMENT_LABELS = {
-    "full_time": "Полная занятость",
-    "part_time": "Частичная занятость",
-    "project": "Проектная работа",
+    "full_time": "Постоянная работа",
+    "part_time": "Подработка",
     "internship": "Стажировка",
     "volunteer": "Волонтёрство",
 }
@@ -108,7 +113,7 @@ TRAVEL_LABELS = {
     "up_to_2_hours": "Не дольше 2 часов",
     "up_to_3_hours": "Не дольше 3 часов",
 }
-DISPLAY_EMPLOYMENT = {**EMPLOYMENT_LABELS, "full_time": "Постоянная работа"}
+DISPLAY_EMPLOYMENT = EMPLOYMENT_LABELS
 DISPLAY_WORK = {**WORK_LABELS, "office": "На месте работодателя", "remote": "Удалённо"}
 
 
@@ -154,7 +159,7 @@ def build_position_prompt(profile: Any, current: PositionValues, mode: str) -> l
         "Ответь только JSON без markdown с ключами title, salary, currency, "
         "specializations, employment, work_format, commute, business_trips. "
         "employment и work_format — массивы enum. Допустимые employment: "
-        "full_time, part_time, project, internship, volunteer. Допустимые "
+        "full_time, part_time, internship, volunteer. Допустимые "
         "work_format: office, hybrid, remote. Допустимые commute: no_limit, "
         "up_to_1_hour, up_to_2_hours, up_to_3_hours. salary — целое число или null. "
         "Никогда не выдумывай salary, currency или условия. В режиме fill не меняй "
@@ -691,7 +696,7 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
         # deliberately avoided because it can close the whole editor form.
         el.click()
         panel.wait_for(state="hidden", timeout=_CONTROL_WAIT_TIMEOUT_MS)
-    except PlaywrightError as exc:
+    except (PlaywrightError, RuntimeError) as exc:
         _dump_control_failure(page, selector, exc)
         raise
 

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -18,6 +18,23 @@ from hhru_bot.resume_state import ResumeProfessionalRole, ResumeState
 pytestmark = pytest.mark.unit
 
 
+def test_employment_labels_match_confirmed_live_panel():
+    # Confirmed live DOM (#799, 2026-08-30): the "Тип занятости" panel shows
+    # exactly these 4 options with these texts — no separate "Частичная
+    # занятость"/"Проектная работа". A future hh.ru text drift should fail
+    # here first, not as a live "вариант формы не найден".
+    assert resume_position.EMPLOYMENT_LABELS == {
+        "full_time": "Постоянная работа",
+        "part_time": "Подработка",
+        "internship": "Стажировка",
+        "volunteer": "Волонтёрство",
+    }
+    # DISPLAY_EMPLOYMENT must stay the same object/mapping as EMPLOYMENT_LABELS
+    # (#799 root cause): two divergent dicts for click vs. display is exactly
+    # what broke --employment full_time.
+    assert resume_position.DISPLAY_EMPLOYMENT == resume_position.EMPLOYMENT_LABELS
+
+
 def test_position_response_accepts_structured_values_without_inventing_salary():
     plan = parse_position_response(
         '{"title":"Backend engineer","salary":null,"currency":null,'


### PR DESCRIPTION
## Проблема

`resume-position --employment full_time` падал: `[FAIL] вариант формы не найден: Полная занятость`.

`EMPLOYMENT_LABELS` использовался для клика по опции, но содержал устаревшие тексты ("Полная занятость"/"Частичная занятость"/"Проектная работа"), тогда как `DISPLAY_EMPLOYMENT` уже содержал верный текст ("Постоянная работа") — но использовался только для dry-run отображения, не для клика.

## Живое подтверждение

Confirmed live DOM (2026-08-30) на `/resume/edit/{id}/position`, панель "Тип занятости" открыта кликом в браузере (черновик "Test Resume 787"): ровно 4 опции —

```
Постоянная работа
Подработка
Стажировка
Волонтёрство
```

Отдельной "Проектной работы" панель не содержит — hh.ru объединил категории занятости.

Дополнительно прогнан **боевой WRITE**-тест (с разрешения пользователя) на том же черновике:
```
./scripts/run.sh --config .../config.yaml resume-position --resume a1d75539ff1106985b0039ed1f377079695358 --employment full_time --force
[OK] Раздел желаемой работы резюме 'a1d75539ff1106985b0039ed1f377079695358' обновлён.
[RUN] ... status=completed attempted=1 success=1 failed=0
```

## Изменения

- `EMPLOYMENT_LABELS` исправлен под подтверждённые тексты, `project` удалён (панели такой опции нет)
- `DISPLAY_EMPLOYMENT` теперь `= EMPLOYMENT_LABELS` — единый источник для клика и для чтения (расхождение между ними и было первопричиной бага)
- CLI `--employment` choices и LLM-промпт (`build_position_prompt`) синхронизированы (`project` убран из enum)
- `_dump_control_failure` теперь ловит и `RuntimeError`, не только `PlaywrightError` — "вариант формы не найден" раньше не оставлял диагностического дампа (пункт 3 issue)

## Тесты

- `pytest` (полный сьют, `-n 4 --dist worksteal`) — зелёный
- `ruff check` + `ruff format --check` — чисто
- `scripts/gen_cli_docs.py --check` — README актуален (изменения choices не задели справку)
- Живой READ (`--dry-run`) + живой WRITE (см. выше) прогон подтверждён

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Es4vn3WGhCAzYqMvvT1Tzs