### PR TITLE
fix: wait for resume specialization catalog

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -719,6 +719,13 @@ def _set_specializations(page: Page, values: list[str]) -> None:
 
     page.locator(SPECIALIZATION_ADD).click()
     modal = page.locator(SPECIALIZATION_MODAL)
+    try:
+        # With no inherited profession cards, the add click starts the modal
+        # render directly.  The locator can already exist in the DOM while
+        # still being hidden, so count() alone races React hydration.
+        modal.first.wait_for(state="visible", timeout=_CONTROL_WAIT_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        raise RuntimeError("панель выбора специализаций не открылась") from exc
     if modal.count() != 1:
         raise RuntimeError("панель выбора специализаций не открылась")
     search = page.locator(SPECIALIZATION_SEARCH)

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -679,6 +679,9 @@ def test_set_specializations_waits_out_the_filter_render_race():
 
     resume_position._set_specializations(page, ["Программист, разработчик"])
 
+    page.locator(resume_position.SPECIALIZATION_MODAL).first.wait_for.assert_called_once_with(
+        state="visible", timeout=resume_position._CONTROL_WAIT_TIMEOUT_MS
+    )
     option.first.wait_for.assert_called_once_with(
         state="visible", timeout=resume_position._CONTROL_WAIT_TIMEOUT_MS
     )


### PR DESCRIPTION
## Status
Superseded by #886, which addresses the confirmed chip-popular rendering path.

## Summary
- This PR explored waiting for the specialization catalog modal after opening it.
- The later live investigation in #886 found that hh.ru can render a flat preselected radio-chip list instead of the modal.

Do not merge this PR; #886 is the single PR for #881.