### PR TITLE
fix(about): open editor via resume-scoped route on empty resume

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -11,11 +11,12 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
-from .browser import goto_hh, open_hydrated_resume_editor
+from .browser import HH_BASE_URL, goto_hh, open_hydrated_resume_editor
 from .selector_groups import resume_page
 
 if TYPE_CHECKING:
@@ -123,9 +124,10 @@ def _fallback_about(existing: str, profile: AIProfile | None, mode: str) -> Abou
 def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     """Open the confirmed inline editor and return its current textarea value.
 
-    The trigger button is absent on empty resumes. Navigate without
-    ``ready_selector`` so the command does not hang for 2+ minutes when
-    the selector is missing; verify the button explicitly afterwards.
+    The trigger button is absent on empty resumes (#790). Navigate without
+    ``ready_selector`` so the command does not hang for 2+ minutes when the
+    selector is missing; the trigger's visibility is checked explicitly with a
+    short timeout instead.
 
     ``goto_hh`` only guarantees URL commit, not rendered DOM, so wait for
     the trigger to become visible before the strict count check.
@@ -134,11 +136,15 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
     try:
         trigger.wait_for(state="visible", timeout=10_000)
-    except PlaywrightError as exc:
-        raise AboutGenerationError(
-            "кнопка редактирования «Обо мне» не появилась после навигации "
-            f"(резюме, вероятно, пустое — раздел ещё не создан): {exc}"
-        ) from exc
+    except PlaywrightError:
+        # #790: on a resume with no "Обо мне" section yet, the trigger never
+        # appears. Live confirmation (2026-08-30, same resume-scoped route
+        # already accepted below as a valid edit route per #527): navigating
+        # straight to /resume/edit/{resume_id}/about opens the editor
+        # directly, pre-bound to this resume_id — same pattern as #787/#797
+        # (experience) and #787/#798 (skills) for the shared "no in-page
+        # add-trigger for an empty section" failure mode.
+        return _open_about_editor_via_edit_route(page, resume)
     if trigger.count() != 1:
         raise AboutGenerationError(
             "кнопка редактирования «Обо мне» не найдена однозначно "
@@ -166,6 +172,29 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
         )
     except RuntimeError as exc:
         raise AboutGenerationError(str(exc)) from exc
+    return field.input_value()
+
+
+def _open_about_editor_via_edit_route(page: Page, resume: ResumeConfig) -> str:
+    """Open the about editor directly via its resume-scoped edit route.
+
+    Used when the in-page trigger is absent (empty resume, #790). Confirmed
+    live (2026-08-30): navigating straight to this route opens the editor
+    pre-bound to ``resume.resume_id``, with no trigger click involved — same
+    resume-scoped-route pattern as #797 (experience) and #798 (skills).
+    """
+    edit_path = f"/resume/edit/{resume.resume_id}/about"
+    try:
+        goto_hh(page, f"{HH_BASE_URL}{edit_path}")
+    except PlaywrightError as exc:
+        raise AboutGenerationError(f"форма «Обо мне» не открылась: {exc}") from exc
+    if urlsplit(page.url).path.rstrip("/") != edit_path:
+        raise AboutGenerationError(f"форма «Обо мне» открыта не для того резюме ({page.url})")
+    field = page.locator(resume_page.RESUME_ABOUT_EDITOR)
+    try:
+        field.wait_for(state="visible", timeout=10_000)
+    except PlaywrightError as exc:
+        raise AboutGenerationError(f"форма «Обо мне» не открылась: {exc}") from exc
     return field.input_value()
 
 

--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -15,6 +15,7 @@ from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from .browser import HH_BASE_URL, goto_hh, open_hydrated_resume_editor
 from .selector_groups import resume_page
@@ -136,14 +137,19 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
     try:
         trigger.wait_for(state="visible", timeout=10_000)
-    except PlaywrightError:
+    except PlaywrightTimeoutError:
         # #790: on a resume with no "Обо мне" section yet, the trigger never
-        # appears. Live confirmation (2026-08-30, same resume-scoped route
-        # already accepted below as a valid edit route per #527): navigating
-        # straight to /resume/edit/{resume_id}/about opens the editor
-        # directly, pre-bound to this resume_id — same pattern as #787/#797
-        # (experience) and #787/#798 (skills) for the shared "no in-page
-        # add-trigger for an empty section" failure mode.
+        # becomes visible — this is the specific "not visible within timeout"
+        # signal, not any Playwright failure. Live confirmation (2026-08-30,
+        # same resume-scoped route already accepted below as a valid edit
+        # route per #527): navigating straight to
+        # /resume/edit/{resume_id}/about opens the editor directly, pre-bound
+        # to this resume_id — same pattern as #787/#797 (experience) and
+        # #787/#798 (skills) for the shared "no in-page add-trigger for an
+        # empty section" failure mode. A non-timeout PlaywrightError (closed
+        # context, navigation failure, etc.) is a different, unrelated
+        # failure and must not be silently reinterpreted as "empty resume" —
+        # it propagates unguarded so the real cause stays visible.
         return _open_about_editor_via_edit_route(page, resume)
     if trigger.count() != 1:
         raise AboutGenerationError(

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.about as about_module
 from hhru_bot.about import (
@@ -274,6 +275,30 @@ def test_open_about_editor_uses_edit_route_when_button_missing(monkeypatch):
     trigger.count.assert_not_called()
     trigger.click.assert_not_called()
     assert page.url == "https://hh.ru/resume/edit/resume-id/about"
+
+
+def test_open_about_editor_propagates_non_timeout_error(monkeypatch):
+    """A non-timeout PlaywrightError (closed context, navigation failure, etc.)
+    from the trigger wait must NOT be silently reinterpreted as "empty resume"
+    and redirected to the edit-route fallback — it is a different, unrelated
+    failure and should propagate so the real cause stays visible."""
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock(name="trigger")
+    trigger.wait_for.side_effect = PlaywrightError(
+        "Target page, context or browser has been closed"
+    )
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(PlaywrightError, match="closed"):
+        open_about_editor(page, bare_resume("resume-id"))
+
+    trigger.count.assert_not_called()
+    trigger.click.assert_not_called()
 
 
 def test_open_about_editor_edit_route_rejects_wrong_resume(monkeypatch):

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -242,9 +242,11 @@ def test_open_about_editor_still_fails_closed_on_unexpected_route(monkeypatch):
         open_about_editor(page, bare_resume("resume-id"))
 
 
-def test_open_about_editor_fails_fast_when_button_missing(monkeypatch):
-    """An empty resume has no about button; the command must fail immediately
-    instead of hanging for 2+ minutes on ready_selector timeout (#790)."""
+def test_open_about_editor_uses_edit_route_when_button_missing(monkeypatch):
+    """An empty resume has no about button (#790): instead of hanging for 2+
+    minutes on ready_selector timeout, or failing fast, navigate straight to
+    the resume-scoped edit route (live-confirmed #790, same pattern as
+    #797/#798) and open the editor from there."""
     page = MagicMock(name="Page")
     page.url = "https://hh.ru/resume/resume-id"
     trigger = MagicMock(name="trigger")
@@ -253,17 +255,74 @@ def test_open_about_editor_fails_fast_when_button_missing(monkeypatch):
 
     trigger.wait_for.side_effect = PlaywrightTimeoutError("not visible")
 
+    field = MagicMock(name="field")
+    field.input_value.return_value = ""
+    field.wait_for.return_value = None
+
+    def goto_side_effect(_page, url, **_kwargs):
+        page.url = url
+
     page.locator.side_effect = lambda selector: {
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
-    monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(about_module, "goto_hh", goto_side_effect)
 
-    with pytest.raises(AboutGenerationError, match="не появилась после навигации"):
-        open_about_editor(page, bare_resume("resume-id"))
+    assert open_about_editor(page, bare_resume("resume-id")) == ""
 
     trigger.wait_for.assert_called_once()
     trigger.count.assert_not_called()
     trigger.click.assert_not_called()
+    assert page.url == "https://hh.ru/resume/edit/resume-id/about"
+
+
+def test_open_about_editor_edit_route_rejects_wrong_resume(monkeypatch):
+    """The edit-route fallback must fail closed if it lands on another resume."""
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock(name="trigger")
+    trigger.count.return_value = 0
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    trigger.wait_for.side_effect = PlaywrightTimeoutError("not visible")
+
+    def goto_side_effect(_page, url, **_kwargs):
+        page.url = "https://hh.ru/resume/edit/other-id/about"
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", goto_side_effect)
+
+    with pytest.raises(AboutGenerationError, match="не для того резюме"):
+        open_about_editor(page, bare_resume("resume-id"))
+
+
+def test_open_about_editor_edit_route_fails_closed_when_editor_absent(monkeypatch):
+    """If the edit route opens but the editor field never renders, fail closed
+    instead of silently reading an empty/wrong value."""
+    page = MagicMock(name="Page")
+    page.url = "https://hh.ru/resume/resume-id"
+    trigger = MagicMock(name="trigger")
+    trigger.count.return_value = 0
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    trigger.wait_for.side_effect = PlaywrightTimeoutError("not visible")
+
+    field = MagicMock(name="field")
+    field.wait_for.side_effect = PlaywrightTimeoutError("not visible")
+
+    def goto_side_effect(_page, url, **_kwargs):
+        page.url = url
+
+    page.locator.side_effect = lambda selector: {
+        about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
+        about_module.resume_page.RESUME_ABOUT_EDITOR: field,
+    }[selector]
+    monkeypatch.setattr(about_module, "goto_hh", goto_side_effect)
+
+    with pytest.raises(AboutGenerationError, match="не открылась"):
+        open_about_editor(page, bare_resume("resume-id"))
 
 
 def test_open_about_editor_fails_fast_when_button_ambiguous(monkeypatch):


### PR DESCRIPTION
## Что

Аспект 1 из #790 (аспект 2 — fail-fast без 2-минутного зависания — уже закрыт #795).

`open_about_editor` при отсутствии триггера `[data-qa='resume-edit-button-about']`
(пустое резюме, раздел «Обо мне» ещё не создан) теперь не падает с ошибкой, а
идёт напрямую на resume-scoped роут `/resume/edit/{resume_id}/about` — тот же
паттерн, что уже смерджен для experience (#797) и skills (#798) по разведке #787.

Роут `/resume/edit/{id}/about` был уже подтверждён живым дампом как валидный
`edit_path` для этого модуля (issue #527, тесты `test_open_about_editor_accepts_draft_edit_route*`)
— сюда добавлена только прямая навигация на него, без клика по отсутствующему
триггеру.

## Live-верификация (2026-08-30, `PYTHONPATH=src`, источник кода подтверждён `hhru_bot.__file__`)

Резюме `a1d75539ff1106985b0039ed1f377079695358` ("Test Resume 787") — статус
**черновик**, подтверждён через `list-resumes` перед записью.

Read-only probe до фикса (подтверждает баг):
```
[FAIL] a1d75539ff... — кнопка редактирования «Обо мне» не появилась после
навигации (резюме, вероятно, пустое — раздел ещё не создан): Locator.wait_for:
Timeout 10000ms exceeded.
```

`--dry-run` после фикса (фолбэк сработал, вместо фейла — предложенный текст):
```
[DRY-RUN] «Обо мне» (manual):
re-verify #790 fix after install conflict
[INFO] Ничего не сохранено.
```

Боевой WRITE (`about --force`) на черновике:
```
[OK] Раздел «Обо мне» резюме a1d75539ff1106985b0039ed1f377079695358 сохранён
```

Live-запись выполнена с явного разрешения пользователя (WRITE только на
черновиках, боевые резюме не тронуты).

## Тесты

- `pytest -n 4 --dist worksteal` — зелёно, полная сюита.
- `ruff check` / `ruff format --check` — чисто.
- `scripts/gen_cli_docs.py --check` — синхронизирован (CLI-сигнатуры не менялись).
- Новые unit-тесты в `tests/test_about.py`: успешный фолбэк на edit-route,
  fail-closed при попадании не на тот резюме, fail-closed при ненайденном
  редакторе после навигации.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)