### PR TITLE
fix(resume-position): wizard-minimum + editor fallback для chip-popular (#881)

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -94,13 +94,30 @@ def _print_classification(role, *, reason: str = "", queries: list[str] | None =
         print(f"  reason: {reason}")
 
 
+def _click_save_and_wait(page) -> None:
+    """Click the editor SAVE button and wait for the form to close.
+
+    Shared by the pure-editor path and the wizard-minimum fallback (#890):
+    both end up applying the plan through ``apply_position`` on the same
+    ``/resume/edit/{id}/position`` form and must confirm the same way. Any
+    failure here is a grey-zone post-click failure — the caller wraps it in
+    ``_SaveConfirmationUncertain`` once the mutating click has landed.
+    """
+    from ..resume_position import SAVE
+
+    if page.locator(SAVE).count() != 1:
+        raise RuntimeError("кнопка сохранения формы не подтверждена")
+    page.locator(SAVE).click()
+    page.locator("[data-qa='resume-edit-position-form']").wait_for(state="hidden", timeout=10_000)
+
+
 def _run(args: argparse.Namespace, progress) -> bool:
     from ..ai.llm_client import LLMClient
     from ..browser import BrowserLaunchError, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..resume_position import (
         CANCEL,
-        SAVE,
+        ChipPopularUnavailable,
         PositionValues,
         apply_position,
         build_position_prompt,
@@ -109,7 +126,9 @@ def _run(args: argparse.Namespace, progress) -> bool:
         open_position_form,
         parse_position_response,
         save_position_wizard,
+        save_position_wizard_minimum,
         validate_wizard_plan,
+        verify_wizard_minimum_save,
         verify_wizard_save,
     )
 
@@ -309,21 +328,52 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     nonlocal first_click_started
                     first_click_started = True
 
+                verified_state = None
+                published_note = (
+                    "[INFO] professional_role завершён; публикация требует "
+                    "отдельной read-only проверки."
+                )
                 try:
-                    save_position_wizard(
-                        page,
-                        resume,
-                        plan,
-                        role_id=role.role_id,
-                        before_first_click=mark_first_click_started,
-                    )
-                    verified_state = verify_wizard_save(
-                        page,
-                        resume,
-                        expected_title=plan.title or "",
-                        expected_role_id=role.role_id,
-                        expected_role_label=role.label,
-                    )
+                    try:
+                        save_position_wizard(
+                            page,
+                            resume,
+                            plan,
+                            role_id=role.role_id,
+                            before_first_click=mark_first_click_started,
+                        )
+                        verified_state = verify_wizard_save(
+                            page,
+                            resume,
+                            expected_title=plan.title or "",
+                            expected_role_id=role.role_id,
+                            expected_role_label=role.label,
+                        )
+                    except ChipPopularUnavailable:
+                        # #890: this DOM shape structurally cannot save the
+                        # exact requested specialization (confirmed live —
+                        # the catalog leaf is absent from its narrow
+                        # sub-modal). Save ANY valid placeholder category
+                        # just to clear professional_role, then reopen the
+                        # form — it must now be in editor mode, where the
+                        # already-working `_set_specializations` catalog
+                        # search sets the exact specialization.
+                        save_position_wizard_minimum(
+                            page, resume, before_first_click=mark_first_click_started
+                        )
+                        verify_wizard_minimum_save(page, resume)
+                        fixup_flow = open_position_form(page, resume)
+                        if fixup_flow.kind != "editor" or fixup_flow.resume_id != resume.resume_id:
+                            raise RuntimeError(
+                                "wizard-minimum сохранён, но форма не перешла в editor-режим"
+                            ) from None
+                        apply_position(page, plan, current=fixup_flow.values)
+                        _click_save_and_wait(page)
+                        published_note = (
+                            "[INFO] professional_role завершён через wizard-minimum "
+                            "fallback (#890); точная специализация применена в "
+                            "editor-режиме."
+                        )
                 except Exception as exc:
                     if not first_click_started:
                         raise
@@ -334,23 +384,15 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 print(f"[OK] professional_role резюме '{resume.id}' сохранён и проверен.")
                 from ..resume_state import is_published
 
-                if is_published(verified_state):
+                if verified_state is not None and is_published(verified_state):
                     print("[INFO] hh.ru подтвердил автоматическую публикацию: isSearchable=true.")
                 else:
-                    print(
-                        "[INFO] professional_role завершён; публикация требует "
-                        "отдельной read-only проверки."
-                    )
+                    print(published_note)
                 return False
             progress.begin_attempt()
             apply_position(page, plan, current=current)
-            if page.locator(SAVE).count() != 1:
-                raise RuntimeError("кнопка сохранения формы не подтверждена")
             try:
-                page.locator(SAVE).click()
-                page.locator("[data-qa='resume-edit-position-form']").wait_for(
-                    state="hidden", timeout=10_000
-                )
+                _click_save_and_wait(page)
             except Exception as exc:  # click already landed; result is uncertain
                 raise _SaveConfirmationUncertain(
                     f"сохранение не подтверждено (uncertain) после клика: {exc}"

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -74,11 +74,33 @@ from .selector_groups.resume_page import (
 
 logger = logging.getLogger("hhru_bot.resume_position")
 
+
+class ChipPopularUnavailable(RuntimeError):
+    """The chip-popular shape (#881/#889) cannot confirm the exact catalog
+    specialization — it is a fixed list of ~37 generic categories plus a
+    narrow "Уточните профессию" sub-modal (~15 items each) that does not
+    contain most real catalog leaves (confirmed live DOM 2026-08-31: role_id
+    96 "Программист, разработчик" is absent from the "Программист" sub-list).
+    A dedicated exception type (not a plain RuntimeError) lets the caller
+    distinguish "this shape cannot do it, try the wizard-minimum fallback"
+    from every other wizard failure, which must still surface as-is.
+    """
+
+
 # The chip-popular radio does not carry the profession in its data-qa (every
 # chip on the screen shares the same data-qa); the profession lives in the
 # input's ``value`` attribute instead (#881, live DOM 2026-08-31). Scope the
 # base selector down to the one radio matching the confirmed catalog label.
 WIZARD_POSITION_CHIP_POPULAR = WIZARD_POSITION_CHIP_POPULAR_BASE + "[value='{}']"
+
+# Fixed, deterministic placeholder for the wizard-minimum fallback (#890):
+# any of the ~37 chip-popular categories clears `nextIncompleteScreenId`
+# equally well, since its content is discarded immediately by the editor-mode
+# `_set_specializations` call that follows. A hardcoded, always-identical
+# choice (first item on the confirmed live list) is deliberate — not derived
+# from `plan.title` or randomized — per the project's anti-fraud principle of
+# not behaving unpredictably towards hh.ru (CLAUDE.md).
+WIZARD_MINIMUM_PLACEHOLDER_TITLE = "Администратор"
 
 # Explicit, generous but bounded — avoids a silent 30s-default hang per call
 # (CLAUDE.md requires an inline timeout with a comment for every post-render
@@ -553,59 +575,24 @@ def save_position_wizard(
             search.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
             break
         if chip.count() == 1:
-            # Second post-NEXT shape (#881, live DOM 2026-08-31): hh.ru skips
-            # the catalog modal for a draft that already carries an inherited
-            # role and instead pre-checks the matching "popular" chip. The
-            # tree-selector search input never appears in this shape, so
-            # falling through to the modal path below would misclassify a
-            # valid save as a failure.
-            chip.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
-            if not chip.first.is_checked():
-                raise RuntimeError(
-                    f"чип должности «{plan.title}» найден, но не отмечен — "
-                    "автоматический выбор не подтверждён"
-                )
-            if chip.first.is_disabled():
-                raise RuntimeError(
-                    f"чип должности «{plan.title}» отмечен, но отключён — "
-                    "сохранение через chip-popular не подтверждено"
-                )
-            # The initial checked state is only the server-provided popular
-            # suggestion. Re-select the exact catalog chip so the wizard
-            # registers the choice before the final NEXT. The radio input is
-            # disabled in this shape; its wrapping card is the hit target.
-            chip_card = chip.first.locator("xpath=ancestor::label[1]")
-            if chip_card.count() != 1:
-                raise RuntimeError("карточка chip должности не подтверждена")
-            chip_card.click()
-            # The chip and the final NEXT button are rendered together by the
-            # SPA.  The button locator from the first screen can resolve
-            # before its click handler is attached on this second render.
-            next_button.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
-            try:
-                next_button.click()
-            except PlaywrightError:
-                # Playwright can report an intercepted/detached click after
-                # the SPA has already navigated.  The changed route is the
-                # positive save signal; only re-raise while still on the
-                # professional_role screen.
-                if not _is_wizard_path(getattr(page, "url", "")):
-                    return
-                raise
-            # A checked chip is only a positive selection signal.  Wait for
-            # the wizard route to leave professional_role after the final
-            # NEXT, otherwise verify_wizard_save can read the old state while
-            # the SPA is still committing the save.
-            try:
-                page.wait_for_url(
-                    lambda url: urlsplit(str(url)).path != WIZARD_PATH,
-                    wait_until="commit",
-                    timeout=30_000,
-                )
-            except PlaywrightError:
-                _dump_wizard_failure(page, resume.resume_id, "chip_popular_post_next")
-                raise
-            return
+            # Second post-NEXT shape (#881/#889, live DOM 2026-08-31): hh.ru
+            # skips the full tree-selector catalog modal and instead shows a
+            # fixed list of ~37 generic categories, each opening a narrow
+            # "Уточните профессию" sub-modal with ~15 items. This shape
+            # cannot reach an arbitrary catalog leaf: live DOM confirmed
+            # role_id 96 "Программист, разработчик" is absent from the
+            # sub-modal under its own general category "Программист" — the
+            # chip's checked state only reflects the just-typed title, never
+            # the requested ``expected_label``. Clicking the chip and NEXT
+            # here would either fail closed (unchecked/disabled) or silently
+            # save the WRONG specialization (checked+enabled). Neither
+            # outcome can satisfy ``expected_label``, so this shape is
+            # unusable for an exact save and the caller must fall back to
+            # the wizard-minimum + editor path instead of attempting it.
+            raise ChipPopularUnavailable(
+                f"chip-popular shape не может сохранить точную специализацию "
+                f"«{expected_label}» — каталог этого экрана её не содержит"
+            )
         page.wait_for_timeout(WIZARD_VERIFY_POLL_MS)
     else:
         raise RuntimeError("каталог профессий не появился после очистки прежних profession IDs")
@@ -652,6 +639,135 @@ def save_position_wizard(
         wait_until="commit",
         timeout=30_000,
     )
+
+
+def save_position_wizard_minimum(
+    page: Page,
+    resume: ResumeConfig,
+    *,
+    before_first_click: Callable[[], None] | None = None,
+) -> str:
+    """Save ANY valid chip-popular category to clear professional_role (#890).
+
+    This is the fallback for :func:`save_position_wizard` raising
+    :class:`ChipPopularUnavailable`: the chip-popular shape cannot reach an
+    arbitrary catalog leaf, but the caller does not need it to — it only
+    needs `nextIncompleteScreenId` to stop being `"professional_role"` so
+    :func:`open_position_form` returns ``kind="editor"`` next time, where the
+    exact specialization is set through the already-working
+    ``apply_position``/``_set_specializations`` catalog search. The saved
+    title is deliberately the fixed :data:`WIZARD_MINIMUM_PLACEHOLDER_TITLE`,
+    not ``plan.title`` — its content is thrown away immediately by the editor
+    step that follows, so there is nothing to get right here beyond a valid,
+    checked, non-disabled chip.
+
+    Returns the placeholder title actually saved, for the caller to log/pass
+    to the editor step's ``current`` baseline.
+    """
+    if not is_position_wizard(page, resume.resume_id):
+        raise RuntimeError("professional_role identity не подтверждён перед сохранением")
+
+    title = WIZARD_MINIMUM_PLACEHOLDER_TITLE
+    position = page.locator(WIZARD_POSITION)
+    if position.count() != 1:
+        raise RuntimeError(f"поле должности визарда неоднозначно: {position.count()}")
+    clear = page.locator(WIZARD_POSITION_CLEAR)
+    clear_count = clear.count()
+    if clear_count > 1:
+        raise RuntimeError(f"очистка должности визарда неоднозначна: {clear_count}")
+    if clear_count == 1:
+        clear.click()
+        clear_deadline = time.monotonic() + WIZARD_WAIT_MS / 1000
+        while time.monotonic() < clear_deadline and position.input_value():
+            page.wait_for_timeout(WIZARD_VERIFY_POLL_MS)
+    if position.input_value():
+        raise RuntimeError("визард не подтвердил очистку прежней должности и profession IDs")
+
+    position.fill(title)
+    next_button = page.locator(WIZARD_NEXT)
+    try:
+        next_button.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
+    except PlaywrightError as exc:
+        raise RuntimeError(f"кнопка продолжения визарда не появилась: {exc}") from exc
+    if next_button.count() != 1:
+        raise RuntimeError(f"кнопка продолжения визарда неоднозначна: {next_button.count()}")
+    if before_first_click is not None:
+        before_first_click()
+    next_button.click()
+
+    chip = page.locator(WIZARD_POSITION_CHIP_POPULAR.format(title))
+    deadline = time.monotonic() + WIZARD_WAIT_MS / 1000
+    while time.monotonic() < deadline:
+        if not _is_wizard_path(getattr(page, "url", "")):
+            return title
+        if chip.count() == 1:
+            break
+        page.wait_for_timeout(WIZARD_VERIFY_POLL_MS)
+    else:
+        raise RuntimeError(
+            f"chip-popular для «{title}» не появился — минимальное сохранение невозможно"
+        )
+    chip.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
+    if not chip.first.is_checked():
+        raise RuntimeError(f"чип должности «{title}» найден, но не отмечен")
+    if chip.first.is_disabled():
+        raise RuntimeError(f"чип должности «{title}» отмечен, но отключён")
+    # The radio input itself is disabled in this shape; its wrapping card is
+    # the actual hit target (same pattern as the currency-chip click in
+    # ``apply_position`` below).
+    chip_card = chip.first.locator("xpath=ancestor::label[1]")
+    if chip_card.count() != 1:
+        raise RuntimeError("карточка chip должности не подтверждена")
+    chip_card.click()
+    next_button.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
+    try:
+        next_button.click()
+    except PlaywrightError:
+        # The route change itself is the positive signal; only re-raise if
+        # we are still stuck on professional_role.
+        if not _is_wizard_path(getattr(page, "url", "")):
+            return title
+        raise
+    try:
+        page.wait_for_url(
+            lambda url: urlsplit(str(url)).path != WIZARD_PATH,
+            wait_until="commit",
+            timeout=30_000,
+        )
+    except PlaywrightError:
+        _dump_wizard_failure(page, resume.resume_id, "wizard_minimum_post_next")
+        raise
+    return title
+
+
+def verify_wizard_minimum_save(page: Page, resume: ResumeConfig) -> ResumeState:
+    """Poll only for professional_role clearing — no title/role match (#890).
+
+    Deliberately narrower than :func:`verify_wizard_save`: the wizard-minimum
+    step saves a throwaway placeholder on purpose, so checking its title or
+    role against anything would be a foot-gun (a future call could weaken
+    real verification by passing loose expectations). This function proves
+    exactly one fact — the draft left the professional_role screen — leaving
+    the exact specialization to the editor-mode step that follows.
+    """
+    deadline = time.monotonic() + WIZARD_VERIFY_TIMEOUT_MS / 1000
+    state = ResumeState()
+    while time.monotonic() < deadline:
+        goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
+        require_authenticated_page(page)
+        route_matches = resume_identity_matches(page, resume.resume_id) or is_position_wizard(
+            page, resume.resume_id
+        )
+        if not route_matches:
+            raise RuntimeError("post-save readback открыт не для того резюме")
+        state = parse_resume_state(page.content(), resume.resume_id)
+        if state.status is not None and state.next_incomplete_screen_id != "professional_role":
+            return state
+        page.wait_for_timeout(WIZARD_VERIFY_POLL_MS)
+
+    if state.status is None:
+        raise RuntimeError("post-save readback не подтвердил состояние резюме (wizard-minimum)")
+    raise RuntimeError("post-save readback всё ещё показывает professional_role (wizard-minimum)")
 
 
 def verify_wizard_save(

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -664,6 +664,202 @@ def test_draft_position_classifies_failure_at_first_click_boundary(
     assert row[other] == row["success"] == row["skipped"] == 0
 
 
+def _draft_position_args(history_path: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        title="Python-разработчик",
+        specialization=["Программист, разработчик"],
+        salary=None,
+        currency=None,
+        employment=None,
+        work_format=None,
+        commute=None,
+        business_trips=None,
+        mode=None,
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+
+def test_chip_popular_unavailable_falls_back_to_wizard_minimum_and_succeeds(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """#890: when the chip-popular shape cannot save the exact catalog leaf,
+    the command must save a throwaway placeholder via
+    ``save_position_wizard_minimum``, confirm it via
+    ``verify_wizard_minimum_save``, reopen the form as an editor, and finish
+    through the existing ``apply_position``/SAVE path — recording exactly
+    ONE durable attempt as success, not two attempts and not uncertain.
+    """
+    import hhru_bot.commands.resume_position as command
+    from hhru_bot.professional_roles import ProfessionalRole
+    from hhru_bot.resume_position import (
+        ChipPopularUnavailable,
+        PositionFlowContext,
+        PositionValues,
+    )
+    from hhru_bot.resume_state import ResumeState
+
+    resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    class _Locator:
+        def count(self):
+            return 1
+
+        def click(self):
+            return None
+
+        def wait_for(self, *, state=None, timeout=None):
+            return None
+
+    class _Page:
+        url = "https://hh.ru/profile/resume/professional_role?resume=r1"
+
+        def locator(self, _selector):
+            return _Locator()
+
+    page = _Page()
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: page)
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+
+    flows = iter(
+        [
+            PositionFlowContext(
+                "wizard",
+                "r1",
+                PositionValues(title="Python-разработчик"),
+                ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+            ),
+            # second call: re-bind right before WRITE, still wizard
+            PositionFlowContext(
+                "wizard",
+                "r1",
+                PositionValues(title="Python-разработчик"),
+                ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+            ),
+            # third call: after wizard-minimum, the draft is now an editor
+            PositionFlowContext(
+                "editor",
+                "r1",
+                PositionValues(title="Администратор"),
+                ResumeState(status="not_finished"),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.open_position_form", lambda _page, _resume: next(flows)
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.is_position_wizard", lambda _page, _resume_id: True
+    )
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.resolve_explicit_role",
+        lambda _page, label: ProfessionalRole("96", label, "ИТ"),
+    )
+
+    def fail_with_chip_popular(*_args, before_first_click, **_kwargs):
+        before_first_click()
+        raise ChipPopularUnavailable("chip-popular не содержит нужную специализацию")
+
+    minimum_calls: list[bool] = []
+
+    def fake_minimum(_page, _resume, *, before_first_click=None):
+        minimum_calls.append(True)
+        return "Администратор"
+
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_with_chip_popular)
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fake_minimum)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.verify_wizard_minimum_save",
+        lambda _page, _resume: ResumeState(status="not_finished"),
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.apply_position", lambda _page, _plan, current=None: None
+    )
+
+    history_path = tmp_path / "history.db"
+    assert command.run(_draft_position_args(history_path)) is False
+    out = capsys.readouterr().out
+    assert "[OK]" in out
+    assert minimum_calls == [True]
+
+    row = History(history_path).command_runs()[-1]
+    assert row["command"] == "resume_position"
+    assert row["attempted"] == row["success"] == 1
+    assert row["failed"] == row["uncertain"] == row["skipped"] == 0
+
+
+def test_chip_popular_unavailable_fallback_failure_is_uncertain_not_double_counted(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """If the wizard-minimum fallback itself fails, the whole two-stage
+    attempt must still record exactly ONE durable attempt as uncertain — not
+    failed, and not a second `begin_attempt()` for the fallback stage.
+    """
+    import hhru_bot.commands.resume_position as command
+    from hhru_bot.professional_roles import ProfessionalRole
+    from hhru_bot.resume_position import ChipPopularUnavailable, PositionFlowContext, PositionValues
+    from hhru_bot.resume_state import ResumeState
+
+    resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    page = SimpleNamespace(url="https://hh.ru/profile/resume/professional_role?resume=r1")
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: page)
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.open_position_form",
+        lambda _page, _resume: PositionFlowContext(
+            "wizard",
+            "r1",
+            PositionValues(title="Python-разработчик"),
+            ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+        ),
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.is_position_wizard", lambda _page, _resume_id: True
+    )
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.resolve_explicit_role",
+        lambda _page, label: ProfessionalRole("96", label, "ИТ"),
+    )
+
+    def fail_with_chip_popular(*_args, before_first_click, **_kwargs):
+        before_first_click()
+        raise ChipPopularUnavailable("chip-popular не содержит нужную специализацию")
+
+    def fail_minimum(*_args, **_kwargs):
+        raise RuntimeError("wizard-minimum тоже не сработал")
+
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_with_chip_popular)
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fail_minimum)
+
+    history_path = tmp_path / "history.db"
+    assert command.run(_draft_position_args(history_path)) is True
+    out = capsys.readouterr().out
+    assert "(uncertain)" in out
+
+    row = History(history_path).command_runs()[-1]
+    assert row["attempted"] == row["uncertain"] == 1
+    assert row["failed"] == row["success"] == row["skipped"] == 0
+
+
 def test_edit_experience_hard_failure_wins_over_uncertain_in_same_batch(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -1,8 +1,7 @@
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
-from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.resume_position as resume_position
 from hhru_bot.config import bare_resume
@@ -325,16 +324,21 @@ def test_save_position_wizard_handles_existing_or_empty_role(
     submit.click.assert_called_once_with()
 
 
-@pytest.mark.parametrize("click_reports_after_navigation", [False, True])
-def test_save_position_wizard_uses_preselected_popular_chip_when_catalog_modal_is_skipped(
-    click_reports_after_navigation,
-):
-    # Live DOM, #881 (2026-08-31): on a copy-resume draft that already carries
-    # an inherited role, hh.ru skips the tree-selector catalog modal entirely
-    # after NEXT and instead renders flat "chip-popular" radios, with the
-    # inherited profession pre-checked. The tree-selector search input never
-    # appears, so treating its absence as a hard failure turned a valid save
-    # into a permanent `uncertain`.
+def test_save_position_wizard_raises_chip_popular_unavailable_when_catalog_modal_is_skipped():
+    # Live DOM, #881/#889 (2026-08-31): on a copy-resume draft that already
+    # carries an inherited role, hh.ru skips the tree-selector catalog modal
+    # entirely after NEXT and instead renders a fixed list of ~37 generic
+    # "chip-popular" categories, each opening a narrow "Уточните профессию"
+    # sub-modal with ~15 items. This shape structurally cannot reach an
+    # arbitrary catalog leaf (confirmed live: role_id 96 "Программист,
+    # разработчик" is absent from the sub-modal under its own general
+    # category "Программист") — whether the chip is checked/enabled or not,
+    # it never carries the requested specialization. Earlier code tried to
+    # click through this shape and either failed closed on an unchecked chip
+    # or silently saved the WRONG specialization when checked; both are
+    # wrong. The only correct behavior is to raise a distinguishable
+    # exception so the caller falls back to the wizard-minimum + editor path
+    # (#890) instead of attempting a save this shape cannot honor.
     resume = bare_resume("resume-id")
     page = MagicMock()
     page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
@@ -353,9 +357,6 @@ def test_save_position_wizard_uses_preselected_popular_chip_when_catalog_modal_i
     chip.first = chip
     chip.is_checked.return_value = True
     chip.is_disabled.return_value = False
-    chip_card = MagicMock()
-    chip_card.count.return_value = 1
-    chip.locator.return_value = chip_card
     page.locator.side_effect = lambda selector: {
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
@@ -363,35 +364,91 @@ def test_save_position_wizard_uses_preselected_popular_chip_when_catalog_modal_i
         resume_position.WIZARD_CATEGORY_SEARCH: search,
         resume_position.WIZARD_POSITION_CHIP_POPULAR.format("Python-разработчик"): chip,
     }[selector]
-    if click_reports_after_navigation:
 
-        def click_side_effect():
-            if next_button.click.call_count == 2:
-                page.url = "https://hh.ru/applicant/resumes/suitable_vacancies?published=true"
-                raise PlaywrightError("detached after navigation")
+    with pytest.raises(resume_position.ChipPopularUnavailable, match="Программист, разработчик"):
+        resume_position.save_position_wizard(
+            page,
+            resume,
+            PositionValues(
+                title="Python-разработчик", specializations=["Программист, разработчик"]
+            ),
+            role_id="96",
+        )
 
-        next_button.click.side_effect = click_side_effect
+    # Only the first NEXT click (to leave the title screen); the chip is
+    # never clicked and no second NEXT is attempted.
+    next_button.click.assert_called_once_with()
+    chip.check.assert_not_called()
+    chip.click.assert_not_called()
 
-    resume_position.save_position_wizard(
-        page,
-        resume,
-        PositionValues(title="Python-разработчик", specializations=["Программист, разработчик"]),
-        role_id="96",
-    )
 
-    assert next_button.click.call_count == 2
-    assert next_button.first.wait_for.call_count == 2
-    chip_card.click.assert_called_once_with()
-    if click_reports_after_navigation:
-        page.wait_for_url.assert_not_called()
+@pytest.mark.parametrize("clear_count", [1, 0])
+def test_save_position_wizard_minimum_saves_any_placeholder_category_via_chip(clear_count):
+    # #890: the wizard-minimum fallback does not care WHICH profession gets
+    # saved — its only job is to clear `nextIncompleteScreenId` so the
+    # caller can reopen the resume in editor mode and set the exact
+    # specialization there via the already-working `_set_specializations`
+    # catalog search. It uses the fixed placeholder category, clicks its
+    # chip, and confirms the route left professional_role. A fresh
+    # copy-resume draft with no inherited role has no clear control at all
+    # (clear_count=0) — same fresh-draft case already handled in
+    # save_position_wizard (#889).
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
+    position = MagicMock()
+    position.count.return_value = 1
+    position.input_value.return_value = ""
+    clear = MagicMock()
+    clear.count.return_value = clear_count
+    next_button = MagicMock()
+    next_button.count.return_value = 1
+    next_button.first = next_button
+    chip = MagicMock()
+    chip.count.return_value = 1
+    chip.first = chip
+    chip.is_checked.return_value = True
+    chip.is_disabled.return_value = False
+    chip_card = MagicMock()
+    chip_card.count.return_value = 1
+    chip.locator.return_value = chip_card
+    page.locator.side_effect = lambda selector: {
+        resume_position.WIZARD_POSITION: position,
+        resume_position.WIZARD_POSITION_CLEAR: clear,
+        resume_position.WIZARD_NEXT: next_button,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
+            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
+        ): chip,
+    }[selector]
+
+    def click_side_effect():
+        if next_button.click.call_count == 2:
+            page.url = "https://hh.ru/resume/resume-id"
+
+    next_button.click.side_effect = click_side_effect
+
+    saved_title = resume_position.save_position_wizard_minimum(page, resume)
+
+    assert saved_title == resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
+    if clear_count:
+        clear.click.assert_called_once_with()
     else:
-        page.wait_for_url.assert_called_once_with(ANY, wait_until="commit", timeout=30_000)
+        clear.click.assert_not_called()
+    position.fill.assert_called_once_with(resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE)
+    chip_card.click.assert_called_once_with()
+    assert next_button.click.call_count == 2
 
 
-def test_save_position_wizard_rejects_unchecked_popular_chip():
-    # The chip shape (#881) is only a safe skip of the modal when hh.ru itself
-    # pre-checked the inherited profession; an unchecked chip means the save
-    # is not actually confirmed and must fail closed, not click NEXT blindly.
+def test_save_position_wizard_minimum_rejects_wrong_identity():
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=other-id"
+
+    with pytest.raises(RuntimeError, match="identity не подтверждён"):
+        resume_position.save_position_wizard_minimum(page, resume)
+
+
+def test_save_position_wizard_minimum_fails_closed_on_unchecked_chip():
     resume = bare_resume("resume-id")
     page = MagicMock()
     page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
@@ -403,32 +460,115 @@ def test_save_position_wizard_rejects_unchecked_popular_chip():
     next_button = MagicMock()
     next_button.count.return_value = 1
     next_button.first = next_button
-    search = MagicMock()
-    search.count.return_value = 0
     chip = MagicMock()
     chip.count.return_value = 1
     chip.first = chip
     chip.is_checked.return_value = False
-    chip.is_disabled.return_value = False
     page.locator.side_effect = lambda selector: {
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
-        resume_position.WIZARD_CATEGORY_SEARCH: search,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format("Python-разработчик"): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
+            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
+        ): chip,
     }[selector]
 
     with pytest.raises(RuntimeError, match="не отмечен"):
-        resume_position.save_position_wizard(
-            page,
-            resume,
-            PositionValues(
-                title="Python-разработчик", specializations=["Программист, разработчик"]
-            ),
-            role_id="96",
-        )
+        resume_position.save_position_wizard_minimum(page, resume)
 
-    next_button.click.assert_called_once_with()  # only the first NEXT, not a second
+    next_button.click.assert_called_once_with()
+
+
+def test_save_position_wizard_minimum_fails_closed_on_disabled_chip():
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
+    position = MagicMock()
+    position.count.return_value = 1
+    position.input_value.return_value = ""
+    clear = MagicMock()
+    clear.count.return_value = 1
+    next_button = MagicMock()
+    next_button.count.return_value = 1
+    next_button.first = next_button
+    chip = MagicMock()
+    chip.count.return_value = 1
+    chip.first = chip
+    chip.is_checked.return_value = True
+    chip.is_disabled.return_value = True
+    page.locator.side_effect = lambda selector: {
+        resume_position.WIZARD_POSITION: position,
+        resume_position.WIZARD_POSITION_CLEAR: clear,
+        resume_position.WIZARD_NEXT: next_button,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
+            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
+        ): chip,
+    }[selector]
+
+    with pytest.raises(RuntimeError, match="отключён"):
+        resume_position.save_position_wizard_minimum(page, resume)
+
+    next_button.click.assert_called_once_with()
+
+
+def test_save_position_wizard_minimum_fails_closed_when_chip_never_appears():
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
+    position = MagicMock()
+    position.count.return_value = 1
+    position.input_value.return_value = ""
+    clear = MagicMock()
+    clear.count.return_value = 1
+    next_button = MagicMock()
+    next_button.count.return_value = 1
+    next_button.first = next_button
+    chip = MagicMock()
+    chip.count.return_value = 0  # never renders — unexpected third shape
+    page.locator.side_effect = lambda selector: {
+        resume_position.WIZARD_POSITION: position,
+        resume_position.WIZARD_POSITION_CLEAR: clear,
+        resume_position.WIZARD_NEXT: next_button,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
+            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
+        ): chip,
+    }[selector]
+
+    with pytest.raises(RuntimeError, match="chip-popular"):
+        resume_position.save_position_wizard_minimum(page, resume)
+
+
+def test_verify_wizard_minimum_save_returns_once_professional_role_clears(monkeypatch):
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "resume_identity_matches", lambda _page, _resume_id: True)
+    states = [
+        ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+        ResumeState(status="not_finished", next_incomplete_screen_id="educations"),
+    ]
+    monkeypatch.setattr(
+        resume_position, "parse_resume_state", lambda *_args, **_kwargs: states.pop(0)
+    )
+
+    result = resume_position.verify_wizard_minimum_save(page, resume)
+
+    assert result.next_incomplete_screen_id == "educations"
+
+
+def test_verify_wizard_minimum_save_times_out_while_professional_role_persists(monkeypatch):
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    state = ResumeState(status="not_finished", next_incomplete_screen_id="professional_role")
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
+    monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: state)
+    monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 31]))
+
+    with pytest.raises(RuntimeError, match="всё ещё показывает professional_role"):
+        resume_position.verify_wizard_minimum_save(page, resume)
 
 
 def test_save_position_wizard_clicks_final_next_when_catalog_only_closes_modal():


