### PR TITLE
fix(edit-education): PRIMARY_ROUTE допускает id-хвост существующей записи

### DIFF
--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -42,7 +42,15 @@ ADDITIONAL_TRIGGER = "[data-qa='resume-edit-button-additionalEducation-{index}']
 # the form; they do not persist anything until SAVE_BUTTON is clicked.
 PRIMARY_ADD = "[data-qa='resume-list-card-education'] [data-qa='link']"
 ADDITIONAL_ADD = "[data-qa='resume-list-card-additionalEducation'] [data-qa='link']"
-PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)")
+# #814: у уже существующей записи (index=0 присутствует) hh.ru открывает
+# /profile/edit/primaryEducation/{entry_id}?resumeFrom=... -- с id-хвостом,
+# а не /profile/edit/primaryEducation без хвоста (тот путь — только для
+# пустой секции через PRIMARY_ADD, см. живой DOM issue #814). Опциональный
+# `(?:/[^/?#]+)?` покрывает обе ветки. Guard от чужого резюме держится не на
+# этом regex (он проверяет только экран), а на отдельной проверке
+# `expected_query={"resumeFrom": resume_id}` в вызове ниже -- расширение
+# хвоста id записи её не ослабляет.
+PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation(?:/[^/?#]+)?(?=[?#]|$)")
 ADDITIONAL_ROUTE = re.compile(r"/profile/edit/additionalEducation/[^/?#]+")
 # The two education editors are DIFFERENT screens with different controls, so a
 # single pair of buttons cannot serve both (live probe 2026-08-30):

--- a/tests/test_resume_education_primary_route.py
+++ b/tests/test_resume_education_primary_route.py
@@ -1,0 +1,47 @@
+"""PRIMARY_ROUTE regex regression (#814).
+
+hh.ru opens two different URL shapes for the primary-education editor
+depending on whether the section already has an entry (live DOM, #814):
+
+* empty section (via PRIMARY_ADD)         -> /profile/edit/primaryEducation
+* existing entry (via PRIMARY_TRIGGER-0)  -> /profile/edit/primaryEducation/{entry_id}
+
+PRIMARY_ROUTE must accept both (the #794 no-tail case is a regression guard)
+while still rejecting an unrelated path -- the actual guard against opening a
+*different resume's* form is the separate `expected_query={"resumeFrom": ...}`
+check in `_edit_block` (browser.py's `open_hydrated_resume_editor`), not this
+regex. This regex only has to keep recognizing the primary-education screen,
+not double as an identity check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hhru_bot.resume_education import PRIMARY_ROUTE
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/profile/edit/primaryEducation",
+        "/profile/edit/primaryEducation/104508559",
+    ],
+)
+def test_primary_route_matches_empty_and_existing_entry_shapes(path):
+    assert PRIMARY_ROUTE.fullmatch(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/profile/edit/additionalEducation",
+        "/profile/edit/additionalEducation/104508559",
+        "/profile/edit/primaryEducationExtra",
+        "/profile/edit/primaryEducation/104508559/extra",
+    ],
+)
+def test_primary_route_rejects_unrelated_paths(path):
+    assert not PRIMARY_ROUTE.fullmatch(path)


### PR DESCRIPTION
## Проблема

`PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation(?=[?#]|$)")` требовал,
чтобы сразу после `primaryEducation` шли `?`, `#` или конец строки. Но при уже
существующей записи образования hh.ru открывает
`/profile/edit/primaryEducation/{entry_id}?resumeFrom=...` — с id-хвостом,
route-guard не матчил, и `edit-education --section primary` стабильно падал с
`[FAIL] форма образования 0 открыта не для того резюме`.

## Фикс

Regex расширен опциональным `(?:/[^/?#]+)?` хвостом (по образцу уже
существующего `ADDITIONAL_ROUTE`):

```
PRIMARY_ROUTE = re.compile(r"/profile/edit/primaryEducation(?:/[^/?#]+)?(?=[?#]|$)")
```

## Почему guard от чужого резюме не ослаблен

Этот regex — только про то, что мы на правильном ЭКРАНЕ (primary, не
additional и не что-то ещё). Фактический guard от открытия формы **чужого**
резюме — отдельная проверка `expected_query={"resumeFrom": resume_id}` в
`_edit_block` (`browser.open_hydrated_resume_editor`), которую фикс не
трогает. Добавлен тест `test_resume_education_primary_route.py`, покрывающий
и обе валидные формы пути (пустая секция / существующая запись), и
посторонние пути (`additionalEducation`, `primaryEducationExtra`,
`primaryEducation/{id}/extra`) — все они по-прежнему не матчатся.

## Живая проверка

`edit-education --resume <черновик из issue> --section primary --dry-run`:
- до фикса: стабильный `[FAIL] ... открыта не для того резюме` (3 прогона
  подряд, зафиксировано в issue);
- после фикса: `[OK] primary: обработано записей: 1; save не нажимался`.

`--dry-run` не мутирует данные на hh.ru (Save не нажимается).

## Тесты

- `ruff check` / `ruff format --check` — чисто.
- `pytest` — полный набор зелёный.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)