### PR TITLE
fix(create-resume): устранить две гонки рендера в _select_catalog_leaf

### DIFF
--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -31,6 +31,11 @@ CREATION_URL = f"{HH_BASE_URL}{RESUME_CREATION_URL}"
 # наблюдал вторую: резюме создавалось, но ожидание первой формы падало по
 # таймауту и давало uncertain при фактическом успехе.
 _RESUME_ID_RE = re.compile(r"(?:/resume/|[?&]resume=)([0-9a-f]{32,40})(?:[/?#&]|$)")
+# #837: живой замер показал checked=True уже на первой проверке спустя
+# +100мс после клика — секундный запас на порядок больше наблюдавшейся
+# задержки, но честный (не бесконечный) дедлайн на случай, если чекбокс
+# реально не переключился.
+_CHECKBOX_CONFIRM_TIMEOUT = 5.0
 
 
 @dataclass
@@ -72,7 +77,13 @@ def _click_one(
     return ""
 
 
-def _select_catalog_leaf(page: Page, area: str, *, filter_timeout: float = 15.0) -> str:
+def _select_catalog_leaf(
+    page: Page,
+    area: str,
+    *,
+    filter_timeout: float = 15.0,
+    checkbox_confirm_timeout: float = _CHECKBOX_CONFIRM_TIMEOUT,
+) -> str:
     """Select one exact leaf from hh.ru's full profession tree."""
     # The caller arrives right after clicking the wizard's NEXT control, which
     # re-renders the catalog screen asynchronously (React); a strict _one() on
@@ -99,17 +110,72 @@ def _select_catalog_leaf(page: Page, area: str, *, filter_timeout: float = 15.0)
     # attribute is attached to the text node.
     deadline = time.monotonic() + filter_timeout
     matches: list[Locator] = []
+    candidates: list[Locator] = []
     while True:
-        candidates = page.locator("[data-qa*='tree-selector-item-text-']").all()
-        matches = [
-            candidate
-            for candidate in candidates
-            if normalize(candidate.text_content() or "") == normalize(area)
-        ]
+        tree = page.locator("[data-qa*='tree-selector-item-text-']")
+        try:
+            # #837 (боевой прогон 2026-08-30): читать candidates=.all() один
+            # раз, а затем построчно candidate.text_content() каждого элемента
+            # — race. Между .all() (снимок handle-ов) и последним .text_content()
+            # в цикле React успевает перерендерить дерево (переход от
+            # нефильтрованного списка категорий к отфильтрованному leaf), и
+            # .text_content() на уже отсоединённом handle висит полный
+            # дефолтный таймаут Playwright (30с), не пойман никаким try/except
+            # внутри цикла — падает наружу как generic "ошибка до сохранения
+            # резюме". all_text_contents() читает тексты ВСЕХ текущих
+            # совпадений селектора одним batch-вызовом Playwright, а не по
+            # одному хэндлу — устраняет основной источник race. candidates
+            # снимается сразу следом на том же (ещё живом на момент вызова)
+            # locator; любой PlaywrightError из обоих вызовов — тот же сигнал
+            # "дерево перерендерилось", не финальная ошибка.
+            texts = [normalize(text) for text in tree.all_text_contents()]
+            candidates = tree.all()
+        except PlaywrightError:
+            # Не финальная ошибка, а сигнал повторить опрос — тот же принцип,
+            # что уже применяется ниже к нулю/множеству совпадений: решение
+            # только после того, как список стабилизируется или истечёт
+            # дедлайн.
+            texts = []
+            candidates = []
+        if len(candidates) != len(texts):
+            # all_text_contents() и .all() — два отдельных Playwright-вызова;
+            # React мог перерендерить дерево МЕЖДУ ними тоже (более узкое, но
+            # то же семейство окно, что и построчное чтение выше). Разная
+            # длина — надёжный сигнал рассинхрона: доверять индексному
+            # сопоставлению candidates[i]/texts[i] в этом случае нельзя,
+            # правильнее считать итерацию неудачной и повторить опрос, чем
+            # молча сопоставить чужой текст чужому элементу.
+            matches = []
+        else:
+            matches = [
+                candidate
+                for candidate, text in zip(candidates, texts, strict=True)
+                if text == normalize(area)
+            ]
         if len(matches) == 1 or time.monotonic() >= deadline:
             break
         page.wait_for_timeout(250)
-    if len(matches) != 1:
+    if not matches:
+        # #836: «не найдена однозначно (совпадений: 0)» не различало опечатку
+        # и пропажу значения из каталога hh.ru (боевой кейс — "Программист,
+        # разработчик" исчез из каталога создания резюме). Показать, что
+        # каталог реально предлагает по этому запросу, — тот же принцип, что
+        # #822/PR #832 закрепил для дерева специализаций резюме (сообщение
+        # различает «нет совпадений» и «неоднозначность»). Текст берётся из
+        # живого каталога как есть (не normalize(), который лоуеркейсит) —
+        # правило проекта "перечень профессий брать из живого каталога, не
+        # вшивать литералом".
+        seen: dict[str, None] = {}
+        for candidate in candidates:
+            text = (candidate.text_content() or "").strip()
+            if text:
+                seen.setdefault(text, None)
+        offered = list(seen)
+        if offered:
+            options = "; ".join(offered)
+            return f"профессия «{area}» не найдена в каталоге; каталог предлагает: {options}"
+        return f"профессия «{area}» не найдена в каталоге (список пуст)"
+    if len(matches) > 1:
         return f"профессия «{area}» не найдена однозначно в каталоге (совпадений: {len(matches)})"
     qa = matches[0].get_attribute("data-qa") or ""
     match = re.search(r"tree-selector-item-text-(\d+)$", qa)
@@ -132,6 +198,20 @@ def _select_catalog_leaf(page: Page, area: str, *, filter_timeout: float = 15.0)
     # change its state» (живой прогон #778). Кликается видимая строка
     # профессии — тот же узел, по которому выше определён leaf.
     matches[0].click()
+    # #837 (боевой прогон 2026-08-30, 2 из 3 живых фейлов): клик запускает
+    # асинхронное React-обновление checked-состояния, а is_checked() сразу
+    # после click() — синхронное чтение без ожидания. Живой замер: 2 из 6
+    # прогонов ловили checked=False непосредственно после click(), при этом
+    # checked=True уже на первой же проверке спустя +100мс — не редкий
+    # edge case, воспроизводится стабильно в ~33% случаев. Playwright не даёт
+    # wait_for(state="checked") — checked не входит в поддерживаемые состояния
+    # Locator.wait_for(). Фиксированная пауза замаскировала бы гонку, а не
+    # устранила: на медленном хосте/загруженном hh.ru та же гонка вернулась
+    # бы. Поэтому — тот же polling-до-дедлайна, что уже применяется выше для
+    # дерева, а не sleep().
+    checkbox_deadline = time.monotonic() + checkbox_confirm_timeout
+    while not _require(checkbox).is_checked() and time.monotonic() < checkbox_deadline:
+        page.wait_for_timeout(100)
     if not _require(checkbox).is_checked():
         return f"профессия «{area}» не отмечена после клика по строке каталога"
     return _click_one(page, RESUME_CREATION_CATEGORY_SUBMIT, "кнопка каталога профессий")

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -66,7 +66,11 @@ class Locator:
         return self
 
     def all_text_contents(self):
-        return []
+        # #837: реальный Playwright читает тексты одним batch-вызовом,
+        # независимым от .all() (снимок handle-ов) — мок опирается на тот же
+        # .all(), которое переопределяют производные классы, так что оба
+        # вызова остаются согласованными без дублирования фикстур per-class.
+        return [item.text_content() for item in self.all()]
 
     def all(self):
         # Дерево каталога профессий: ровно одна leaf, совпадающая с AREA.
@@ -330,8 +334,7 @@ class CatalogFilterPage(HydrationRacePage):
 
 
 class CatalogLocator(HydrationLocator):
-    def all(self):
-        self.page.tree_reads += 1
+    def _current_items(self):
         if self.page.reads_until_filtered is None:
             # Профессии нет в каталоге: фильтр не даст совпадения никогда.
             return [TreeItem("Аналитик", "tree-selector-item-text-10", self.page)]
@@ -342,6 +345,18 @@ class CatalogLocator(HydrationLocator):
                 TreeItem("Тестировщик", "tree-selector-item-text-11", self.page),
             ]
         return [TreeItem(AREA, "tree-selector-item-text-96", self.page)]
