### PR TITLE
fix(resume-position): избежать таймаута drop-base для no-op и реальной смены значения (#823)

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -343,7 +343,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     )
                 return False
             progress.begin_attempt()
-            apply_position(page, plan)
+            apply_position(page, plan, current=current)
             if page.locator(SAVE).count() != 1:
                 raise RuntimeError("кнопка сохранения формы не подтверждена")
             try:

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -692,9 +692,14 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
         if option.count() != 1:
             raise RuntimeError(f"вариант формы не найден: {labels[value]}")
         option.click()
-        # Selecting an option does not close this dropdown.  Escape is
+        # Re-clicking the trigger (the earlier approach) does not close this
+        # panel — confirmed live (#823): the panel re-opens/stays open even
+        # after a genuine value change, not just a no-op selection. This
+        # dropdown closes on an outside click instead, same as clicking away
+        # from any Magritte popup; (0, 0) is always outside the panel, which
+        # is positioned near the field, not the viewport corner. Escape is
         # deliberately avoided because it can close the whole editor form.
-        el.click()
+        page.mouse.click(0, 0)
         panel.wait_for(state="hidden", timeout=_CONTROL_WAIT_TIMEOUT_MS)
     except (PlaywrightError, RuntimeError) as exc:
         _dump_control_failure(page, selector, exc)
@@ -740,8 +745,17 @@ def _set_specializations(page: Page, values: list[str]) -> None:
     modal.wait_for(state="hidden", timeout=10_000)
 
 
-def apply_position(page: Page, plan: PositionValues) -> None:
-    """Fill fields only. Caller owns confirmation and must click SAVE explicitly."""
+def apply_position(page: Page, plan: PositionValues, current: PositionValues | None = None) -> None:
+    """Fill fields only. Caller owns confirmation and must click SAVE explicitly.
+
+    ``current`` is the value already on the draft (from the just-opened form/
+    display), used only to skip a no-op ``_set_control`` click (#823): a live
+    run requesting the value already on the resume hung the full 5s timeout
+    and failed a command that had nothing to change. Skipping keeps the
+    request an honest no-op instead of clicking an option that was already
+    selected. ``current=None`` (e.g. ``copy_resume``'s bare-title call)
+    preserves the previous unconditional behaviour.
+    """
     if plan.title == "":
         raise ValueError(
             "Пустой title отклоняется hh.ru. Укажите значение, например: "
@@ -786,15 +800,23 @@ def apply_position(page: Page, plan: PositionValues) -> None:
         if currency_chip.count() != 1:
             raise RuntimeError(f"чип валюты не подтверждён: {plan.currency}")
         currency_chip.click()
+    current_employment = current.employment if current else None
     if plan.employment:
         for value in plan.employment:
+            if current_employment == [value]:
+                continue
             _set_control(page, EMPLOYMENT, value, EMPLOYMENT_LABELS)
+    current_work_format = current.work_format if current else None
     if plan.work_format:
         for value in plan.work_format:
+            if current_work_format == [value]:
+                continue
             _set_control(page, WORK_FORMAT, value, WORK_LABELS)
-    if plan.commute:
+    if plan.commute and (current is None or current.commute != plan.commute):
         _set_control(page, TRAVEL, plan.commute, TRAVEL_LABELS)
-    if plan.business_trips is not None:
+    if plan.business_trips is not None and (
+        current is None or current.business_trips != plan.business_trips
+    ):
         _set_control(
             page,
             BUSINESS_TRIPS,

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -405,7 +405,9 @@ def test_resume_position_write_success_does_not_double_count_on_exit_error(
             ResumeState(status="new", is_searchable=True),
         ),
     )
-    monkeypatch.setattr("hhru_bot.resume_position.apply_position", lambda page, plan: None)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.apply_position", lambda page, plan, current=None: None
+    )
 
     history_path = tmp_path / "h.db"
     result = resume_position_cmd.run(

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -558,7 +558,9 @@ def test_resume_position_grey_zone_post_click_failure_is_uncertain_not_failed(
             ResumeState(status="new", is_searchable=True),
         ),
     )
