### PR TITLE
fix(edit-education): прямой роут для пустого доп. образования и trigger-shape по data-qa (#857)

### DIFF
--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -59,6 +59,19 @@ ADDITIONAL_ROUTE = re.compile(r"/profile/edit/additionalEducation/[^/?#]+")
 #   additional -> /resume/edit/<id>/additionalEducation -> resume-partial-edit-*
 # Each candidate is count=0 on the other screen; keep them separate rather than
 # guessing one shared id.
+# #857 (live probe 2026-08-30): the additionalEducation CARD on the resume page
+# renders ONLY when at least one additional entry is already attached to the
+# resume (entries are profile-level and are attached on the wizard's educations
+# screen). A resume with zero attached additional entries has neither the card
+# nor the Add link -- but the resume-scoped direct route below still renders
+# the full resume-partial-edit form (confirmed live on such a resume). It is
+# the only confirmed way in for that case, so _edit_block falls back to it.
+ADDITIONAL_DIRECT_PATH = "/resume/edit/{resume_id}/additionalEducation"
+# The primary education card is the always-present hydration marker used for
+# the additional block's pre-loop wait (see _edit_block): #812's invariant
+# ("Уровень образования" field always exists) means the card renders on every
+# resume page even when the additional card legitimately does not.
+PRIMARY_EDUCATION_CARD = "[data-qa='resume-list-card-education']"
 CANCEL_BUTTON = "[data-qa='profile-layout-cancel-button']"
 SAVE_BUTTON = "[data-qa='profile-layout-save-button']"
 ADDITIONAL_CANCEL_BUTTON = "[data-qa='resume-partial-edit-cancel']"
@@ -92,16 +105,32 @@ _PRIMARY_FIELDS = {
     "specialty": "[data-qa='profile-education-specialty-input']",
     "year": "[data-qa='profile-education-year-input']",
 }
-# The additional-education form carries NO data-qa on any of its inputs — they
-# are bound only through aria-labelledby + <label> (Magritte, live probe
-# 2026-08-30; every profile-education-additional-* candidate is count=0 there).
-# The visible label is the only stable handle, addressed through
-# browser.labelled_field, which requires one exact match and fails closed.
+# The additional-education form opened through the DIRECT route carries NO
+# data-qa on any of its inputs — they are bound only through aria-labelledby +
+# <label> (Magritte, live probe 2026-08-30; every profile-education-additional-*
+# candidate is count=0 there). The visible label is the only stable handle,
+# addressed through browser.labelled_field, which requires one exact match and
+# fails closed.
 _ADDITIONAL_LABELS = {
     "institution": "Название",
     "organization": "Проводившая организация",
     "specialty": "Специализация",
     "year": "Год окончания",
+}
+# #857 (live drill, 2026-08-30): the SAME semantic form opened through the
+# resume card's row trigger is a DIFFERENT shape -- its inputs carry data-qa
+# and their <label> elements bind with EMPTY text (dumped live on the trigger-
+# opened form), so get_by_label is unreliable there: it resolved and verified
+# an institution fill that hh.ru then did not persist (2 of 3 trigger-shape
+# saves took the value, one silently reverted -- same fill-then-reset race
+# class as #825, but the address itself is the weak link). These data-qa were
+# confirmed by dumping the opened form; year reuses the primary editor's year
+# input.
+_ADDITIONAL_TRIGGER_SHAPE_FIELDS = {
+    "institution": "[data-qa='profile-education-additional-name']",
+    "organization": "[data-qa='profile-education-additional-organization']",
+    "specialty": "[data-qa='profile-education-additional-specialty']",
+    "year": "[data-qa='profile-education-year-input']",
 }
 FORM_TIMEOUT_MS = 15_000
 # #825: было отсутствие явного timeout у wait_for_url после клика Save, из-за
@@ -230,14 +259,22 @@ def generate_education_plan(
         )
 
 
-def _field_locator(page, name: str, *, additional: bool):
-    """Resolve one education field on whichever of the two forms is open.
+def _field_locator(page, name: str, *, additional: bool, trigger_shape: bool = False):
+    """Resolve one education field on whichever of the additional shapes is open.
 
-    Both paths require exactly one match and raise otherwise, so a drifted
+    All paths require exactly one match and raise otherwise, so a drifted
     selector or an ambiguous label stops the write instead of filling the
-    wrong control.
+    wrong control. #857: the additional block has TWO shapes -- direct-route
+    (label-addressed) and trigger-opened (data-qa, see
+    _ADDITIONAL_TRIGGER_SHAPE_FIELDS); primary stays data-qa.
     """
     if additional:
+        if trigger_shape:
+            selector = _ADDITIONAL_TRIGGER_SHAPE_FIELDS[name]
+            locator = page.locator(selector)
+            if locator.count() != 1:
+                raise PageStateIndeterminate(f"поле {selector} не найдено однозначно")
+            return locator
         return labelled_field(page, _ADDITIONAL_LABELS[name])
     locator = page.locator(_PRIMARY_FIELDS[name])
     if locator.count() != 1:
@@ -329,14 +366,17 @@ def _edit_block(
     # education card asynchronously, and a strict count() right after goto_hh
     # can race it and see 0 even though the card renders moments later. The
     # "Уровень образования" field always exists on hh.ru (unlike about/skills,
-    # this section is never legitimately absent), so exactly one of the two
-    # possible markers -- the first row's edit trigger (records already
-    # present) or the confirmed Add link (section empty) -- must eventually
-    # appear; wait for either before the first strict check below.
+    # this section is never legitimately absent), so exactly one of the
+    # possible markers must eventually appear. #857: for the additional block
+    # the card and Add link may BOTH legitimately never render (no attached
+    # entries), so the always-present primary education card completes the
+    # marker set there; the per-row logic below reaches the form through the
+    # direct route in that case.
+    pre_loop = page.locator(trigger.format(index=0)).or_(page.locator(add_selector))
+    if additional:
+        pre_loop = pre_loop.or_(page.locator(PRIMARY_EDUCATION_CARD))
     try:
-        page.locator(trigger.format(index=0)).or_(page.locator(add_selector)).first.wait_for(
-            state="visible", timeout=FORM_TIMEOUT_MS
-        )
+        pre_loop.first.wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
     except PlaywrightTimeoutError as exc:
         return EducationResult(
             kind,
@@ -358,7 +398,7 @@ def _edit_block(
             # The confirmed Add link is the only safe way to create a missing
             # row. Never guess an unverified route or API endpoint.
             button = page.locator(add_selector)
-            if button.count() != 1:
+            if button.count() != 1 and not additional:
                 return EducationResult(
                     kind,
                     False,
@@ -367,27 +407,62 @@ def _edit_block(
                     uncertain=saved_count > 0,
                     saved=saved_count,
                 )
+        # #857: additional with neither an existing row trigger nor the Add
+        # link (no card at all -- zero attached profile entries) opens the
+        # form through its resume-scoped direct route instead. The resume_id
+        # is part of the URL, so the identity check below binds the form to
+        # the right resume; nothing is scoped to a clickable trigger that
+        # does not exist.
+        direct_route = additional and button_count == 0 and button.count() != 1
+        # #857 (live drill): the additional form renders TWO control shapes
+        # depending on how it was opened. Opened through the direct route it
+        # carries resume-partial-edit-save/cancel (as the 2026-08-30 probe
+        # that picked these selectors saw); opened through the resume card's
+        # row trigger it renders profile-layout-save-button/cancel-button --
+        # the SAME controls as the primary editor -- and the
+        # resume-partial-edit buttons are count=0 there (confirmed live by
+        # clicking the trigger and dumping the controls, no save pressed).
+        # The editor hydration marker follows the same choice.
+        if additional and not direct_route:
+            row_save_selector = SAVE_BUTTON
+            row_cancel_selector = CANCEL_BUTTON
+        else:
+            row_save_selector = save_selector
+            row_cancel_selector = cancel_selector
         save_clicked = False
         try:
-            open_hydrated_resume_editor(
-                page,
-                trigger_selector=(
-                    trigger.format(index=index) if button_count == 1 else add_selector
-                ),
-                # The additional form exposes no data-qa on its inputs, so its
-                # hydration marker is the editor's own save control (live probe
-                # 2026-08-30: present on the rendered form, absent before it).
-                editor_selector=(
-                    ADDITIONAL_SAVE_BUTTON if additional else _PRIMARY_FIELDS["institution"]
-                ),
-                profile_path=f"/resume/{resume_id}",
-                edit_path=route,
-                timeout=FORM_TIMEOUT_MS,
-                trigger_error=f"триггер образования {index} не найден однозначно",
-                open_error=f"форма образования {index} не открылась",
-                wrong_route_error=f"форма образования {index} открыта не для того резюме",
-                expected_query={"resumeFrom": resume_id} if not additional else None,
-            )
+            if direct_route:
+                goto_hh(page, f"{HH_BASE_URL}{ADDITIONAL_DIRECT_PATH.format(resume_id=resume_id)}")
+                editor_marker = page.locator(row_save_selector)
+                editor_marker.first.wait_for(state="visible", timeout=FORM_TIMEOUT_MS)
+                current_path = urlsplit(page.url).path
+                if (
+                    not current_path.endswith("/additionalEducation")
+                    or resume_id not in current_path
+                ):
+                    raise RuntimeError(
+                        f"форма доп. образования открыта не для того резюме: {page.url}"
+                    )
+            else:
+                open_hydrated_resume_editor(
+                    page,
+                    trigger_selector=(
+                        trigger.format(index=index) if button_count == 1 else add_selector
+                    ),
+                    # The additional form exposes no data-qa on its inputs, so its
+                    # hydration marker is the editor's own save control (live probe
+                    # 2026-08-30: present on the rendered form, absent before it).
+                    editor_selector=(
+                        row_save_selector if additional else _PRIMARY_FIELDS["institution"]
+                    ),
+                    profile_path=f"/resume/{resume_id}",
+                    edit_path=route,
+                    timeout=FORM_TIMEOUT_MS,
+                    trigger_error=f"триггер образования {index} не найден однозначно",
+                    open_error=f"форма образования {index} не открылась",
+                    wrong_route_error=f"форма образования {index} открыта не для того резюме",
+                    expected_query={"resumeFrom": resume_id} if not additional else None,
+                )
             for name in field_names:
                 value = getattr(record, name)
                 # Empty LLM fields mean "unknown", not "erase the current value".
@@ -396,7 +471,12 @@ def _edit_block(
                 if not value:
                     continue
                 try:
-                    locator = _field_locator(page, name, additional=additional)
+                    locator = _field_locator(
+                        page,
+                        name,
+                        additional=additional,
+                        trigger_shape=additional and not direct_route,
+                    )
                 except PageStateIndeterminate as exc:
                     return EducationResult(
                         kind,
@@ -428,9 +508,9 @@ def _edit_block(
                         saved=saved_count,
                     )
             if dry_run:
-                page.locator(cancel_selector).first.click()
+                page.locator(row_cancel_selector).first.click()
             else:
-                save = page.locator(save_selector)
+                save = page.locator(row_save_selector)
                 if save.count() != 1:
                     return EducationResult(
                         kind,
@@ -529,21 +609,38 @@ def _edit_block(
                         uncertain=True,
                         saved=saved_count,
                     )
-                if page.get_by_text(institution_value).count() == 0:
-                    _dump_save_failure(
-                        page,
-                        index,
-                        kind,
-                        RuntimeError(f"{institution_value!r} не найден на резюме после сохранения"),
-                    )
-                    return EducationResult(
-                        kind,
-                        False,
-                        f"строка {index}: запись не отображается на резюме после сохранения "
-                        f"({institution_value!r} не найден)",
-                        uncertain=True,
-                        saved=saved_count,
-                    )
+                # #857 (live drill): the text check races the SPA's hydration
+                # of the resume page -- wait_for_url(commit) confirms the URL,
+                # not the rendered card, so an immediate get_by_text().count()
+                # saw 0 for a record hh.ru had genuinely saved (the record
+                # appeared once hydration finished, confirmed by a follow-up
+                # read-only probe). Poll for the text within a bounded budget
+                # (same "commit не значит отрисовано" class as the pre-loop
+                # wait above; FORM_TIMEOUT_MS, not FIELD_VERIFY_TIMEOUT_MS --
+                # the live drill's card rendered well after 3s) instead of
+                # trusting a single immediate read.
+                text_deadline = time.monotonic() + FORM_TIMEOUT_MS / 1000
+                while True:
+                    if page.get_by_text(institution_value).count() > 0:
+                        break
+                    if time.monotonic() >= text_deadline:
+                        _dump_save_failure(
+                            page,
+                            index,
+                            kind,
+                            RuntimeError(
+                                f"{institution_value!r} не найден на резюме после сохранения"
+                            ),
+                        )
+                        return EducationResult(
+                            kind,
+                            False,
+                            f"строка {index}: запись не отображается на резюме после сохранения "
+                            f"({institution_value!r} не найден)",
+                            uncertain=True,
+                            saved=saved_count,
+                        )
+                    page.wait_for_timeout(FIELD_VERIFY_POLL_MS)
                 saved_count += 1
         except (PlaywrightError, RuntimeError) as exc:
             # open_hydrated_resume_editor raises RuntimeError (not PlaywrightError)

--- a/tests/test_resume_education_additional_direct.py
+++ b/tests/test_resume_education_additional_direct.py
@@ -1,0 +1,181 @@
+"""Regression tests for #857: the additional-education block must fall back to
+its resume-scoped direct route when the resume page renders no additional
+card and no Add link.
+
+Live probe (2026-08-30): hh.ru renders the additionalEducation card ONLY when
+at least one additional entry is already attached to the resume (entries are
+profile-level). A resume with zero attached entries has neither the card nor
+the Add link, so the pre-#857 code failed with "блок образования не
+отобразился" before ever reaching a save. The direct route
+/resume/edit/{id}/additionalEducation still renders the full
+resume-partial-edit form for such resumes (confirmed live), so the block
+opens the form there instead of failing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from hhru_bot import resume_education
+from hhru_bot.config_sections.education import EducationRecord
+from hhru_bot.resume_education import _edit_block
+
+pytestmark = pytest.mark.unit
+
+
+class _AlwaysReadyLocator:
+    def count(self):
+        return 1
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        pass
+
+    def fill(self, value):
+        self._value = value
+
+    def input_value(self):
+        return getattr(self, "_value", "")
+
+    def click(self):
+        pass
+
+
+class _NeverLocator:
+    def __init__(self):
+        self.count_reads = 0
+
+    def count(self):
+        self.count_reads += 1
+        return 0
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        raise PlaywrightTimeoutError("never renders")
+
+    def or_(self, other):
+        return _OrChain(self, other)
+
+
+class _OrChain:
+    def __init__(self, *parts):
+        self._parts = parts
+
+    def count(self):
+        return sum(part.count() for part in self._parts)
+
+    def or_(self, other):
+        return _OrChain(*self._parts, other)
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state=None, timeout=None):  # noqa: ARG002
+        for part in self._parts:
+            if part.count() >= 1:
+                return
+        raise PlaywrightTimeoutError("no marker rendered")
+
+
+class _FakePage:
+    """No additional card and no Add link ever render (the #857 live case);
+    the primary education card hydrates immediately; the direct route renders
+    the save button."""
+
+    def __init__(self, direct_url: str | None = None):
+        self.url = "https://hh.ru/resume/RID"
+        self._direct_url = direct_url
+
+    def goto_direct(self, url: str):
+        if self._direct_url is not None:
+            self.url = self._direct_url
+
+    def locator(self, selector: str):
+        if selector == resume_education.PRIMARY_EDUCATION_CARD:
+            return _AlwaysReadyLocator()
+        if selector == resume_education.ADDITIONAL_SAVE_BUTTON:
+            return _AlwaysReadyLocator()
+        return _NeverLocator().or_(_NeverLocator())
+
+    def get_by_text(self, text):  # noqa: ARG002
+        class _T:
+            def count(self):
+                return 1
+
+        return _T()
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        pass
+
+    def wait_for_timeout(self, timeout):  # noqa: ARG002
+        pass
+
+    def content(self):
+        return "<html></html>"
+
+
+_RECORD = EducationRecord(
+    institution="Курс 857",
+    level="",
+    faculty="",
+    organization="Орг 857",
+    specialty="Спец",
+    year="2020",
+)
+
+
+def _patch_common(monkeypatch, page: _FakePage):
+    monkeypatch.setattr(resume_education, "goto_hh", lambda p, url: page.goto_direct(url))
+    monkeypatch.setattr(resume_education, "labelled_field", lambda p, label: _AlwaysReadyLocator())
+    monkeypatch.setattr(resume_education, "resume_identity_matches", lambda p, rid: True)
+    monkeypatch.setattr(resume_education, "dismiss_cookie_banner", lambda p: None)
+
+
+def test_additional_without_card_uses_direct_route(monkeypatch):
+    page = _FakePage(direct_url="https://hh.ru/resume/edit/RID/additionalEducation")
+    _patch_common(monkeypatch, page)
+
+    result = _edit_block(page, [_RECORD], additional=True, dry_run=False, resume_id="RID")
+
+    assert result.success is True, result.reason
+    assert result.saved == 1
+
+
+def test_primary_without_card_still_fails_closed(monkeypatch):
+    page = _FakePage(direct_url="https://hh.ru/resume/edit/RID/additionalEducation")
+    _patch_common(monkeypatch, page)
+
+    result = _edit_block(page, [_RECORD], additional=False, dry_run=False, resume_id="RID")
+
+    assert result.success is False
+    assert result.uncertain is False
+    assert "не отобразился" in result.reason
+
+
+def test_direct_route_wrong_resume_fails_closed(monkeypatch):
+    page = _FakePage(direct_url="https://hh.ru/resume/edit/OTHER/additionalEducation")
+    _patch_common(monkeypatch, page)
+
+    result = _edit_block(page, [_RECORD], additional=True, dry_run=False, resume_id="RID")
+
+    assert result.success is False
+    assert result.uncertain is False
+    assert "не для того резюме" in result.reason
+
+
+def test_direct_route_redirect_away_fails_closed(monkeypatch):
+    page = _FakePage(direct_url="https://hh.ru/resume/RID")
+    _patch_common(monkeypatch, page)
+
+    result = _edit_block(page, [_RECORD], additional=True, dry_run=False, resume_id="RID")
+
+    assert result.success is False
+    assert result.uncertain is False

