### PR TITLE
fix(edit-experience): пропускать disabled end-year при current=true (#800)

### DIFF
--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -2073,6 +2073,30 @@ selectors:
     last_verified_at: '2026-08-29'
     verified_flow: authenticated_experience_editor_write_confirmed (draft resume, zero existing entries)
     verified_by: human
+  resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX:
+    value: '[data-qa=''checkbox'']'
+    criticality: write
+    declared_at: src/hhru_bot/selector_groups/resume_experience.py:52
+    decision: documented_live
+    sources: {}
+    live_matches: []
+    active: true
+    coverage_status: intentionally_local
+    bindings: {}
+    status: intentionally local
+    origin: browser_dom
+    verification: browser_observed
+    evidence:
+      source: src/hhru_bot/selector_groups/resume_experience.py:52
+      note: 'Live read-only confirmed 2026-08-30 (#800): opened /resume/edit/{resume_id}/experience on a draft resume (same
+        page as #786/#787). The "Работаю сейчас" checkbox above the end-date fields is checked by default on a new entry;
+        while checked, resume-editor-experience-end-year-input and resume-editor-experience-end-month-input are disabled
+        (input.disabled / [aria-disabled="true"]). document.querySelectorAll("[data-qa=''checkbox'']") resolved to exactly
+        one match on this form. Toggling the checkbox off (read-only DOM probe, form not saved) re-enabled both end-date
+        controls, confirming the causal link.'
+    last_verified_at: '2026-08-30'
+    verified_flow: authenticated_experience_editor_read_only
+    verified_by: human
   resume_experience.FIRST_EXPERIENCE_COMPANY:
     value: '[data-qa=''resume-editor-experience-company-input'']'
     criticality: write

--- a/selectors/reference-matrix.md
+++ b/selectors/reference-matrix.md
@@ -96,6 +96,7 @@
 | resume_experience.EXPERIENCE_START_YEAR | `[data-qa='resume-editor-experience-start-year-input']` | — | — | — | live_dom |
 | resume_experience.FIRST_EXPERIENCE_CANCEL | `[data-qa='resume-partial-edit-cancel']` | — | — | — | live_dom |
 | resume_experience.FIRST_EXPERIENCE_COMPANY | `[data-qa='resume-editor-experience-company-input']` | — | — | — | live_dom |
+| resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX | `[data-qa='checkbox']` | — | — | — | documented_live |
 | resume_experience.FIRST_EXPERIENCE_POSITION | `[data-qa='resume-editor-experience-position-input']` | — | — | — | live_dom |
 | resume_experience.FIRST_EXPERIENCE_SAVE | `[data-qa='resume-partial-edit-save']` | — | — | — | live_dom |
 | resume_list.RESUME_DUPLICATE_INLINE | `[data-qa='resume-dublicate']` | — | — | — | live_dom |

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -37,6 +37,7 @@ from .selector_groups.resume_experience import (
     EXPERIENCE_START_YEAR,
     FIRST_EXPERIENCE_CANCEL,
     FIRST_EXPERIENCE_COMPANY,
+    FIRST_EXPERIENCE_CURRENT_CHECKBOX,
     FIRST_EXPERIENCE_POSITION,
     FIRST_EXPERIENCE_SAVE,
 )
@@ -332,8 +333,44 @@ def edit_experience_on_hh(
             _fill(page.locator(company_selector), entry.company)
             _fill(page.locator(position_selector), entry.position)
             _fill(page.locator(EXPERIENCE_START_YEAR), entry.start_year)
-            if page.locator(EXPERIENCE_END_YEAR).count() == 1:
-                _fill(page.locator(EXPERIENCE_END_YEAR), "" if entry.current else entry.end_year)
+            end_year_locator = page.locator(EXPERIENCE_END_YEAR)
+            if end_year_locator.count() == 1:
+                # #800: the end-year field is disabled while the "Работаю
+                # сейчас" checkbox is checked (checked by default on a new
+                # entry). Filling a disabled field just retries fill() until
+                # Playwright's timeout — check is_enabled() first rather than
+                # attempting the fill unconditionally.
+                end_year_enabled = end_year_locator.is_enabled()
+                if entry.current:
+                    if end_year_enabled:
+                        _fill(end_year_locator, "")
+                    # else: already disabled/blank — nothing to do.
+                elif end_year_enabled:
+                    _fill(end_year_locator, entry.end_year)
+                elif first_entry:
+                    # Checkbox selector is confirmed only on the first-row
+                    # editor's distinct DOM shape (#800) — uncheck it to
+                    # unlock the end-date fields before filling.
+                    checkbox = page.locator(FIRST_EXPERIENCE_CURRENT_CHECKBOX)
+                    if checkbox.count() != 1:
+                        return results + [
+                            ExperienceResult(
+                                f"строка {index}: чекбокс 'Работаю сейчас' "
+                                "не подтверждён однозначно"
+                            )
+                        ]
+                    checkbox.click()
+                    end_year_locator.wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
+                    _fill(end_year_locator, entry.end_year)
+                else:
+                    # Indexed row editor: no confirmed checkbox selector for
+                    # this DOM shape — fail closed rather than guess.
+                    return results + [
+                        ExperienceResult(
+                            f"строка {index}: поле окончания заблокировано, чекбокс "
+                            "'Работаю сейчас' для этой формы не подтверждён"
+                        )
+                    ]
             _fill(page.locator(EXPERIENCE_DESCRIPTION), entry.description())
             if entry.company_url and page.locator(EXPERIENCE_COMPANY_URL).count() == 1:
                 _fill(page.locator(EXPERIENCE_COMPANY_URL), entry.company_url)

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -360,7 +360,11 @@ def edit_experience_on_hh(
                             )
                         ]
                     checkbox.click()
-                    end_year_locator.wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
+                    # No wait_for(state=...) covers "enabled" specifically —
+                    # the field is already visible while disabled, so that
+                    # would be a no-op. fill()'s own actionability check
+                    # already waits for enabled (with its own timeout), so
+                    # nothing further is needed here.
                     _fill(end_year_locator, entry.end_year)
                 else:
                     # Indexed row editor: no confirmed checkbox selector for

--- a/src/hhru_bot/selector_groups/_generated.py
+++ b/src/hhru_bot/selector_groups/_generated.py
@@ -93,6 +93,7 @@ VALUES: dict[str, str] = {
     "resume_experience.EXPERIENCE_START_YEAR": "[data-qa='resume-editor-experience-start-year-input']",
     "resume_experience.FIRST_EXPERIENCE_CANCEL": "[data-qa='resume-partial-edit-cancel']",
     "resume_experience.FIRST_EXPERIENCE_COMPANY": "[data-qa='resume-editor-experience-company-input']",
+    "resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX": "[data-qa='checkbox']",
     "resume_experience.FIRST_EXPERIENCE_POSITION": "[data-qa='resume-editor-experience-position-input']",
     "resume_experience.FIRST_EXPERIENCE_SAVE": "[data-qa='resume-partial-edit-save']",
     "resume_list.RESUME_DUPLICATE_INLINE": "[data-qa='resume-dublicate']",

--- a/src/hhru_bot/selector_groups/resume_experience.py
+++ b/src/hhru_bot/selector_groups/resume_experience.py
@@ -41,3 +41,12 @@ FIRST_EXPERIENCE_COMPANY = _selector("resume_experience.FIRST_EXPERIENCE_COMPANY
 FIRST_EXPERIENCE_POSITION = _selector("resume_experience.FIRST_EXPERIENCE_POSITION")
 FIRST_EXPERIENCE_SAVE = _selector("resume_experience.FIRST_EXPERIENCE_SAVE")
 FIRST_EXPERIENCE_CANCEL = _selector("resume_experience.FIRST_EXPERIENCE_CANCEL")
+
+# #800: "Работаю сейчас" checkbox above the end-date fields (confirmed live
+# 2026-08-30 on /resume/edit/{resume_id}/experience, draft resume). Checked
+# by default on a new entry — while checked, the end-year/end-month controls
+# are disabled. The underlying magritte checkbox component's own data-qa
+# ("checkbox") is a generic, non-unique token; it was confirmed to resolve to
+# exactly one match on this form (count()==1), so it is used as-is rather
+# than scoped further.
+FIRST_EXPERIENCE_CURRENT_CHECKBOX = _selector("resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX")

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -74,8 +74,9 @@ def test_fill_plan_rejects_identity_or_count_changes():
 
 
 class _Locator:
-    def __init__(self, count=0):
+    def __init__(self, count=0, *, enabled=True):
         self._count = count
+        self._enabled = enabled
 
     def count(self):
         return self._count
@@ -94,6 +95,9 @@ class _Locator:
 
     def input_value(self):
         return ""
+
+    def is_enabled(self):
+        return self._enabled
 
 
 class _Page:
@@ -250,6 +254,75 @@ def test_edit_experience_existing_row_edit_does_not_require_count_growth(monkeyp
         dry_run=False,
     )
 
+    assert results == [ExperienceResult("строка 0: сохранено и привязано к резюме", True)]
+
+
+class _DisabledEndYearSavePage(_SavePage):
+    """#800: end-year is disabled by default (checkbox "Работаю сейчас"
+    checked) on a fresh first-entry form — the fixture that reproduces the
+    original timeout bug (fill() retried against a disabled field)."""
+
+    def __init__(self, *args, uncheck_enables=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._uncheck_enables = uncheck_enables
+        self.checkbox_clicked = False
+
+    def locator(self, selector):
+        if selector == "[data-qa='resume-editor-experience-end-year-input']":
+            enabled = self._uncheck_enables and self.checkbox_clicked
+            return _Locator(count=1, enabled=enabled)
+        if selector == "[data-qa='checkbox']":
+            page = self
+
+            class _CheckboxLocator(_Locator):
+                def click(self):
+                    page.checkbox_clicked = True
+
+            return _CheckboxLocator(count=1)
+        return super().locator(selector)
+
+
+def test_edit_experience_current_true_skips_disabled_end_year(monkeypatch):
+    """#800: entry.current=True on a form whose end-year is already disabled
+    (default state of a fresh entry) must not call fill() on it — that used
+    to retry until Playwright's 30s timeout."""
+    monkeypatch.setattr("hhru_bot.experience.open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr("hhru_bot.experience.goto_hh", _fake_goto_to_edit_path)
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, resume_id: True)
+    monkeypatch.setattr("hhru_bot.experience.require_authenticated_page", lambda page: None)
+
+    page = _DisabledEndYearSavePage(rows=0, grow_on_reload_by=1)
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan([ExperienceEntry(company="Acme", position="Engineer", current=True)]),
+        dry_run=False,
+    )
+
+    assert results == [ExperienceResult("строка 0: сохранено и привязано к резюме", True)]
+    assert page.checkbox_clicked is False
+
+
+def test_edit_experience_current_false_unchecks_checkbox_to_unlock_end_year(monkeypatch):
+    """#800: entry.current=False but the end-year field is still disabled
+    (checkbox defaults to checked on a new entry) — the checkbox must be
+    unchecked before filling end_year, not left blocking the field."""
+    monkeypatch.setattr("hhru_bot.experience.open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr("hhru_bot.experience.goto_hh", _fake_goto_to_edit_path)
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, resume_id: True)
+    monkeypatch.setattr("hhru_bot.experience.require_authenticated_page", lambda page: None)
+
+    page = _DisabledEndYearSavePage(rows=0, grow_on_reload_by=1, uncheck_enables=True)
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan(
+            [ExperienceEntry(company="Acme", position="Engineer", current=False, end_year="2024")]
+        ),
+        dry_run=False,
+    )
+
+    assert page.checkbox_clicked is True
     assert results == [ExperienceResult("строка 0: сохранено и привязано к резюме", True)]
 
 

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -172,7 +172,10 @@ def test_every_selector_has_canonical_coverage_and_all_groups_are_audited():
     # #792: +1 competitor_resume.DETAIL_TITLE_POSITION (desired-role h1 fix).
     # #786/#787: +4 resume_experience.FIRST_EXPERIENCE_* contracts (first-row
     # editor at /resume/edit/{id}/experience, live write-confirmed).
-    assert len(catalog["selectors"]) == 247
+    # #800: +1 resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX ("Работаю
+    # сейчас" checkbox that gates the disabled end-date fields, confirmed
+    # live read-only on the same first-row editor).
+    assert len(catalog["selectors"]) == 248
     assert all(
         row.get("coverage_status") in contracts.AUDIT_STATUSES
         for row in catalog["selectors"].values()
@@ -1006,7 +1009,7 @@ def test_refresh_dry_run_reports_baseline_and_never_writes(monkeypatch, capsys, 
     output = capsys.readouterr().out
     assert "DRY-RUN" in output
     assert "no files, branches, or PRs were written" in output
-    assert "local selector contracts: 247" in output
+    assert "local selector contracts: 248" in output
     assert "Semantic mismatches:" in output
 
 


### PR DESCRIPTION
## Проблема

`edit-experience --entry '...,"current":true,...'` падал по таймауту на резюме без опыта работы (первая запись, resume-scoped route из #797):

```
[FAIL] <resume_id> — строка 0: Locator.fill: Timeout 30000ms exceeded.
  - waiting for locator("[data-qa='resume-editor-experience-end-year-input']")
    - locator resolved to <input disabled value="" .../>
    - fill("")
    ... - element is not enabled
```

Живой DOM (`/resume/edit/{resume_id}/experience`) показывает чекбокс **"Работаю сейчас"**, отмеченный по умолчанию на новой записи — пока он отмечен, поле "Год" в блоке "Окончание" disabled. Код в `experience.py:335-336` безусловно вызывал `.fill()` на этом поле.

## Фикс

- Проверяем `is_enabled()` перед `.fill()` на end-year.
- `entry.current=True` на disabled поле → пропускаем (поле уже в нужном состоянии, ничего делать не нужно).
- `entry.current=False` на disabled поле → снимаем чекбокс "Работаю сейчас" (селектор `FIRST_EXPERIENCE_CURRENT_CHECKBOX`, подтверждён только для first-entry формы) и ждём разблокировки перед заполнением.
- Индексный редактор существующих строк (`not first_entry`) не имеет подтверждённого селектора чекбокса на этом DOM-шейпе — fail-closed вместо угадывания (сообщает `[FAIL]`, не пытается кликнуть непроверенный элемент).

## Селектор

`resume_experience.FIRST_EXPERIENCE_CURRENT_CHECKBOX` = `[data-qa='checkbox']` — подтверждён live read-only 2026-08-30: единственный матч на форме first-entry, снятие чекбокса разблокирует `end-year`/`end-month`. Добавлен в `selectors/reference-map.yaml` (`decision: documented_live`) и сгенерирован в `_generated.py`/`reference-matrix.md` через `scripts/selector_contracts.py` (`check` проходит, 248 контрактов).

## Тестирование

- 2 новых юнит-теста (`test_edit_experience_current_true_skips_disabled_end_year`, `test_edit_experience_current_false_unchecks_checkbox_to_unlock_end_year`) + существующие 14 в `tests/test_experience.py` — все зелёные.
- `ruff check` / `ruff format --check` — чисто.
- Полный `pytest` (кроме двух предсуществующих flaky тестов под конкурентной нагрузкой параллельных воркеров на машине — `test_concurrent_process_rollovers_allocate_distinct_archives`, `test_stdout_streams_progress_line_by_line_before_process_completes` — оба проходят изолированно, не касаются изменённых файлов).
- **Живой прогон** на черновике "Test Resume 800 QA" (создан для проверки, разрешение пользователя на WRITE только на черновиках): `edit-experience --entry '{"current":true,...}'` больше не падает на disabled-поле — доходит до клика Save (первоначальный дефект #800 устранён). Финальный клик Save дал `uncertain` по независящей от фикса причине — известное поведение hh.ru навигации после submit (см. CLAUDE.md #179/#207, `wait_for_url` может таймаутить даже при успешном клике). Форма с тем же disabled/checkbox-состоянием заполнена и сохранена вручную для контроля — сохранение прошло, опыт появился на резюме, поведение чекбокса подтверждено на живом DOM.

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)