### PR TITLE
fix(create-resume): report hh.ru resume limit

### DIFF
--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -36,6 +36,10 @@ _RESUME_ID_RE = re.compile(r"(?:/resume/|[?&]resume=)([0-9a-f]{32,40})(?:[/?#&]|
 # задержки, но честный (не бесконечный) дедлайн на случай, если чекбокс
 # реально не переключился.
 _CHECKBOX_CONFIRM_TIMEOUT = 5.0
+_RESUME_LIMIT_REASON = (
+    "лимит резюме hh.ru (~20) достигнут или кнопка создания недоступна; "
+    "удалите ненужные резюме и повторите попытку"
+)
 
 
 @dataclass
@@ -305,6 +309,11 @@ def create_resume_on_hh(
     try:
         page.locator(RESUME_CREATE_BUTTON).first.wait_for(state="visible", timeout=15000)
     except PlaywrightError as exc:
+        # На лимите hh.ru кнопку не рендерит вовсе. Не маскировать этот
+        # наблюдаемый отказ под проблему гидрации/сети: создание без кнопки
+        # невозможно, поэтому остаёмся fail-closed.
+        if page.locator(RESUME_CREATE_BUTTON).count() == 0:
+            return CreateResumeResult(False, reason=_RESUME_LIMIT_REASON)
         return CreateResumeResult(False, reason=f"список резюме не отрисовался: {exc}")
     duplicate_reason = _existing_resume_reason(page, title)
     if duplicate_reason:
@@ -312,6 +321,11 @@ def create_resume_on_hh(
     create_button, reason = _one(page, RESUME_CREATE_BUTTON, "кнопка создания резюме")
     if reason:
         return CreateResumeResult(False, reason=reason)
+    # count() подтверждает только наличие узла. При исчерпанном лимите hh.ru
+    # узел остаётся в DOM, но становится disabled; клик по нему даёт сетевую
+    # ошибку и скрывает настоящую причину.
+    if _require(create_button).is_disabled():
+        return CreateResumeResult(False, reason=_RESUME_LIMIT_REASON)
 
     if dry_run:
         goto_hh(page, CREATION_URL)

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -17,6 +17,7 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page as PlaywrightPage
 
 import hhru_bot.create_resume as create
+from _fakes import _parse_root
 from hhru_bot.create_resume import _select_catalog_leaf as _real_select
 from hhru_bot.selector_groups.resume_list import RESUME_LIST_CARD
 from hhru_bot.selector_groups.resume_page import (
@@ -84,6 +85,9 @@ class Locator:
     def get_attribute(self, name):  # noqa: ARG002
         return None
 
+    def is_disabled(self):
+        return False
+
     def check(self):
         self.page.clicks.append(f"check:{self.selector}")
 
@@ -103,6 +107,27 @@ class Locator:
 
     def fill(self, value):
         self.page.filled.append((self.selector, value))
+
+
+CREATE_BUTTON_HTML = "<button data-qa='mainmenu_createResume'>{label}</button>"
+
+
+class HtmlCreateButtonLocator(Locator):
+    def __init__(self, page, selector, *, count, disabled):
+        super().__init__(page, selector, count=count)
+        self._disabled = disabled
+
+    def wait_for(self, *, state, timeout):  # noqa: ARG002
+        if self._count == 0:
+            raise PlaywrightError(f"not visible: {self.selector}")
+
+    def is_disabled(self):
+        return self._disabled
+
+    def click(self, *, timeout=None):  # noqa: ARG002
+        if self._disabled:
+            raise PlaywrightError("ERR_CONNECTION_RESET")
+        super().click()
 
 
 class Page:
@@ -129,6 +154,28 @@ class Page:
         return None
 
 
+class HtmlCreateButtonPage(Page):
+    """Existing create-resume fake with the list button sourced from HTML."""
+
+    def __init__(self, html):
+        super().__init__(fail_on_wait=None)
+        buttons = _parse_root(html).find_all(
+            tag=None, qa_match=lambda qa: qa == "mainmenu_createResume"
+        )
+        self.create_button_present = bool(buttons)
+        self.create_button_disabled = bool(buttons and "disabled" in buttons[0].attrs)
+
+    def locator(self, selector):
+        if selector == RESUME_CREATE_BUTTON:
+            return HtmlCreateButtonLocator(
+                self,
+                selector,
+                count=int(self.create_button_present),
+                disabled=self.create_button_disabled,
+            )
+        return super().locator(selector)
+
+
 def _run(page, before_click=None):
     return create.create_resume_on_hh(
         cast(PlaywrightPage, cast(object, page)),
@@ -137,6 +184,38 @@ def _run(page, before_click=None):
         dry_run=False,
         before_click=before_click,
     )
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<button data-qa='mainmenu_createResume' disabled>Создать</button>",
+        "<main>список резюме</main>",
+    ],
+)
+def test_resume_limit_is_reported_before_create_click(monkeypatch, html):
+    """The list HTML exposes the hh.ru resume limit as disabled/missing button."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = HtmlCreateButtonPage(html)
+
+    result = _run(page)
+
+    assert not result.success
+    assert not result.uncertain
+    assert "лимит" in result.reason.lower()
+    assert "удал" in result.reason.lower()
+    assert RESUME_CREATE_BUTTON not in page.clicks
+
+
+def test_active_create_button_keeps_existing_behavior(monkeypatch):
+    """An enabled button still enters the existing wizard flow."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = HtmlCreateButtonPage(CREATE_BUTTON_HTML.format(label="Создать"))
+
+    result = _run(page)
+
+    assert RESUME_CREATE_BUTTON in page.clicks
+    assert "лимит" not in result.reason.lower()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #871

## Summary
- Проверяет `is_disabled()` до клика по кнопке создания резюме.
- Отсутствующую или disabled-кнопку сообщает как лимит hh.ru (~20) с подсказкой удалить ненужные резюме.
- Добавлены HTML-fixture тесты для disabled, отсутствующей и активной кнопки.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` (382 files, passed; 2 skipped)

## Live evidence
- До фикса: прогон с сохранённой сессией дошёл до браузера, но за 45 секунд не вернул CLI-результат; процесс остановлен по таймауту.
- После фикса: тот же live-прогон также не вернул CLI-результат за 45 секунд; процесс остановлен по таймауту.

Удаление резюме не выполнялось; боевые резюме не затрагивались. PR оставлен для мерджа пользователем.