### PR TITLE
fix(resume-position): verify wizard save before fallback

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -137,6 +137,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
         CANCEL,
         ChipPopularUnavailable,
         PositionValues,
+        WizardRoleMismatch,
         apply_position,
         build_position_prompt,
         fill_only_missing,
@@ -383,30 +384,46 @@ def _run(args: argparse.Namespace, progress) -> bool:
                             expected_role_label=role.label,
                         )
                     except ChipPopularUnavailable:
-                        # #890: this DOM shape structurally cannot save the
-                        # exact requested specialization (confirmed live —
-                        # the catalog leaf is absent from its narrow
-                        # sub-modal). Save ANY valid placeholder category
-                        # just to clear professional_role, then reopen the
-                        # form — it must now be in editor mode, where the
-                        # already-working `_set_specializations` catalog
-                        # search sets the exact specialization.
-                        save_position_wizard_minimum(
-                            page, resume, before_first_click=mark_first_click_started
-                        )
-                        verify_wizard_minimum_save(page, resume)
-                        fixup_flow = open_position_form(page, resume)
-                        if fixup_flow.kind != "editor" or fixup_flow.resume_id != resume.resume_id:
-                            raise RuntimeError(
-                                "wizard-minimum сохранён, но форма не перешла в editor-режим"
-                            ) from None
-                        apply_position(page, plan, current=fixup_flow.values)
-                        _click_save_and_wait(page)
-                        published_note = (
-                            "[INFO] professional_role завершён через wizard-minimum "
-                            "fallback (#890); точная специализация применена в "
-                            "editor-режиме."
-                        )
+                        # The first NEXT may already have committed the exact
+                        # role while the DOM moved to an unusable chip shape.
+                        # Verify the identity-bound SSR state before touching
+                        # the wizard again; only a confirmed role mismatch
+                        # justifies the minimum fallback.
+                        try:
+                            verified_state = verify_wizard_save(
+                                page,
+                                resume,
+                                expected_title=plan.title or "",
+                                expected_role_id=role.role_id,
+                                expected_role_label=role.label,
+                            )
+                        except WizardRoleMismatch:
+                            # The role really did not match; preserve the
+                            # existing minimum-wizard fallback for that case.
+                            save_position_wizard_minimum(
+                                page, resume, before_first_click=mark_first_click_started
+                            )
+                            verify_wizard_minimum_save(page, resume)
+                            fixup_flow = open_position_form(page, resume)
+                            if (
+                                fixup_flow.kind != "editor"
+                                or fixup_flow.resume_id != resume.resume_id
+                            ):
+                                raise RuntimeError(
+                                    "wizard-minimum сохранён, но форма не перешла в editor-режим"
+                                ) from None
+                            apply_position(page, plan, current=fixup_flow.values)
+                            _click_save_and_wait(page)
+                            published_note = (
+                                "[INFO] professional_role завершён через wizard-minimum "
+                                "fallback (#890); точная специализация применена в "
+                                "editor-режиме."
+                            )
+                        else:
+                            published_note = (
+                                "[INFO] professional_role сохранён с первого NEXT; "
+                                "chip-fallback не потребовался."
+                            )
                 except Exception as exc:
                     if not first_click_started:
                         raise

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -75,6 +75,14 @@ from .selector_groups.resume_page import (
 logger = logging.getLogger("hhru_bot.resume_position")
 
 
+class WizardRoleMismatch(RuntimeError):
+    """Post-save readback found a different professional role.
+
+    This is the one verification failure for which the legacy minimum-wizard
+    fallback remains appropriate; transport/state failures stay fail-closed.
+    """
+
+
 class ChipPopularUnavailable(RuntimeError):
     """The chip-popular shape (#881/#889) cannot confirm the exact catalog
     specialization — it is a fixed list of ~37 generic categories plus a
@@ -824,7 +832,7 @@ def verify_wizard_save(
         and (role.label is None or role.label == expected_role_label)
         for role in state.professional_roles
     ):
-        raise RuntimeError(
+        raise WizardRoleMismatch(
             f"post-save professional role не совпал: ожидалось "
             f"{expected_role_id}:{expected_role_label}, прочитано "
             f"{observed_roles or '<пусто>'}"

--- a/tests/fixtures/post_save_professional_role_mismatch.html
+++ b/tests/fixtures/post_save_professional_role_mismatch.html
@@ -1,0 +1,1 @@
+<template id="HH-Lux-InitialState">{"applicantResume":{"id":"00001","status":"not_finished","isSearchable":false,"nextIncompleteScreenId":"professional_role","professionalRole":[{"id":31,"text":"Грузчик"}]}}</template>

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -7,6 +7,7 @@ import importlib
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -702,6 +703,7 @@ def test_chip_popular_unavailable_falls_back_to_wizard_minimum_and_succeeds(
         ChipPopularUnavailable,
         PositionFlowContext,
         PositionValues,
+        WizardRoleMismatch,
     )
     from hhru_bot.resume_state import ResumeState
 
@@ -780,6 +782,10 @@ def test_chip_popular_unavailable_falls_back_to_wizard_minimum_and_succeeds(
         return "Администратор"
 
     monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_with_chip_popular)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.verify_wizard_save",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(WizardRoleMismatch("роль не совпала")),
+    )
     monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fake_minimum)
     monkeypatch.setattr(
         "hhru_bot.resume_position.verify_wizard_minimum_save",
@@ -810,7 +816,12 @@ def test_chip_popular_unavailable_fallback_failure_is_uncertain_not_double_count
     """
     import hhru_bot.commands.resume_position as command
     from hhru_bot.professional_roles import ProfessionalRole
-    from hhru_bot.resume_position import ChipPopularUnavailable, PositionFlowContext, PositionValues
+    from hhru_bot.resume_position import (
+        ChipPopularUnavailable,
+        PositionFlowContext,
+        PositionValues,
+        WizardRoleMismatch,
+    )
     from hhru_bot.resume_state import ResumeState
 
     resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
@@ -850,6 +861,10 @@ def test_chip_popular_unavailable_fallback_failure_is_uncertain_not_double_count
         raise RuntimeError("wizard-minimum тоже не сработал")
 
     monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_with_chip_popular)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.verify_wizard_save",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(WizardRoleMismatch("роль не совпала")),
