### PR TITLE
fix(edit-skills): исправить false-negative пост-save проверку навыков (#813)

### DIFF
--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -3168,6 +3168,34 @@ selectors:
     last_verified_at: '2026-08-25'
     verified_flow: authenticated_resume_editor_read_only
     verified_by: codex
+  resume_page.RESUME_SKILLS_DISPLAY_TAG:
+    value: '[data-qa=''skills-card''] [data-qa^=''skill-tag-'']'
+    criticality: write
+    declared_at: src/hhru_bot/selector_groups/resume_page.py:53
+    decision: live_dom
+    sources: {}
+    live_matches:
+    - skills-card
+    - skill-tag-1114
+    - skill-tag-8941557
+    - skill-tag-21160118
+    - skill-tag-21827124
+    active: true
+    coverage_status: intentionally_local
+    bindings: {}
+    status: intentionally local
+    origin: browser_dom
+    verification: browser_observed
+    evidence:
+      source: src/hhru_bot/selector_groups/resume_page.py:53
+      note: 'Issue #813: RESUME_SKILLS_CHIP (chips-trigger-chip-*) is the keySkills editor''s own combobox widget and does
+        not exist on the resume card once the editor closes after save, so the post-save verification always observed zero
+        chips there regardless of what actually saved. Confirmed live 2026-08-30 (read-only Playwright DOM dump, authenticated
+        session) on resume 9bb2b4d2ff10f96f1d0039ed1f323968737936: saved skills render as Magritte tags data-qa=''skill-tag-{id}''
+        grouped under data-qa=''skills-card'', independent of the editor''s chip markup.'
+    last_verified_at: '2026-08-30'
+    verified_flow: authenticated_resume_card_read_only
+    verified_by: claude
   resume_page.RESUME_SKILLS_EDIT_BUTTON:
     value: '[data-qa=''skills-add'']'
     criticality: write

--- a/selectors/reference-matrix.md
+++ b/selectors/reference-matrix.md
@@ -144,6 +144,7 @@
 | resume_page.RESUME_PUBLISH_BUTTON_DATA_QA | `[data-qa='resume-publish']` | — | — | — | unavailable |
 | resume_page.RESUME_SKILLS_CHIP | `[data-qa^='chips-trigger-chip-']` | — | — | — | live_dom |
 | resume_page.RESUME_SKILLS_CHIP_INPUT | `[data-qa='chips-trigger-input']` | — | — | — | live_dom |
+| resume_page.RESUME_SKILLS_DISPLAY_TAG | `[data-qa='skills-card'] [data-qa^='skill-tag-']` | — | — | — | live_dom |
 | resume_page.RESUME_SKILLS_EDIT_BUTTON | `[data-qa='skills-add']` | — | — | — | live_dom |
 | resume_page.RESUME_SKILLS_INPUT | `[data-qa='resume-editor-skills-input']` | — | — | — | live_dom |
 | resume_page.RESUME_SKILLS_RECOMMENDED | `[data-qa^='resume-editor-skills-recommended-']` | — | — | — | live_dom |

--- a/src/hhru_bot/commands/edit_skills.py
+++ b/src/hhru_bot/commands/edit_skills.py
@@ -90,6 +90,7 @@ def register(subparsers) -> None:
 def _run(args: argparse.Namespace, progress) -> bool:
     from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
+    from ..history import History
     from ..skills import (
         build_skills_prompt,
         edit_skills_on_hh,
@@ -179,13 +180,39 @@ def _run(args: argparse.Namespace, progress) -> bool:
         # (CLAUDE.md #163/#176, #465 review round 3): the click may already
         # have reached hh.ru, so this is not a definite failure.
         if not args.dry_run:
-            progress.finish(result)
+            status = progress.finish(result)
+            # #813: record_action was missing entirely for this command — an
+            # uncertain outcome here (a real click that could not be
+            # confirmed) never reached the actions table, so it was invisible
+            # to `uncertain list`/`stats` and could not be blocked or
+            # reconciled via has_unresolved_uncertain either (CLAUDE.md
+            # "попытка засчитывается ровно один раз, в ровно одном месте").
+            # Only the acted branch writes a row, matching edit_experience.py:
+            # a pre-click failure (form/session not found) leaves no trace on
+            # hh.ru and stays a plain retryable [FAIL], never uncertain.
+            if result.acted:
+                History(args.history).record_action(
+                    resume.resume_id,
+                    resume.resume_id,
+                    "edit_skills",
+                    status,
+                    result.reason,
+                    run_id=progress.run_id,
+                )
         prefix = "[FAIL] (uncertain)" if result.acted else "[FAIL]"
         print(f"{prefix} {resume.id} — {result.reason}")
         return True
     _print_success(resume.id, result, dry_run=args.dry_run)
     if not args.dry_run:
-        progress.finish(result)
+        status = progress.finish(result)
+        History(args.history).record_action(
+            resume.resume_id,
+            resume.resume_id,
+            "edit_skills",
+            status,
+            "; ".join(result.added) or "без изменений",
+            run_id=progress.run_id,
+        )
     return False
 
 

--- a/src/hhru_bot/selector_groups/_generated.py
+++ b/src/hhru_bot/selector_groups/_generated.py
@@ -141,6 +141,7 @@ VALUES: dict[str, str] = {
     "resume_page.RESUME_POSITION_DROPDOWN": "[data-qa='drop-base']",
     "resume_page.RESUME_SKILLS_CHIP": "[data-qa^='chips-trigger-chip-']",
     "resume_page.RESUME_SKILLS_CHIP_INPUT": "[data-qa='chips-trigger-input']",
+    "resume_page.RESUME_SKILLS_DISPLAY_TAG": "[data-qa='skills-card'] [data-qa^='skill-tag-']",
     "resume_page.RESUME_SKILLS_EDIT_BUTTON": "[data-qa='skills-add']",
     "resume_page.RESUME_SKILLS_INPUT": "[data-qa='resume-editor-skills-input']",
     "resume_page.RESUME_SKILLS_RECOMMENDED": "[data-qa^='resume-editor-skills-recommended-']",

--- a/src/hhru_bot/selector_groups/resume_page.py
+++ b/src/hhru_bot/selector_groups/resume_page.py
@@ -37,7 +37,36 @@ RESUME_SKILLS_EDIT_BUTTON = _selector("resume_page.RESUME_SKILLS_EDIT_BUTTON")
 RESUME_SKILLS_INPUT = _selector("resume_page.RESUME_SKILLS_INPUT")
 RESUME_SKILLS_CHIP_INPUT = _selector("resume_page.RESUME_SKILLS_CHIP_INPUT")
 RESUME_SKILLS_RECOMMENDED = _selector("resume_page.RESUME_SKILLS_RECOMMENDED")
+# RESUME_SKILLS_CHIP (`chips-trigger-chip-*`) is the combobox widget's own chip
+# markup, mounted only inside the keySkills editor. It is the right selector
+# while the editor is open (dry-run cancel path, mid-edit reads), but it does
+# not exist on the resume card the page returns to after save closes the
+# editor (#813) — reading it there always observes zero chips regardless of
+# what actually saved, a selector-scope bug rather than a render race.
 RESUME_SKILLS_CHIP = _selector("resume_page.RESUME_SKILLS_CHIP")
+# The published resume card renders each saved skill as a Magritte tag with
+# `data-qa='skill-tag-{id}'`, grouped under `data-qa='skills-card'` — confirmed
+# live 2026-08-30 (issue #813) via a Playwright DOM dump of a resume with
+# saved skills (`skill-tag-1114` etc.), independent of the editor's own
+# `chips-trigger-chip-*` markup above. This is the only selector that reflects
+# what actually landed on hh.ru after the editor closes.
+RESUME_SKILLS_DISPLAY_TAG = _selector("resume_page.RESUME_SKILLS_DISPLAY_TAG")
+# Saving the keySkills editor with at least one skill that has no confirmed
+# level (a brand-new skill, or an existing skill hh.ru could not carry a level
+# for) does not return to the resume card directly — it navigates to a second
+# wizard step, `/resume/edit/{id}/skillsLevels?fromBlock=keySkills`, with one
+# radio group per pending skill (confirmed live 2026-08-30, issue #813). Each
+# radio's `name` attribute is the skill name immediately followed by the
+# Russian level label with no separator (e.g. `name="SeleniumСредний"`); the
+# level cards render no `data-qa` of their own, and skill names can contain
+# arbitrary characters, so the selector below is a raw `name=` attribute
+# selector built by the caller per (skill, level), not a template constant
+# here. This step reuses RESUME_PARTIAL_EDIT_SAVE for its own Save button.
+# Skipping this step (as the pre-#813 code did) leaves the skill saved with no
+# level ("Уровень не указан") and the editor stuck here, which is why the
+# post-save chip/tag read observed zero: the skill never reached the resume
+# card at all.
+RESUME_SKILLS_LEVEL_RADIO_TEMPLATE = "input[name='{skill_and_level}']"
 RESUME_PARTIAL_EDIT_CANCEL = _selector("resume_page.RESUME_PARTIAL_EDIT_CANCEL")
 RESUME_PARTIAL_EDIT_SAVE = _selector("resume_page.RESUME_PARTIAL_EDIT_SAVE")
 

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -228,6 +228,11 @@ def _confirm_skill_levels(page: Page, additions: tuple[Skill, ...]) -> str | Non
             # (e.g. a name hh.ru folded into an existing skill) — skip rather
             # than fail-closed on a single missing one; the final Counter
             # check downstream still catches a skill that never landed.
+            # #820: that Counter check only compares chip NAMES, not levels —
+            # a skill that lands on the resume without a level because its
+            # radio was missing here still reports [OK]. Narrowing this skip
+            # is not the fix; #820 tracks reading the level back off the
+            # resume card and comparing it too.
             continue
         try:
             radio.click(force=True, timeout=SKILLS_LEVELS_STEP_TIMEOUT_MS)

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -28,6 +28,13 @@ logger = logging.getLogger("hhru_bot.skills")
 
 LEVELS = frozenset(("basic", "intermediate", "advanced"))
 EDITOR_MOUNT_TIMEOUT_MS = 30_000
+# #813: the Russian labels hh.ru's skillsLevels wizard step uses as the tail
+# half of each level radio's `name` attribute (confirmed live 2026-08-30,
+# `input[name='SeleniumСредний']` etc.). This is UI text, not a data-qa value,
+# so it is kept local to this module rather than in selector_groups/ — it is
+# not a CSS selector fragment, just a string this module concatenates into one.
+_LEVEL_LABELS = {"basic": "Базовый", "intermediate": "Средний", "advanced": "Продвинутый"}
+SKILLS_LEVELS_STEP_TIMEOUT_MS = 15_000
 # #801: the skill chip input is an autocomplete combobox. A blind fill+Enter
 # for the next skill can race the browser's handling of the previous one and
 # concatenate two skill names into a single chip instead of creating two
@@ -131,6 +138,15 @@ def build_skills_prompt(
 
 
 def read_skills(page: Page) -> tuple[str, ...]:
+    """Read the chips inside the still-open keySkills editor (form scope only).
+
+    ``RESUME_SKILLS_CHIP`` (``chips-trigger-chip-*``) is the combobox widget's
+    own markup and only exists while the editor is mounted. Do not use this
+    for a post-save check: saving closes the editor and returns the page to
+    the resume card, where this selector always observes zero chips
+    regardless of what actually saved (#813). Use ``read_display_skills`` for
+    that.
+    """
     chips = page.locator(resume_page.RESUME_SKILLS_CHIP)
     count = chips.count()
     if count == 0:
@@ -138,6 +154,26 @@ def read_skills(page: Page) -> tuple[str, ...]:
     values = []
     for i in range(count):
         value = chips.nth(i).inner_text().strip()
+        if value:
+            values.append(value)
+    return tuple(values)
+
+
+def read_display_skills(page: Page) -> tuple[str, ...]:
+    """Read the saved skill tags from the resume card (post-editor, #813).
+
+    ``RESUME_SKILLS_DISPLAY_TAG`` targets the Magritte tags hh.ru renders on
+    the resume itself, independent of the editor's own chip widget. This is
+    the only selector that reflects what actually landed on hh.ru once the
+    editor has closed.
+    """
+    tags = page.locator(resume_page.RESUME_SKILLS_DISPLAY_TAG)
+    count = tags.count()
+    if count == 0:
+        return ()
+    values = []
+    for i in range(count):
+        value = tags.nth(i).inner_text().strip()
         if value:
             values.append(value)
     return tuple(values)
@@ -154,6 +190,60 @@ def _skill_key(name: str) -> str:
     preserved in the success report; this key is only for equality comparison.
     """
     return " ".join(name.split()).casefold()
+
+
+def _confirm_skill_levels(page: Page, additions: tuple[Skill, ...]) -> str | None:
+    """Confirm the levels wizard step hh.ru inserts after saving new skills.
+
+    Saving the keySkills editor with at least one skill lacking a confirmed
+    level does not return to the resume card directly: hh.ru navigates to a
+    second step, ``/resume/edit/{id}/skillsLevels?fromBlock=keySkills``, with
+    one radio group per pending skill (#813, confirmed live 2026-08-30). Not
+    every ``additions`` name is guaranteed to appear there — a duplicate
+    already-known-elsewhere skill can be silently absorbed — so each radio
+    click is best-effort and a missing one is not itself a failure; the
+    caller's post-save Counter check is what stays fail-closed on the result.
+
+    Returns an error string on an unrecoverable problem (radio not found
+    uniquely, second save not found/click failed), or ``None`` if this step
+    was not present (first save returned straight to the resume card) or was
+    handled.
+    """
+    edit_path_prefix = "/resume/edit/"
+    if not urlsplit(page.url).path.rstrip("/").endswith("/skillsLevels"):
+        return None
+    if not urlsplit(page.url).path.startswith(edit_path_prefix):
+        return None
+    for skill in additions:
+        label = _LEVEL_LABELS.get(skill.level)
+        if label is None:
+            continue
+        radio = page.locator(
+            resume_page.RESUME_SKILLS_LEVEL_RADIO_TEMPLATE.format(
+                skill_and_level=f"{skill.name}{label}"
+            )
+        )
+        if radio.count() != 1:
+            # Not every addition necessarily gets its own radio group here
+            # (e.g. a name hh.ru folded into an existing skill) — skip rather
+            # than fail-closed on a single missing one; the final Counter
+            # check downstream still catches a skill that never landed.
+            continue
+        try:
+            radio.click(force=True, timeout=SKILLS_LEVELS_STEP_TIMEOUT_MS)
+        except PlaywrightError as exc:
+            return (
+                f"выбор уровня навыка {skill.name!r} на экране skillsLevels не подтверждён: {exc}"
+            )
+    save = page.locator(resume_page.RESUME_PARTIAL_EDIT_SAVE)
+    if save.count() != 1:
+        return "кнопка сохранения уровней навыков не найдена однозначно"
+    try:
+        save.click()
+        save.wait_for(state="hidden", timeout=SKILLS_LEVELS_STEP_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        return f"сохранение уровней навыков не подтверждено: {exc}"
+    return None
 
 
 def edit_skills_on_hh(
@@ -276,22 +366,46 @@ def edit_skills_on_hh(
             reason=f"сохранение навыков не подтверждено: {exc}",
             acted=True,
         )
+    # #813: a skill with no previously-confirmed level (any brand-new addition)
+    # routes through a second wizard step instead of returning to the resume
+    # card directly. Without handling it, the skill saves with no level at all
+    # ("Уровень не указан") and the editor never reaches the resume card, so
+    # the post-save Counter check below correctly — not falsely — observed a
+    # mismatch: the click already reached hh.ru (acted=True), so this is
+    # uncertain, not a plain failure.
+    levels_error = _confirm_skill_levels(page, additions)
+    if levels_error is not None:
+        return SkillsResult(
+            False,
+            existing,
+            skills,
+            tuple(s.name for s in additions),
+            reason=levels_error,
+            acted=True,
+        )
     # editor.wait_for(state="hidden") only confirms the overlay closed, not that
     # the underlying resume page has re-rendered the chip list (CLAUDE.md: "commit
-    # не значит отрисовано"). Give the chip count a short window to settle before
+    # не значит отрисовано"). Give the tag count a short window to settle before
     # the strict read below, matching the wait_for(state="visible") pattern used
     # after other mutating clicks (resume_position.py, bump.py, etc.) — a mismatch
     # is still fail-closed after the wait, this only avoids racing the re-render.
+    #
+    # #813: the wait (and the read below) target RESUME_SKILLS_DISPLAY_TAG, the
+    # resume card's own markup, NOT RESUME_SKILLS_CHIP — that selector is the
+    # editor's own combobox widget and no longer exists once the editor has
+    # closed, so waiting on it/reading it here always observed zero regardless
+    # of what actually saved (a selector-scope bug, not a render race: the
+    # wait above already gave the DOM time to settle, and it still read 0).
     expected_chip_count = len(existing) + len(additions)
     if expected_chip_count > 0:
         try:
-            page.locator(resume_page.RESUME_SKILLS_CHIP).nth(expected_chip_count - 1).wait_for(
-                state="visible", timeout=5_000
-            )
+            page.locator(resume_page.RESUME_SKILLS_DISPLAY_TAG).nth(
+                expected_chip_count - 1
+            ).wait_for(state="visible", timeout=5_000)
         except PlaywrightError:
             pass
     try:
-        observed = read_skills(page)
+        observed = read_display_skills(page)
     except PlaywrightError as exc:
         return SkillsResult(
             False,

--- a/tests/test_edit_skills_command.py
+++ b/tests/test_edit_skills_command.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 import hhru_bot.commands.edit_skills as command
+from hhru_bot.history import History
 from hhru_bot.skills import Skill, SkillsResult
 
 pytestmark = pytest.mark.unit
@@ -178,3 +179,105 @@ def test_ai_planning_rejects_wrong_resume_route_before_read_or_llm(monkeypatch, 
     # validation error itself is unchanged, only how the command reports it.
     assert command.run(args) is True
     assert "страница нужного резюме не подтверждена" in capsys.readouterr().out
+
+
+def _run_args(tmp_path, *, dry_run: bool, force: bool = True) -> argparse.Namespace:
+    return argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="requested",
+        mode="append",
+        skill=["Docker=intermediate"],
+        dry_run=dry_run,
+        force=force,
+        history=str(tmp_path / "history.db"),
+    )
+
+
+def _stub_common(monkeypatch, resume) -> None:
+    config = SimpleNamespace(ai=None, storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_args: resume)
+    monkeypatch.setattr("hhru_bot.browser.launch_context", _launch_context)
+
+
+def test_uncertain_result_is_recorded_in_actions(monkeypatch, tmp_path):
+    """#813: an acted-but-unconfirmed save must land in the actions table —
+    previously edit-skills never called record_action at all, so `uncertain`
+    was invisible to `uncertain list`/`stats` and has_unresolved_uncertain
+    could never see (or block a retry on) it either."""
+    resume = SimpleNamespace(id="requested", resume_id="requested-id")
+    _stub_common(monkeypatch, resume)
+    result = SkillsResult(
+        success=False,
+        existing=(),
+        proposed=(Skill("Docker", "intermediate"),),
+        acted=True,
+        reason="сохранение навыков не подтверждено: наблюдаемое состояние чипов не совпало",
+    )
+    monkeypatch.setattr("hhru_bot.skills.edit_skills_on_hh", lambda *_a, **_kw: result)
+
+    args = _run_args(tmp_path, dry_run=False)
+    assert command.run(args) is True
+
+    rows = History(args.history).list_actions("requested-id", "all")
+    assert len(rows) == 1
+    assert rows[0]["action"] == "edit_skills"
+    assert rows[0]["status"] == "uncertain"
+
+
+def test_success_result_is_recorded_in_actions(monkeypatch, tmp_path):
+    resume = SimpleNamespace(id="requested", resume_id="requested-id")
+    _stub_common(monkeypatch, resume)
+    result = SkillsResult(
+        success=True,
+        existing=(),
+        proposed=(Skill("Docker", "intermediate"),),
+        added=("Docker",),
+        acted=True,
+    )
+    monkeypatch.setattr("hhru_bot.skills.edit_skills_on_hh", lambda *_a, **_kw: result)
+
+    args = _run_args(tmp_path, dry_run=False)
+    assert command.run(args) is False
+
+    rows = History(args.history).list_actions("requested-id", "all")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "success"
+
+
+def test_pre_click_failure_is_not_recorded_in_actions(monkeypatch, tmp_path):
+    """A failure with acted=False (form/session not found) leaves no trace on
+    hh.ru — same fail-closed distinction edit_experience.py already makes."""
+    resume = SimpleNamespace(id="requested", resume_id="requested-id")
+    _stub_common(monkeypatch, resume)
+    result = SkillsResult(
+        success=False,
+        existing=(),
+        proposed=(Skill("Docker", "intermediate"),),
+        acted=False,
+        reason="форма навыков не открылась",
+    )
+    monkeypatch.setattr("hhru_bot.skills.edit_skills_on_hh", lambda *_a, **_kw: result)
+
+    args = _run_args(tmp_path, dry_run=False)
+    assert command.run(args) is True
+
+    assert History(args.history).list_actions("requested-id", "all") == []
+
+
+def test_dry_run_does_not_record_actions(monkeypatch, tmp_path):
+    resume = SimpleNamespace(id="requested", resume_id="requested-id")
+    _stub_common(monkeypatch, resume)
+    result = SkillsResult(
+        success=True,
+        existing=(),
+        proposed=(Skill("Docker", "intermediate"),),
+        added=("Docker",),
+    )
+    monkeypatch.setattr("hhru_bot.skills.edit_skills_on_hh", lambda *_a, **_kw: result)
+
+    args = _run_args(tmp_path, dry_run=True)
+    assert command.run(args) is False
+
+    assert History(args.history).list_actions("requested-id", "all") == []

--- a/tests/test_selector_contracts.py
+++ b/tests/test_selector_contracts.py
@@ -183,7 +183,10 @@ def test_every_selector_has_canonical_coverage_and_all_groups_are_audited():
     # #811: +4 resume_experience.{EXPERIENCE_START_MONTH,EXPERIENCE_END_MONTH,
     # EXPERIENCE_MONTH_OPTION,EXPERIENCE_MONTH_LISTBOX} — the "Месяц" comboboxes
     # the experience form requires, confirmed live 2026-08-30.
-    assert len(catalog["selectors"]) == 251
+    # #813: +1 resume_page.RESUME_SKILLS_DISPLAY_TAG (resume card's own skill
+    # tags, used for the post-save verification instead of the editor's own
+    # chip widget which no longer exists once the editor closes).
+    assert len(catalog["selectors"]) == 252
     assert all(
         row.get("coverage_status") in contracts.AUDIT_STATUSES
         for row in catalog["selectors"].values()
@@ -1028,7 +1031,7 @@ def test_refresh_dry_run_reports_baseline_and_never_writes(monkeypatch, capsys, 
     output = capsys.readouterr().out
     assert "DRY-RUN" in output
     assert "no files, branches, or PRs were written" in output
-    assert "local selector contracts: 251" in output
+    assert "local selector contracts: 252" in output
     assert "Semantic mismatches:" in output
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -10,6 +10,7 @@ import hhru_bot.skills as skills_module
 from hhru_bot.config import bare_resume
 from hhru_bot.skills import (
     Skill,
+    _confirm_skill_levels,
     build_skills_prompt,
     edit_skills_on_hh,
     parse_manual_skills,
@@ -196,16 +197,28 @@ def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) ->
 
 
 def _mock_chip_locator() -> MagicMock:
-    """A RESUME_SKILLS_CHIP locator stub whose .nth().wait_for() no-ops.
+    """A RESUME_SKILLS_CHIP (editor combobox) locator stub for the fill+Enter loop.
 
-    #801: .filter(has_text=...) also resolves immediately with one match, so
-    the post-fill+Enter commit-wait loop in edit_skills_on_hh does not poll
-    until CHIP_COMMIT_TIMEOUT_MS on every addition.
+    #801: .filter(has_text=...) resolves immediately with one match, so the
+    post-fill+Enter commit-wait loop in edit_skills_on_hh does not poll until
+    CHIP_COMMIT_TIMEOUT_MS on every addition. #813: the post-save settle-wait
+    now targets RESUME_SKILLS_DISPLAY_TAG instead (see _mock_display_tag_locator),
+    not this locator's .nth().wait_for().
     """
     chip_locator = MagicMock()
-    chip_locator.nth.return_value.wait_for.return_value = None
     chip_locator.filter.return_value.count.return_value = 1
     return chip_locator
+
+
+def _mock_display_tag_locator() -> MagicMock:
+    """A RESUME_SKILLS_DISPLAY_TAG locator stub whose .nth().wait_for() no-ops.
+
+    #813: the post-save settle-wait reads the resume card's own skill tags,
+    not the editor's chip widget (which no longer exists once the editor closes).
+    """
+    tag_locator = MagicMock()
+    tag_locator.nth.return_value.wait_for.return_value = None
+    return tag_locator
 
 
 def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None:
@@ -221,6 +234,7 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     save = MagicMock()
     save.count.return_value = 1
     chip_locator = _mock_chip_locator()
+    tag_locator = _mock_display_tag_locator()
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
@@ -228,13 +242,15 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: tag_locator,
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
-    read_skills = MagicMock(side_effect=[("Python",), ("Python", "Docker")])
-    monkeypatch.setattr(skills_module, "read_skills", read_skills)
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=("Python",)))
+    read_display_skills = MagicMock(return_value=("Python", "Docker"))
+    monkeypatch.setattr(skills_module, "read_display_skills", read_display_skills)
 
     result = edit_skills_on_hh(
         page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
@@ -243,12 +259,12 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     assert result.success is True
     assert result.added == ("Docker",)
     assert result.acted is True
-    assert read_skills.call_count == 2
-    # #536 round 1: the post-save read must wait for the chip container to
-    # settle instead of racing the React re-render right after the editor
-    # (a separate overlay) reports hidden.
-    chip_locator.nth.assert_called_once_with(1)
-    chip_locator.nth.return_value.wait_for.assert_called_once_with(state="visible", timeout=5_000)
+    read_display_skills.assert_called_once()
+    # #536 round 1 / #813: the post-save read must wait for the resume card's
+    # own skill tags to settle instead of racing the React re-render right
+    # after the editor (a separate overlay) reports hidden.
+    tag_locator.nth.assert_called_once_with(1)
+    tag_locator.nth.return_value.wait_for.assert_called_once_with(state="visible", timeout=5_000)
 
 
 def test_edit_skills_waits_for_each_chip_before_next_addition(monkeypatch) -> None:
@@ -273,13 +289,16 @@ def test_edit_skills_waits_for_each_chip_before_next_addition(monkeypatch) -> No
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
-    read_skills = MagicMock(side_effect=[(), ("FastAPI", "LangChain")])
-    monkeypatch.setattr(skills_module, "read_skills", read_skills)
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=()))
+    monkeypatch.setattr(
+        skills_module, "read_display_skills", MagicMock(return_value=("FastAPI", "LangChain"))
+    )
 
     result = edit_skills_on_hh(
         page,
@@ -313,7 +332,6 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
     save = MagicMock()
     save.count.return_value = 1
     chip_locator = MagicMock()
-    chip_locator.nth.return_value.wait_for.return_value = None
     # The expected chip never appears — simulates a merged/rejected chip.
     chip_locator.filter.return_value.count.return_value = 0
     trigger = MagicMock()
@@ -323,13 +341,15 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=()))
     monkeypatch.setattr(
-        skills_module, "read_skills", MagicMock(side_effect=[(), ("FastAPILangChain",)])
+        skills_module, "read_display_skills", MagicMock(return_value=("FastAPILangChain",))
     )
     monkeypatch.setattr(skills_module.time, "monotonic", MagicMock(side_effect=range(10_000)))
     monkeypatch.setattr(page, "wait_for_timeout", MagicMock())
@@ -368,14 +388,14 @@ def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
-    monkeypatch.setattr(
-        skills_module, "read_skills", MagicMock(side_effect=[("Python",), ("Python",)])
-    )
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=("Python",)))
+    monkeypatch.setattr(skills_module, "read_display_skills", MagicMock(return_value=("Python",)))
 
     result = edit_skills_on_hh(
         page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
@@ -401,23 +421,23 @@ def test_edit_skills_post_save_wait_timeout_falls_through_to_strict_read(monkeyp
     input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
-    chip_locator = MagicMock()
-    chip_locator.nth.return_value.wait_for.side_effect = PlaywrightError("timeout")
+    tag_locator = MagicMock()
+    tag_locator.nth.return_value.wait_for.side_effect = PlaywrightError("timeout")
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
-        skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: tag_locator,
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
-    monkeypatch.setattr(
-        skills_module, "read_skills", MagicMock(side_effect=[("Python",), ("Python",)])
-    )
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=("Python",)))
+    monkeypatch.setattr(skills_module, "read_display_skills", MagicMock(return_value=("Python",)))
 
     result = edit_skills_on_hh(
         page, resume, (Skill("Docker", "intermediate"),), dry_run=False, mode="append"
@@ -454,6 +474,7 @@ def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatc
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
@@ -461,10 +482,11 @@ def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatc
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
     # hh.ru rendered the added chip with a double internal space; the plan carries
     # a single space (parse_skill_plan normalized it).
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=("Python",)))
     monkeypatch.setattr(
         skills_module,
-        "read_skills",
-        MagicMock(side_effect=[("Python",), ("Python", "Machine  Learning")]),
+        "read_display_skills",
+        MagicMock(return_value=("Python", "Machine  Learning")),
     )
 
     result = edit_skills_on_hh(
@@ -563,6 +585,7 @@ def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) 
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
         skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
