### PR TITLE
fix(edit-education): wait for education card hydration before strict count()

### DIFF
--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from .browser import (
     HH_BASE_URL,
@@ -228,6 +229,25 @@ def _edit_block(
     saved_count = 0
     if not records:
         return EducationResult(kind, True, "нет записей для изменения")
+    # #812: goto_hh only guarantees URL commit, not rendered DOM (CLAUDE.md,
+    # "commit не значит отрисовано") -- the resume page hydrates the
+    # education card asynchronously, and a strict count() right after goto_hh
+    # can race it and see 0 even though the card renders moments later. The
+    # "Уровень образования" field always exists on hh.ru (unlike about/skills,
+    # this section is never legitimately absent), so exactly one of the two
+    # possible markers -- the first row's edit trigger (records already
+    # present) or the confirmed Add link (section empty) -- must eventually
+    # appear; wait for either before the first strict check below.
+    try:
+        page.locator(trigger.format(index=0)).or_(page.locator(add_selector)).first.wait_for(
+            state="visible", timeout=FORM_TIMEOUT_MS
+        )
+    except PlaywrightTimeoutError as exc:
+        return EducationResult(
+            kind,
+            False,
+            f"блок образования не отобразился за {FORM_TIMEOUT_MS}мс: {exc}",
+        )
     for index, record in enumerate(records):
         button = page.locator(trigger.format(index=index))
         button_count = button.count()

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -40,6 +40,16 @@ class FakeFieldLocator:
     def fill(self, value):  # noqa: ARG002
         pass
 
+    def or_(self, other):  # noqa: ARG002
+        return self
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        pass
+
 
 class FakeTrigger:
     def __init__(self, count):
@@ -47,6 +57,16 @@ class FakeTrigger:
 
     def count(self):
         return self._count
+
+    def or_(self, other):  # noqa: ARG002
+        return self
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        pass
 
 
 class FakePage:

--- a/tests/test_resume_education_form_shapes.py
+++ b/tests/test_resume_education_form_shapes.py
@@ -42,6 +42,12 @@ class RecordingLocator:
     def click(self):
         self._page.clicked.append(self._selector)
 
+    def or_(self, other):  # noqa: ARG002
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        pass
+
 
 class LabelPage:
     """Fake page that only resolves fields the live additional form exposes.

--- a/tests/test_resume_education_hydration_wait.py
+++ b/tests/test_resume_education_hydration_wait.py
@@ -1,0 +1,159 @@
+"""Regression test for #812: _edit_block must wait for the education card to
+hydrate before its first strict count() check.
+
+``goto_hh`` only guarantees the URL committed, not that the resume page's
+React SPA has rendered the education card yet (CLAUDE.md: "commit не значит
+отрисовано"). Before this fix, _edit_block went straight to
+``page.locator(trigger).count()`` / ``page.locator(add_selector).count()``
+right after navigation, so a slow hydration made a correct card look
+"selector not confirmed" -- a live-observed flaky failure (issue #812),
+not a real selector drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from hhru_bot import resume_education
+from hhru_bot.config_sections.education import EducationRecord
+from hhru_bot.resume_education import _edit_block
+
+pytestmark = pytest.mark.unit
+
+
+class _OrWrapper:
+    """Models Locator.or_(...).first.wait_for(...) for two underlying fakes."""
+
+    def __init__(self, primary, fallback):
+        self._primary = primary
+        self._fallback = fallback
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        # Mirrors real Playwright semantics closely enough for this test:
+        # polls both sides a bounded number of times (simulating hydration
+        # completing a couple of reads in) and times out only if neither ever
+        # reports count() >= 1 -- the exact race the fix addresses.
+        for _ in range(5):
+            if self._primary.count() >= 1 or self._fallback.count() >= 1:
+                return
+        raise PlaywrightTimeoutError("Timeout waiting for locator")
+
+
+class _HydratingLocator:
+    """A locator whose count() only becomes truthy after N reads.
+
+    Simulates the education card rendering asynchronously after goto_hh
+    commits: the first few reads see an empty DOM, then hydration completes.
+    """
+
+    def __init__(self, ready_after: int, value_when_ready: int = 1):
+        self._reads = 0
+        self._ready_after = ready_after
+        self._value_when_ready = value_when_ready
+
+    def count(self):
+        self._reads += 1
+        return self._value_when_ready if self._reads > self._ready_after else 0
+
+    def or_(self, other):
+        return _OrWrapper(self, other)
+
+    @property
+    def first(self):
+        return self
+
+    def fill(self, value):  # noqa: ARG002
+        pass
+
+    def click(self):
+        pass
+
+
+class _NeverReadyLocator(_HydratingLocator):
+    def __init__(self):
+        super().__init__(ready_after=10_000)
+
+
+class _RacyPage:
+    """Fake page: PRIMARY_ADD hydrates after one throwaway read, trigger-0
+    never appears (mirrors #812's confirmed live scenario -- empty education
+    section, only the Add link is the real marker)."""
+
+    def __init__(self):
+        self.url = "https://hh.ru/resume/RID"
+        self._trigger = _NeverReadyLocator()
+        self._add = _HydratingLocator(ready_after=1)
+
+    def locator(self, selector: str):
+        if selector.startswith("[data-qa='resume-edit-button-"):
+            return self._trigger
+        if selector == resume_education.PRIMARY_ADD:
+            return self._add
+        return _HydratingLocator(ready_after=0)
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        pass
+
+
+def test_race_resolves_once_add_link_hydrates(monkeypatch):
+    """The pre-fix code read count() exactly once right after goto_hh and
+    would see 0 on both trigger and add link -- reporting the false
+    "confirmed Add link not found" failure from #812. The fix's explicit
+    wait_for(state="visible") must let the race resolve instead."""
+    page = _RacyPage()
+    opened: dict = {}
+
+    def fake_open_hydrated_resume_editor(page_arg, **kwargs):  # noqa: ARG001
+        opened["trigger_selector"] = kwargs.get("trigger_selector")
+        return page.locator(kwargs.get("editor_selector", "x"))
+
+    monkeypatch.setattr(
+        resume_education, "open_hydrated_resume_editor", fake_open_hydrated_resume_editor
+    )
+
+    records = [
+        EducationRecord(
+            institution="МГУ", level="", faculty="", organization="", specialty="", year="2015"
+        ),
+    ]
+
+    result = _edit_block(page, records, additional=False, dry_run=True, resume_id="RID")
+
+    assert result.success is True
+    assert opened["trigger_selector"] == resume_education.PRIMARY_ADD
+
+
+def test_wait_timeout_reports_failure_without_raising(monkeypatch):
+    """If the card genuinely never hydrates (or a selector really drifted),
+    the wait must time out into a normal EducationResult failure -- never an
+    unhandled exception, keeping the fail-closed contract from #368."""
+
+    class _StuckPage:
+        def __init__(self):
+            self.url = "https://hh.ru/resume/RID"
+
+        def locator(self, selector: str):  # noqa: ARG002
+            return _NeverReadyLocator()
+
+    monkeypatch.setattr(
+        resume_education,
+        "open_hydrated_resume_editor",
+        lambda *a, **k: pytest.fail("must not open the editor when the card never hydrates"),
+    )
+
+    records = [
+        EducationRecord(
+            institution="МГУ", level="", faculty="", organization="", specialty="", year="2015"
+        ),
+    ]
+
+    result = _edit_block(_StuckPage(), records, additional=False, dry_run=True, resume_id="RID")
+
+    assert result.success is False
+    assert result.uncertain is False
+    assert "не отобразился" in result.reason


### PR DESCRIPTION
## Что чинит

`edit_education_on_hh` шла напрямую от `goto_hh` к строгой проверке
`page.locator(...).count()` для триггера строки/подтверждённой ссылки
«Добавить». `goto_hh` гарантирует только commit URL, не готовность React-SPA
(CLAUDE.md, «commit не значит отрисовано») — асинхронная гидратация карточки
образования могла race'иться со строгой проверкой, и корректный селектор
выглядел как «не подтверждён» (живой симптом #812: два подряд запуска на
одном и том же resume_id/аргументах дали ДВЕ РАЗНЫЕ ошибки).

## Фикс

Перед первой строгой проверкой в `_edit_block` добавлен явный
`page.locator(trigger-0).or_(page.locator(add_selector)).first.wait_for(state="visible", timeout=FORM_TIMEOUT_MS)`
— тот же inline-паттерн, что уже применён в `resume_position.py` / `skills.py`
/ `about.py` / `apply/steps.py`. Общего хелпера в `browser.py` намеренно нет
(CLAUDE.md фиксирует это как принятое решение проекта — таймауты и обоснование
разные для каждого места).

Ждём ЛЮБОЙ из двух возможных маркеров (`.or_`), потому что «Уровень
образования» на резюме hh.ru гарантированно есть всегда (в отличие от
about/skills, где секция может легитимно отсутствовать) — значит либо триггер
строки 0 (запись уже есть), либо подтверждённая ссылка «Добавить» (секция
пуста) точно появится.

## П.2 issue: `ready_selector` в `goto_hh` — решил НЕ передавать

`goto_hh(page, resume_url, ready_selector=...)` не подходит здесь, потому что
маркер готовности зависит от исхода (триггер vs Add-ссылка) и от секции
(`primary`/`additional`), а `goto_hh` вызывается один раз для всей страницы
резюме без контекста конкретной секции. Только `_edit_block` знает, какой
селектор актуален для запрошенной секции — поэтому ожидание живёт там же, где
и вся остальная логика этой секции, по тому же паттерну, что about.py/skills.py
уже используют (they also skip `ready_selector` and wait explicitly after
`goto_hh`).

## Тесты

`tests/test_resume_education_hydration_wait.py` — новый файл:
- `test_race_resolves_once_add_link_hydrates`: фейковый локатор, чей
  `count()` становится truthy только после N чтений, напрямую моделирует
  гонку из #812 — без фикса это возвращало бы ложный отказ на первом же чтении.
- `test_wait_timeout_reports_failure_without_raising`: если карточка
  ДЕЙСТВИТЕЛЬНО никогда не гидратируется (реальный дрейф селектора), таймаут
  обязан вернуться как обычный `EducationResult(success=False)`, а не
  необработанное исключение — сохраняет fail-closed контракт #368.

Существующие фейки (`FakeTrigger`/`FakeFieldLocator` в
`test_resume_education_edit_block.py`, `RecordingLocator` в
`test_resume_education_form_shapes.py`) дополнены `or_()`/`first`/`wait_for()`
под новую поверхность вызовов.

## Живая проверка (2026-08-30, несколько прогонов подряд)

Черновик из issue (`e55a5767ff1106cd650039ed1f4c576d547134`) на момент
верификации в `list-resumes` уже отсутствовал (видимо удалён между
написанием issue и работой над фиксом) — использовал два других черновика.

**Черновик `24b16b4aff1106ca100039ed1f726766334230`** (уже содержит запись
primary-образования):
- 4 подряд `--dry-run` прогона: все `[OK]`, без гонки.

**Свежесозданный пустой черновик `9e2ee76eff1106f0b10039ed1f78633556304a`**
(специально создан для проверки именно Add-link ветки — пустая секция, как
в исходном сценарии issue):
- 5+ подряд `--dry-run` прогонов после первого боевого save: все `[OK]`.
- Один боевой `--force` save: клик Save прошёл, последующий `--dry-run`
  подтвердил, что запись реально сохранилась на hh.ru.
- Повторный `--force` на уже непустой секции упёрся в **отдельную**,
  не связанную с гидратацией проблему (см. ниже) и корректно вернул
  `[FAIL] (uncertain)` вместо падения с трассировкой — fail-closed контракт
  не нарушен.

## Побочная находка: заведён #814 (route-guard баг, НЕ в scope этого PR)

Во время живой проверки обнаружено, что `PRIMARY_ROUTE` (введён PR #794 для
issue #788) матчит только `/profile/edit/primaryEducation` БЕЗ id-хвоста —
но когда primary-запись уже существует, клик по триггеру строки открывает
`/profile/edit/primaryEducation/{entry_id}?resumeFrom=...` — С id-хвостом,
который текущий regex отвергает как "форма открыта не для того резюме".
PR #794 тестировал только пустую секцию (Add-link); непустая секция на живом
DOM проверена не была. Это отдельный, предсуществующий баг — не трогаю его
здесь, чтобы не расширять scope; см. #814 для деталей и фикса.

## Проверки перед пушем

- `ruff check .` — чисто
- `ruff format --check .` — чисто
- `pytest -q -n 4 --dist worksteal` — полный сьют зелёный
- `scripts/gen_cli_docs.py --check` — README синхронизирован

Closes #812