+    )
     monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fail_minimum)
 
     history_path = tmp_path / "history.db"
@@ -1095,3 +1110,62 @@ def test_browser_launch_error_propagates_to_cli_environment_handler(
 
     with pytest.raises(BrowserLaunchError):
         command.run(args)
+
+
+def test_chip_popular_unavailable_uses_verified_save_without_minimum_fallback(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A committed exact role must finish successfully without the fallback."""
+    import hhru_bot.commands.resume_position as command
+    from hhru_bot.professional_roles import ProfessionalRole
+    from hhru_bot.resume_position import (
+        ChipPopularUnavailable,
+        PositionFlowContext,
+        PositionValues,
+    )
+    from hhru_bot.resume_state import ResumeState
+
+    resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    class _Page:
+        url = "https://hh.ru/profile/resume/professional_role?resume=r1"
+
+        def locator(self, _selector):
+            return SimpleNamespace(count=lambda: 1, click=lambda: None)
+
+    page = _Page()
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: page)
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    flow = PositionFlowContext(
+        "wizard",
+        "r1",
+        PositionValues(title="Python-разработчик"),
+        ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+    )
+    monkeypatch.setattr("hhru_bot.resume_position.open_position_form", lambda *_a: flow)
+    monkeypatch.setattr("hhru_bot.resume_position.is_position_wizard", lambda *_a: True)
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.resolve_explicit_role",
+        lambda _page, label: ProfessionalRole("96", label, "ИТ"),
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.save_position_wizard",
+        lambda *_a, **_kw: (_ for _ in ()).throw(ChipPopularUnavailable("chip")),
+    )
+    verified = ResumeState(status="new", is_searchable=True)
+    verify = MagicMock(return_value=verified)
+    monkeypatch.setattr("hhru_bot.resume_position.verify_wizard_save", verify)
+    minimum = MagicMock()
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", minimum)
+
+    assert command.run(_draft_position_args(tmp_path / "history.db")) is False
+    assert verify.call_count == 1
+    minimum.assert_not_called()
+    assert "автоматическую публикацию" in capsys.readouterr().out

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -1317,3 +1318,14 @@ def test_verify_wizard_save_rejects_wrong_server_role(monkeypatch):
             expected_role_id="10",
             expected_role_label="Аналитик",
         )
+
+
+def test_live_post_save_dump_fixture_captures_unmatched_role():
+    """Sanitized fixture from the single #899 live post-save dump."""
+    fixture = Path(__file__).with_name("fixtures") / "post_save_professional_role_mismatch.html"
+    state = resume_position.parse_resume_state(fixture.read_text(encoding="utf-8"), "00001")
+
+    assert state.status == "not_finished"
+    assert state.is_searchable is False
+    assert state.next_incomplete_screen_id == "professional_role"
+    assert [(role.role_id, role.label) for role in state.professional_roles] == [("31", "Грузчик")]


### PR DESCRIPTION
## Summary
- re-read identity-bound SSR state after ChipPopularUnavailable
- skip wizard-minimum when the exact role was already committed by the first NEXT
- retain fallback only for an explicit professional-role mismatch; state/transport failures remain uncertain

Closes #899

## Tests
- ruff check .
- ruff format --check .
- full pytest -q (100% passed)

## Live verification
Not run: closing the last professional_role screen is an irreversible auto-publication action. Awaiting explicit approval for one concrete live run.