@@ -570,10 +593,9 @@ def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) 
     monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
     # Existing chip already carries a double space; the plan re-offers the same
     # skill with a single space — it must be deduped, not re-added.
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=("Python  Dev",)))
     monkeypatch.setattr(
-        skills_module,
-        "read_skills",
-        MagicMock(side_effect=[("Python  Dev",), ("Python  Dev",)]),
+        skills_module, "read_display_skills", MagicMock(return_value=("Python  Dev",))
     )
 
     result = edit_skills_on_hh(
@@ -707,3 +729,133 @@ def test_edit_skills_editor_wait_timeout_on_empty_resume_returns_failure(monkeyp
 
     assert result.success is False
     assert "форма навыков не открылась" in result.reason
+
+
+def test_confirm_skill_levels_noop_when_not_on_levels_step() -> None:
+    """The first save can return straight to the resume card (no pending
+    levels) — this must be a silent no-op, not a false failure (#813)."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+
+    assert _confirm_skill_levels(page, (Skill("Docker", "intermediate"),)) is None
+    page.locator.assert_not_called()
+
+
+def test_confirm_skill_levels_clicks_matching_radio_and_saves() -> None:
+    """#813: each addition's level radio (name={skill}{Russian label}) is
+    clicked, then the step's own Save is clicked and awaited hidden."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/skillsLevels?fromBlock=keySkills"
+    radio = MagicMock()
+    radio.count.return_value = 1
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        "input[name='SeleniumСредний']": radio,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+    }[selector]
+
+    error = _confirm_skill_levels(page, (Skill("Selenium", "intermediate"),))
+
+    assert error is None
+    radio.click.assert_called_once_with(
+        force=True, timeout=skills_module.SKILLS_LEVELS_STEP_TIMEOUT_MS
+    )
+    save.click.assert_called_once()
+    save.wait_for.assert_called_once_with(
+        state="hidden", timeout=skills_module.SKILLS_LEVELS_STEP_TIMEOUT_MS
+    )
+
+
+def test_confirm_skill_levels_skips_missing_radio_without_failing() -> None:
+    """A name hh.ru silently absorbed elsewhere may have no radio group here —
+    that alone must not fail the step; the caller's Counter check still
+    catches a skill that never actually landed."""
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/skillsLevels?fromBlock=keySkills"
+    missing_radio = MagicMock()
+    missing_radio.count.return_value = 0
+    save = MagicMock()
+    save.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        "input[name='SeleniumСредний']": missing_radio,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+    }[selector]
+
+    error = _confirm_skill_levels(page, (Skill("Selenium", "intermediate"),))
+
+    assert error is None
+    missing_radio.click.assert_not_called()
+    save.click.assert_called_once()
+
+
+def test_confirm_skill_levels_reports_missing_save_button() -> None:
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/edit/resume-id/skillsLevels?fromBlock=keySkills"
+    save = MagicMock()
+    save.count.return_value = 0
+    page.locator.return_value = save
+
+    error = _confirm_skill_levels(page, ())
+
+    assert error == "кнопка сохранения уровней навыков не найдена однозначно"
+
+
+def test_edit_skills_handles_levels_wizard_step_for_new_skill(monkeypatch) -> None:
+    """End-to-end #813 regression: a brand-new skill routes through the
+    skillsLevels step, and the post-save read must see it once that step's
+    own Save completes — not the zero the pre-fix code observed."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    editor = MagicMock()
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    input_.input_value.return_value = ""
+    save = MagicMock()
+    save.count.return_value = 1
+    chip_locator = _mock_chip_locator()
+    tag_locator = _mock_display_tag_locator()
+    levels_radio = MagicMock()
+    levels_radio.count.return_value = 1
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+
+    # editor.wait_for(state="hidden") succeeds (first save closed the editor);
+    # the URL only flips to the levels step once that click actually happens.
+    def save_click_side_effect():
+        page.url = "https://hh.ru/resume/edit/resume-id/skillsLevels?fromBlock=keySkills"
+
+    save.click.side_effect = save_click_side_effect
+
+    def locate(selector):
+        if selector == "input[name='SeleniumСредний']":
+            return levels_radio
+        return {
+            skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+            skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+            skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+            skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
+            skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: tag_locator,
+        }[selector]
+
+    page.locator.side_effect = locate
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=()))
+    monkeypatch.setattr(skills_module, "read_display_skills", MagicMock(return_value=("Selenium",)))
+
+    result = edit_skills_on_hh(
+        page, resume, (Skill("Selenium", "intermediate"),), dry_run=False, mode="append"
+    )
+
+    assert result.success is True
+    assert result.added == ("Selenium",)
+    levels_radio.click.assert_called_once_with(
+        force=True, timeout=skills_module.SKILLS_LEVELS_STEP_TIMEOUT_MS
+    )
+    # Save is clicked twice: once for the keySkills editor, once for the
+    # levels step this test exercises.
+    assert save.click.call_count == 2


### PR DESCRIPTION
## Что было
Боевой прогон `edit-skills` на черновике возвращал `[FAIL] (uncertain)` — "ожидалось N, наблюдалось 0" — хотя навыки реально сохранялись на hh.ru.

## Два независимых бага (оба подтверждены живым Playwright-DOM, 2026-08-30)

**1. Неверный scope селектора чтения** (главная гипотеза issue #813). `RESUME_SKILLS_CHIP` (`chips-trigger-chip-*`) — markup комбобокса самого редактора keySkills; он не существует на карточке резюме, куда страница возвращается после save. Пост-save проверка читала этот селектор и всегда видела 0 — баг скоупа, а не гонка рендера. Добавлен подтверждённый живьём `RESUME_SKILLS_DISPLAY_TAG` (`[data-qa='skills-card'] [data-qa^='skill-tag-']`) и `read_display_skills()`, по образцу уже существующего в проекте паттерна `read_position`/`read_display_position` (`resume_position.py`).

**2. Пропущенный шаг wizard'а** (обнаружено в процессе диагностики, не входило в исходную гипотезу issue). Сохранение навыка без ранее подтверждённого уровня (любой НОВЫЙ навык) не возвращает на карточку резюме напрямую — hh.ru переводит на отдельный экран `/resume/edit/{id}/skillsLevels?fromBlock=keySkills` с radio-выбором уровня для каждого такого навыка; только второй `Save` там сохраняет их с указанным уровнем. Прежний код не проходил этот экран вообще: навык сохранялся с "Уровень не указан", а пост-save проверка справедливо видела расхождение. Добавлена `_confirm_skill_levels()`.

## Отдельно обнаружено и исправлено
`edit_skills.py` вообще не вызывал `history.record_action()` — ни uncertain, ни success не попадали в `actions`. Добавлена запись по образцу `edit_experience.py`/`edit_education.py`.

## По п.3 issue (has_unresolved_uncertain)
`edit_skills` НЕ читается `has_unresolved_uncertain` нигде в коде — это семейство row-mutation команд (`edit_experience`/`edit_education`/`edit_skills`) намеренно не подключено к preflight-гейту (см. комментарий `edit_education.py:233`), `record_action` там audit/stats-only. Блокировка повторного запуска для этой команды структурно невозможна. Тестовый черновик `24b16b4aff1106ca100039ed1f726766334230` сейчас НЕ заблокирован: uncertain-строка от этого расследования (id=148) резолвится более поздней success-строкой (id=150). Если бы блокировка когда-либо потребовалась — применима ручная reconciliation из CLAUDE.md (раздел 6): подтвердить состояние на hh.ru, вставить success-строку вручную.

## Живой WRITE-тест
`edit-skills --resume 24b16b4aff1106ca100039ed1f726766334230 --skill "Cucumber=advanced" --force` → `[OK]`, навык сохранён с уровнем "Продвинутый" (подтверждено повторным чтением DOM резюме через Playwright). Использован черновик (не опубликованные резюме).

## Проверка
- `ruff check` / `ruff format --check` — чисто
- `pytest` полный набор — все зелёные (36.5s, бюджет 60s)
- `scripts/gen_cli_docs.py --check` — синхронизирован

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)