### PR TITLE
fix(resume-position): дождаться React-рендера дерева специализаций перед проверкой

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -726,6 +726,19 @@ def _set_specializations(page: Page, values: list[str]) -> None:
         option = page.locator(SPECIALIZATION_OPTION).filter(
             has_text=re.compile(rf"^{re.escape(value)}$")
         )
+        # search.fill() triggers an async React re-render of the filtered tree
+        # (#822 live repro): reading option.count() right after fill() is a
+        # race and can observe either the still-unfiltered default category
+        # rows or a not-yet-rendered empty list, in both cases 0 matches for
+        # a leaf that is genuinely present. Waiting for the first match (or a
+        # bounded timeout confirming it never renders) turns that race into a
+        # deterministic read, matching the wait_for(state="visible") pattern
+        # this project already uses after every action that starts a React
+        # render (CLAUDE.md, resume_position.py's own _set_control).
+        try:
+            option.first.wait_for(state="visible", timeout=_CONTROL_WAIT_TIMEOUT_MS)
+        except PlaywrightError as exc:
+            raise RuntimeError(f"специализация не найдена в дереве резюме: {value}") from exc
         option_ids = {option.nth(index).get_attribute("data-qa") for index in range(option.count())}
         # The same leaf is rendered once under every matching parent category;
         # its data-qa id is the stable identity.  Different ids with the same

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -546,6 +546,93 @@ def test_apply_position_sets_confirmed_specializations(monkeypatch):
     set_specializations.assert_called_once_with(page, ["Аналитик"])
 
 
+def _mock_specialization_locators(page, *, option_data_qa):
+    """Common scaffolding for _set_specializations tests below.
+
+    Mocks every locator _set_specializations touches; option_data_qa controls
+    what the filtered SPECIALIZATION_OPTION locator resolves to (its .first
+    is what option.first.wait_for()/click() operate on).
+    """
+    add = MagicMock()
+    add.count.return_value = 1
+    cards = MagicMock()
+    cards.count.return_value = 0
+    modal = MagicMock()
+    modal.count.return_value = 1
+    search = MagicMock()
+    search.count.return_value = 1
+    submit = MagicMock()
+    submit.count.return_value = 1
+    option_tree = MagicMock()
+    option = MagicMock()
+    option.count.return_value = len(option_data_qa)
+    option.nth.side_effect = lambda i: SimpleNamespace(
+        get_attribute=lambda _name: option_data_qa[i]
+    )
+    option_tree.filter.return_value = option
+
+    def locate(selector):
+        return {
+            resume_position.SPECIALIZATION_ADD: add,
+            resume_position.SPECIALIZATION_DELETE: cards,
+            resume_position.SPECIALIZATION_MODAL: modal,
+            resume_position.SPECIALIZATION_SEARCH: search,
+            resume_position.SPECIALIZATION_SUBMIT: submit,
+            resume_position.SPECIALIZATION_OPTION: option_tree,
+        }[selector]
+
+    page.locator.side_effect = locate
+    return option
+
+
+def test_set_specializations_waits_out_the_filter_render_race():
+    """#822 live repro: search.fill() starts an async React re-render, so a
+    leaf genuinely present in the tree can read as 0 matches immediately
+    after fill(). option.first.wait_for() must absorb that race instead of
+    the stale read failing with "не найден однозначно"."""
+    page = MagicMock()
+    option = _mock_specialization_locators(
+        page, option_data_qa=["tree-selector-item tree-selector-item-96"]
+    )
+
+    resume_position._set_specializations(page, ["Программист, разработчик"])
+
+    option.first.wait_for.assert_called_once_with(
+        state="visible", timeout=resume_position._CONTROL_WAIT_TIMEOUT_MS
+    )
+    option.first.click.assert_called_once()
+
+
+def test_set_specializations_reports_missing_leaf_after_timeout():
+    """No match ever renders (not a race) — a distinct, honest message from
+    the ambiguous-match case below."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    page = MagicMock()
+    option = _mock_specialization_locators(page, option_data_qa=[])
+    option.first.wait_for.side_effect = PlaywrightError("Timeout 5000ms exceeded.")
+
+    with pytest.raises(RuntimeError, match="не найдена в дереве резюме"):
+        resume_position._set_specializations(page, ["Несуществующая специальность"])
+
+
+def test_set_specializations_still_rejects_genuine_ambiguity():
+    """Two distinct data-qa ids for the same label is real ambiguity, not the
+    render race — the wait succeeds (>=1 match) but the count check must
+    still fail it."""
+    page = MagicMock()
+    _mock_specialization_locators(
+        page,
+        option_data_qa=[
+            "tree-selector-item tree-selector-item-10",
+            "tree-selector-item tree-selector-item-20",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="не найден однозначно"):
+        resume_position._set_specializations(page, ["Аналитик"])
+
+
 def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     """#337: an SSR anchor has no handler until hydration, and URL stays put."""
     resume = bare_resume("resume-id")


