### PR TITLE
fix(resume-position): keep dry-run out of wizard

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -195,11 +195,19 @@ def _run(args: argparse.Namespace, progress) -> bool:
     profile = resume.ai_profile
     try:
         llm = None if manual else LLMClient(config.ai)
+        explicit_specialization = getattr(args, "specialization", None)
         with launch_context(
             config.storage_state_file, headless=args.headless, user_agent=config.user_agent
         ) as context:
             page = context.new_page()
-            flow = open_position_form(page, resume)
+            # Resolving an explicit role uses the read-only vacancy catalog. In
+            # dry-run there is no reason to enter the resume wizard afterwards:
+            # its entry card is a different UI and its first NEXT can publish a
+            # draft. Keep the wizard entirely untouched in this path (#904).
+            if args.dry_run and explicit_specialization:
+                flow = open_position_form(page, resume, enter_wizard=False)
+            else:
+                flow = open_position_form(page, resume)
             current = flow.values
             wizard = flow.kind == "wizard"
             if manual:
@@ -263,7 +271,6 @@ def _run(args: argparse.Namespace, progress) -> bool:
             role = None
             classification_reason = ""
             classification_queries: list[str] = []
-            explicit_specialization = getattr(args, "specialization", None)
             if wizard:
                 from ..professional_roles import resolve_explicit_role, suggest_role
 

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -442,6 +442,12 @@ def open_position_form(
     require_authenticated_page(page)
     if _is_wizard_path(getattr(page, "url", "")):
         if not enter_wizard:
+            # state.title is currently the only title source on this
+            # read-only path. Live verification showed it is None when
+            # nextIncompleteScreenId=common (00002), because that flow does
+            # not enter the wizard. The professional_role case was not
+            # verified: 00001 was run with an explicit --title. The confirmed
+            # profileResumes.resumeHash source belongs in follow-up #910.
             state = parse_resume_state(page.content(), resume.resume_id)
             if state.status is None:
                 raise RuntimeError("состояние резюме не подтверждено перед выбором position flow")

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -448,7 +448,7 @@ def open_position_form(
             return PositionFlowContext(
                 kind="wizard",
                 resume_id=resume.resume_id,
-                values=PositionValues(),
+                values=PositionValues(title=state.title),
                 state=state,
                 values_read=False,
             )
@@ -468,7 +468,7 @@ def open_position_form(
             return PositionFlowContext(
                 kind="wizard",
                 resume_id=resume.resume_id,
-                values=PositionValues(),
+                values=PositionValues(title=state.title),
                 state=state,
                 values_read=False,
             )

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -171,6 +171,7 @@ class PositionFlowContext:
     resume_id: str
     values: PositionValues
     state: ResumeState
+    values_read: bool = True
 
 
 def _profile_context(profile: Any) -> dict[str, Any]:
@@ -428,7 +429,9 @@ def _dump_wizard_failure(page: Page, resume_id: str, reason: str) -> str:
     return str(html_path)
 
 
-def open_position_form(page: Page, resume: ResumeConfig) -> PositionFlowContext:
+def open_position_form(
+    page: Page, resume: ResumeConfig, *, enter_wizard: bool = True
+) -> PositionFlowContext:
     """Open the state-selected position flow for exactly one resume.
 
     hh.ru does not consistently redirect unfinished drafts from ``/resume/<id>``
@@ -438,6 +441,17 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionFlowContext:
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     require_authenticated_page(page)
     if _is_wizard_path(getattr(page, "url", "")):
+        if not enter_wizard:
+            state = parse_resume_state(page.content(), resume.resume_id)
+            if state.status is None:
+                raise RuntimeError("состояние резюме не подтверждено перед выбором position flow")
+            return PositionFlowContext(
+                kind="wizard",
+                resume_id=resume.resume_id,
+                values=PositionValues(),
+                state=state,
+                values_read=False,
+            )
         return _open_position_wizard(
             page,
             resume,
@@ -450,6 +464,14 @@ def open_position_form(page: Page, resume: ResumeConfig) -> PositionFlowContext:
     if state.status is None:
         raise RuntimeError("состояние резюме не подтверждено перед выбором position flow")
     if state.next_incomplete_screen_id == "professional_role":
+        if not enter_wizard:
+            return PositionFlowContext(
+                kind="wizard",
+                resume_id=resume.resume_id,
+                values=PositionValues(),
+                state=state,
+                values_read=False,
+            )
         return _open_position_wizard(page, resume, state=state)
 
     current = read_display_position(page)

--- a/src/hhru_bot/resume_state.py
+++ b/src/hhru_bot/resume_state.py
@@ -20,6 +20,7 @@ class ResumeState:
     can_publish_or_update: bool | None = None
     next_incomplete_screen_id: str | None = None
     professional_roles: tuple[ResumeProfessionalRole, ...] = ()
+    title: str | None = None
 
 
 def is_published(state: ResumeState) -> bool:
@@ -74,13 +75,29 @@ def _state_from_mapping(
     if next_incomplete is None and isinstance(scheme, dict):
         next_incomplete = scheme.get("nextIncompleteScreenId")
     roles = _parse_professional_roles(details or record)
+    title = _parse_resume_title(details or record)
     return ResumeState(
         status=record.get("status"),
         is_searchable=record.get("isSearchable"),
         can_publish_or_update=record.get("canPublishOrUpdate"),
         next_incomplete_screen_id=next_incomplete,
         professional_roles=roles,
+        title=title,
     )
+
+
+def _parse_resume_title(record: dict) -> str | None:
+    """Read the draft title from the identity-bound bootstrap record."""
+    for key in ("title", "desiredPosition"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    position = record.get("position")
+    if isinstance(position, dict):
+        value = position.get("title")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _parse_professional_roles(record: dict) -> tuple[ResumeProfessionalRole, ...]:

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -332,7 +332,7 @@ def test_resume_position_draft_dry_run_resolves_explicit_live_role(tmp_path, cap
     monkeypatch.setattr("hhru_bot.browser.launch_context", _wizard_context)
     monkeypatch.setattr(
         "hhru_bot.resume_position.open_position_form",
-        lambda page, resume: PositionFlowContext(
+        lambda page, resume, **_kwargs: PositionFlowContext(
             "wizard",
             resume.resume_id,
             PositionValues(title="AI Team Lead"),

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -140,7 +140,7 @@ def test_open_position_form_can_inspect_wizard_without_entering_chip_screen(monk
     page.content.return_value = (
         '{"scheme":{"nextIncompleteScreenId":"education"},'
         '"resume":{"id":"00001","status":"not_finished",'
-        '"isSearchable":false,"canPublishOrUpdate":false}}'
+        '"isSearchable":false,"canPublishOrUpdate":false,"title":"Existing draft"}}'
     )
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
@@ -149,6 +149,7 @@ def test_open_position_form_can_inspect_wizard_without_entering_chip_screen(monk
 
     assert flow.kind == "wizard"
     assert flow.state.next_incomplete_screen_id == "education"
+    assert flow.values.title == "Existing draft"
     assert flow.values_read is False
     page.locator.assert_not_called()
 

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -133,6 +133,26 @@ def test_open_position_form_reads_draft_wizard_title(monkeypatch):
     assert flow.values.title == "AI Team Lead"
 
 
+def test_open_position_form_can_inspect_wizard_without_entering_chip_screen(monkeypatch):
+    resume = bare_resume("00001")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=00001"
+    page.content.return_value = (
+        '{"scheme":{"nextIncompleteScreenId":"education"},'
+        '"resume":{"id":"00001","status":"not_finished",'
+        '"isSearchable":false,"canPublishOrUpdate":false}}'
+    )
+    monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+
+    flow = resume_position.open_position_form(page, resume, enter_wizard=False)
+
+    assert flow.kind == "wizard"
+    assert flow.state.next_incomplete_screen_id == "education"
+    assert flow.values_read is False
+    page.locator.assert_not_called()
+
+
 def test_open_position_form_routes_profile_state_to_identity_bound_wizard(monkeypatch):
     """Regression: hh.ru may keep /resume/<id> despite professional_role state."""
     resume = bare_resume("resume-id")


### PR DESCRIPTION
Closes #904

## Summary
- keep `resume-position --dry-run --specialization` out of the resume chip wizard
- read the wizard state from SSR instead of constructing a literal state
- mark wizard values as unread when the wizard is intentionally not entered

## Live verification
Target is reported as resume `00001` (draft copy; real ID omitted).

Command completed successfully with `attempted=0`:

```text
[DRY-RUN] Proposed values for desired-work section:
  title: AI Team Lead
  salary: None
  currency: None
  specializations: ['Аналитик']
  employment: None
  work_format: None
  commute: None
  business_trips: None
[CLASSIFICATION] Live hh.ru catalog agreement:
  role_id: 10
  profession: Аналитик
[INFO] Nothing was written to hh.ru.
[RUN] status=completed attempted=0 success=0 failed=0 uncertain=0 skipped=0
```

The command did not enter the chip wizard and performed no fill/click there. Post-run read-only verification reported resume `00001` still as draft with title `Должность не указана`; `professional_role` remained incomplete and no publication occurred.

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q`



## Follow-up

SSR title extraction is tracked separately in #910.
