### PR TITLE
feat: explain publish blocker on common screen

### DIFF
--- a/src/hhru_bot/commands/_common_resume_guidance.py
+++ b/src/hhru_bot/commands/_common_resume_guidance.py
@@ -1,0 +1,38 @@
+"""Actionable guidance for the resume's uncovered common screen."""
+
+from __future__ import annotations
+
+import shlex
+
+COMMON_RESUME_FIELDS = (
+    "birthday",
+    "area",
+    "workTicket",
+    "firstName",
+    "lastName",
+    "gender",
+    "phone",
+    "citizenship",
+    "relocation",
+    "metro",
+    "schedule",
+    "employment",
+    "work_format",
+    "businessTrip",
+)
+
+
+def print_common_resume_guidance(resume, *, include_publish: bool = False) -> None:
+    """Explain why publication is blocked and provide a safe next step."""
+    resume_arg = shlex.quote(str(resume.id))
+    fields = ", ".join(COMMON_RESUME_FIELDS)
+    print(f"[INFO] Экран common не заполнен; проверьте поля: {fields}.")
+    print(
+        "[INFO] CLI пока не умеет сохранять общие данные резюме "
+        "(ФИО, дату рождения, город, контакты и связанные параметры)."
+    )
+    print("[NEXT] 1. Откройте резюме на hh.ru и заполните экран «Основное» вручную.")
+    print("[NEXT] 2. Сохраните форму и убедитесь, что обязательные поля больше не отмечены.")
+    if include_publish:
+        print("[NEXT] 3. После сохранения снова проверьте публикацию без клика:")
+        print(f"  hhru publish-resume --resume {resume_arg} --dry-run")

--- a/src/hhru_bot/commands/publish_resume.py
+++ b/src/hhru_bot/commands/publish_resume.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
+from ._common_resume_guidance import print_common_resume_guidance
 from ._professional_role_guidance import print_professional_role_guidance
 
 
@@ -91,6 +92,8 @@ def run(args: argparse.Namespace):
             print(f"{prefix} {resume.id} — {result.reason}")
             if result.next_incomplete_screen_id == "professional_role":
                 print_professional_role_guidance(resume, include_publish=True)
+            elif result.next_incomplete_screen_id == "common":
+                print_common_resume_guidance(resume, include_publish=True)
             return True
         if args.dry_run:
             print(f"[DRY-RUN] Резюме {resume.id}: {result.reason}")

--- a/tests/test_publish_resume_command.py
+++ b/tests/test_publish_resume_command.py
@@ -214,6 +214,27 @@ def test_professional_role_blocker_prints_actionable_cached_catalog_workflow(env
     assert "publish-resume --resume python --dry-run" in out
 
 
+def test_common_blocker_prints_actionable_manual_workflow(env, capsys, tmp_path):
+    env.result = PublishResumeResult(
+        "python",
+        False,
+        "незавершённый шаг nextIncompleteScreenId=common; клик запрещён",
+        status="not_finished",
+        is_searchable=False,
+        next_incomplete_screen_id="common",
+    )
+
+    assert cmd.run(_args(tmp_path, dry_run=True)) is True
+
+    out = capsys.readouterr().out
+    assert "Экран common не заполнен" in out
+    assert "birthday" in out
+    assert "firstName" in out
+    assert "work_format" in out
+    assert "заполните экран «Основное» вручную" in out
+    assert "publish-resume --resume python --dry-run" in out
+
+
 def test_run_not_authenticated_is_not_recorded_and_exits(env, capsys, tmp_path):
     env.exc = NotAuthenticated("сессия истекла")
     assert cmd.run(_args(tmp_path, force=True)) is True


### PR DESCRIPTION
Closes #872

## Summary
- add `common` `nextIncompleteScreenId` guidance to `publish-resume`
- report the live-confirmed common-screen field set and manual UI next steps
- add command-level regression coverage for the actionable output

This PR intentionally does not implement saving the common screen. A follow-up is required for a full UI workflow covering birthday, area, name, gender, phone, citizenship, relocation, metro, schedule, employment, work format, and business trips.

The live delete flow was not confirmed by a live deletion run; manual user verification is required.

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q src tests`