--- a/tests/test_resume_education_form_shapes.py
+++ b/tests/test_resume_education_form_shapes.py
@@ -1,17 +1,21 @@
-"""The two education editors are different screens (#773).
+"""The education editors are different screens (#773, #857).
 
-Live probe 2026-08-30 showed the additional-education form shares neither its
-buttons nor its field addressing with the primary one:
+Live probes 2026-08-30 showed the additional-education form shares neither its
+buttons nor its field addressing with the primary one, AND renders two shapes
+of its own depending on the entry point (#857 live drill):
 
 * primary    -> /profile/edit/primaryEducation        -> ``profile-layout-*``
   buttons, ``profile-education-*-input`` fields;
-* additional -> /resume/edit/<id>/additionalEducation -> ``resume-partial-edit-*``
-  buttons, and inputs with NO ``data-qa`` at all, bound only through
-  ``aria-labelledby`` + ``<label>`` (Magritte).
+* additional, direct route /resume/edit/<id>/additionalEducation ->
+  ``resume-partial-edit-*`` buttons, inputs with NO ``data-qa`` bound only
+  through ``aria-labelledby`` + ``<label>`` (Magritte);
+* additional, opened through the resume card row trigger ->
+  ``profile-layout-*`` buttons (same as primary) and data-qa
+  ``profile-education-additional-*`` fields whose <label> bindings are EMPTY.
 
-These tests pin that split so a future edit cannot collapse the two shapes back
-into one set of selectors, and pin the fail-closed behaviour of the
-label-addressed path.
+These tests pin that split so a future edit cannot collapse the shapes back
+into one set of selectors, and pin the fail-closed behaviour of each
+addressing path.
 """
 
 from __future__ import annotations
@@ -55,15 +59,15 @@ class RecordingLocator:
 
 
 class LabelPage:
-    """Fake page that only resolves fields the live additional form exposes.
+    """Fake page modeling the trigger-opened additional form (#857).
 
-    ``locator`` deliberately reports count=0 for every ``data-qa`` field
-    selector: on the real additional-education form those attributes do not
-    exist, so a fake that answered count=1 would hide exactly the drift this
-    change fixes.
+    The additional ``profile-education-additional-*`` data-qa resolve (live
+    dump of that shape); every other ``profile-education-*`` data-qa stays
+    count=0 so a fake cannot silently answer for the primary editor fields.
+    The direct-route label bindings stay available through ``get_by_label``.
     """
 
-    def __init__(self, *, labels=None, label_count=1, resume_id="RID"):
+    def __init__(self, *, labels=None, label_count=1, resume_id="RID", qa_count=1):
         self.filled: list[tuple[str, str]] = []
         self.clicked: list[str] = []
         self.url = f"https://hh.ru/resume/{resume_id}"
@@ -71,10 +75,13 @@ class LabelPage:
             labels if labels is not None else set(resume_education._ADDITIONAL_LABELS.values())
         )
         self._label_count = label_count
+        self._qa_count = qa_count
 
     def locator(self, selector: str):
         if selector.startswith("[data-qa='resume-edit-button-"):
             return RecordingLocator(self, selector, count=1)
+        if selector in resume_education._ADDITIONAL_TRIGGER_SHAPE_FIELDS.values():
+            return RecordingLocator(self, selector, count=self._qa_count)
         if selector.startswith("[data-qa='profile-education-"):
             return RecordingLocator(self, selector, count=0)
         return RecordingLocator(self, selector, count=1)
@@ -123,7 +130,7 @@ def test_ambiguous_label_fails_closed(label_count):
         _field_locator(page, "institution", additional=True)
 
 
-def test_additional_block_dry_run_fills_by_label_and_cancels_partial_editor(monkeypatch):
+def test_additional_block_trigger_shape_fills_by_data_qa(monkeypatch):
     monkeypatch.setattr(resume_education, "open_hydrated_resume_editor", lambda *a, **k: None)
     page = LabelPage()
     record = EducationRecord(
@@ -138,20 +145,24 @@ def test_additional_block_dry_run_fills_by_label_and_cancels_partial_editor(monk
     result = _edit_block(page, [record], additional=True, dry_run=True, resume_id="RID")
 
     assert result.success, result.reason
-    # Filled through labels, not through any data-qa selector.
+    # Trigger shape: filled through the confirmed data-qa, never through
+    # get_by_label (empty label bindings, live-dumped #857).
     assert page.filled == [
-        ("label:Название", "Курсы"),
-        ("label:Проводившая организация", "Организация"),
-        ("label:Специализация", "Специализация"),
-        ("label:Год окончания", "2020"),
+        ("[data-qa='profile-education-additional-name']", "Курсы"),
+        ("[data-qa='profile-education-additional-organization']", "Организация"),
+        ("[data-qa='profile-education-additional-specialty']", "Специализация"),
+        ("[data-qa='profile-education-year-input']", "2020"),
     ]
-    # Dry run must leave the editor through the partial-edit cancel button.
-    assert page.clicked == [resume_education.ADDITIONAL_CANCEL_BUTTON]
+    # Dry run must leave the editor through its cancel button. #857 live
+    # finding: the trigger-opened additional form renders the SAME
+    # profile-layout controls as the primary editor, not the
+    # resume-partial-edit pair (those belong to the direct-route shape).
+    assert page.clicked == [resume_education.CANCEL_BUTTON]
 
 
-def test_additional_block_reports_unresolvable_label_without_saving(monkeypatch):
+def test_additional_block_reports_unresolvable_field_without_saving(monkeypatch):
     monkeypatch.setattr(resume_education, "open_hydrated_resume_editor", lambda *a, **k: None)
-    page = LabelPage(labels={"Название"})
+    page = LabelPage(qa_count=0)
     record = EducationRecord(
         institution="Курсы",
         level="",
@@ -164,7 +175,7 @@ def test_additional_block_reports_unresolvable_label_without_saving(monkeypatch)
     result = _edit_block(page, [record], additional=True, dry_run=False, resume_id="RID")
 
     assert not result.success
-    assert "Проводившая организация" in result.reason
+    assert "не найдено однозначно" in result.reason
     assert result.saved == 0
     assert not result.uncertain
-    assert resume_education.ADDITIONAL_SAVE_BUTTON not in page.clicked
+    assert resume_education.SAVE_BUTTON not in page.clicked


### PR DESCRIPTION
Closes #857 (частично — части 1/4/5; полный отчёт дрилла в issue).

Живой дрилл #857 (2026-08-30, временные резюме на реальном аккаунте) поймал три независимых дефекта additional-секции `edit-education`:

1. **Карточка additionalEducation рендерится только при хотя бы одной прикреплённой записи** (записи привязываются на экране educations визарда). У резюме без записей нет ни карточки, ни Add-ссылки — команда падала «блок образования не отобразился» до первого Save. Фолбэк: прямой роут `/resume/edit/{id}/additionalEducation` (live-подтверждён: рендерит полную resume-partial-edit форму; resume_id в URL связывает форму с резюме).

2. **Триггерная форма additional — третий shape**: кнопки `profile-layout-save/cancel` (как у primary), поля с data-qa `profile-education-additional-*` и ПУСТЫМИ `<label>`-биндингами. `get_by_label('Название')` на нём нестабилен: живой прогон поймал молчаливый реверс institution после успешной проверки `fill()`. Селекторы save/cancel/полей теперь выбираются по пути открытия (direct route → label + resume-partial-edit-\*; триггер → data-qa + profile-layout-\*).

3. **Позитивный текст-чек после Save гонял гидратацию** страницы резюме (`wait_for_url` commit не значит «отрисовано»): запись сохранена, а CLI вернул uncertain. Заменён на ограниченный полл (FORM_TIMEOUT_MS / FIELD_VERIFY_POLL_MS).

### Live-доказательства (прогрессия прогонов на одном тестовом резюме)
- прогон 1: uncertain — запись сохранена, ложный uncertain из-за (3); подтверждено read-only пробой (entry 27008850 на резюме)
- прогоны 2–3: OK (после shape-фикса кнопок)
- прогон 4: uncertain — частичная потеря institution (get_by_label слабое звено, (2))
- прогоны 5–6: uncertain — клик Save no-op, fail-closed честно не заявил успех
- ручной реплей с data-qa + ожиданиями: сохранил успешно; состояние подтверждено пробой и во встроенном браузере

### Заодно проверено живьём в рамках #857
- `delete-education-entry --kind additional` — OK (entry 27008850 удалена)
- `delete-resume` опубликованного резюме — OK ×2 (оба тестовых резюме удалены, аккаунт чист)
- `resume-position` tree-selector: 3 разные специализации подряд («Тестировщик», «Системный аналитик», «Менеджер продукта») — 3/3 OK
- визард hh.ru **автопубликует** резюме на финальном «Сохранить и продолжить»; на недопройденном визарде `publish-resume` честно блокируется guard'ом nextIncompleteScreenId — CLI-публикация для визард-черновиков структурно недостижима (см. отчёт в issue)

### Тесты
- `tests/test_resume_education_additional_direct.py` — новые: direct-route fallback, wrong-resume fail-closed, primary без фолбэка
- `tests/test_resume_education_form_shapes.py` — переписан под три shape
- полный pytest зелёный, ruff check/format --check чисты (замечания только в untracked черновых скриптах разведки)