### PR TITLE
fix(resume-position): wizard minimum then editor specialization fixup

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -135,7 +135,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
     from ..config import ConfigError, load_config_or_exit
     from ..resume_position import (
         CANCEL,
-        ChipPopularUnavailable,
         PositionValues,
         apply_position,
         build_position_prompt,
@@ -143,7 +142,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
         is_position_wizard,
         open_position_form,
         parse_position_response,
-        save_position_wizard,
         save_position_wizard_minimum,
         validate_wizard_plan,
         verify_wizard_minimum_save,
@@ -367,14 +365,22 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     "отдельной read-only проверки."
                 )
                 try:
+                    # The chip wizard cannot represent role_id, and its first
+                    # NEXT may close the screen immediately. Do not attempt an
+                    # exact save there: record the known-wrong prerequisite
+                    # category directly, then perform the mandatory fixup.
+                    save_position_wizard_minimum(
+                        page, resume, before_first_click=mark_first_click_started
+                    )
+                    verify_wizard_minimum_save(page, resume)
+                    fixup_flow = open_position_form(page, resume)
+                    if fixup_flow.kind != "editor" or fixup_flow.resume_id != resume.resume_id:
+                        raise RuntimeError(
+                            "wizard-minimum сохранён, но форма не перешла в editor-режим"
+                        ) from None
                     try:
-                        save_position_wizard(
-                            page,
-                            resume,
-                            plan,
-                            role_id=role.role_id,
-                            before_first_click=mark_first_click_started,
-                        )
+                        apply_position(page, plan, current=fixup_flow.values)
+                        _click_save_and_wait(page)
                         verified_state = verify_wizard_save(
                             page,
                             resume,
@@ -382,31 +388,17 @@ def _run(args: argparse.Namespace, progress) -> bool:
                             expected_role_id=role.role_id,
                             expected_role_label=role.label,
                         )
