### PR TITLE
fix(edit-skills): дождаться подтверждения каждого чипа перед следующим fill+Enter

### DIFF
--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import time
 from collections import Counter
 from dataclasses import dataclass
 from typing import Any
@@ -26,6 +28,16 @@ logger = logging.getLogger("hhru_bot.skills")
 
 LEVELS = frozenset(("basic", "intermediate", "advanced"))
 EDITOR_MOUNT_TIMEOUT_MS = 30_000
+# #801: the skill chip input is an autocomplete combobox. A blind fill+Enter
+# for the next skill can race the browser's handling of the previous one and
+# concatenate two skill names into a single chip instead of creating two
+# separate chips. CHIP_COMMIT_TIMEOUT_MS bounds how long each iteration waits
+# for a positive signal (an exact-text chip appeared AND the input cleared)
+# before moving on; CHIP_COMMIT_POLL_MS is the poll interval, matching the
+# poll-loop pattern already used for a similar input-clear wait in
+# resume_position.py.
+CHIP_COMMIT_TIMEOUT_MS = 5_000
+CHIP_COMMIT_POLL_MS = 100
 
 
 @dataclass(frozen=True)
@@ -217,9 +229,33 @@ def edit_skills_on_hh(
         return SkillsResult(
             False, existing, skills, reason="поле ввода навыка не найдено однозначно"
         )
+    chips = page.locator(resume_page.RESUME_SKILLS_CHIP)
     for skill in additions:
         input_.fill(skill.name)
         input_.press("Enter")
+        # #801: wait for a positive commit signal before the next iteration's
+        # fill() — a blind fill+Enter pair for consecutive skills can race the
+        # combobox's autocomplete handling and concatenate two names into one
+        # chip (e.g. "FastAPI" + "LangChain" -> "FastAPILangChain"). Checking
+        # only that the chip count grew would not catch this: a merged chip
+        # still increments the count by one. The positive signal is a chip
+        # whose text exactly equals this skill's name AND the input cleared
+        # back to empty — a timeout does not roll back (the Enter may already
+        # have reached hh.ru), so it stops issuing further input and lets the
+        # existing post-save Counter check fail-closed on the resulting
+        # mismatch (same principle as "commit не значит отрисовано" elsewhere
+        # in this codebase).
+        expected_chip = chips.filter(has_text=re.compile(rf"^{re.escape(skill.name)}$"))
+        deadline = time.monotonic() + CHIP_COMMIT_TIMEOUT_MS / 1000
+        while time.monotonic() < deadline and (expected_chip.count() == 0 or input_.input_value()):
+            page.wait_for_timeout(CHIP_COMMIT_POLL_MS)
+        if expected_chip.count() == 0 or input_.input_value():
+            logger.warning(
+                "чип навыка %r не подтверждён за %dмс, дальнейший ввод остановлен",
+                skill.name,
+                CHIP_COMMIT_TIMEOUT_MS,
+            )
+            break
     save = page.locator(resume_page.RESUME_PARTIAL_EDIT_SAVE)
     if save.count() != 1:
         return SkillsResult(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -196,9 +196,15 @@ def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) ->
 
 
 def _mock_chip_locator() -> MagicMock:
-    """A RESUME_SKILLS_CHIP locator stub whose .nth().wait_for() no-ops."""
+    """A RESUME_SKILLS_CHIP locator stub whose .nth().wait_for() no-ops.
+
+    #801: .filter(has_text=...) also resolves immediately with one match, so
+    the post-fill+Enter commit-wait loop in edit_skills_on_hh does not poll
+    until CHIP_COMMIT_TIMEOUT_MS on every addition.
+    """
     chip_locator = MagicMock()
     chip_locator.nth.return_value.wait_for.return_value = None
+    chip_locator.filter.return_value.count.return_value = 1
     return chip_locator
 
 
@@ -211,6 +217,7 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     editor.wait_for.return_value = None
     input_ = MagicMock()
     input_.count.return_value = 1
+    input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
     chip_locator = _mock_chip_locator()
@@ -244,6 +251,104 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     chip_locator.nth.return_value.wait_for.assert_called_once_with(state="visible", timeout=5_000)
 
 
+def test_edit_skills_waits_for_each_chip_before_next_addition(monkeypatch) -> None:
+    """#801: consecutive additions must each be confirmed by an exact-text chip
+    (and a cleared input) before the next fill+Enter — a blind fill+Enter pair
+    is what let "FastAPI" + "LangChain" merge into "FastAPILangChain"."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    input_.input_value.return_value = ""
+    save = MagicMock()
+    save.count.return_value = 1
+    chip_locator = _mock_chip_locator()
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    read_skills = MagicMock(side_effect=[(), ("FastAPI", "LangChain")])
+    monkeypatch.setattr(skills_module, "read_skills", read_skills)
+
+    result = edit_skills_on_hh(
+        page,
+        resume,
+        (Skill("FastAPI", "intermediate"), Skill("LangChain", "intermediate")),
+        dry_run=False,
+        mode="append",
+    )
+
+    assert result.success is True
+    assert result.added == ("FastAPI", "LangChain")
+    assert input_.fill.call_args_list == [call("FastAPI"), call("LangChain")]
+    assert input_.press.call_count == 2
+    # Each addition is confirmed by its own exact-text filter, not a shared
+    # chip-count check that a merged chip would also satisfy.
+    filter_calls = [c.kwargs["has_text"].pattern for c in chip_locator.filter.call_args_list]
+    assert filter_calls == ["^FastAPI$", "^LangChain$"]
+
+
+def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
+    """#801: if a chip never confirms, further additions must not be typed —
+    the resulting mismatch is left for the post-save Counter check to catch."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    input_.input_value.return_value = ""
+    save = MagicMock()
+    save.count.return_value = 1
+    chip_locator = MagicMock()
+    chip_locator.nth.return_value.wait_for.return_value = None
+    # The expected chip never appears — simulates a merged/rejected chip.
+    chip_locator.filter.return_value.count.return_value = 0
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(
+        skills_module, "read_skills", MagicMock(side_effect=[(), ("FastAPILangChain",)])
+    )
+    monkeypatch.setattr(skills_module.time, "monotonic", MagicMock(side_effect=range(10_000)))
+    monkeypatch.setattr(page, "wait_for_timeout", MagicMock())
+
+    result = edit_skills_on_hh(
+        page,
+        resume,
+        (Skill("FastAPI", "intermediate"), Skill("LangChain", "intermediate")),
+        dry_run=False,
+        mode="append",
+    )
+
+    assert result.success is False
+    assert result.acted is True
+    # Only the first skill was typed; the timeout stopped the loop before the
+    # second fill+Enter could race the still-unsettled first one.
+    assert input_.fill.call_args_list == [call("FastAPI")]
+
+
 def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
     """A successful save click with a missing chip must not produce [OK]."""
     resume = bare_resume("resume-id")
@@ -253,6 +358,7 @@ def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
     editor.wait_for.return_value = None
     input_ = MagicMock()
     input_.count.return_value = 1
+    input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
     trigger = MagicMock()
@@ -292,6 +398,7 @@ def test_edit_skills_post_save_wait_timeout_falls_through_to_strict_read(monkeyp
     editor.wait_for.return_value = None
     input_ = MagicMock()
     input_.count.return_value = 1
+    input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
     chip_locator = MagicMock()
@@ -337,6 +444,7 @@ def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatc
     editor.wait_for.return_value = None
     input_ = MagicMock()
     input_.count.return_value = 1
+    input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
     trigger = MagicMock()
@@ -445,6 +553,7 @@ def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) 
     editor.wait_for.return_value = None
     input_ = MagicMock()
     input_.count.return_value = 1
+    input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
     trigger = MagicMock()


### PR DESCRIPTION
## Проблема

#801: поле ввода навыков (`RESUME_SKILLS_CHIP_INPUT`) — комбобокс с автокомплитом. Старый код (`skills.py:220-222`) слепо делал `fill(name)` + `press("Enter")` для каждого навыка подряд, без проверки, что предыдущий ввод действительно зафиксировался чипом. Живое воспроизведение из issue: `FastAPI` + `LangChain` слились в один чип `FastAPILangChain` вместо двух.

## Фикс

После каждого `fill+Enter` цикл теперь ждёт (до 5с, интервал 100мс — паттерн, уже применяемый в `resume_position.py` для похожего input-clear wait) позитивный сигнал:
- появился чип, чей текст **точно** совпадает с именем навыка (`chips.filter(has_text=re.compile(...))`);
- поле ввода снова пусто (`input_.input_value()`).

Важно: сигнал — точное совпадение текста, а не просто рост счётчика чипов. Склеенный чип `FastAPILangChain` тоже увеличивает count на 1, поэтому проверка по одному лишь количеству не поймала бы регресс.

При таймауте дальнейший ввод останавливается (без отката уже введённого — Enter мог уже уйти на сервер) и итоговое расхождение ловит уже существующая fail-closed проверка `Counter` после save (`uncertain`, `acted=True`).

## Тесты

- `test_edit_skills_waits_for_each_chip_before_next_addition` — позитивный кейс: два навыка подряд, каждый подтверждается отдельным `filter(has_text=...)` вызовом.
- `test_edit_skills_stops_input_after_chip_commit_timeout` — таймаут на первом навыке останавливает ввод второго, итог — `uncertain`.
- Обновлены существующие моки (`_mock_chip_locator`, 5 тестов с `dry_run=False`) под новую проверку — без этого они реально таймаутили по 5с на каждой итерации (не хэнг, но раздували сюиту).

## Живая проверка (запрошено в преамбуле issue)

Выполнено на черновике `Test Resume 787` (`a1d75539ff1106985b0039ed1f377079695358`, статус "черновик", разрешение на WRITE на черновиках получено явно). Код запускался через `PYTHONPATH=src python3 -m hhru_bot.cli` из этого worktree (не через переустановленный editable install, который в момент прогона указывал на другой параллельный worktree).

Последовательное добавление `FastAPI`, `Python`, `LangChain`, `RAG` (двумя прогонами по два навыка) дало на резюме **четыре раздельных чипа** — без единого случая склейки:

```
Навыки
Продвинутый уровень
FastAPI
Python
Средний уровень
LangChain
RAG
```

## Проверки перед пушем

- `ruff check src tests` — чисто
- `ruff format --check src tests` — чисто
- `pytest -n 4 --dist worksteal` — 372 теста зелёные, ~51с (бюджет 240с)
- `scripts/gen_cli_docs.py --check` — синхронизирован, правок не требовалось (существующая команда, не новая)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)