-    monkeypatch.setattr("hhru_bot.resume_position.apply_position", lambda page, plan: None)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.apply_position", lambda page, plan, current=None: None
+    )
 
     history_path = tmp_path / "history.db"
     args = argparse.Namespace(

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -427,7 +427,86 @@ def test_apply_position_clicks_currency_chip_label_not_radio_input():
     currency_chip.click.assert_called_once_with()
 
 
-def test_set_control_reopens_dropdown_for_each_value():
+def test_apply_position_skips_set_control_when_value_already_current(monkeypatch):
+    # #823: requesting a value already on the draft must not touch the
+    # dropdown at all — Magritte doesn't close it after a no-op selection.
+    calls = []
+    monkeypatch.setattr(
+        resume_position,
+        "_set_control",
+        lambda page, selector, value, labels: calls.append((selector, value)),
+    )
+    page = MagicMock()
+    current = PositionValues(
+        employment=["full_time"],
+        work_format=["remote"],
+        commute="no_limit",
+        business_trips=True,
+    )
+    plan = PositionValues(
+        employment=["full_time"],
+        work_format=["remote"],
+        commute="no_limit",
+        business_trips=True,
+    )
+
+    resume_position.apply_position(page, plan, current=current)
+
+    assert calls == []
+
+
+def test_apply_position_calls_set_control_when_value_differs_from_current(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        resume_position,
+        "_set_control",
+        lambda page, selector, value, labels: calls.append((selector, value)),
+    )
+    page = MagicMock()
+    current = PositionValues(
+        employment=["full_time"],
+        work_format=["remote"],
+        commute="no_limit",
+        business_trips=True,
+    )
+    plan = PositionValues(
+        employment=["part_time"],
+        work_format=["hybrid"],
+        commute="up_to_1_hour",
+        business_trips=False,
+    )
+
+    resume_position.apply_position(page, plan, current=current)
+
+    assert calls == [
+        (resume_position.EMPLOYMENT, "part_time"),
+        (resume_position.WORK_FORMAT, "hybrid"),
+        (resume_position.TRAVEL, "up_to_1_hour"),
+        (resume_position.BUSINESS_TRIPS, "false"),
+    ]
+
+
+def test_apply_position_calls_set_control_unconditionally_without_current(monkeypatch):
+    # current=None (e.g. copy_resume's bare-title call) preserves the
+    # previous unconditional behaviour.
+    calls = []
+    monkeypatch.setattr(
+        resume_position,
+        "_set_control",
+        lambda page, selector, value, labels: calls.append((selector, value)),
+    )
+    page = MagicMock()
+    plan = PositionValues(commute="no_limit", business_trips=True)
+
+    resume_position.apply_position(page, plan)
+
+    assert calls == [
+        (resume_position.TRAVEL, "no_limit"),
+        (resume_position.BUSINESS_TRIPS, "true"),
+    ]
+
+
+def test_set_control_closes_dropdown_via_outside_click_for_each_value():
     class FakeOption:
         def __init__(self, panel, label):
             self.panel = panel
@@ -465,7 +544,7 @@ def test_set_control_reopens_dropdown_for_each_value():
 
         def click(self):
             self.clicks += 1
-            self.panel.open = not self.panel.open
+            self.panel.open = True
 
     panel = FakePanel()
     control = FakeControl(panel)
@@ -473,6 +552,9 @@ def test_set_control_reopens_dropdown_for_each_value():
     page.locator.side_effect = lambda selector: (
         panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
     )
+    # An outside click closes this dropdown (#823 live probe) — re-clicking
+    # the trigger does not, even for a genuine value change.
+    page.mouse.click.side_effect = lambda *_args, **_kwargs: setattr(panel, "open", False)
 
     resume_position._set_control(
         page, resume_position.WORK_FORMAT, "remote", resume_position.WORK_LABELS
@@ -482,7 +564,7 @@ def test_set_control_reopens_dropdown_for_each_value():
     )
 
     assert panel.selected == ["Удалённо", "Гибрид"]
-    assert control.clicks == 4
+    assert control.clicks == 2
 
 
 def test_set_control_passes_explicit_timeout_to_panel_waits():


### PR DESCRIPTION
## Проблема (#823)

`_set_control()` кликал опцию Magritte-панели и безусловно ждал скрытия
`[data-qa='drop-base']` через повторный клик по триггеру. Живой прогон
показал таймаут 5с и `[FAIL]`, когда запрошенное значение уже совпадало
с текущим на резюме (клик по уже выбранной radio-опции не меняет DOM ->
панель не закрывается).

## Расследование живым прогоном

Live-проверка на черновике (headless Playwright, `--config` на боевую
сессию из `data/config.yaml`) показала, что проблема шире описанной в
issue: повторный клик по триггеру не закрывает эту панель **даже при
реальной смене значения** — не только в no-op сценарии. Дамп подтвердил:
значение сменилось (radio реально переключился), но `aria-expanded`
триггера остался `true`, панель осталась открытой.

## Решение — оба варианта из issue, оба нужны

1. **(а) Честный no-op.** `apply_position()` получил опциональный
   параметр `current: PositionValues`; для `employment`/`work_format`/
   `commute`/`business_trips` `_set_control` пропускается, если
   запрошенное значение уже равно текущему. `current=None` (вызов из
   `copy_resume.py`) сохраняет старое безусловное поведение.
2. **(б, шире issue) Закрытие через outside-click.** Повторный клик по
   триггеру заменён на `page.mouse.click(0, 0)` — клик вне панели.
   Подтверждено живым прогоном на сценарии реальной смены значения:
   `no_limit -> up_to_1_hour` прошёл `[OK]`, дамп больше не создаётся.

Оба фикса нужны одновременно: (а) убирает лишний поход в браузер для
no-op, (б) чинит саму панель для случаев, когда значение реально меняется
(без (б) сценарий реальной смены остался бы сломанным).

## Живой прогон (черновик из аккаунта пользователя, не публикуемое резюме)

Все три сценария прогнаны на одном черновике через `resume-position --force`:

1. `no_limit -> no_limit` (повтор того же значения, ДО фикса — воспроизведённый
   таймаут 5с и `[FAIL]` из issue): теперь `[OK]`, без обращения к `_set_control`.
2. `no_limit -> up_to_1_hour` (реальная смена значения): `[OK]` через
   outside-click-закрытие панели.
3. `up_to_1_hour -> up_to_1_hour` (повтор нового значения): `[OK]`, без
   обращения к `_set_control`.

Резюме возвращено к исходному `commute=no_limit` после теста.

## Побочная находка (вне scope, не чинится в этом PR)

`TRAVEL_LABELS` в `resume_position.py` содержит `up_to_2_hours`/
`up_to_3_hours`, которых нет среди реальных опций панели на живом DOM
("Не имеет значения" / "Не дольше 1 часа" / "Не дольше 1,5 часов").
Стоит завести отдельное issue.

## Проверки

- `ruff check` + `ruff format --check` — чисто.
- `pytest` — полный прогон зелёный (добавлены unit-тесты на skip-логику
  no-op в `apply_position` и на новый механизм закрытия панели через
  outside-click в `_set_control`).
- `scripts/gen_cli_docs.py --check` — README синхронизирован (сигнатура
  команды не менялась).

Closes #823
