### PR TITLE
fix(edit-experience): гидрационное окно кнопки «Развернуть» панели резюме (#858)

### DIFF
--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -2173,13 +2173,14 @@ selectors:
         button. Live DOM trace found the button''s lowest common ancestor with the panel''s <h3> heading is 6 DIV levels up
         (a different, deeper container than the 2-level ancestor that holds the checkboxes themselves), so it is addressed
         as a page-wide control rather than scoped through the h3 — confirmed unique (count()==1) on the live shared-editor
-        screen, where it is the only "Развернуть"-labeled button. **Known live instability, NOT fully resolved by this PR**:
-        a plain Locator.click() on this button was confirmed to NOT expand the list on several live attempts despite elementFromPoint
-        confirming the click lands on the correct <span> (no #824-style interception) — the button IS visible/enabled/not
-        disabled. A focus()+keyboard.press("Space") sequence expanded the list successfully on ONE live attempt (cell count
-        2->8) but FAILED to expand it on a later attempt with the same sequence — the underlying activation mechanism for
-        this specific Magritte button variant remains unconfirmed and is tracked as a follow-up (see experience.py''s _reconcile_experience_resume_panel
-        docstring). The selector match itself (finding the button) is reliable; only its activation is not.'
+        screen, where it is the only "Развернуть"-labeled button. **#858 RESOLVED (live drill 2026-08-30, no save)**: the
+        PR #856 activation instability is a React HYDRATION WINDOW — the server-rendered button is visible/enabled ~1.5s
+        before React attaches its listeners; during that window the element carries no __reactFiber/__reactProps instance
+        keys and every click (Playwright actionability all pass, elementFromPoint on the button''s own label) is silently
+        swallowed. Measured on repeated live loads: clicks at 1.6-2.3s after load failed, the first click after both keys
+        appeared (~2.5s) succeeded every time. EXPERIENCE_RESUME_PANEL_EXPAND selector itself was correct all along;
+        _reconcile_experience_resume_panel now waits for the fiber+props readiness signal before clicking and retries
+        with confirmation (button must disappear) as defence in depth.'
     last_verified_at: '2026-08-30'
     verified_flow: authenticated_experience_editor_live_write_confirmed (17-resume account, draft target resume, expand activation
       unreliable)

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
-from playwright.sync_api import Page
+from playwright.sync_api import Locator, Page
 
 from .browser import (
     HH_BASE_URL,
@@ -445,6 +445,42 @@ def _experience_row_indexes(page: Page) -> list[int]:
 
 PANEL_TIMEOUT_MS = 5_000
 
+# #858: bounded retry around the panel expand click. Live drill 2026-08-30
+# measured the hydration window at ~1.5s after the button becomes visible;
+# 5 attempts x 400ms settle comfortably covers it with headroom for a slow
+# page, and any leftover failure still raises ResumePanelReconciliationError
+# (fail closed, no save).
+EXPAND_RETRY_ATTEMPTS = 5
+EXPAND_RETRY_DELAY_MS = 400
+
+
+def _wait_for_react_hydration(page: Page, locator: Locator, *, timeout_ms: int) -> None:
+    """Wait until ``locator``'s element carries React instance keys.
+
+    #858 root cause: hh.ru's Magritte buttons are server-rendered, so the
+    element is visible and enabled BEFORE React hydrates it — during that
+    window clicks are silently swallowed (no onClick listener is attached
+    yet). A hydrated element always carries the ``__reactFiber$…`` and
+    ``__reactProps$…`` instance keys, so their presence is a deterministic
+    readiness signal; polling it turns the previously nondeterministic
+    "click sometimes does nothing" into an explicit wait.
+    """
+    deadline = timeout_ms / 1000.0
+    try:
+        page.wait_for_function(
+            """(el) => {
+                const keys = Object.keys(el);
+                return keys.some((k) => k.startsWith('__reactFiber'))
+                    && keys.some((k) => k.startsWith('__reactProps'));
+            }""",
+            arg=locator.element_handle(timeout=timeout_ms),
+            timeout=deadline * 1000,
+        )
+    except PlaywrightError as exc:
+        raise ResumePanelReconciliationError(
+            f"кнопка панели резюме не гидрировалась за {timeout_ms}мс: {exc}"
+        ) from exc
+
 
 class ResumePanelReconciliationError(ValueError):
     """Raised when the "Резюме с этим местом работы" panel cannot be
@@ -483,20 +519,20 @@ def _reconcile_experience_resume_panel(
     than no save at all, the same fail-closed principle already used
     throughout this module for save-binding verification.
 
-    PR #856 LIVE WRITE test (2026-08-30, 17-resume account): the expand
-    button's ACTIVATION was found unreliable — a plain ``.click()`` did not
-    expand the list on several live attempts even though the click target
-    was confirmed correct (no #824-style interception: elementFromPoint
-    resolves to the button's own label span). A ``focus()`` +
-    ``keyboard.press("Space")`` sequence expanded the list on one live
-    attempt but failed to on a later one with the identical sequence — the
-    underlying activation mechanism for this specific Magritte button
-    variant is not yet understood. Both are attempted below (click first,
-    then the keyboard sequence as a second attempt) since either narrows the
-    failure window even without explaining it; this remains a known,
-    tracked instability (follow-up needed), not a silently-accepted gap —
-    the fail-closed error below still fires if BOTH attempts leave the
-    button in place.
+    #858 LIVE drill (2026-08-30, read-only UI drill on the draft resume, no
+    save): the PR #856 instability is a HYDRATION WINDOW, not a broken
+    activation mechanism. The button is server-rendered into the DOM early
+    and is visible/enabled for ~1.5s BEFORE React attaches its event
+    listeners — during that window it carries no ``__reactFiber``/
+    ``__reactProps`` instance keys and any click (Playwright's actionability
+    checks all pass) is silently swallowed. Once both keys appear, a plain
+    ``.click()`` expands the list on the first try, every time (confirmed on
+    repeated page loads: clicks at 1.6–2.3s after load all failed, the first
+    click after fiber+props attach succeeded). So: wait for hydration before
+    clicking, and keep a bounded retry-with-confirmation loop (issue #858
+    item 3) as defence in depth — each attempt is only counted as done when
+    the button actually disappears (replaced by "Свернуть"), never on click
+    success alone.
     """
     scope = page.locator(EXPERIENCE_RESUME_PANEL_SCOPE)
     if scope.count() != 1:
@@ -512,20 +548,22 @@ def _reconcile_experience_resume_panel(
         # control scoped to this panel.
         try:
             expand.wait_for(state="visible", timeout=PANEL_TIMEOUT_MS)
-            expand.click()
-            try:
-                expand.wait_for(state="hidden", timeout=PANEL_TIMEOUT_MS)
-            except PlaywrightError:
-                # #782/#856 live trace: plain click() confirmed unreliable
-                # for this specific control (see docstring above) — a
-                # keyboard-activation retry via focus()+Space was live-
-                # confirmed to succeed at least once where click() alone did
-                # not. Only attempted once as a second line of defence, not
-                # looped: the fail-closed error below still fires if this
-                # also does not hide the button.
-                expand.focus()
-                page.keyboard.press("Space")
-                expand.wait_for(state="hidden", timeout=PANEL_TIMEOUT_MS)
+            _wait_for_react_hydration(page, expand, timeout_ms=PANEL_TIMEOUT_MS)
+            last_exc: PlaywrightError | None = None
+            for _ in range(EXPAND_RETRY_ATTEMPTS):
+                try:
+                    expand.click()
+                    expand.wait_for(state="hidden", timeout=PANEL_TIMEOUT_MS)
+                    last_exc = None
+                    break
+                except PlaywrightError as exc:
+                    last_exc = exc
+                    # A swallowed click still leaves the button visible; a
+                    # short settle before re-clicking avoids racing the very
+                    # re-render that is about to attach the handlers.
+                    page.wait_for_timeout(EXPAND_RETRY_DELAY_MS)
+            if last_exc is not None:
+                raise last_exc
         except PlaywrightError as exc:
             raise ResumePanelReconciliationError(
                 f"не удалось развернуть панель 'Резюме с этим местом работы': {exc}"

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,4 +1,5 @@
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 from hhru_bot.experience import (
     ExperienceEntry,
@@ -180,6 +181,9 @@ class _Locator:
 
     def is_checked(self):
         return self._checked
+
+    def element_handle(self, *, timeout=None):
+        return object()
 
     @property
     def first(self):
@@ -375,6 +379,12 @@ class _SavePage:
         return _Locator(count=1)
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):
+        return None
+
+    def wait_for_function(self, _fn, *, arg=None, timeout=None):
+        return None
+
+    def wait_for_timeout(self, _ms):
         return None
 
     def reload(self, *, timeout=None, wait_until=None):
@@ -933,7 +943,8 @@ class _AddButtonPage:
     live-confirmed collapse threshold.
     """
 
-    def __init__(self, initial_indexes, panel_titles: dict[str, bool], *, has_expand=None):
+    def __init__(self, initial_indexes, panel_titles: dict[str, bool], *, has_expand=None,
+                 expand_swallowed_clicks: int = 0):
         self.url = "https://hh.ru/resume/resume-1"
         self.indexes = list(initial_indexes)
         self._reloaded = False
@@ -942,6 +953,11 @@ class _AddButtonPage:
             for title, checked in panel_titles.items()
         }
         self._has_expand = has_expand if has_expand is not None else len(panel_titles) > 2
+        # #858: the first N clicks on the expand control are "swallowed" by
+        # the pre-hydration window — click() succeeds but the button stays
+        # visible (wait_for(state="hidden") raises), mirroring the live drill.
+        self._expand_swallowed_clicks = expand_swallowed_clicks
+        self.expand_attempts = 0
         self.expand_clicked = False
         self.add_clicked = False
 
@@ -970,7 +986,13 @@ class _AddButtonPage:
 
             class _ExpandLocator(_Locator):
                 def click(self, *, timeout=None, **_kwargs):
+                    page.expand_attempts += 1
                     page.expand_clicked = True
+
+                def wait_for(self, *, timeout=None, state=None):
+                    if state == "hidden" and page.expand_attempts <= page._expand_swallowed_clicks:
+                        raise PlaywrightError("swallowed by pre-hydration window (#858)")
+                    return None
 
             return _ExpandLocator(count=1)
         if selector.startswith("xpath=") and "этим местом работы" in selector:
@@ -978,6 +1000,14 @@ class _AddButtonPage:
         return _Locator(count=1)
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):
+        return None
+
+    def wait_for_function(self, _fn, *, arg=None, timeout=None):
+        # #858: hydration readiness probe — the fake's expand control is
+        # treated as hydrated immediately.
+        return None
+
+    def wait_for_timeout(self, _ms):
         return None
 
     def reload(self, *, timeout=None, wait_until=None):
@@ -1110,6 +1140,58 @@ def test_edit_experience_via_add_button_expands_collapsed_panel(monkeypatch):
 
     assert page.expand_clicked is True
     assert results == [ExperienceResult("строка 7: сохранено и привязано к резюме", True)]
+
+
+def test_edit_experience_via_add_button_retries_swallowed_expand_clicks(monkeypatch):
+    """#858: hh.ru server-renders the expand button before React hydrates it
+    (live drill 2026-08-30: clicks at 1.6-2.3s after load were silently
+    swallowed, the first click after __reactFiber/__reactProps attached
+    worked). Reconciliation must retry the click — with post-click
+    confirmation — instead of failing on the first swallowed one."""
+    _add_button_fixture(monkeypatch, None)
+    page = _AddButtonPage(
+        [2, 3],
+        panel_titles={"Target Resume": True, "ai-engineer": True, "python": True},
+        expand_swallowed_clicks=2,
+    )
+
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan([ExperienceEntry(company="Acme", position="Engineer")]),
+        dry_run=False,
+        indexes=[7],
+        resume_titles={"resume-1": "Target Resume", "o1": "ai-engineer", "o2": "python"},
+    )
+
+    assert page.expand_attempts == 3  # two swallowed, third confirmed
+    assert results == [ExperienceResult("строка 7: сохранено и привязано к резюме", True)]
+
+
+def test_edit_experience_via_add_button_fails_closed_when_all_expand_clicks_swallowed(monkeypatch):
+    """#858 fail-closed: if every retry is swallowed (list never expands),
+    reconciliation must still refuse before any save click — the retry loop
+    narrows the failure window, it does not lower the confirmation bar."""
+    _add_button_fixture(monkeypatch, None)
+    page = _AddButtonPage(
+        [2, 3],
+        panel_titles={"Target Resume": True, "ai-engineer": True, "python": True},
+        expand_swallowed_clicks=99,
+    )
+
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan([ExperienceEntry(company="Acme", position="Engineer")]),
+        dry_run=False,
+        indexes=[7],
+        resume_titles={"resume-1": "Target Resume", "o1": "ai-engineer", "o2": "python"},
+    )
+
+    assert page.expand_attempts == 5  # EXPAND_RETRY_ATTEMPTS, then give up
+    assert len(results) == 1
+    assert not results[0].success
+    assert "не удалось развернуть панель" in results[0].reason
 
 
 def test_edit_experience_via_add_button_fails_closed_when_checkbox_count_mismatches(monkeypatch):

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -943,8 +943,14 @@ class _AddButtonPage:
     live-confirmed collapse threshold.
     """
 
-    def __init__(self, initial_indexes, panel_titles: dict[str, bool], *, has_expand=None,
-                 expand_swallowed_clicks: int = 0):
+    def __init__(
+        self,
+        initial_indexes,
+        panel_titles: dict[str, bool],
+        *,
+        has_expand=None,
+        expand_swallowed_clicks: int = 0,
+    ):
         self.url = "https://hh.ru/resume/resume-1"
         self.indexes = list(initial_indexes)
         self._reloaded = False


### PR DESCRIPTION
## Проблема (#858)

PR #856 задокументировал: кнопка «Развернуть» панели «Резюме с этим местом работы» находится корректно, но активируется нестабильно — обычный click() иногда не раскрывает список, focus()+Space сработал один раз из двух, dispatchEvent не сработал вовсе.

## Причина — установлена живым drill'ом (2026-08-30)

Кнопка **сервер-рендерится в DOM до гидрации React**: ~1.5с она видима, enabled, не перекрыта (elementFromPoint — её собственный label), но на элементе ещё нет `__reactFiber$…`/`__reactProps$…` — обработчик onClick не привязан, и клик молча теряется. Все actionability-проверки Playwright при этом проходят.

Замеры на повторных живых загрузках shared-editor экрана (тестовый черновик `24b16b4a…`, без save):
- кнопка видна с ~1.1–1.5с; до ~1.5с на ней нет fiber/props (SSR-разметка);
- клики в 1.6с / 1.9с / 2.3с — проглочены (кнопка на месте, чекбоксов по-прежнему 2);
- первый клик после появления fiber+props (~2.5с) — срабатывает всегда, во всех прогонах.

Ни click-механика, ни Magritte-вариант кнопки не виноваты — это классическое окно гидрации.

## Фикс

1. **`_wait_for_react_hydration()`** — детерминированное ожидание готовности: поллинг `__reactFiber`+`__reactProps` на `element_handle()` кнопки (вместо слепого клика сразу после `wait_for(visible)`).
2. **Retry-loop с подтверждением** (п.3 ишью): до 5 попыток × 400мс; попытка засчитывается только если кнопка реально исчезла (wait_for hidden), не по факту click(). Исчерпание → прежний fail-closed `ResumePanelReconciliationError` до save.
3. **reference-map.yaml**: evidence `EXPERIENCE_RESUME_PANEL_EXPAND` обновлён с «known instability, NOT resolved» на «hydration window, resolved», с замерами.
4. **Юнит-тесты**: 2 проглоченных клика → 3-й подтверждён (OK); все проглочены → ровно 5 попыток и отказ до save (fail-closed).

## Проверка

- `pytest tests/` — 187 passed.
- Живой drill: подтверждено, что после гидрации обычный `.click()` работает с первой попытки — прежний focus()+Space fallback удалён как не нужный.

## Provenance

PR от агента (ZCode, ветка `fix/858-resume-panel-expand-hydration`), базируется на немерженном PR #856 (`ao/hhru-415/fix-edit-experience`) — мержить после #856. Live-работа: только read-only UI drill (навигация + клик «Развернуть», чисто клиентское раскрытие списка), save/submit не нажимались.

Closes #858