### PR DESCRIPTION
## Что случилось

`resume-position --specialization "Программист, разработчик"` падал:

```
[FAIL] вариант специализации не найден однозначно: Программист, разработчик
```

## Разбор (живой DOM, 2026-08-30)

Гипотеза issue — "Программист, разработчик" будто бы родительская категория
дерева специализаций резюме без собственного leaf-пункта — **не подтвердилась**.
Живая проверка панели "Уточните специальность" показала обратное:

- В дереве под категорией "Информационные технологии" есть чекбокс
  `data-qa="tree-selector-item tree-selector-item-96 tree-selector-child-category-11"`
  с текстом ровно `"Программист, разработчик"`.
- `96` — тот же `role_id`, что и в каталоге `professional-roles` (поиск вакансий).
  Для этого конкретного узла оба каталога hh.ru совпадают 1:1.
- Ручной выбор через UI (поиск в панели → чекбокс) отрабатывает штатно,
  без каких-либо признаков "категория, а не leaf".

Значит вопрос из issue ("отказ с перечислением leaf, или выбор всех leaf под
категорией") оказался неприменим: сам сценарий "категория верхнего уровня без
собственного leaf" здесь не воспроизводится — leaf есть.

## Настоящая причина

`_set_specializations()` в `src/hhru_bot/resume_position.py` читала
`option.count()` сразу после `search.fill(value)`, не дожидаясь асинхронного
React-рендера отфильтрованного дерева. Живым прогоном воспроизведена гонка
детерминированно (2 из 2 прогонов без ожидания):

```
OPTION count (filtered, no wait): 0
ALL OPTION count (unfiltered): 6   # ещё неотфильтрованный список категории
option_ids: set()
```

Оба возможных промежуточных кадра (неотфильтрованный список категории или
ещё пустой рендер) дают 0 совпадений по regex — и код ошибочно трактовал это
как "не найдено/неоднозначно", хотя leaf реально есть в дереве.

## Фикс

Добавлен `option.first.wait_for(state="visible", timeout=_CONTROL_WAIT_TIMEOUT_MS)`
перед строгой проверкой `count()` — тот же паттерн, что уже используется в
`_set_control()` и других местах проекта после любого действия, запускающего
React-рендер (см. CLAUDE.md, раздел про `wait_until="commit"`/гидратацию).

Таймаут различает две причины падения:
- рендер ещё не случился → теперь дожидаемся, ложного `[FAIL]` больше нет;
- значения в дереве реально нет → отдельное сообщение
  `специализация не найдена в дереве резюме: <value>`, не путающееся с
  настоящей неоднозначностью (`не найден однозначно`, для двух разных
  data-qa под одним текстом — этот случай остался нетронутым и по-прежнему
  фейлится).

## Живой прогон

Три независимых черновика (`create-resume --area "Программист, разработчик"`
→ `resume-position --specialization "Программист, разработчик"`), resume_id
заменены на поддельные вида `00001` в этом описании:

- До фикса: все 3 прогона падали с `[FAIL] вариант специализации не найден
  однозначно: Программист, разработчик`.
- После фикса (черновик `00001`, без `--commute`/`--business-trips` —
  затронуты параллельной работой над `_set_control` в #823):
  ```
  [OK] Раздел желаемой работы резюме '00001' обновлён.
  ```
  Открыл сохранённую карточку резюме в браузере — специализация
  "Программист, разработчик" на месте, заголовок/зарплата/тип занятости
  тоже сохранились.

Опубликованные резюме (ai-engineer/ai-teamlead/python/marketing) не
затрагивались — все прогоны на отдельных тестовых черновиках.

## Тесты

- `test_set_specializations_waits_out_the_filter_render_race` — гонка рендера
  поглощается ожиданием, специализация выбирается.
- `test_set_specializations_reports_missing_leaf_after_timeout` — таймаут без
  единого совпадения даёт отдельное, не вводящее в заблуждение сообщение.
- `test_set_specializations_still_rejects_genuine_ambiguity` — настоящая
  неоднозначность (два разных data-qa под одним текстом) по-прежнему падает.

`ruff check` / `ruff format --check` / полный `pytest` (3018 passed, 2 skipped) — зелёные.

Closes #822