### PR DESCRIPTION
## Что было

chip-popular shape (#889) не может сохранить точную заявленную специализацию:
под общей категорией "Программист" её подкаталог "Уточните профессию" (~15
популярных подкатегорий) НЕ содержит role_id=96 "Программист, разработчик"
вовсе. Даже когда title дословно совпадает с каталожной леткой, реальная
специализация после chip-пути оставалась случайным/унаследованным значением
— подтверждено живым резюме `288275dfff1107b8b70039ed1f4c615a433169`
(title="Программист, разработчик", специализация="Грузчик").

## Fix

- `ChipPopularUnavailable(RuntimeError)` — новый тип для "эта DOM-форма
  структурно не может сохранить точную специализацию".
- `save_position_wizard` больше не пытается кликать chip для точного
  сохранения — сразу поднимает `ChipPopularUnavailable`.
- `save_position_wizard_minimum` — сохраняет ЛЮБУЮ валидную категорию
  (фиксированный плейсхолдер "Администратор"), единственная цель —
  перевести `nextIncompleteScreenId` в состояние, отличное от
  `professional_role`.
- `verify_wizard_minimum_save` — узкая verify-функция только для этого
  факта.
- `commands/resume_position.py`: при `ChipPopularUnavailable` — вызывает
  wizard-minimum, переоткрывает `open_position_form` (должен вернуть
  `kind="editor"`), применяет точную специализацию через уже рабочий
  `apply_position`/`_set_specializations`. Один `progress.begin_attempt()`/
  `finish()` на весь двухступенчатый путь.

## Тесты

TDD red→green, 8 новых unit-тестов, 2 интеграционных теста durable-history.
Вся сюита (395 тестов) зелёная. ruff check/format чисты. Mutation testing:
594/1445 killed (было 588 до расширения тестов); выжившие мутанты —
косметика (текст сообщений, kwargs моков), не логика.

## Живой прогон — статус: НЕ полностью успешен

Живой прогон на свежей копии резюме дал `[FAIL] (uncertain)`, не success:
`save_position_wizard_minimum` упал на `position.fill("Администратор")` —
поле оказалось `disabled` в момент вызова, а URL страницы в этот момент уже
был `suitable_vacancies?...&published=true`. Похоже, основной путь успел
продвинуть экран дальше состояния, которое fallback ожидает застать.

Ничего не сломано на аккаунте (`uncertain`, не `success`, fail-closed
сработал как задумано) — но фикс в текущем виде не решает задачу #881
полностью. Мерджу как промежуточный шаг (не ухудшает текущее поведение
относительно #889, добавляет типизацию ошибки и инфраструктуру для
дальнейшей отладки) с открытым follow-up эпиком на разбор причин
`uncertain` по частям.

Follow-up: #893 (эпик с разбивкой гипотез на отдельные research-issue).

Refs #881 #888 #889 #890 #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)