### PR TITLE
fix(edit-education): проверять что fill() реально сохранил значение (#825)

### DIFF
--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -259,10 +259,16 @@ def _fill_and_verify(page, locator, value: str) -> bool:
     already used for this same class of race elsewhere in the project
     (resume_position.py's WIZARD_VERIFY_POLL_MS, skills.py's CHIP_COMMIT_POLL_MS).
     """
+    # Review (PR #855): compare trimmed, not exact -- hh.ru may normalize the
+    # DOM value (collapsing/trimming whitespace) without that meaning the
+    # fill was lost. An exact match would retry the full budget and then
+    # falsely fail a field hh.ru genuinely accepted, just reformatted. This
+    # still catches the real #825 defect (value reverts to "").
+    expected = value.strip()
     deadline = time.monotonic() + FIELD_VERIFY_TIMEOUT_MS / 1000
     while True:
         locator.fill(value)
-        if locator.input_value() == value:
+        if locator.input_value().strip() == expected:
             return True
         if time.monotonic() >= deadline:
             return False
@@ -270,11 +276,15 @@ def _fill_and_verify(page, locator, value: str) -> bool:
 
 
 def _dump_save_failure(page, index: int, kind: str, exc: Exception) -> None:
-    """Best-effort DOM/screenshot dump on a post-save-click failure (#825).
+    """Best-effort DOM/screenshot dump on a fill or post-save-click failure (#825).
 
-    A live failure (`save.click()` followed by a timed-out `wait_for_url`)
-    previously left no trace to diagnose beyond reproducing it live by hand.
-    Mirrors ``resume_position._dump_control_failure`` -- same pattern, applied
+    Two distinct failure points share this helper: a field whose value did
+    not survive ``fill()`` (``_fill_and_verify``, BEFORE Save is ever
+    clicked) and a save-click outcome that could not be confirmed
+    (`save.click()` followed by a timed-out `wait_for_url`, or an unconfirmed
+    identity/text check, AFTER the click). Both previously left no trace to
+    diagnose beyond reproducing them live by hand. Mirrors
+    ``resume_position._dump_control_failure`` -- same pattern, applied
     to this module's own failure point.
     """
     LOG_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlsplit
@@ -112,6 +113,22 @@ FORM_TIMEOUT_MS = 15_000
 # сохранения (навигация происходит за секунды по всем живым прогонам), но не
 # держит CLI минуты на заведомо неуспешном пути.
 SAVE_TIMEOUT_MS = 20_000
+# #825: `open_hydrated_resume_editor`'s hydration marker is the primary form's
+# own institution INPUT becoming visible (see editor_selector below) -- but
+# "visible" only proves the empty <input> node exists in the DOM, not that
+# hh.ru's Magritte controlled component has finished initializing its React
+# state. A live dump caught the exact race: institution/year were filled,
+# Save was clicked, and hh.ru's own client-side validation rejected the
+# submit because the fields were empty on the DOM at click time -- the
+# `.fill()` calls landed, but a subsequent React re-render (still settling
+# right after the editor "became visible") reset the controlled inputs back
+# to their initial empty value, wiping out the just-typed text before Save
+# ever read it. This is the same "commit не значит отрисовано" class already
+# fixed for resume_position.py's wizard title field (WIZARD_VERIFY_POLL_MS) --
+# poll input_value() after fill() and retry rather than trust a single
+# best-effort `.fill()`.
+FIELD_VERIFY_TIMEOUT_MS = 3_000
+FIELD_VERIFY_POLL_MS = 200
 
 
 @dataclass(frozen=True)
@@ -226,6 +243,30 @@ def _field_locator(page, name: str, *, additional: bool):
     if locator.count() != 1:
         raise PageStateIndeterminate(f"поле {_PRIMARY_FIELDS[name]} не найдено однозначно")
     return locator
+
+
+def _fill_and_verify(page, locator, value: str) -> bool:
+    """Fill a field and confirm the value actually stuck (#825).
+
+    ``.fill()`` succeeding is not proof the value survives -- a Magritte
+    controlled input can reset itself to its initial (often empty) state in
+    an async React re-render that lands moments after the editor's hydration
+    marker became visible (see FIELD_VERIFY_TIMEOUT_MS comment above). Retry
+    the fill within a short budget instead of trusting a single attempt;
+    return False (never raise) so the caller can fail the row closed with a
+    clear reason rather than clicking Save on a field the DOM disagrees with.
+    Uses page.wait_for_timeout (not time.sleep) to match the polling idiom
+    already used for this same class of race elsewhere in the project
+    (resume_position.py's WIZARD_VERIFY_POLL_MS, skills.py's CHIP_COMMIT_POLL_MS).
+    """
+    deadline = time.monotonic() + FIELD_VERIFY_TIMEOUT_MS / 1000
+    while True:
+        locator.fill(value)
+        if locator.input_value() == value:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        page.wait_for_timeout(FIELD_VERIFY_POLL_MS)
 
 
 def _dump_save_failure(page, index: int, kind: str, exc: Exception) -> None:
@@ -354,7 +395,28 @@ def _edit_block(
                         uncertain=saved_count > 0,
                         saved=saved_count,
                     )
-                locator.fill(value)
+                if not _fill_and_verify(page, locator, value):
+                    # #825: the field accepted fill() but the DOM value did not
+                    # stick within FIELD_VERIFY_TIMEOUT_MS -- clicking Save on a
+                    # field the form itself disagrees with only reproduces the
+                    # observed live failure (hh.ru's client-side validation
+                    # rejects the empty field, Save no-ops, wait_for_url times
+                    # out). No click has happened yet on this row, so this is a
+                    # clean pre-click failure, not uncertain.
+                    _dump_save_failure(
+                        page,
+                        index,
+                        kind,
+                        RuntimeError(f"поле {name!r} не сохранило значение после fill()"),
+                    )
+                    return EducationResult(
+                        kind,
+                        False,
+                        f"строка {index}: поле {name!r} не приняло значение "
+                        f"(осталось {locator.input_value()!r} вместо {value!r})",
+                        uncertain=saved_count > 0,
+                        saved=saved_count,
+                    )
             if dry_run:
                 page.locator(cancel_selector).first.click()
             else:

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -35,11 +35,21 @@ class FakeSaveButton:
 
 
 class FakeFieldLocator:
+    """Models a field that keeps whatever ``fill()`` last wrote (the normal,
+    successfully-hydrated case). ``FakeRevertingFieldLocator`` below models
+    the #825 defect this file's new test targets."""
+
+    def __init__(self):
+        self._value = ""
+
     def count(self):
         return 1
 
-    def fill(self, value):  # noqa: ARG002
-        pass
+    def fill(self, value):
+        self._value = value
+
+    def input_value(self):
+        return self._value
 
     def click(self, *, timeout=None):  # noqa: ARG002
         pass
@@ -53,6 +63,20 @@ class FakeFieldLocator:
 
     def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
         pass
+
+
+class FakeRevertingFieldLocator(FakeFieldLocator):
+    """Models the #825 defect: fill() lands on the DOM node, but an async
+    React re-render (a Magritte controlled input settling right after the
+    editor's hydration marker became visible) resets the field back to empty
+    before the value is ever read again -- input_value() always reports "",
+    regardless of what fill() just wrote."""
+
+    def fill(self, value):  # noqa: ARG002
+        pass
+
+    def input_value(self):
+        return ""
 
 
 class FakeAbsentLocator:
@@ -94,6 +118,7 @@ class FakePage:
         resume_id: str = "RID",
         wait_for_url_error: Exception | None = None,
         institution_found: bool = True,
+        reverting_field_selector: str | None = None,
     ):
         self._trigger_count = trigger_count
         self.saved_rows: list[int] = []
@@ -104,6 +129,10 @@ class FakePage:
         # though the navigation (and save) already happened for real.
         self._wait_for_url_error = wait_for_url_error
         self._institution_found = institution_found
+        # #825: names the one field selector that should behave like the live
+        # defect (fill() lands, input_value() keeps reporting "") -- every
+        # other field keeps the normal FakeFieldLocator behavior.
+        self._reverting_field_selector = reverting_field_selector
 
     def locator(self, selector: str):
         if selector.startswith("[data-qa='resume-edit-button-"):
@@ -112,7 +141,12 @@ class FakePage:
             return FakeSaveButton(self)
         if selector == "[data-qa='cookies-policy-informer-accept']":
             return FakeAbsentLocator()
+        if selector == self._reverting_field_selector:
+            return FakeRevertingFieldLocator()
         return FakeFieldLocator()
+
+    def wait_for_timeout(self, timeout):  # noqa: ARG002
+        pass
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
         if self._wait_for_url_error is not None:
@@ -271,3 +305,52 @@ def test_wait_for_url_timeout_with_confirmed_identity_but_missing_text_is_uncert
     assert result.uncertain is True
     assert result.saved == 0
     assert "не отображается" in result.reason
+
+
+def test_field_that_reverts_after_fill_fails_before_save_click(monkeypatch):
+    """#825: live root cause -- institution/year were passed correctly but the
+    saved screenshot showed both fields EMPTY and flagged by hh.ru's own
+    "Пожалуйста, укажите" validation. save.click() had already fired, so the
+    old code (a bare locator.fill(value) with no readback) sent Save on a form
+    it never actually filled, then timed out waiting for a navigation that
+    hh.ru's client-side validation was never going to allow.
+
+    This models the exact mechanism: the institution field's fill() lands on
+    the DOM node but never survives (a Magritte controlled input resetting
+    itself in an async re-render). The fix must catch this BEFORE clicking
+    Save -- not just report a better-diagnosed uncertain after the fact.
+    """
+    page = FakePage(
+        trigger_count=1,
+        resume_id="RID",
+        reverting_field_selector="[data-qa='profile-education-university-input']",
+    )
+
+    def fake_open_hydrated_resume_editor(page_arg, **kwargs):  # noqa: ARG001
+        page.current_index = 0
+        return page.locator(next(iter(kwargs.get("editor_selector", "") or "x")))
+
+    monkeypatch.setattr(
+        resume_education, "open_hydrated_resume_editor", fake_open_hydrated_resume_editor
+    )
+
+    records = [
+        EducationRecord(
+            institution="МГУ им. М.В. Ломоносова",
+            level="",
+            faculty="",
+            organization="",
+            specialty="",
+            year="2022",
+        ),
+    ]
+
+    result = _edit_block(page, records, additional=False, dry_run=False, resume_id="RID")
+
+    # Save must never be clicked on a field the DOM disagrees with.
+    assert page.saved_rows == []
+    assert result.success is False
+    assert result.uncertain is False
+    assert result.saved == 0
+    assert "institution" in result.reason
+    assert "не приняло значение" in result.reason

--- a/tests/test_resume_education_form_shapes.py
+++ b/tests/test_resume_education_form_shapes.py
@@ -31,6 +31,7 @@ class RecordingLocator:
         self._page = page
         self._selector = selector
         self._count = count
+        self._value = ""
         self.first = self
 
     def count(self):
@@ -38,6 +39,10 @@ class RecordingLocator:
 
     def fill(self, value):
         self._page.filled.append((self._selector, value))
+        self._value = value
+
+    def input_value(self):
+        return self._value
 
     def click(self):
         self._page.clicked.append(self._selector)
@@ -79,6 +84,9 @@ class LabelPage:
         return RecordingLocator(self, f"label:{text}", count=count)
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        pass
+
+    def wait_for_timeout(self, timeout):  # noqa: ARG002
         pass
 
 

--- a/tests/test_resume_education_hydration_wait.py
+++ b/tests/test_resume_education_hydration_wait.py
@@ -67,8 +67,11 @@ class _HydratingLocator:
     def first(self):
         return self
 
-    def fill(self, value):  # noqa: ARG002
-        pass
+    def fill(self, value):
+        self._value = value
+
+    def input_value(self):
+        return getattr(self, "_value", "")
 
     def click(self):
         pass
@@ -97,6 +100,9 @@ class _RacyPage:
         return _HydratingLocator(ready_after=0)
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        pass
+
+    def wait_for_timeout(self, timeout):  # noqa: ARG002
         pass
 
 


### PR DESCRIPTION
## Живой прогон не выполнен, сессия протухла

Файл `data/storage_state/hh_session.json` от 16 августа, `whoami --online` даёт `[FAIL]`, live-запросы падают `resume-access-denied`. Код и юнит-тесты сделаны без живой проверки; шаги воспроизведения — ниже.

## Причина (из последнего комментария в #825, DOM-дамп)

`resume_education_primary_0_save_failure.png`: поля "Название учебного заведения" и "Год окончания" оба **пустые**, подсвечены hh.ru-валидацией "Пожалуйста, укажите" — хотя `--institution`/`--year` переданы верно, а клик по Save отработал (кнопка не задизейблена). Значит проблема не в ожидании навигации после клика (это чинили в #838), а в заполнении полей ДО клика Save.

Механизм — тот же класс "commit не значит отрисовано" из CLAUDE.md: `open_hydrated_resume_editor` ждёт лишь видимости институт-поля как маркера готовности формы. "Visible" не означает, что React/Magritte controlled input уже закончил инициализацию состояния — `.fill()` может попасть в DOM-узел раньше, чем React допишет свой рендер и обнулит контролируемое значение обратно к исходному (пустому). Тот же паттерн гонки, что уже чинили в #837/#839 для `create_resume.py`, только в обратную сторону — там читали устаревшее значение, здесь запись стирается уже после того, как Playwright её записал.

## Фикс

`_field_locator(...).fill(value)` заменён на `_fill_and_verify(page, locator, value)`:
- после `fill()` читаем `input_value()`;
- если значение не совпало — короткий verify-цикл (3с, опрос каждые 200мс — тот же идиом, что `WIZARD_VERIFY_POLL_MS` в `resume_position.py`), повторяя `fill()`;
- если значение так и не удержалось — строка образования падает **до** клика Save с понятной причиной и диагностическим дампом (`_dump_save_failure`), вместо клика по форме, которую браузер сам не заполнил, с последующим неинформативным таймаутом навигации.

## Тесты

Новый регрессионный тест (`test_field_that_reverts_after_fill_fails_before_save_click`) моделирует именно эту гонку: `fill()` физически "долетает" до узла, но `input_value()` всегда возвращает `""` — как контролируемый инпут, сбрасывающий себя в асинхронном ре-рендере. Проверяет, что Save в этом случае **не нажимается вовсе** и результат — плановый `[FAIL]` (не `uncertain`, поскольку клика ещё не было).

Существующие фейковые локаторы (`_edit_block`, `form_shapes`, `hydration_wait`) дополнены `input_value()`/`wait_for_timeout` под новый вызов, без изменения проверяемого поведения — все прежние тесты зелёные без правок логики.

## Шаги воспроизведения после оживления сессии

```
./scripts/run.sh --account default edit-education --resume <resume_id> \
  --section primary --institution "МГУ им. М.В. Ломоносова (тест)" \
  --faculty "..." --specialty "..." --year 2022 --force
```

Сверить на странице резюме, что раздел "Образование" заполнился (а не остался пустым с "Ещё вы можете добавить: Основное образование"). Тестировать только на черновиках, реальные резюме не хардкодить.

## Проверки перед пушем

- `ruff check src tests` — чисто
- `ruff format --check src tests` — чисто
- `pytest -q -n 4 --dist worksteal` — полный набор зелёный, 32с (бюджет 60с)
- `scripts/gen_cli_docs.py --check` — синхронизирован

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)