-                    except ChipPopularUnavailable:
-                        # #890: this DOM shape structurally cannot save the
-                        # exact requested specialization (confirmed live —
-                        # the catalog leaf is absent from its narrow
-                        # sub-modal). Save ANY valid placeholder category
-                        # just to clear professional_role, then reopen the
-                        # form — it must now be in editor mode, where the
-                        # already-working `_set_specializations` catalog
-                        # search sets the exact specialization.
-                        save_position_wizard_minimum(
-                            page, resume, before_first_click=mark_first_click_started
-                        )
-                        verify_wizard_minimum_save(page, resume)
-                        fixup_flow = open_position_form(page, resume)
-                        if fixup_flow.kind != "editor" or fixup_flow.resume_id != resume.resume_id:
-                            raise RuntimeError(
-                                "wizard-minimum сохранён, но форма не перешла в editor-режим"
-                            ) from None
-                        apply_position(page, plan, current=fixup_flow.values)
-                        _click_save_and_wait(page)
-                        published_note = (
-                            "[INFO] professional_role завершён через wizard-minimum "
-                            "fallback (#890); точная специализация применена в "
-                            "editor-режиме."
-                        )
+                    except Exception as exc:
+                        raise RuntimeError(
+                            "осознанно неверная профессия wizard-minimum сохранена, "
+                            "но обязательное исправление в editor-режиме не удалось: "
+                            f"{exc}"
+                        ) from exc
+                    published_note = (
+                        "[INFO] professional_role завершён через wizard-minimum "
+                        "fallback (#890); точная специализация применена в "
+                        "editor-режиме."
+                    )
                 except Exception as exc:
                     if not first_click_started:
                         raise

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -87,14 +87,15 @@ class ChipPopularUnavailable(RuntimeError):
     """
 
 
-# The chip-popular radio does not carry the profession in its data-qa (every
-# chip on the screen shares the same data-qa); the profession lives in the
-# input's ``value`` attribute instead (#881, live DOM 2026-08-31). Scope the
-# base selector down to the one radio matching the confirmed catalog label.
-WIZARD_POSITION_CHIP_POPULAR = WIZARD_POSITION_CHIP_POPULAR_BASE + "[value='{}']"
+# The chip-popular radio does not carry the typed profession in its data-qa.
+# In fact the title input is not retained on this screen: hh.ru highlights one
+# of the fixed generic categories. Keep the unscoped selector for this shape;
+# selecting by the requested title would miss the chips (or, worse, imply that
+# the highlighted generic category was the requested catalog leaf).
+WIZARD_POSITION_CHIP_POPULAR = WIZARD_POSITION_CHIP_POPULAR_BASE
 
 # Fixed, deterministic placeholder for the wizard-minimum fallback (#890):
-# any of the ~37 chip-popular categories clears `nextIncompleteScreenId`
+# any of the fixed chip-popular categories clears `nextIncompleteScreenId`
 # equally well, since its content is discarded immediately by the editor-mode
 # `_set_specializations` call that follows. A hardcoded, always-identical
 # choice (first item on the confirmed live list) is deliberate — not derived
@@ -563,10 +564,10 @@ def save_position_wizard(
 
     expected_label = plan.specializations[0]
     search = page.locator(WIZARD_CATEGORY_SEARCH)
-    # The chip's ``value`` mirrors the just-typed title, not the catalog
-    # specialization label confirmed below for the modal path (#881, live DOM
-    # 2026-08-31) — hh.ru pre-fills the chip from what the user entered above.
-    chip = page.locator(WIZARD_POSITION_CHIP_POPULAR.format(plan.title))
+    # The chip list is a different entity from the role_id catalog: its
+    # values are generic text labels and the input does not retain what was
+    # typed (#890 live DOM 2026-08-31).
+    chip = page.locator(WIZARD_POSITION_CHIP_POPULAR)
     transition_deadline = time.monotonic() + WIZARD_WAIT_MS / 1000
     while time.monotonic() < transition_deadline:
         if not _is_wizard_path(getattr(page, "url", "")):
@@ -695,27 +696,28 @@ def save_position_wizard_minimum(
         before_first_click()
     next_button.click()
 
-    chip = page.locator(WIZARD_POSITION_CHIP_POPULAR.format(title))
+    chips = page.locator(WIZARD_POSITION_CHIP_POPULAR)
     deadline = time.monotonic() + WIZARD_WAIT_MS / 1000
     while time.monotonic() < deadline:
         if not _is_wizard_path(getattr(page, "url", "")):
             return title
-        if chip.count() == 1:
+        if chips.count() > 0:
             break
         page.wait_for_timeout(WIZARD_VERIFY_POLL_MS)
     else:
         raise RuntimeError(
             f"chip-popular для «{title}» не появился — минимальное сохранение невозможно"
         )
-    chip.first.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
-    if not chip.first.is_checked():
-        raise RuntimeError(f"чип должности «{title}» найден, но не отмечен")
-    if chip.first.is_disabled():
-        raise RuntimeError(f"чип должности «{title}» отмечен, но отключён")
-    # The radio input itself is disabled in this shape; its wrapping card is
-    # the actual hit target (same pattern as the currency-chip click in
-    # ``apply_position`` below).
-    chip_card = chip.first.locator("xpath=ancestor::label[1]")
+    # The title typed on the previous screen is not a stable chip value. Pick
+    # the first generic category in the server-rendered order: this is an
+    # intentional, known-wrong wizard minimum and is replaced immediately in
+    # editor mode. Never claim it is the requested profession.
+    chip = chips.first
+    chip.wait_for(state="visible", timeout=WIZARD_WAIT_MS)
+    # The radio input itself may be disabled in this shape; its wrapping card
+    # is the actual hit target (same pattern as the currency-chip click in
+    # ``apply_position`` below). Check the card, not the input's disabled flag.
+    chip_card = chip.locator("xpath=ancestor::label[1]")
     if chip_card.count() != 1:
         raise RuntimeError("карточка chip должности не подтверждена")
     chip_card.click()
@@ -744,8 +746,9 @@ def verify_wizard_minimum_save(page: Page, resume: ResumeConfig) -> ResumeState:
     """Poll only for professional_role clearing — no title/role match (#890).
 
     Deliberately narrower than :func:`verify_wizard_save`: the wizard-minimum
-    step saves a throwaway placeholder on purpose, so checking its title or
-    role against anything would be a foot-gun (a future call could weaken
+    step intentionally records a known-wrong prerequisite category, so
+    checking its title or role against anything would be a foot-gun (a future
+    call could weaken
     real verification by passing loose expectations). This function proves
     exactly one fact — the draft left the professional_role screen — leaving
     the exact specialization to the editor-mode step that follows.

--- a/src/hhru_bot/selector_groups/resume_page.py
+++ b/src/hhru_bot/selector_groups/resume_page.py
@@ -167,10 +167,12 @@ RESUME_CREATION_CATEGORY_SUBMIT = _selector("resume_page.RESUME_CREATION_CATEGOR
 RESUME_CREATION_CATEGORY_INPUT = _selector("resume_page.RESUME_CREATION_CATEGORY_INPUT")
 
 # Second post-NEXT shape (#881, confirmed live DOM 2026-08-31 on a copy-resume
-# draft): when the wizard already carries an inherited role from cloning, hh.ru
-# skips the catalog modal above entirely and instead renders a flat list of
-# radio "chips" for popular professions, with the inherited one pre-selected
-# (checked). ``save_position_wizard`` must check for this shape before treating
+# draft): after the title step hh.ru skips the catalog modal above entirely and
+# instead renders a flat list of
+# radio "chips" for popular professions, with the text entered on the previous
+# step highlighted as a chip (checked). Copies start with no professional role;
+# the text is not retained in the input and has no role_id. The saver must
+# check for this shape before treating
 # an absent catalog search input as a failure — see the two-shape branch there.
 RESUME_CREATION_POSITION_CHIP_POPULAR = _selector(
     "resume_page.RESUME_CREATION_POSITION_CHIP_POPULAR"

--- a/tests/fixtures/resume_position_wizard_chips.html
+++ b/tests/fixtures/resume_position_wizard_chips.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="ru"><body>
+  <input data-qa="resume-profile-position-input" value="">
+  <div role="listbox">
+      <label><input data-qa="resume-profile-position-chip-popular" value="Администратор">Администратор</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Аналитик">Аналитик</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Бухгалтер">Бухгалтер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Водитель">Водитель</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Врач">Врач</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Грузчик">Грузчик</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Дизайнер">Дизайнер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Директор">Директор</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Инженер">Инженер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Кладовщик">Кладовщик</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Копирайтер">Копирайтер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Курьер">Курьер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Менеджер">Менеджер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Мерчандайзер">Мерчандайзер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Монтажник">Монтажник</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Начинающий специалист">Начинающий специалист</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Оператор">Оператор</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Официант">Официант</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Охранник">Охранник</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Повар">Повар</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Помощник">Помощник</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Преподаватель">Преподаватель</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Продавец">Продавец</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Промоутер">Промоутер</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Рабочий">Рабочий</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Руководитель">Руководитель</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Секретарь">Секретарь</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Слесарь">Слесарь</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Сотрудник пункта выдачи заказов">Сотрудник пункта выдачи заказов</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Специалист">Специалист</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Тайный покупатель">Тайный покупатель</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Торговый представитель">Торговый представитель</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Уборщик">Уборщик</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Упаковщик">Упаковщик</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Экономист">Экономист</label>
+      <label><input data-qa="resume-profile-position-chip-popular" value="Юрист">Юрист</label>
+  </div>
+</body></html>

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -383,7 +383,10 @@ def test_resume_position_wizard_write_rebinds_and_never_reports_editor_success(
         PositionValues(title="AI Engineer"),
         ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
     )
-    open_flow = MagicMock(return_value=flow)
+    editor_flow = PositionFlowContext(
+        "editor", REMOTE_ONLY_HASH, PositionValues(title="Администратор"), ResumeState(status="new")
+    )
+    open_flow = MagicMock(side_effect=[flow, flow, editor_flow])
     save = MagicMock()
     monkeypatch.setattr("hhru_bot.browser.launch_context", _wizard_context)
     monkeypatch.setattr("hhru_bot.resume_position.open_position_form", open_flow)
@@ -391,10 +394,18 @@ def test_resume_position_wizard_write_rebinds_and_never_reports_editor_success(
         "hhru_bot.professional_roles.resolve_explicit_role",
         lambda page, label: ProfessionalRole("10", label, "Информационные технологии"),
     )
-    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", save)
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", save)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.verify_wizard_minimum_save",
+        lambda *_args, **_kwargs: ResumeState(status="new", is_searchable=True),
+    )
     monkeypatch.setattr(
         "hhru_bot.resume_position.verify_wizard_save",
-        lambda *_args, **_kwargs: ResumeState(status="new", is_searchable=True),
+        lambda *_args, **_kwargs: ResumeState(status="new", is_searchable=False),
+    )
+    monkeypatch.setattr("hhru_bot.resume_position.apply_position", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "hhru_bot.commands.resume_position._click_save_and_wait", lambda *_args: None
     )
 
     result = resume_position_cmd.run(
@@ -411,10 +422,10 @@ def test_resume_position_wizard_write_rebinds_and_never_reports_editor_success(
 
     out = capsys.readouterr().out
     assert result is False
-    assert open_flow.call_count == 2
+    assert open_flow.call_count == 3
     save.assert_called_once()
     assert "[OK] professional_role" in out
-    assert "автоматическую публикацию" in out
+    assert "точная специализация применена" in out
     assert "[OK] Раздел желаемой работы" not in out
 
 

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -633,7 +633,7 @@ def test_draft_position_classifies_failure_at_first_click_boundary(
             before_first_click()
         raise RuntimeError("browser drift")
 
-    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_save)
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fail_save)
 
     history_path = tmp_path / "history.db"
     args = argparse.Namespace(
@@ -786,6 +786,10 @@ def test_chip_popular_unavailable_falls_back_to_wizard_minimum_and_succeeds(
         lambda _page, _resume: ResumeState(status="not_finished"),
     )
     monkeypatch.setattr(
+        "hhru_bot.resume_position.verify_wizard_save",
+        lambda *_args, **_kwargs: ResumeState(status="not_finished"),
+    )
+    monkeypatch.setattr(
         "hhru_bot.resume_position.apply_position", lambda _page, _plan, current=None: None
     )
 
@@ -810,7 +814,7 @@ def test_chip_popular_unavailable_fallback_failure_is_uncertain_not_double_count
     """
     import hhru_bot.commands.resume_position as command
     from hhru_bot.professional_roles import ProfessionalRole
-    from hhru_bot.resume_position import ChipPopularUnavailable, PositionFlowContext, PositionValues
+    from hhru_bot.resume_position import PositionFlowContext, PositionValues
     from hhru_bot.resume_state import ResumeState
 
     resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
@@ -842,14 +846,10 @@ def test_chip_popular_unavailable_fallback_failure_is_uncertain_not_double_count
         lambda _page, label: ProfessionalRole("96", label, "ИТ"),
     )
 
-    def fail_with_chip_popular(*_args, before_first_click, **_kwargs):
+    def fail_minimum(*_args, before_first_click=None, **_kwargs):
         before_first_click()
-        raise ChipPopularUnavailable("chip-popular не содержит нужную специализацию")
-
-    def fail_minimum(*_args, **_kwargs):
         raise RuntimeError("wizard-minimum тоже не сработал")
 
-    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard", fail_with_chip_popular)
     monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", fail_minimum)
 
     history_path = tmp_path / "history.db"

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -298,7 +298,7 @@ def test_save_position_wizard_handles_existing_or_empty_role(
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
         resume_position.WIZARD_CATEGORY_SEARCH: search,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format("AI Engineer"): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
         resume_position.WIZARD_CATEGORY_INPUT.format("10"): checkbox,
         resume_position.WIZARD_CATEGORY_SUBMIT: submit,
     }[selector]
@@ -356,13 +356,14 @@ def test_save_position_wizard_raises_chip_popular_unavailable_when_catalog_modal
     chip.count.return_value = 1
     chip.first = chip
     chip.is_checked.return_value = True
-    chip.is_disabled.return_value = False
+    # Live DOM disables the radio input; the label card remains clickable.
+    chip.is_disabled.return_value = True
     page.locator.side_effect = lambda selector: {
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
         resume_position.WIZARD_CATEGORY_SEARCH: search,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format("Python-разработчик"): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
     }[selector]
 
     with pytest.raises(resume_position.ChipPopularUnavailable, match="Программист, разработчик"):
@@ -408,7 +409,8 @@ def test_save_position_wizard_minimum_saves_any_placeholder_category_via_chip(cl
     chip.count.return_value = 1
     chip.first = chip
     chip.is_checked.return_value = True
-    chip.is_disabled.return_value = False
+    # The live radio input is disabled; its wrapping label is clickable.
+    chip.is_disabled.return_value = True
     chip_card = MagicMock()
     chip_card.count.return_value = 1
     chip.locator.return_value = chip_card
@@ -416,9 +418,7 @@ def test_save_position_wizard_minimum_saves_any_placeholder_category_via_chip(cl
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
-            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
-        ): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
     }[selector]
 
     def click_side_effect():
@@ -448,7 +448,7 @@ def test_save_position_wizard_minimum_rejects_wrong_identity():
         resume_position.save_position_wizard_minimum(page, resume)
 
 
-def test_save_position_wizard_minimum_fails_closed_on_unchecked_chip():
+def test_save_position_wizard_minimum_rejects_chip_without_clickable_card():
     resume = bare_resume("resume-id")
     page = MagicMock()
     page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
@@ -463,17 +463,15 @@ def test_save_position_wizard_minimum_fails_closed_on_unchecked_chip():
     chip = MagicMock()
     chip.count.return_value = 1
     chip.first = chip
-    chip.is_checked.return_value = False
+    chip.is_disabled.return_value = False
     page.locator.side_effect = lambda selector: {
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
-            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
-        ): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
     }[selector]
 
-    with pytest.raises(RuntimeError, match="не отмечен"):
+    with pytest.raises(RuntimeError, match="карточка chip"):
         resume_position.save_position_wizard_minimum(page, resume)
 
     next_button.click.assert_called_once_with()
@@ -496,16 +494,15 @@ def test_save_position_wizard_minimum_fails_closed_on_disabled_chip():
     chip.first = chip
     chip.is_checked.return_value = True
     chip.is_disabled.return_value = True
+    chip.locator.return_value.count.return_value = 0
     page.locator.side_effect = lambda selector: {
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
-            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
-        ): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
     }[selector]
 
-    with pytest.raises(RuntimeError, match="отключён"):
+    with pytest.raises(RuntimeError, match="карточка chip"):
         resume_position.save_position_wizard_minimum(page, resume)
 
     next_button.click.assert_called_once_with()
@@ -529,9 +526,7 @@ def test_save_position_wizard_minimum_fails_closed_when_chip_never_appears():
         resume_position.WIZARD_POSITION: position,
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format(
-            resume_position.WIZARD_MINIMUM_PLACEHOLDER_TITLE
-        ): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
     }[selector]
 
     with pytest.raises(RuntimeError, match="chip-popular"):
@@ -610,7 +605,7 @@ def test_save_position_wizard_clicks_final_next_when_catalog_only_closes_modal()
         resume_position.WIZARD_POSITION_CLEAR: clear,
         resume_position.WIZARD_NEXT: next_button,
         resume_position.WIZARD_CATEGORY_SEARCH: search,
-        resume_position.WIZARD_POSITION_CHIP_POPULAR.format("AI Engineer"): chip,
+        resume_position.WIZARD_POSITION_CHIP_POPULAR: chip,
         resume_position.WIZARD_CATEGORY_INPUT.format("10"): checkbox,
         resume_position.WIZARD_CATEGORY_SUBMIT: submit,
     }[selector]

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -10,6 +10,7 @@ import hhru_bot.resume_position as resume_position
 pytestmark = pytest.mark.integration
 
 FIXTURE = Path(__file__).parent / "fixtures" / "resume_position_specializations.html"
+WIZARD_CHIPS_FIXTURE = Path(__file__).parent / "fixtures" / "resume_position_wizard_chips.html"
 
 
 def _page():
@@ -18,6 +19,24 @@ def _page():
     page = browser.new_page()
     page.set_content(FIXTURE.read_text(encoding="utf-8"))
     return playwright, browser, page
+
+
+@pytest.mark.browser_unit
+def test_wizard_chip_fixture_is_generic_and_does_not_retain_typed_catalog_leaf():
+    playwright = sync_playwright().start()
+    browser = playwright.chromium.launch()
+    page = browser.new_page()
+    page.set_content(WIZARD_CHIPS_FIXTURE.read_text(encoding="utf-8"))
+    try:
+        chips = page.locator(resume_position.WIZARD_POSITION_CHIP_POPULAR)
+        assert chips.count() == 36
+        assert page.locator(resume_position.WIZARD_POSITION).input_value() == ""
+        assert chips.filter(has_text="Программист, разработчик").count() == 0
+        assert chips.filter(has_text="Программист").count() == 0
+        assert chips.first.get_attribute("value") == "Администратор"
+    finally:
+        browser.close()
+        playwright.stop()
 
 
 @pytest.mark.browser_unit


### PR DESCRIPTION
Closes #890

## Summary
- Treat the chip wizard as a text-only 36-category surface with no role_id.
- Record a deliberately wrong, deterministic wizard prerequisite category, then reopen and require editor mode for the exact specialization.
- Make any failed mandatory editor correction explicit instead of silently leaving the wrong role.
- Add HTML characterization fixture for the 36 generic chips and non-retained input.

## Live evidence
- Read-only authenticated run on draft copy `00001` (real id redacted): `open_position_form` returned `kind="editor"`, `next_incomplete_screen_id="common"`, title `Инженер по автоматизации`. No apply/save/mutation.
- The unsafe first-NEXT experiment was not run; #899 already establishes that the wizard can close and auto-publish on that click.

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q src tests` (100%, 2 skipped)

Known risk: wizard-minimum intentionally exposes a known-wrong category until the immediate editor correction completes; failures are surfaced as uncertain after the mutating click.