### PR TITLE
test: characterize resume specialization catalog

### DIFF
--- a/tests/fixtures/resume_position_specializations.html
+++ b/tests/fixtures/resume_position_specializations.html
@@ -7,29 +7,53 @@
     </button>
     <section data-qa="professional-roles-modal" role="dialog" hidden>
       <input data-qa="tree-selector-search-input" aria-label="Поиск специализации">
+      <div id="catalog-options">
       <div data-qa="tree-selector-category">Финансы</div>
-      <div data-qa="tree-selector-item tree-selector-item-1 tree-selector-child-96"><span data-qa="cell-text-content">Бухгалтер</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-1 tree-selector-child-96" data-label="Бухгалтер"><span data-qa="cell-text-content">Бухгалтер</span></div>
       <div data-qa="tree-selector-category">Образование</div>
-      <div data-qa="tree-selector-item tree-selector-item-2 tree-selector-child-101"><span data-qa="cell-text-content">Учитель, преподаватель, педагог</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-2 tree-selector-child-101" data-label="Учитель, преподаватель, педагог"><span data-qa="cell-text-content">Учитель, преподаватель, педагог</span></div>
       <div data-qa="tree-selector-category">Продажи</div>
-      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202" data-label="Менеджер по продажам, менеджер по работе с клиентами"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
       <div data-qa="tree-selector-category">Маркетинг</div>
-      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202" data-label="Менеджер по продажам, менеджер по работе с клиентами"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
       <div data-qa="tree-selector-category">Сервис</div>
-      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202" data-label="Менеджер по продажам, менеджер по работе с клиентами"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
       <div data-qa="tree-selector-category">Торговля</div>
-      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202" data-label="Менеджер по продажам, менеджер по работе с клиентами"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
       <div data-qa="tree-selector-category">Искусство</div>
-      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
-      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303" data-label="Дизайнер, художник"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303" data-label="Дизайнер, художник"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
       <div data-qa="tree-selector-category">Транспорт</div>
-      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
-      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
-      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404" data-label="Водитель, экспедитор"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404" data-label="Водитель, экспедитор"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404" data-label="Водитель, экспедитор"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      </div>
       <button type="button" data-qa="professional-roles-submit">Готово</button>
     </section>
   </main>
   <script>
+    const optionRoot = document.querySelector("#catalog-options");
+    const originalOptions = [...optionRoot.querySelectorAll("[data-qa^='tree-selector-item']")];
+    const selectedIds = new Set();
+    const renderOptions = (query) => {
+      const matches = originalOptions.filter((option) => option.dataset.label.includes(query));
+      optionRoot.replaceChildren(...matches.map((option) => {
+        const clone = option.cloneNode(true);
+        if (selectedIds.has(clone.getAttribute("data-qa"))) {
+          clone.setAttribute("aria-selected", "true");
+        }
+        return clone;
+      }));
+    };
+    optionRoot.addEventListener("click", (event) => {
+      const option = event.target.closest("[data-qa^='tree-selector-item']");
+      if (option) selectedIds.add(option.getAttribute("data-qa"));
+    });
+    document.querySelector("[data-qa='tree-selector-search-input']")
+      .addEventListener("input", (event) => {
+        optionRoot.replaceChildren();
+        setTimeout(() => renderOptions(event.target.value), 20);
+      });
     const modal = document.querySelector("[data-qa='professional-roles-modal']");
     document.querySelector("[data-qa='resume-position-professional-role-add-button']")
       .addEventListener("click", () => modal.hidden = false);