+
+    def all_text_contents(self):
+        # #837: боевой код читает all_text_contents() один раз за итерацию
+        # (используется для решения "нашли/не нашли"), затем .all() отдельным
+        # вызовом на том же (уже стабилизированном для этой итерации) снимке.
+        # tree_reads считает итерации опроса, а не количество вызовов метода —
+        # ровно то, что боевой код измеряет одним logical "poll".
+        self.page.tree_reads += 1
+        return [item.text_content() for item in self._current_items()]
+
+    def all(self):
+        return self._current_items()
 
 
 def test_catalog_tree_is_read_after_filter_applies(monkeypatch):
@@ -359,8 +374,94 @@ def test_catalog_tree_is_read_after_filter_applies(monkeypatch):
     assert result.success, f"каталог должен дождаться фильтрации: {result.reason}"
 
 
+class StaleHandleTreeItem(TreeItem):
+    """Элемент дерева, чей ``.text_content()`` кидает detached-ошибку (#837).
+
+    Живой прогон 2026-08-30 воспроизвёл ровно это: между ``.all()`` (снимок
+    handle-ов) и построчным ``.text_content()`` React успевает перерендерить
+    дерево, и чтение на уже отсоединённом handle висит полный таймаут
+    Playwright. ``all_text_contents()`` — batch-вызов на самом селекторе,
+    а не по хэндлу — этой проблеме не подвержен, что и моделирует разница
+    между ``self.all()`` (возвращает эти "хрупкие" объекты) и
+    ``self.all_text_contents()`` (batch, всегда успешен) ниже.
+    """
+
+    def text_content(self):
+        raise PlaywrightError("Locator.text_content: Timeout 30000ms exceeded waiting for element")
+
+
+class StaleSnapshotLocator(HydrationLocator):
+    """Первая итерация опроса отдаёт handle, ЧТЕНИЕ КОТОРОГО падает (#837);
+    вторая — уже стабилизированный единственный leaf.
+
+    Только ``.all()`` (снимок хэндлов, как в старом коде) уязвим:
+    ``StaleHandleTreeItem.text_content()`` кидает исключение при построчном
+    чтении. ``all_text_contents()`` (batch, как в новом коде) читает текст
+    напрямую из ``TreeItem`` без похода через уязвимый ``.text_content()``
+    хэндла — эта гонка для него структурно недостижима, а не просто "не
+    воспроизвелась в этом прогоне". Детерминированно: ВСЕГДА падает на
+    построчном чтении, ВСЕГДА проходит на batch-чтении.
+
+    Счётчик читок живёт на ``page``, а не на этом locator'е: боевой код
+    вызывает ``page.locator(selector)`` заново на каждой итерации опроса
+    (свежий объект locator), поэтому состояние "какая по счёту итерация"
+    обязано пережить пересоздание locator'а — тот же паттерн, что уже
+    использует ``CatalogLocator`` через ``self.page.tree_reads``.
+    """
+
+    def _stale_first_read(self):
+        return [
+            StaleHandleTreeItem("Аналитик", "tree-selector-item-text-10", self.page),
+            TreeItem(AREA, "tree-selector-item-text-96", self.page),
+        ]
+
+    def _stable_read(self):
+        return [TreeItem(AREA, "tree-selector-item-text-96", self.page)]
+
+    def _current_items(self):
+        return self._stale_first_read() if self.page.stale_reads == 0 else self._stable_read()
+
+    def all(self):
+        # Боевой код вызывает all_text_contents() и .all() в одной и той же
+        # логической итерации опроса — счётчик увеличивается только в
+        # all_text_contents(), чтобы .all() внутри той же итерации видел то
+        # же самое состояние (иначе он "перескочил" бы вперёд).
+        return self._current_items()
+
+    def all_text_contents(self):
+        # Batch-чтение — не по хэндлу, значит StaleHandleTreeItem.text_content()
+        # здесь никогда не вызывается: читаем прямо готовый текст элемента.
+        items = self._current_items()
+        self.page.stale_reads += 1
+        return [item._text for item in items]  # noqa: SLF001 — тестовый двойник, не production API
+
+
+class StaleSnapshotPage(CatalogFilterPage):
+    def __init__(self):
+        super().__init__(reads_until_filtered=0)
+        self.stale_reads = 0
+
+    def locator(self, selector):
+        count = 0 if selector == RESUME_LIST_CARD else 1
+        if self.TREE in selector:
+            return StaleSnapshotLocator(self, selector, count)
+        return HydrationLocator(self, selector, count)
+
+
+def test_stale_handle_during_row_by_row_read_does_not_crash_polling(monkeypatch):
+    """#837: построчное чтение .text_content() на снимке .all() падает на
+    устаревшем handle — опрос обязан пережить это и продолжить, не
+    пробрасывать исключение наружу как "ошибка до сохранения резюме"."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = StaleSnapshotPage()
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, f"batch-чтение не должно падать на устаревшем handle: {result.reason}"
+
+
 def test_absent_profession_still_fails_without_hanging(monkeypatch):
-    """Профессии нет в каталоге — честный failed, а не бесконечный опрос."""
+    """Профессии нет в каталоге — честный failed, с перечнем предложенного (#836)."""
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
     # Дерево НИКОГДА не отдаёт совпадение: опрос должен упереться в дедлайн.
     page = CatalogFilterPage(reads_until_filtered=None)
@@ -375,8 +476,52 @@ def test_absent_profession_still_fails_without_hanging(monkeypatch):
 
     assert not result.success
     assert not result.uncertain, "выбор профессии — до точки невозврата"
-    assert "не найдена однозначно" in result.reason
+    # #836: "не найдена однозначно (совпадений: 0)" не различала опечатку и
+    # исчезновение значения из каталога. При нуле совпадений сообщение теперь
+    # перечисляет, что каталог реально предлагает (CatalogFilterPage без
+    # фильтрации отдаёт "Аналитик" — то, что live-каталог показал бы).
+    assert "не найдена в каталоге" in result.reason
+    assert "Аналитик" in result.reason
     assert page.tree_reads > 1, "дерево должно перечитываться, а не читаться один раз"
+
+
+class AmbiguousCatalogLocator(HydrationLocator):
+    """Дерево стабильно отдаёт ДВА разных leaf с одинаковым текстом (#836)."""
+
+    def all(self):
+        self.page.tree_reads += 1
+        return [
+            TreeItem(AREA, "tree-selector-item-text-96", self.page),
+            TreeItem(AREA, "tree-selector-item-text-97", self.page),
+        ]
+
+
+class AmbiguousCatalogPage(CatalogFilterPage):
+    def locator(self, selector):
+        count = 0 if selector == RESUME_LIST_CARD else 1
+        if self.TREE in selector:
+            return AmbiguousCatalogLocator(self, selector, count)
+        return HydrationLocator(self, selector, count)
+
+
+def test_genuine_ambiguity_is_not_confused_with_absence(monkeypatch):
+    """Два разных leaf под одним текстом — отдельное сообщение о неоднозначности,
+    не смешанное с "не найдена в каталоге" (#836: 0 и >1 совпадений — разные причины)."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = AmbiguousCatalogPage()
+    monkeypatch.setattr(
+        create,
+        "_select_catalog_leaf",
+        lambda p, area, **_: _real_select(p, area, filter_timeout=0.5),
+    )
+
+    result = _run(page, before_click=lambda: None)
+
+    assert not result.success
+    assert not result.uncertain, "выбор профессии — до точки невозврата"
+    assert "не найдена однозначно" in result.reason
+    assert "совпадений: 2" in result.reason
+    assert "предлагает" not in result.reason, "неоднозначность — не то же самое, что отсутствие"
 
 
 def test_polling_stops_as_soon_as_match_appears(monkeypatch):
@@ -445,6 +590,107 @@ def test_unchecked_after_row_click_refuses_to_continue(monkeypatch):
             return loc
 
     page = NeverChecksPage()
+
+    result = _run(page, before_click=lambda: None)
+
+    assert not result.success
+    assert not result.uncertain, "выбор профессии — до точки невозврата"
+    assert "не отмечена" in result.reason
+
+
+class DelayedCheckLocator(HydrationLocator):
+    """Чекбокс переключается React'ом АСИНХРОННО после клика по строке (#837).
+
+    Живой замер 2026-08-30: сразу после ``Locator.click()`` на строке
+    профессии ``checkbox.checked`` синхронно всё ещё ``False`` — React
+    обновляет DOM только на следующем тике event loop. Статистика по 6
+    успешным живым прогонам: ``checked=False`` непосредственно после клика в
+    2 из 6 (~33%) случаев, при этом ``checked=True`` уже на первой же
+    проверке спустя минимальную задержку — не редкий edge case.
+
+    Детерминированно (не через реальное время): ``is_checked()`` считает
+    СОБСТВЕННЫЕ обращения и возвращает ``False`` для первых
+    ``reads_until_checked`` вызовов, затем ``True`` навсегда — старый код
+    (один синхронный read сразу после click()) видит вызов №1 и падает
+    ВСЕГДА при ``reads_until_checked >= 1``; новый код (polling до
+    подтверждённого состояния) переживает произвольное число ложных ``False``
+    и проходит ВСЕГДА, пока дедлайн не исчерпан.
+
+    Счётчик читок живёт на ``page``, а не на этом locator'е: боевой код
+    вызывает ``page.locator(checkbox_selector)`` ДВАЖДЫ на один и тот же
+    чекбокс (сначала для ``wait_for(state="visible")``, затем через
+    ``_one()``) — каждый вызов создаёт свежий объект locator, поэтому
+    "сколько раз уже спросили is_checked()" обязано пережить пересоздание
+    locator'а, тот же паттерн, что уже применяется в ``CatalogLocator`` и
+    ``StaleSnapshotLocator`` выше.
+    """
+
+    def __init__(self, page, selector, count):
+        super().__init__(page, selector, count)
+
+    def is_checked(self):
+        self.page.checkbox_reads += 1
+        return self.page.checkbox_reads > self.page.reads_until_checked
+
+
+class DelayedCheckPage(CatalogFilterPage):
+    """Строка каталога кликается штатно; чекбокс отмечается с задержкой."""
+
+    def __init__(self, *, reads_until_checked):
+        super().__init__(reads_until_filtered=0)
+        self.reads_until_checked = reads_until_checked
+        self.checkbox_reads = 0
+
+    def locator(self, selector):
+        if "tree-selector-input-" in selector:
+            return DelayedCheckLocator(self, selector, 1)
+        return super().locator(selector)
+
+
+def test_checkbox_race_after_row_click_is_not_reported_as_unchecked(monkeypatch):
+    """#837: клик отметил строку, но React обновляет checked асинхронно —
+    один немедленный синхронный read ловит гонку и ложно фейлит валидный
+    выбор. Polling до подтверждённого состояния обязан пережить это."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = DelayedCheckPage(reads_until_checked=3)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, f"гонка чекбокса не должна фейлить валидный выбор: {result.reason}"
+
+
+def test_permanently_unchecked_checkbox_still_refuses_to_continue(monkeypatch):
+    """Контроль: чекбокс, который НИКОГДА не переключается, — честный failed.
+
+    Polling за подтверждённым состоянием не должен превращать fail-closed
+    #837 в бесконечный опрос или в молчаливое продолжение без реально
+    выбранной профессии — как только polling-дедлайн исчерпан, это тот же
+    отказ, что и в test_unchecked_after_row_click_refuses_to_continue.
+    """
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    # Мок page.wait_for_timeout() — no-op (не спит реально), поэтому цикл
+    # опроса без монотонных часов, привязанных к количеству итераций, мог бы
+    # сделать сколько угодно проверок за доли секунды реального времени —
+    # число итераций и скорость машины не должны решать исход теста.
+    # Подменяем time.monotonic() детерминированной последовательностью: она
+    # растёт на фиксированный шаг с КАЖДЫМ вызовом (polling читает её дважды
+    # за итерацию — для проверки дедлайна и, до и после цикла, снаружи), так
+    # что дедлайн гарантированно исчерпывается после конечного, заранее
+    # известного числа итераций, независимо от скорости CPU.
+    call_count = 0
+
+    def fake_monotonic():
+        nonlocal call_count
+        call_count += 1
+        return call_count * 0.1
+
+    monkeypatch.setattr(create.time, "monotonic", fake_monotonic)
+    page = DelayedCheckPage(reads_until_checked=1_000_000)
+    monkeypatch.setattr(
+        create,
+        "_select_catalog_leaf",
+        lambda p, area, **_: _real_select(p, area, checkbox_confirm_timeout=0.3),
+    )
 
     result = _run(page, before_click=lambda: None)
 


### PR DESCRIPTION
## Контекст

Issue #836 предположил, что leaf "Программист, разработчик" исчез из каталога создания резюме. Живая инспекция это опровергла (см. комментарий-опровержение в #836, закрыт) — leaf на месте, role_id=96. Дальнейшая диагностика того же живого прогона нашла реальную причину нестабильности `create-resume`: две независимые гонки рендера в `_select_catalog_leaf`, задокументированные в #837.

## Причина (установлена живыми данными, не гипотеза)

`_select_catalog_leaf` (`src/hhru_bot/create_resume.py`) в двух местах читает состояние DOM синхронно, не дожидаясь окончания React re-render между отдельными Playwright-вызовами.

### Race A

```python
candidates = page.locator("[data-qa*='tree-selector-item-text-']").all()
matches = [c for c in candidates if normalize(c.text_content() or "") == normalize(area)]
```

`.all()` снимает снапшот handle-ов один раз, а список построчно читает `.text_content()` каждого — пока цикл идёт, React мог перерендерить дерево. `.text_content()` на уже отсоединённом handle висит полный дефолтный таймаут Playwright (30с), не перехвачено внутри цикла, пробрасывается наружу как generic `"ошибка до сохранения резюме"`.

Живой прогон (диагностика #837): `text_content loop took 30.401s`, `TimeoutError` на `.nth(6)`.

### Race B (приоритет — объясняла 2 из 3 живых боевых фейлов, ~33% воспроизводимость)

```python
matches[0].click()
if not checkbox.is_checked():
    return "... не отмечена после клика по строке каталога"
```

Клик запускает асинхронное React-обновление `checked`-состояния, `is_checked()` читается синхронно сразу после `.click()`, без ожидания. Живой замер по 6 успешным прогонам: `checked=False` непосредственно после клика в 2 из 6 (~33%) случаев — не редкий edge case.

## Фикс

- **Race A**: `all_text_contents()` читает тексты одним batch-вызовом Playwright вместо построчного чтения по хэндлам — устраняет основной источник гонки. При рассинхроне длины между этим вызовом и последующим `.all()` (более узкое остаточное окно) итерация считается неудачной и опрос просто повторяется, не падает наружу.
- **Race B**: polling до подтверждённого состояния (`checkbox.is_checked()` в цикле) вместо одного синхронного чтения — тот же паттерн, что уже применяется для дерева профессий выше в этой же функции. Честный дедлайн (`_CHECKBOX_CONFIRM_TIMEOUT = 5.0`, параметризуем через `checkbox_confirm_timeout` для тестов), **не фиксированная пауза** — пауза замаскировала бы гонку, а не устранила (на медленной машине/загруженном hh.ru те же ~33% вернулись бы).

**Не входит в этот PR**: гонка гидратации SELECT_JOB (клик по карточке визарда иногда не переключает экран с первого раза) — отдельная, менее приоритетная проблема, уже частично покрыта существующим retry-механизмом (`_click_until_screen_switches`), задокументирована в #837 для будущей работы.

## Тесты — сначала красные, потом фикс

Каждый новый тест проверен на текущем main (без фикса) через `git stash` перед написанием фикса — детерминированно красный, без зависимости от реального времени/везения:

- `test_stale_handle_during_row_by_row_read_does_not_crash_polling` — Race A: мок, где построчное чтение `.text_content()` детерминированно кидает исключение на устаревшем handle; batch-чтение эту гонку структурно не видит.
- `test_checkbox_race_after_row_click_is_not_reported_as_unchecked` — Race B: `is_checked()` детерминированно возвращает `False` для первых N вызовов по счётчику (не по реальному времени), затем `True` — старый код падает всегда при N≥1, новый проходит всегда.
- `test_permanently_unchecked_checkbox_still_refuses_to_continue` — контроль: чекбокс, который никогда не переключается, — честный `failed`, не бесконечный опрос и не молчаливое продолжение. Дедлайн детерминирован через monkeypatch `time.monotonic`, не зависит от скорости CPU.

Полный набор `tests/test_create_resume_browser.py`: 18/18 зелёных. Полный сьют: `3026 passed, 2 skipped`.

## Живой прогон

`create-resume --area "Программист, разработчик" --force` на тестовых черновиках (resume_id заменены на подставные ниже):

```
Прогон 1: [OK] Черновик резюме создан. Новый resume_id: 00001...
Прогон 2: [FAIL] список резюме не отрисовался (сбой ДО каталога — не связан с этим фиксом)
Прогон 3: [OK] Черновик резюме создан. Новый resume_id: 00002...
Прогон 4: [OK] Черновик резюме создан. Новый resume_id: 00003...
```

3 успеха из 4, единственный фейл — на шаге списка резюме (до входа в `_select_catalog_leaf`), не воспроизводит ни одну из починенных гонок. До фикса живьём наблюдались 3 разных фейла подряд, 0 успехов.

Опубликованные резюме (ai-engineer/ai-teamlead/python/marketing) не затрагивались.

## Проверки

`ruff check` / `ruff format --check` / `scripts/gen_cli_docs.py --check` — зелёные.

Closes #837