### PR TITLE
feat(resume-titles): reject duplicate account titles before any save click (#911)

### DIFF
--- a/src/hhru_bot/commands/copy_resume.py
+++ b/src/hhru_bot/commands/copy_resume.py
@@ -427,6 +427,17 @@ def run(args: argparse.Namespace):
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
                 page = context.new_page()
+                # #911: должности в аккаунте уникальны — дубликат отклоняется
+                # ДО клика «Дублировать». После копирования title молча не
+                # сохранился бы (живая проверка пользователя), а откатывать
+                # созданную копию команда не умеет.
+                if title is not None:
+                    from ..resume_titles import account_duplicate_reason
+
+                    duplicate_reason = account_duplicate_reason(page, title)
+                    if duplicate_reason:
+                        print(f"[FAIL] {resume.id} — {duplicate_reason}")
+                        return True
                 result = copy_resume_on_hh(
                     page,
                     resume,

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -299,6 +299,27 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 plan.title = effective_title
                 plan.specializations = [role.label]
                 validate_wizard_plan(plan)
+            # #911: должности в аккаунте уникальны — дубликат отклоняется ДО
+            # клика сохранения: после клика отказ hh.ru молчит (живая проверка
+            # пользователя, 2026-09-01). Проверка читает список отдельной
+            # вкладкой того же контекста: визард/редактор уже открыты на текущей
+            # странице, и уход на список их не должен закрывать. Карточка самого
+            # резюме исключается: сохранить должность, которую оно уже носит, —
+            # не дубль.
+            written_title = (plan.title or "").strip()
+            if written_title:
+                from ..resume_titles import account_duplicate_reason
+
+                # Вкладка не закрывается руками: команда завершается выходом
+                # из launch_context, который закрывает все страницы контекста.
+                duplicate_reason = account_duplicate_reason(
+                    context.new_page(), written_title, exclude_resume_id=resume.resume_id
+                )
+                if duplicate_reason:
+                    if not wizard:
+                        page.locator(CANCEL).click()
+                    print(f"[FAIL] {duplicate_reason}")
+                    return True
             auto_publish = _professional_role_closes_resume(flow)
             if auto_publish and not args.dry_run and not getattr(args, "allow_auto_publish", False):
                 print(

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -44,6 +44,7 @@ from .selector_groups.resume_list import (
     RESUME_DUPLICATE_MENU_ITEM,
     RESUME_LIST_ACTION_MORE,
     RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_QA_PREFIX,
     RESUME_LIST_CARD_LINK_TPL,
     RESUME_LIST_CARD_TITLE,
     RESUME_PROFILE_READY,
@@ -62,7 +63,6 @@ PROFILE_POLL_MS = 250
 MENU_CLICK_TIMEOUT_MS = 1_000
 
 _RESUME_HASH_RE = re.compile(r"/resume/([0-9a-f]{32,40})")
-_CARD_LINK_PREFIX = "resume-card-link-"
 
 
 def _monotonic() -> float:
@@ -321,10 +321,10 @@ def _reload_resumes_list(page: Page) -> str:
 def _card_hashes(page: Page) -> set[str]:
     """Хэши всех резюме в списке /applicant/resumes (для diff до/после)."""
     hashes: set[str] = set()
-    for link in page.locator(f"[data-qa^='{_CARD_LINK_PREFIX}']").all():
+    for link in page.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
         qa = link.get_attribute("data-qa") or ""
-        if qa.startswith(_CARD_LINK_PREFIX):
-            hashes.add(qa[len(_CARD_LINK_PREFIX) :])
+        if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
+            hashes.add(qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :])
     return hashes
 
 
@@ -437,10 +437,10 @@ def list_resume_cards(
     cards: list[ResumeCard] = []
     for card in cards_locator.all():
         resume_id = ""
-        for link in card.locator(f"[data-qa^='{_CARD_LINK_PREFIX}']").all():
+        for link in card.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
             qa = link.get_attribute("data-qa") or ""
-            if qa.startswith(_CARD_LINK_PREFIX):
-                resume_id = qa[len(_CARD_LINK_PREFIX) :]
+            if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
+                resume_id = qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :]
                 break
         if not resume_id:
             # Codex adversarial review (PR #322): вложенный селектор ссылки-хэша

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -12,7 +12,7 @@ from playwright.sync_api import Locator, Page
 
 from .browser import HH_BASE_URL, RESUMES_FULL_LIST_URL, goto_hh
 from .external_forms.detect import normalize
-from .selector_groups.resume_list import RESUME_LIST_CARD, RESUME_LIST_CARD_TITLE
+from .resume_titles import duplicate_title_reason, read_account_titles
 from .selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
     RESUME_CREATION_CATEGORY_INPUT,
@@ -257,35 +257,6 @@ def _click_until_screen_switches(
     return f"экран визарда не переключился после {attempts} попыток: {last_error}"
 
 
-def _existing_title_reason(card_count: int, titles: list[str], title: str) -> str:
-    """Fail-closed duplicate check from a confirmed card count and read titles.
-
-    ``RESUME_LIST_CARD`` is confirmed; ``RESUME_LIST_CARD_TITLE`` is unconfirmed
-    (resume_list.py). A zero-card list is a genuine empty account (the caller
-    anchors list hydration on ``RESUME_CREATE_BUTTON`` before reading) and must
-    not be blocked: an empty account legitimately creates its first resume.
-
-    For a non-empty list, the safety check is only trustworthy if EVERY confirmed
-    card yielded exactly one non-empty title. Any mismatch — fewer titles than
-    cards, a blank title, or extra matches — means the title selector drifted and
-    an existing same-title resume could be invisible, so refuse rather than
-    assume there is no duplicate (Codex cycles 2/3).
-    """
-    if card_count == 0:
-        return ""
-    if len(titles) != card_count or not all(titles):
-        return "не удалось прочитать заголовки всех существующих резюме; создание запрещено"
-    if normalize(title) in {normalize(item) for item in titles}:
-        return f"резюме с должностью «{title}» уже существует; второе создать нельзя"
-    return ""
-
-
-def _existing_resume_reason(page: Page, title: str) -> str:
-    cards = page.locator(RESUME_LIST_CARD)
-    titles = cards.locator(RESUME_LIST_CARD_TITLE).all_text_contents()
-    return _existing_title_reason(cards.count(), titles, title)
-
-
 def create_resume_on_hh(
     page: Page,
     *,
@@ -315,7 +286,13 @@ def create_resume_on_hh(
         if page.locator(RESUME_CREATE_BUTTON).count() == 0:
             return CreateResumeResult(False, reason=_RESUME_LIMIT_REASON)
         return CreateResumeResult(False, reason=f"список резюме не отрисовался: {exc}")
-    duplicate_reason = _existing_resume_reason(page, title)
+    # Дубль-гард (#304, Codex cycles 2/3) вынесен в resume_titles (#911):
+    # должности в аккаунте уникальны, дубликат надо отклонять ДО клика —
+    # после клика отказ hh.ru молчит (живая проверка пользователя).
+    entries, list_reason = read_account_titles(page)
+    if list_reason:
+        return CreateResumeResult(False, reason=list_reason)
+    duplicate_reason = duplicate_title_reason(entries, title)
     if duplicate_reason:
         return CreateResumeResult(False, reason=duplicate_reason)
     create_button, reason = _one(page, RESUME_CREATE_BUTTON, "кнопка создания резюме")

--- a/src/hhru_bot/resume_titles.py
+++ b/src/hhru_bot/resume_titles.py
@@ -55,36 +55,47 @@ def read_account_titles(page: Page) -> tuple[list[AccountTitle], str]:
     список не может доказать отсутствие дубля, поэтому тоже отказ. Тот же
     инвариант, что у create_resume (циклы Codex-review 2/3) и у
     ``copy_resume.list_resume_cards`` (PR #322): неполный список — не список.
+
+    Функция тотальна: Playwright-ошибки чтения (детач карточки ререндером
+    между ``count()`` и чтением, отказ рендерера) конвертируются в ту же
+    причину отказа — команды получают обычный fail-closed ``[FAIL]``, а не
+    трейсбек из префлайта (ревью PR #912: в create/copy-вызовах общего
+    обработчика нет, BaseException-ветка copy-resume ретраит исключение).
     """
     cards = page.locator(RESUME_LIST_CARD)
-    if cards.count() == 0:
-        if page.locator(RESUME_CREATE_BUTTON).count() == 0:
-            return [], "список резюме не отрисовался: проверка дубля должности невозможна"
-        return [], ""
-    entries: list[AccountTitle] = []
-    for card in cards.all():
-        # Счёт строго до чтения: get_attribute/inner_text по отсутствующему
-        # элементу в реальном Playwright ждёт его весь таймаут и кидает
-        # TimeoutError, а не возвращает None — причина отказа должна
-        # формироваться по count()==0, а не падать 30-секундным ожиданием.
-        link = card.locator(RESUME_LIST_CARD_LINK_PREFIX)
-        link_qa = ""
-        if link.count() >= 1:
-            link_qa = link.first.get_attribute("data-qa") or ""
-        resume_id = link_qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :] if link_qa else ""
-        if not resume_id:
-            return [], (
-                "карточка резюме без resume_id (ссылка-хэш не найдена — дрейф разметки); "
-                "список не подтверждён, запись запрещена"
-            )
-        title_locator = card.locator(RESUME_LIST_CARD_TITLE)
-        title = ""
-        if title_locator.count() == 1:
-            title = (title_locator.first.inner_text() or "").strip()
-        if not title:
-            return [], "не удалось прочитать заголовки всех существующих резюме; запись запрещена"
-        entries.append(AccountTitle(resume_id=resume_id, title=title))
-    return entries, ""
+    try:
+        if cards.count() == 0:
+            if page.locator(RESUME_CREATE_BUTTON).count() == 0:
+                return [], "список резюме не отрисовался: проверка дубля должности невозможна"
+            return [], ""
+        entries: list[AccountTitle] = []
+        for card in cards.all():
+            # Счёт строго до чтения: get_attribute/inner_text по отсутствующему
+            # элементу в реальном Playwright ждёт его весь таймаут и кидает
+            # TimeoutError, а не возвращает None — причина отказа должна
+            # формироваться по count()==0, а не падать 30-секундным ожиданием.
+            link = card.locator(RESUME_LIST_CARD_LINK_PREFIX)
+            link_qa = ""
+            if link.count() >= 1:
+                link_qa = link.first.get_attribute("data-qa") or ""
+            resume_id = link_qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :] if link_qa else ""
+            if not resume_id:
+                return [], (
+                    "карточка резюме без resume_id (ссылка-хэш не найдена — дрейф разметки); "
+                    "список не подтверждён, запись запрещена"
+                )
+            title_locator = card.locator(RESUME_LIST_CARD_TITLE)
+            title = ""
+            if title_locator.count() == 1:
+                title = (title_locator.first.inner_text() or "").strip()
+            if not title:
+                return [], (
+                    "не удалось прочитать заголовки всех существующих резюме; запись запрещена"
+                )
+            entries.append(AccountTitle(resume_id=resume_id, title=title))
+        return entries, ""
+    except PlaywrightError as exc:
+        return [], f"не удалось прочитать список резюме: {exc}"
 
 
 def duplicate_title_reason(
@@ -114,8 +125,13 @@ def account_duplicate_reason(page: Page, title: str, *, exclude_resume_id: str =
     Один вызов для команд copy/resume-position: навигация + якорь
     «кнопка создания ИЛИ карточка» (на исчерпанном лимите резюме hh.ru кнопку
     не рендерит вовсе — карточки при этом читаемы) + чтение + чистая проверка.
+    Тотальна, как и :func:`read_account_titles`: отказ навигации — тоже
+    «проверка невозможна» с причиной, а не исключение в команду.
     """
-    goto_hh(page, RESUMES_FULL_LIST_URL)
+    try:
+        goto_hh(page, RESUMES_FULL_LIST_URL)
+    except PlaywrightError as exc:
+        return f"не удалось открыть список резюме: {exc}"
     anchor = page.locator(RESUME_CREATE_BUTTON).or_(page.locator(RESUME_LIST_CARD)).first
     try:
         anchor.wait_for(state="visible", timeout=_LIST_ANCHOR_TIMEOUT_MS)

--- a/src/hhru_bot/resume_titles.py
+++ b/src/hhru_bot/resume_titles.py
@@ -1,0 +1,127 @@
+"""Уникальность должностей в рамках аккаунта hh.ru (#911).
+
+Пользователь установил вручную (2026-09-01, живая проверка в Chrome): все
+должности в одном аккаунте уникальны, и если целевая должность уже существует
+1 в 1 — сохранение молча не проходит, сколько ни кликай. Отказ hh.ru при этом
+невидим: экран не показывает ошибки, визард не переходит. Поэтому каждый путь
+записи должности (create-resume, copy-resume, resume-position) обязан
+отклонять дубликат ДО первого мутирующего клика — после клика отличить
+«молча не сохранилось» от «сохранилось» уже нельзя без отдельной проверки.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+
+from .browser import RESUMES_FULL_LIST_URL, goto_hh
+from .external_forms.detect import normalize
+from .selector_groups.resume_list import (
+    RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_PREFIX,
+    RESUME_LIST_CARD_LINK_QA_PREFIX,
+    RESUME_LIST_CARD_TITLE,
+)
+from .selector_groups.resume_page import RESUME_CREATE_BUTTON
+
+# Тот же якорь гидрации, что у create_resume (#304): список может легитимно
+# быть пустым, поэтому якорится кнопка создания, а не карточки. Щедрый, но
+# конечный таймаут — commit не значит «отрисовано» (CLAUDE.md, паттерн
+# «commit не значит отрисовано»).
+_LIST_ANCHOR_TIMEOUT_MS = 15_000
+
+
+@dataclass(frozen=True)
+class AccountTitle:
+    """Название одного резюме аккаунта, привязанное к его resume_id."""
+
+    resume_id: str
+    title: str
+
+
+def read_account_titles(page: Page) -> tuple[list[AccountTitle], str]:
+    """Прочитать ``(resume_id, название)`` всех резюме с экрана списка.
+
+    Контракт: вызывающий код уже открыл и гидратировал экран списка
+    (create-resume — своей кнопкой-якорем до этого вызова; остальные входы —
+    через :func:`account_duplicate_reason`). Пустой аккаунт — ``([], "")``:
+    у него кнопка создания есть, карточек нет. Ни карточек, ни кнопки —
+    неотрисованный экран, а не пустой аккаунт: проверка дубля невозможна,
+    поэтому отказ, а не молчаливое разрешение (fail-closed).
+
+    Карточка без читаемого resume_id или названия — дрейф разметки: частичный
+    список не может доказать отсутствие дубля, поэтому тоже отказ. Тот же
+    инвариант, что у create_resume (циклы Codex-review 2/3) и у
+    ``copy_resume.list_resume_cards`` (PR #322): неполный список — не список.
+    """
+    cards = page.locator(RESUME_LIST_CARD)
+    if cards.count() == 0:
+        if page.locator(RESUME_CREATE_BUTTON).count() == 0:
+            return [], "список резюме не отрисовался: проверка дубля должности невозможна"
+        return [], ""
+    entries: list[AccountTitle] = []
+    for card in cards.all():
+        # Счёт строго до чтения: get_attribute/inner_text по отсутствующему
+        # элементу в реальном Playwright ждёт его весь таймаут и кидает
+        # TimeoutError, а не возвращает None — причина отказа должна
+        # формироваться по count()==0, а не падать 30-секундным ожиданием.
+        link = card.locator(RESUME_LIST_CARD_LINK_PREFIX)
+        link_qa = ""
+        if link.count() >= 1:
+            link_qa = link.first.get_attribute("data-qa") or ""
+        resume_id = link_qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :] if link_qa else ""
+        if not resume_id:
+            return [], (
+                "карточка резюме без resume_id (ссылка-хэш не найдена — дрейф разметки); "
+                "список не подтверждён, запись запрещена"
+            )
+        title_locator = card.locator(RESUME_LIST_CARD_TITLE)
+        title = ""
+        if title_locator.count() == 1:
+            title = (title_locator.first.inner_text() or "").strip()
+        if not title:
+            return [], "не удалось прочитать заголовки всех существующих резюме; запись запрещена"
+        entries.append(AccountTitle(resume_id=resume_id, title=title))
+    return entries, ""
+
+
+def duplicate_title_reason(
+    entries: list[AccountTitle], title: str, *, exclude_resume_id: str = ""
+) -> str:
+    """``""`` — писать можно; иначе причина отказа (чистая, тестируемая без браузера).
+
+    ``exclude_resume_id`` — резюме, чья карточка игнорируется при сравнении:
+    сохранение должности, которую это резюме уже носит, — не дубль (менять
+    своё собственное название на него же можно). create/copy ничего не
+    исключают: их цель ещё не существует в списке.
+    """
+    if not entries:
+        return ""
+    others = {entry.title for entry in entries if entry.resume_id != exclude_resume_id}
+    if normalize(title) in {normalize(existing) for existing in others}:
+        return (
+            f"резюме с должностью «{title}» уже существует; должности в аккаунте "
+            "уникальны, запись запрещена"
+        )
+    return ""
+
+
+def account_duplicate_reason(page: Page, title: str, *, exclude_resume_id: str = "") -> str:
+    """Открыть список, дождаться гидрации и проверить дубликат должности.
+
+    Один вызов для команд copy/resume-position: навигация + якорь
+    «кнопка создания ИЛИ карточка» (на исчерпанном лимите резюме hh.ru кнопку
+    не рендерит вовсе — карточки при этом читаемы) + чтение + чистая проверка.
+    """
+    goto_hh(page, RESUMES_FULL_LIST_URL)
+    anchor = page.locator(RESUME_CREATE_BUTTON).or_(page.locator(RESUME_LIST_CARD)).first
+    try:
+        anchor.wait_for(state="visible", timeout=_LIST_ANCHOR_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        return f"список резюме не отрисовался: {exc}"
+    entries, reason = read_account_titles(page)
+    if reason:
+        return reason
+    return duplicate_title_reason(entries, title, exclude_resume_id=exclude_resume_id)

--- a/src/hhru_bot/selector_groups/resume_list.py
+++ b/src/hhru_bot/selector_groups/resume_list.py
@@ -34,6 +34,12 @@ RESUME_LIST_CARD = _selector("resume_list.RESUME_LIST_CARD")
 RESUME_LIST_CARD_LINK_TPL = _selector("resume_list.RESUME_LIST_CARD_LINK_TPL")
 RESUME_LIST_CARD_LINK_PREFIX = _selector("resume_list.RESUME_LIST_CARD_LINK_PREFIX")
 
+# Хвост data-qa ссылки карточки после префикса — это и есть resume_id.
+# Отдельная константа (не выводится из селектора строковой хирургией): её
+# читает resume_titles.read_account_titles для привязки названия к резюме,
+# а copy_resume — для diff хэшей до/после копирования (#911).
+RESUME_LIST_CARD_LINK_QA_PREFIX = "resume-card-link-"
+
 # Кнопка «...» (меню действий) на карточке резюме.
 RESUME_LIST_ACTION_MORE = _selector("resume_list.RESUME_LIST_ACTION_MORE")
 

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -136,6 +136,17 @@ class FakeLocator:
     def count(self) -> int:
         return len(self._resolved())
 
+    def all(self) -> list[FakeLocator]:
+        """Список локаторов-элементов; каждый скоуплен своим поддеревом.
+
+        Реальный Playwright ``Locator.all()`` возвращает независимые
+        элементные локаторы, чей ``.locator()`` ищет внутри элемента — здесь
+        это делает ``_CardLocator`` (тот же скоупинг, что у ``.nth()``-карточек
+        переговоров). Вызывается только после ``count() > 0`` — как в бою
+        (copy_resume/resume_titles итерируют карточки после проверки счёта).
+        """
+        return [_CardLocator(node, lambda _v: True, matches=[node]) for node in self._resolved()]
+
     def inner_text(self) -> str:
         # first/nth зафиксировал один узел (self._matches длина 1); иначе — коллекция,
         # у Playwright inner_text на коллекции в strict mode кидает Error. Для тестов

--- a/tests/fixtures/resume_list_titles_911.html
+++ b/tests/fixtures/resume_list_titles_911.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!-- Редуцировано из живого SSR-дампа /applicant/my_resumes (live-прогон #911,
+     2026-09-01, дамп /tmp измерительного прогона; в репозиторий идёт только
+     эта выжимка). Реальные resume_id заменены на очевидно поддельные
+     000...01-04, data-qa-id — на 1001-1004; структура data-qa, вложенность
+     ссылок и заголовков сохранены дословно. -->
+<html lang='ru'><body>
+<button data-qa='mainmenu_createResume'>Создать резюме</button>
+<div data-qa='resume' data-qa-id='1001' data-qa-title='Программист'>
+  <div class='header-wrapper--w2Tdq6njRA8HE8jg'><a data-qa='resume-card-link-00000000000000000000000000000001' tabindex='0' role='button'></a></div>
+  <div data-qa='resume-title'><h3 data-qa='title'>Программист</h3></div>
+</div>
+<div data-qa='resume' data-qa-id='1002' data-qa-title='Программист, разработчик'>
+  <div class='header-wrapper--w2Tdq6njRA8HE8jg'><a data-qa='resume-card-link-00000000000000000000000000000002' tabindex='0' role='button'></a></div>
+  <div data-qa='resume-title'><h3 data-qa='title'>Программист, разработчик</h3></div>
+</div>
+<div data-qa='resume' data-qa-id='1003' data-qa-title='QA инженер тестировщик'>
+  <div class='header-wrapper--w2Tdq6njRA8HE8jg'><a data-qa='resume-card-link-00000000000000000000000000000003' tabindex='0' role='button'></a></div>
+  <div data-qa='resume-title'><h3 data-qa='title'>QA инженер тестировщик</h3></div>
+</div>
+<div data-qa='resume' data-qa-id='1004' data-qa-title='AI Engineer / Инженер агентных систем'>
+  <div class='header-wrapper--w2Tdq6njRA8HE8jg'><a data-qa='resume-card-link-00000000000000000000000000000004' tabindex='0' role='button'></a></div>
+  <div data-qa='resume-title'><h3 data-qa='title'>AI Engineer / Инженер агентных систем</h3></div>
+</div>
+</body></html>

--- a/tests/test_copy_resume_command.py
+++ b/tests/test_copy_resume_command.py
@@ -483,6 +483,12 @@ def env(monkeypatch, tmp_path):
         return state.result
 
     monkeypatch.setattr(hhru_bot.copy_resume, "copy_resume_on_hh", fake_copy)
+    # #911: дубль-гард должности по умолчанию «нет дубля» — двойник страницы
+    # не моделирует список резюме; тесты самого гарда подменяют эту заглушку.
+    monkeypatch.setattr(
+        "hhru_bot.resume_titles.account_duplicate_reason",
+        lambda page, title, exclude_resume_id="": "",
+    )
     return state
 
 
@@ -820,3 +826,44 @@ def test_set_copy_title_raises_when_displayed_title_does_not_match(monkeypatch):
 
     with pytest.raises(RuntimeError, match="title после сохранения не подтверждён"):
         cmd._set_copy_title(page, NEW_ID, "Python-разработчик")
+
+
+# --- Дубль-гард должности (#911): уникальность в рамках аккаунта ---
+
+
+def test_run_duplicate_title_fails_before_clone(env, capsys, tmp_path, monkeypatch):
+    """#911: должности в аккаунте уникальны — дубликат отклоняется ДО клика
+    «Дублировать». После копирования title молча не сохранился бы (живая
+    проверка пользователя), а откатывать созданную копию команда не умеет."""
+    monkeypatch.setattr(
+        "hhru_bot.resume_titles.account_duplicate_reason",
+        lambda page, title, exclude_resume_id="": (
+            "резюме с должностью «Программист» уже существует; "
+            "должности в аккаунте уникальны, запись запрещена"
+        ),
+    )
+
+    assert cmd.run(_args(tmp_path, force=True, title="Программист")) is True
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "уже существует" in out
+    # Копия не создавалась и в аудит не попала.
+    assert env.calls == []
+    assert History(tmp_path / "h.db").count_today(OLD_ID, "copy_resume") == 0
+
+
+def test_run_without_title_skips_duplicate_guard(env, capsys, tmp_path, monkeypatch):
+    """Без --title команда должность не пишет — дубль-гард не нужен."""
+    asked: list[str] = []
+
+    def _spy(page, title, exclude_resume_id=""):  # noqa: ARG001
+        asked.append(title)
+        return ""
+
+    monkeypatch.setattr("hhru_bot.resume_titles.account_duplicate_reason", _spy)
+
+    cmd.run(_args(tmp_path, force=True))
+
+    assert asked == []
+    assert "[OK] Резюме backend скопирован" in capsys.readouterr().out

--- a/tests/test_create_resume.py
+++ b/tests/test_create_resume.py
@@ -1,64 +1,105 @@
-"""Unit-тесты дубль-гарда создания резюме (create_resume, #304).
+"""Интеграционные тесты дубль-гарда create-resume (create_resume + resume_titles).
 
-``_existing_title_reason`` — чистая fail-closed проверка «второе резюме с той же
-должностью создать нельзя». Покрывает согласованный с Codex-review (циклы 2/3)
-инвариант: карточки (подтверждённый ``RESUME_LIST_CARD``) есть, но заголовки
-(неподтверждённый ``RESUME_LIST_CARD_TITLE``) не читаются → отказ, а не молчаливое
-разрешение дубля.
+Дубль-гард «второе резюме с той же должностью создать нельзя» (#304, циклы
+Codex-review 2/3) с #911 живёт в общем модуле ``resume_titles`` (чистая
+проверка — в test_resume_titles.py, вместе с остальными входами записи
+должности). Здесь проверяется проводка: ``create_resume_on_hh`` отклоняет
+дубликат должности ДО первого клика, и отказ hh.ru при этом невидим (живая
+проверка пользователя 2026-09-01: дубликат 1 в 1 молча не сохраняется).
+
+Список резюме гоняется по фикстуре, редуцированной из живого SSR-дампа
+/applicant/my_resumes (#911).
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from hhru_bot.create_resume import _existing_title_reason
+from _fakes import FakeLocator, _parse_root, _parse_selector
+from hhru_bot.create_resume import create_resume_on_hh
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
-
-@pytest.mark.parametrize(
-    ("card_count", "titles", "title", "expected"),
-    [
-        # Пустой аккаунт (0 карточек, список отрисован — якорь RESUME_CREATE_BUTTON)
-        # — легитимно создаёт первое резюме.
-        (0, [], "Backend developer", ""),
-        # Карточки есть, но заголовки не читаются (селектор уехал) → fail-closed.
-        (1, [], "Backend developer", "не удалось прочитать заголовки"),
-        (3, [], "Backend developer", "не удалось прочитать заголовки"),
-        # Частичный сбой (Codex cycle 3): заголовков меньше, чем карточек → fail-closed,
-        # иначе пропущенная карточка была бы сочтена отсутствующей и дубль ушёл бы.
-        (2, ["QA"], "Backend developer", "не удалось прочитать заголовки"),
-        (3, ["QA", "DevOps"], "Backend developer", "не удалось прочитать заголовки"),
-        # Пустой заголовок в читаемом наборе → нельзя доказать отсутствие дубля.
-        (2, ["", "QA"], "Backend developer", "не удалось прочитать заголовки"),
-        # Лишние совпадения (len > card_count) — тот же признак дрейфа селектора.
-        (1, ["QA", "QA"], "Backend developer", "не удалось прочитать заголовки"),
-        # Совпадение по должности → дубль запрещён.
-        (1, ["Backend developer"], "Backend developer", "уже существует"),
-        (2, ["QA", "Backend developer"], "Backend developer", "уже существует"),
-        # Нет совпадения, все заголовки читаемы → разрешено.
-        (1, ["QA"], "Backend developer", ""),
-        (2, ["QA", "DevOps"], "Backend developer", ""),
-    ],
-)
-def test_existing_title_reason(card_count, titles, title, expected):
-    reason = _existing_title_reason(card_count, titles, title)
-    if expected:
-        assert expected in reason
-    else:
-        # Allowed-case assertions must pin reason == "" (not just contain ""):
-        # "" in reason is trivially true for any string and would mask a
-        # regression where a legitimately-allowed case starts failing closed.
-        assert reason == ""
+FIXTURE = Path(__file__).parent / "fixtures" / "resume_list_titles_911.html"
 
 
-@pytest.mark.parametrize(
-    ("existing", "new", "expected"),
-    [
-        # normalize() (external_forms/detect): collapse-whitespace + strip + casefold.
-        ("  Backend   Developer  ", "backend developer", "уже существует"),
-        ("QA Automation Engineer", "qa automation engineer", "уже существует"),
-    ],
-)
-def test_existing_title_reason_normalizes(existing, new, expected):
-    assert expected in _existing_title_reason(1, [existing], new)
+class _ClickthroughLocator(FakeLocator):
+    """Кликабельный локатор: дубль-гард срабатывает раньше, визард не нужен.
+
+    ``click``/``is_disabled`` — no-op, чтобы поток дошёл до якоря визарда и
+    остановился там штатным отказом «визард не отрисовался» (FakeLocator.wait_for
+    поднимает Timeout на отсутствующем элементе).
+    """
+
+    def click(self, *, timeout=None) -> None:  # noqa: ARG002
+        return None
+
+    def is_disabled(self) -> bool:
+        return False
+
+    @property
+    def first(self) -> FakeLocator:
+        # Базовый FakeLocator.first теряет подкласс; сохранить кликабельность
+        # у выбранного элемента (кнопка создания адресуется через .first).
+        matches = self._resolved()
+        return _ClickthroughLocator(
+            self._root, self._qa_match, matches=[matches[0]] if matches else []
+        )
+
+
+class ListPage:
+    """Двойник страницы списка резюме для проверки дубль-гарда."""
+
+    def __init__(self, html: str):
+        self._root = _parse_root(html)
+        self.url = ""
+
+    def locator(self, selector: str) -> FakeLocator:
+        return _ClickthroughLocator(self._root, _parse_selector(selector))
+
+    def goto(self, url, *, wait_until=None, timeout=None):  # noqa: ANN001, ARG002
+        self.url = url
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ANN001, ARG002
+        return None
+
+
+def test_duplicate_title_is_refused_before_any_click():
+    result = create_resume_on_hh(
+        ListPage(FIXTURE.read_text(encoding="utf-8")),
+        area="Программист, разработчик",
+        title="Программист",
+        dry_run=False,
+    )
+    assert not result.success
+    assert not result.uncertain
+    assert "уже существует" in result.reason
+
+
+def test_fresh_title_is_not_refused_by_duplicate_guard():
+    # Дубль-гард не блокирует новый заголовок: отказ приходит позже (визард),
+    # а не от дубль-гарда. Двойник не реализует визард — достаточно
+    # подтверждения, что причина отказа не про дубль.
+    result = create_resume_on_hh(
+        ListPage(FIXTURE.read_text(encoding="utf-8")),
+        area="Программист, разработчик",
+        title="Аналитик данных",
+        dry_run=False,
+    )
+    assert "уже существует" not in (result.reason or "")
+
+
+def test_unreadable_list_fails_closed():
+    # Карточка без названия (дрейф разметки) — список не доказывает отсутствие
+    # дубля, создание обязано отказать, а не молча разрешить.
+    html = FIXTURE.read_text(encoding="utf-8").replace(
+        "<div data-qa='resume-title'><h3 data-qa='title'>QA инженер тестировщик</h3></div>",
+        "",
+    )
+    result = create_resume_on_hh(
+        ListPage(html), area="Программист, разработчик", title="Аналитик данных", dry_run=False
+    )
+    assert not result.success
+    assert "не удалось прочитать заголовки" in result.reason

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -34,6 +34,18 @@ from hhru_bot.commands import (
 
 pytestmark = pytest.mark.unit
 
+
+@pytest.fixture(autouse=True)
+def _no_duplicate_titles(monkeypatch):
+    """#911: дубль-гард должностей по умолчанию «нет дубля» — двойники этих
+    тестов не моделируют список резюме; проводка гарда покрыта в
+    test_resume_position_command.py."""
+    monkeypatch.setattr(
+        "hhru_bot.resume_titles.account_duplicate_reason",
+        lambda page, title, exclude_resume_id="": "",
+    )
+
+
 REMOTE_ONLY_HASH = "35661ef3ff10f971a70039ed1f57656d684c54ab"
 
 

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -15,6 +15,17 @@ from hhru_bot.history import History
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _no_duplicate_titles(monkeypatch):
+    """#911: дубль-гард должностей по умолчанию «нет дубля» — двойники этих
+    тестов не моделируют список резюме; проводка гарда покрыта в
+    test_resume_position_command.py."""
+    monkeypatch.setattr(
+        "hhru_bot.resume_titles.account_duplicate_reason",
+        lambda page, title, exclude_resume_id="": "",
+    )
+
+
 @pytest.mark.parametrize(
     ("module_name", "command_name"),
     [

--- a/tests/test_resume_position_command.py
+++ b/tests/test_resume_position_command.py
@@ -1,0 +1,162 @@
+"""Командная проводка resume-position: дубль-гард должности (#911).
+
+Должности в аккаунте уникальны (живая проверка пользователя 2026-09-01):
+дубликат 1 в 1 молча не сохраняется. Команда обязана отклонять его ДО
+клика сохранения и до запроса подтверждения — после клика отказ hh.ru
+невидим. Здесь проверяется проводка на двойниках; чистая логика гарда — в
+test_resume_titles.py, browser-слой визарда — в test_resume_position.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import hhru_bot.browser
+import hhru_bot.commands.resume_position as cmd
+import hhru_bot.resume_position
+from hhru_bot.resume_position import PositionValues
+
+pytestmark = pytest.mark.integration
+
+RESUME_ID = "c" * 38
+
+
+def _args(tmp_path, **overrides):
+    base = {
+        "config": "unused.yaml",
+        "history": str(tmp_path / "h.db"),
+        "headless": True,
+        "resume": "draft",
+        "dry_run": False,
+        "force": True,
+        "title": "Программист",
+        "specialization": None,
+        "salary": None,
+        "currency": None,
+        "employment": None,
+        "work_format": None,
+        "commute": None,
+        "business_trips": None,
+        "mode": None,
+        "command": "resume-position",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    resume = SimpleNamespace(id="draft", resume_id=RESUME_ID, ai_profile=None)
+
+    monkeypatch.setattr(
+        "hhru_bot.config.load_config_or_exit",
+        lambda path: SimpleNamespace(
+            get_resume=lambda rid: resume,
+            storage_state_file=tmp_path / "s.json",
+            user_agent=None,
+            ai=None,
+        ),
+    )
+
+    clicks: list[str] = []
+
+    class FakePage:
+        def locator(self, selector):
+            return SimpleNamespace(click=lambda: clicks.append(selector))
+
+        def close(self):
+            return None
+
+    class FakeContext:
+        def new_page(self):
+            return FakePage()
+
+    @contextmanager
+    def fake_launch(*a, **kw):
+        yield FakeContext()
+
+    monkeypatch.setattr(hhru_bot.browser, "launch_context", fake_launch)
+
+    # Editor-режим с текущим заголовком «QA»: ручной --title без LLM.
+    flow = SimpleNamespace(
+        kind="editor",
+        resume_id=RESUME_ID,
+        values=PositionValues(title="QA"),
+        state=SimpleNamespace(next_incomplete_screen_id=None),
+    )
+    monkeypatch.setattr(
+        hhru_bot.resume_position,
+        "open_position_form",
+        lambda page, resume, enter_wizard=True: flow,
+    )
+    return SimpleNamespace(clicks=clicks)
+
+
+def test_duplicate_title_refused_before_save(env, capsys, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "hhru_bot.resume_titles.account_duplicate_reason",
+        lambda page, title, exclude_resume_id="": (
+            "резюме с должностью «Программист» уже существует; "
+            "должности в аккаунте уникальны, запись запрещена"
+        ),
+    )
+
+    def no_save(*a, **kw):
+        pytest.fail("сохранение не должно выполняться при дубликате должности")
+
+    monkeypatch.setattr(hhru_bot.resume_position, "apply_position", no_save)
+
+    assert cmd.run(_args(tmp_path)) is True
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "уже существует" in out
+    # Editor-форма закрыта штатной отменой — та же конвенция, что у остальных
+    # отказов editor-пути команды.
+    assert env.clicks
+
+
+def test_guard_passes_target_and_own_resume_identity(env, capsys, tmp_path, monkeypatch):
+    seen: dict[str, str] = {}
+
+    def _spy(page, title, exclude_resume_id=""):
+        seen["title"] = title
+        seen["exclude"] = exclude_resume_id
+        return ""
+
+    monkeypatch.setattr("hhru_bot.resume_titles.account_duplicate_reason", _spy)
+    monkeypatch.setattr(
+        hhru_bot.resume_position, "apply_position", lambda page, plan, current=None: None
+    )
+    monkeypatch.setattr(cmd, "_click_save_and_wait", lambda page: None)
+
+    assert cmd.run(_args(tmp_path)) is False
+
+    # Гарда получает целевую должность и исключает само редактируемое резюме:
+    # сохранить должность, которую оно уже носит, — не дубль.
+    assert seen == {"title": "Программист", "exclude": RESUME_ID}
+    assert "[OK] Раздел желаемой работы резюме 'draft' обновлён." in capsys.readouterr().out
+
+
+def test_no_title_change_skips_guard(env, capsys, tmp_path, monkeypatch):
+    """План без изменения title ничего не пишет в должность — гарда не нужна."""
+    asked: list[str] = []
+
+    def _spy(page, title, exclude_resume_id=""):
+        asked.append(title)
+        return ""
+
+    monkeypatch.setattr("hhru_bot.resume_titles.account_duplicate_reason", _spy)
+    monkeypatch.setattr(
+        hhru_bot.resume_position, "apply_position", lambda page, plan, current=None: None
+    )
+    monkeypatch.setattr(cmd, "_click_save_and_wait", lambda page: None)
+
+    assert cmd.run(_args(tmp_path, title=None, salary=200000)) is False
+
+    assert asked == []
+    assert "[OK] Раздел желаемой работы резюме 'draft' обновлён." in capsys.readouterr().out

--- a/tests/test_resume_titles.py
+++ b/tests/test_resume_titles.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 from _fakes import FakeLocator, _parse_root, _parse_selector
 from hhru_bot.resume_titles import (
@@ -23,6 +24,10 @@ from hhru_bot.resume_titles import (
     account_duplicate_reason,
     duplicate_title_reason,
     read_account_titles,
+)
+from hhru_bot.selector_groups.resume_list import (
+    RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_PREFIX,
 )
 
 pytestmark = pytest.mark.unit
@@ -171,3 +176,85 @@ def test_account_duplicate_reason_excludes_own_resume():
         ListPage(_fixture_html()), "Программист", exclude_resume_id=ID_1
     )
     assert reason == ""
+
+
+class _OneNode:
+    """Локатор-двойник одного узла; при raise_read чтение кидает PlaywrightError.
+
+    Моделирует ререндер между count() и чтением (ревью PR #912): html-фикстура
+    на таком детач не способна, поэтому двойник duck-typed, без _fakes.
+    """
+
+    def __init__(self, *, qa: str | None = None, text: str | None = None, raise_read: bool = False):
+        self._qa = qa
+        self._text = text
+        self._raise_read = raise_read
+
+    @property
+    def first(self) -> _OneNode:
+        return self
+
+    def count(self) -> int:
+        return 1
+
+    def get_attribute(self, name: str) -> str | None:
+        if self._raise_read:
+            raise PlaywrightError("detached by rerender")
+        return self._qa
+
+    def inner_text(self) -> str:
+        if self._raise_read:
+            raise PlaywrightError("detached by rerender")
+        return self._text or ""
+
+
+class _DetachedCard:
+    """Карточка: ссылка читается, заголовок падает посреди чтения."""
+
+    def __init__(self, resume_id: str):
+        self._resume_id = resume_id
+
+    def locator(self, selector: str):  # noqa: ANN202
+        if selector == RESUME_LIST_CARD_LINK_PREFIX:
+            return _OneNode(qa=f"resume-card-link-{self._resume_id}")
+        return _OneNode(text="Программист", raise_read=True)
+
+
+class _DetachedReadPage:
+    """Страница с одной карточкой, у которой чтение заголовка кидает ошибку."""
+
+    url = ""
+
+    def __init__(self):
+        self._cards = [_DetachedCard(ID_1)]
+
+    def locator(self, selector: str):  # noqa: ANN202
+        if selector == RESUME_LIST_CARD:
+            return self
+        return _OneNode()
+
+    def count(self) -> int:
+        return len(self._cards)
+
+    def all(self) -> list[_DetachedCard]:
+        return list(self._cards)
+
+
+def test_reader_converts_dom_read_failure_into_reason():
+    # PlaywrightError чтения (детач ререндером между count() и inner_text())
+    # не покидает ридер: команды получают fail-closed причину, а не трейсбек
+    # (ревью PR #912 — в create/copy-вызвах общего обработчика нет).
+    entries, reason = read_account_titles(_DetachedReadPage())
+    assert entries == []
+    assert "не удалось прочитать список резюме" in reason
+
+
+def test_account_duplicate_reason_survives_goto_failure(monkeypatch):
+    # goto_hh пробрасывает ошибку последней попытки (#80): навигация к списку
+    # тоже «проверка невозможна», а не краш команды.
+    def _crash(page, url, *, ready_selector=None):  # noqa: ANN001, ARG001
+        raise PlaywrightError("net::ERR_FAILED")
+
+    monkeypatch.setattr("hhru_bot.resume_titles.goto_hh", _crash)
+    reason = account_duplicate_reason(ListPage(_fixture_html()), "Программист")
+    assert "не удалось открыть список резюме" in reason

--- a/tests/test_resume_titles.py
+++ b/tests/test_resume_titles.py
@@ -1,0 +1,173 @@
+"""Тесты уникальности должностей аккаунта (resume_titles, #911).
+
+Пользователь установил вручную (2026-09-01): все должности в одном аккаунте
+уникальны, дубликат 1 в 1 молча не сохраняется. Отсюда два инварианта:
+``duplicate_title_reason`` — чистая fail-closed проверка (перенос дубль-гарда
+create-resume #304, циклы Codex-review 2/3, в общий для всех входов модуль) и
+``read_account_titles`` — чтение списка, где частичный/неидентифицируемый
+список не может доказать отсутствие дубля и обязан отказывать.
+
+Хэппи-путь ридера гоняется по фикстуре, редуцированной из ЖИВОГО SSR-дампа
+/applicant/my_resumes (правило #911: фикстуры строить из реального дампа).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from _fakes import FakeLocator, _parse_root, _parse_selector
+from hhru_bot.resume_titles import (
+    AccountTitle,
+    account_duplicate_reason,
+    duplicate_title_reason,
+    read_account_titles,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURE = Path(__file__).parent / "fixtures" / "resume_list_titles_911.html"
+
+# Очевидно поддельные resume_id фикстуры (хвосты), чтобы тесты читались без hex-стен.
+ID_1 = "0" * 31 + "1"
+ID_2 = "0" * 31 + "2"
+ID_3 = "0" * 31 + "3"
+
+
+def _fixture_html() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+class ListPage:
+    """Двойник страницы списка резюме: только ``page.locator``/``goto``."""
+
+    def __init__(self, html: str):
+        self._root = _parse_root(html)
+        self.url = ""
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(self._root, _parse_selector(selector))
+
+    def goto(self, url, *, wait_until=None, timeout=None):  # noqa: ANN001, ARG002
+        self.url = url
+
+
+@pytest.mark.parametrize(
+    ("entries", "title", "exclude", "expected"),
+    [
+        # Пустой аккаунт (карточек нет) — первое резюме создавать можно.
+        ([], "Backend developer", "", ""),
+        # Совпадение по должности → дубль запрещён.
+        ([AccountTitle(ID_1, "Backend developer")], "Backend developer", "", "уже существует"),
+        (
+            [AccountTitle(ID_1, "QA"), AccountTitle(ID_2, "Backend developer")],
+            "Backend developer",
+            "",
+            "уже существует",
+        ),
+        # Нет совпадения — разрешено.
+        ([AccountTitle(ID_1, "QA")], "Backend developer", "", ""),
+        # Своя карточка исключается: сохранить должность, которую резюме уже
+        # носит, — не дубль (переименование в себя же / повторное сохранение).
+        ([AccountTitle(ID_1, "Backend developer")], "Backend developer", ID_1, ""),
+        (
+            [AccountTitle(ID_1, "QA"), AccountTitle(ID_2, "Backend developer")],
+            "Backend developer",
+            ID_2,
+            "",
+        ),
+        # Два одинаковых названия при исключённой одной из карточек — вторая
+        # всё равно дубль: hh.ru не создаёт дубликатов, значит список подозрителен
+        # и отказ безопаснее молчаливого разрешения.
+        (
+            [AccountTitle(ID_1, "QA"), AccountTitle(ID_2, "Backend developer")],
+            "Backend developer",
+            ID_1,
+            "уже существует",
+        ),
+    ],
+)
+def test_duplicate_title_reason(entries, title, exclude, expected):
+    reason = duplicate_title_reason(entries, title, exclude_resume_id=exclude)
+    if expected:
+        assert expected in reason
+    else:
+        # Allowed-case обязан быть строго "" (не «содержит ""»): тривиально
+        # истинное утверждение маскировало бы регрессию fail-closed.
+        assert reason == ""
+
+
+@pytest.mark.parametrize(
+    ("existing", "new", "expected"),
+    [
+        # normalize() (external_forms/detect): collapse-whitespace + strip + casefold.
+        ("  Backend   Developer  ", "backend developer", "уже существует"),
+        ("QA Automation Engineer", "qa automation engineer", "уже существует"),
+    ],
+)
+def test_duplicate_title_reason_normalizes(existing, new, expected):
+    assert expected in duplicate_title_reason([AccountTitle(ID_1, existing)], new)
+
+
+def test_reader_parses_real_dump_fixture():
+    page = ListPage(_fixture_html())
+    entries, reason = read_account_titles(page)
+    assert reason == ""
+    assert [(entry.resume_id, entry.title) for entry in entries] == [
+        (ID_1, "Программист"),
+        (ID_2, "Программист, разработчик"),
+        (ID_3, "QA инженер тестировщик"),
+        ("0" * 31 + "4", "AI Engineer / Инженер агентных систем"),
+    ]
+
+
+def test_reader_fails_closed_when_card_link_missing():
+    # Реальная фикстура с испорченной ссылкой одной карточки (дрейф разметки):
+    # частичный список не может доказать отсутствие дубля.
+    html = _fixture_html().replace(f"resume-card-link-{ID_2}", "broken-link-no-prefix")
+    entries, reason = read_account_titles(ListPage(html))
+    assert entries == []
+    assert "без resume_id" in reason
+
+
+def test_reader_fails_closed_when_title_missing():
+    html = _fixture_html().replace(
+        "<div data-qa='resume-title'><h3 data-qa='title'>QA инженер тестировщик</h3></div>",
+        "",
+    )
+    entries, reason = read_account_titles(ListPage(html))
+    assert entries == []
+    assert "не удалось прочитать заголовки" in reason
+
+
+def test_reader_allows_empty_account_with_create_button():
+    # Пустой аккаунт: карточек нет, кнопка создания есть — легитимно пусто.
+    html = (
+        "<html><body><button data-qa='mainmenu_createResume'>Создать резюме</button></body></html>"
+    )
+    entries, reason = read_account_titles(ListPage(html))
+    assert entries == []
+    assert reason == ""
+
+
+def test_reader_fails_closed_when_nothing_rendered():
+    # Ни карточек, ни кнопки — не «пустой аккаунт», а неотрисованный экран.
+    html = "<html><body></body></html>"
+    entries, reason = read_account_titles(ListPage(html))
+    assert entries == []
+    assert "не отрисовался" in reason
+
+
+def test_account_duplicate_reason_end_to_end():
+    # goto + якорь «кнопка ИЛИ карточка» + чтение + проверка одним вызовом.
+    reason = account_duplicate_reason(ListPage(_fixture_html()), "Программист")
+    assert "уже существует" in reason
+    assert account_duplicate_reason(ListPage(_fixture_html()), "Аналитик данных") == ""
+
+
+def test_account_duplicate_reason_excludes_own_resume():
+    reason = account_duplicate_reason(
+        ListPage(_fixture_html()), "Программист", exclude_resume_id=ID_1
+    )
+    assert reason == ""


### PR DESCRIPTION
Closes #911

## Что делает

Обработка дубликата должности **до первого мутирующего клика** — по факту,
установленному пользователем вручную (2026-09-01): все должности в одном
аккаунте уникальны, и дубликат 1 в 1 **молча не сохраняется** — экран не
показывает ошибки, визард не переходит. После клика отличить «молча не
сохранилось» от «сохранилось» нельзя, поэтому проверка обязана стоять до
клика.

Новый модуль `src/hhru_bot/resume_titles.py`:

- `read_account_titles(page)` — fail-closed чтение списка резюме
  `(resume_id, название)`: карточка без читаемого resume_id (ссылка-хэш)
  или названия, как и неотрисованный экран (ни карточек, ни кнопки
  создания) — отказ, а не молчаливое разрешение. Пустой аккаунт —
  легитимно пусто. Инвариант перенесён из create-resume #304 (циклы
  Codex-review 2/3) и copy-resume (PR #322).
- `duplicate_title_reason(entries, title, exclude_resume_id)` — чистая
  проверка с нормализацией (collapse-whitespace + casefold) и исключением
  самого редактируемого резюме.
- `account_duplicate_reason(page, title, ...)` — навигация + якорь
  гидрации «кнопка создания ИЛИ карточка» (на исчерпанном лимите hh.ru
  кнопку не рендерит — карточки читаемы) + чтение + проверка.

Проводка:

| вход | поведение |
|---|---|
| create-resume | дубль-гард #304 переехал в общий модуль, fail-closed семантика без изменений |
| copy-resume (`--title`) | дубликат отклоняется ДО клика «Дублировать» — иначе осталась бы мусорная копия без title, а откатывать копию нечем |
| resume-position | при записи title список читается отдельной вкладкой того же контекста (открытые визард/редактор не трогаются), своя карточка исключается; отказ — до гейта публикации и подтверждений |
| rename-resume | **оговорка**: записи нет вовсе — `rename_resume_on_hh` в боевом режиме всегда возвращает fail-closed отказ («селектор названия не подтверждён живым DOM», #522), поэтому дубль-дыры не существует; проверка появится вместе с реализацией самого пути переименования |

## Живое подтверждение

- `read_account_titles` прочитал живой список аккаунта (18 записей, все
  названия корректны) — живой прогон измерения #911.
- `account_duplicate_reason('Программист1')` → `''` (корректное «не
  дубль» для свободной должности) — тот же живой прогон; отказ по
  реальному дубликату покрыт тестами на фикстуре из живого дампа.
- Правило уникальности подтверждено пользователем вручную в живом
  браузере (цепочка модалек, комментарий в #911).

Фикстура `tests/fixtures/resume_list_titles_911.html` редуцирована из
живого SSR-дампа `/applicant/my_resumes` (измерительный прогон #911);
реальные resume_id заменены на очевидно поддельные `000...01-04`.

## Измерение #911 (контекст)

Финальный контракт визарда professional_role и ответы на оба исходных
вопроса ишью — в закрывающем комментарии-измерении:
https://github.com/axisrow/hhru/issues/911#issuecomment-5482094595
(сохранение без выбора не проходит; на месте профессии — выбор из
каталога с role_id, свободный текст отбрасывается).

Развилка «прямая запись через модалки vs оставить путь #907» — отдельное
решение пользователя, в этот PR не входит.

## Тесты

- `ruff check` — чисто; `ruff format --check` — чисто.
- Полный pytest по src и tests: **3118 passed, 2 skipped, 3 deselected**.
- Новые: `tests/test_resume_titles.py` (чистая проверка + ридер на
  реальной фикстуре), `tests/test_resume_position_command.py` (проводка
  команды), интеграционные случаи в `tests/test_create_resume.py` и
  `tests/test_copy_resume_command.py`.

## Риски и follow-ups

- Проверка добавляет одну read-only навигацию на список перед записью
  title (copy/resume-position) — на лимите резюме якорь переключается на
  карточки, чтение остаётся рабочим.
- Черновик-артефакт измерения остался в аккаунте (19-е резюме) — удаление
  отдельно на решении пользователя.
- Прямая запись через модалки (если её выберут) — новая ишью: выбор листа
  в дереве требует проработки (детали в #911).