### PR TITLE
test: убрать файл журнала SQLite и два busy-spin теста из сьюта

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import hashlib
+import sqlite3
 
 import playwright._impl._driver
 import playwright._impl._transport
@@ -57,6 +58,37 @@ def _guarded_sync_context_enter(self):
     return _real_sync_context_enter(self)
 
 
+_real_sqlite_connect = sqlite3.connect
+
+
+def _sqlite_connect_without_journal_file(*args, **kwargs):
+    """SQLite без файла журнала: на него уходило ~40% времени прогона.
+
+    Дефолтный `journal_mode=DELETE` создаёт и удаляет файл `-journal` на КАЖДУЮ
+    транзакцию. Сьют открывает `History(tmp_path / ...)` ~690 раз и делает
+    тысячи commit'ов, и на APFS это давало 25.7с system time из 82с wall
+    (замер 2026-08-30). Журнал в памяти + `synchronous=OFF` убирают файловые
+    операции: 82с → 64с однопоточно, system 25.7с → 8.2с — тот же движок, та
+    же схема, тот же отдельный файл БД на тест (изоляция не меняется).
+
+    Что при этом не теряется: ни один тест не проверяет устойчивость БД к
+    обрыву питания — проверяется логика `history.py` (UNIQUE-индексы, lease,
+    dedup), а она работает на той же реальной SQLite. Тесты обрыва процесса
+    (`test_history_competitors`) убивают процесс между транзакциями, а не
+    посреди записи, и на журнал не опираются.
+
+    Ошибка PRAGMA глотается per-connection: read-only соединение (`mode=ro`,
+    `commands/query.py`) может отказать, и это не повод ронять тест.
+    """
+    conn = _real_sqlite_connect(*args, **kwargs)
+    try:
+        conn.execute("PRAGMA journal_mode=MEMORY")
+        conn.execute("PRAGMA synchronous=OFF")
+    except sqlite3.Error:
+        pass
+    return conn
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Ставит защиту ДО сбора тестов (#217).
 
@@ -80,6 +112,9 @@ def pytest_configure(config: pytest.Config) -> None:
     for module in _DRIVER_MODULES:
         module.compute_driver_executable = _guarded_compute_driver_executable
     PlaywrightContextManager.__enter__ = _guarded_sync_context_enter
+    # Под xdist pytest_configure выполняется в каждом воркере — патч доезжает
+    # до всех процессов, где реально открываются соединения.
+    sqlite3.connect = _sqlite_connect_without_journal_file
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -591,6 +591,25 @@ def test_unchecked_after_row_click_refuses_to_continue(monkeypatch):
 
     page = NeverChecksPage()
 
+    # Тест проверяет отказ ПОСЛЕ исчерпания дедлайна, а не сам дедлайн. С
+    # реальным `_CHECKBOX_CONFIRM_TIMEOUT` (5с) и no-op `wait_for_timeout` фейка
+    # цикл подтверждения крутил CPU 5 секунд wall-clock — самый долгий тест
+    # сьюта. Тот же приём, что в test_checkbox_never_confirmed_* ниже:
+    # детерминированные часы + короткий дедлайн.
+    call_count = 0
+
+    def fake_monotonic():
+        nonlocal call_count
+        call_count += 1
+        return call_count * 0.1
+
+    monkeypatch.setattr(create.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(
+        create,
+        "_select_catalog_leaf",
+        lambda p, area, **_: _real_select(p, area, checkbox_confirm_timeout=0.3),
+    )
+
     result = _run(page, before_click=lambda: None)
 
     assert not result.success

--- a/tests/test_resume_education_edit_block.py
+++ b/tests/test_resume_education_edit_block.py
@@ -333,6 +333,11 @@ def test_field_that_reverts_after_fill_fails_before_save_click(monkeypatch):
     monkeypatch.setattr(
         resume_education, "open_hydrated_resume_editor", fake_open_hydrated_resume_editor
     )
+    # Проверяется отказ после исчерпания бюджета readback'а, а не его величина:
+    # с боевыми 3000 мс и no-op wait_for_timeout фейка цикл `_fill_verified`
+    # крутил CPU 3 секунды wall-clock. Значение читается из модуля при вызове,
+    # поэтому monkeypatch достаточно.
+    monkeypatch.setattr(resume_education, "FIELD_VERIFY_TIMEOUT_MS", 50)
 
     records = [
         EducationRecord(


### PR DESCRIPTION
Closes #860

## Что

- `tests/conftest.py`: `sqlite3.connect` патчится в `pytest_configure` на `PRAGMA journal_mode=MEMORY` + `synchronous=OFF`. Движок, схема и отдельный файл БД на тест — те же; уходит только файл `-journal` на каждую транзакцию. Под xdist патч доезжает до каждого воркера (у них свой `pytest_configure`).
- `test_create_resume_browser.py::test_unchecked_after_row_click_refuses_to_continue`: детерминированные часы + `checkbox_confirm_timeout=0.3` — тот же приём, что у соседнего теста в файле. Было 5.0с busy-spin.
- `test_resume_education_edit_block.py::test_field_that_reverts_after_fill_fails_before_save_click`: `FIELD_VERIFY_TIMEOUT_MS` → 50 через monkeypatch. Было 3.0с busy-spin.

Никакого кода в `src/` не тронуто.

## Почему это не потеря качества

- Ни один тест не проверяет устойчивость БД к обрыву питания — проверяется логика `history.py` (UNIQUE-индексы, lease, dedup) на той же реальной SQLite. `test_history_competitors::test_abrupt_process_exit_is_recovered_from_last_checkpoint` убивает процесс между транзакциями и на журнал не опирается — зелёный.
- Оба ускоренных теста проверяют «отказ после исчерпания дедлайна», а не величину дедлайна.

## Замер (однопоточно, `pytest -q`, эта же машина)

| | wall | system |
|---|---|---|
| main | 82с | 25.7с |
| PR | **40.7с** | **7.1с** |

Оговорка: машина в момент замеров была под load average ~74 и в свопе, абсолютные цифры шумят; дельта по system time надёжна. Ожидаю, что на CI под `-n 4` выигрыш заметнее — файловый I/O сериализовал воркеров.

`ruff check` + `ruff format --check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHqxN7WdZGumGCt6HsuEe2