--- a/tests/fixtures/resume_position_specializations.html
+++ b/tests/fixtures/resume_position_specializations.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="ru">
+<body>
+  <main data-qa="resume-position-editor" data-resume-id="00001">
+    <button type="button" data-qa="resume-position-professional-role-add-button">
+      Добавить специализацию
+    </button>
+    <section data-qa="professional-roles-modal" role="dialog" hidden>
+      <input data-qa="tree-selector-search-input" aria-label="Поиск специализации">
+      <div data-qa="tree-selector-category">Финансы</div>
+      <div data-qa="tree-selector-item tree-selector-item-1 tree-selector-child-96"><span data-qa="cell-text-content">Бухгалтер</span></div>
+      <div data-qa="tree-selector-category">Образование</div>
+      <div data-qa="tree-selector-item tree-selector-item-2 tree-selector-child-101"><span data-qa="cell-text-content">Учитель, преподаватель, педагог</span></div>
+      <div data-qa="tree-selector-category">Продажи</div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-category">Маркетинг</div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-category">Сервис</div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-category">Торговля</div>
+      <div data-qa="tree-selector-item tree-selector-item-202 tree-selector-child-202"><span data-qa="cell-text-content">Менеджер по продажам, менеджер по работе с клиентами</span></div>
+      <div data-qa="tree-selector-category">Искусство</div>
+      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-303 tree-selector-child-303"><span data-qa="cell-text-content">Дизайнер, художник</span></div>
+      <div data-qa="tree-selector-category">Транспорт</div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <div data-qa="tree-selector-item tree-selector-item-404 tree-selector-child-404"><span data-qa="cell-text-content">Водитель, экспедитор</span></div>
+      <button type="button" data-qa="professional-roles-submit">Готово</button>
+    </section>
+  </main>
+  <script>
+    const modal = document.querySelector("[data-qa='professional-roles-modal']");
+    document.querySelector("[data-qa='resume-position-professional-role-add-button']")
+      .addEventListener("click", () => modal.hidden = false);
+    document.querySelector("[data-qa='professional-roles-submit']")
+      .addEventListener("click", () => modal.hidden = true);
+  </script>
+</body>
+</html>

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -1,0 +1,68 @@
+"""Characterization of the resume specialization catalog from live #867."""
+
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+import hhru_bot.resume_position as resume_position
+
+pytestmark = pytest.mark.integration
+
+FIXTURE = Path(__file__).parent / "fixtures" / "resume_position_specializations.html"
+
+
+def _page():
+    playwright = sync_playwright().start()
+    browser = playwright.chromium.launch()
+    page = browser.new_page()
+    page.set_content(FIXTURE.read_text(encoding="utf-8"))
+    return playwright, browser, page
+
+
+@pytest.mark.browser_unit
+def test_resume_catalog_reuses_one_leaf_id_across_categories():
+    playwright, browser, page = _page()
+    try:
+        options = page.locator(resume_position.SPECIALIZATION_OPTION)
+        for label, expected_count, expected_id in (
+            ("Учитель, преподаватель, педагог", 1, "101"),
+            ("Менеджер по продажам, менеджер по работе с клиентами", 4, "202"),
+            ("Дизайнер, художник", 2, "303"),
+            ("Водитель, экспедитор", 3, "404"),
+        ):
+            matches = options.filter(has_text=label)
+            assert matches.count() == expected_count
+            assert {
+                item.get_attribute("data-qa").split("tree-selector-child-")[-1]
+                for item in (matches.nth(i) for i in range(matches.count()))
+            } == {expected_id}
+
+        page.locator(resume_position.SPECIALIZATION_ADD).click()
+        resume_position._set_specializations(
+            page,
+            [
+                "Учитель, преподаватель, педагог",
+                "Менеджер по продажам, менеджер по работе с клиентами",
+                "Дизайнер, художник",
+                "Водитель, экспедитор",
+            ],
+        )
+        assert page.locator(resume_position.SPECIALIZATION_MODAL).is_hidden()
+    finally:
+        browser.close()
+        playwright.stop()
+
+
+@pytest.mark.parametrize("value", ["Учитель", "Несуществующая специализация"])
+@pytest.mark.browser_unit
+def test_resume_catalog_rejects_non_leaf_or_missing_specialization(monkeypatch, value):
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    playwright, browser, page = _page()
+    try:
+        page.locator(resume_position.SPECIALIZATION_ADD).click()
+        with pytest.raises(RuntimeError, match="специализация не найдена в дереве резюме"):
+            resume_position._set_specializations(page, [value])
+    finally:
+        browser.close()
+        playwright.stop()

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -49,6 +49,11 @@ def test_resume_catalog_reuses_one_leaf_id_across_categories():
             ],
         )
         assert page.locator(resume_position.SPECIALIZATION_MODAL).is_hidden()
+        filtered = page.locator(resume_position.SPECIALIZATION_OPTION)
+        assert filtered.count() == 3
+        assert {item.get_attribute("data-qa") for item in (filtered.nth(i) for i in range(3))} == {
+            "tree-selector-item tree-selector-item-404 tree-selector-child-404"
+        }
     finally:
         browser.close()
         playwright.stop()


### PR DESCRIPTION
## Summary
- add a resume-position specialization HTML fixture based on the #867 live catalog observations
- characterize exact leaf names, repeated-category IDs, and fail-closed missing/short names

Closes #875

## Tests
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

No live hh.ru runs or mutations.