### PR TITLE
test(resume-position): регресс-стражи невозможности маскировки успешного сохранения (#899)

### DIFF
--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -929,6 +929,156 @@ def test_exact_leaf_title_is_saved_directly_in_wizard(tmp_path: Path, monkeypatc
     assert row["failed"] == row["uncertain"] == 0
 
 
+def test_landed_first_next_save_is_verified_not_masked_by_fallback(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """#899 (регресс-страж): когда первый NEXT прямого пути сам сохраняет
+    специализацию и закрывает экран — живой факт #893 (hh.ru редиректит
+    завершённый professional_role; замер воспроизведён на двух резюме) и
+    #900-инцидент — команда обязана подтвердить сохранение через
+    ``verify_wizard_save`` и записать success: НЕ запускать
+    wizard-minimum fallback по «виду экрана» и НЕ рапортовать (uncertain).
+    Здесь гоняется НАСТОЯЩАЯ ``save_position_wizard`` (не двойник): модалка
+    не подтверждена ни разу, URL уходит с визарда первым же NEXT.
+    """
+    import hhru_bot.commands.resume_position as command
+    import hhru_bot.resume_position as resume_position_module
+    from hhru_bot.professional_roles import ProfessionalRole
+    from hhru_bot.resume_position import PositionFlowContext, PositionValues
+    from hhru_bot.resume_state import ResumeState
+
+    resume = SimpleNamespace(id="r1", resume_id="r1", ai_profile=None)
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None, ai=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.is_position_wizard", lambda _page, _resume_id: True
+    )
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.resolve_explicit_role",
+        lambda _page, label: ProfessionalRole("96", label, "ИТ"),
+    )
+
+    class _Page:
+        def __init__(self) -> None:
+            self.url = "https://hh.ru/profile/resume/professional_role?resume=r1"
+
+        def locator(self, selector):
+            return {
+                resume_position_module.WIZARD_POSITION: _PositionLocator(),
+                resume_position_module.WIZARD_POSITION_CLEAR: _CountLocator(0),
+                resume_position_module.WIZARD_NEXT: _NextLocator(self),
+            }[selector]
+
+        def wait_for_timeout(self, _ms):
+            # Транзитный chip-экран: URL уходит не мгновенно по клику, а
+            # через один тик опроса — живой зазор, в который стреляла
+            # диагностика «по виду экрана» (#892/#899).
+            self.url = "https://hh.ru/resume/r1"
+            return None
+
+    class _PositionLocator:
+        def count(self):
+            return 1
+
+        def input_value(self):
+            return ""
+
+        def fill(self, _value):
+            return None
+
+    class _CountLocator:
+        def __init__(self, count: int) -> None:
+            self._count = count
+
+        def count(self):
+            return self._count
+
+    class _NextLocator:
+        def __init__(self, page: _Page) -> None:
+            self._page = page
+            self.first = self
+
+        def count(self):
+            return 1
+
+        def wait_for(self, *, state=None, timeout=None):
+            return None
+
+        def click(self):
+            # Единственный NEXT живого сценария #899: hh.ru принимает
+            # специализацию и закрывает экран; сам URL уходит позже, тиком
+            # опроса (см. _Page.wait_for_timeout).
+            return None
+
+    page = _Page()
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: page)
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+
+    flow = PositionFlowContext(
+        "wizard",
+        "r1",
+        PositionValues(title="Программист, разработчик"),
+        ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
+    )
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.open_position_form",
+        lambda _page, _resume, **_kwargs: flow,
+    )
+
+    # Модалка каталога не подтверждена ни разу — как в живом прогоне #899:
+    # экран закрылся прямым save, без открытия «Уточните специальность».
+    monkeypatch.setattr(
+        "hhru_bot.resume_position.is_profession_modal_confirmed", lambda _page: False
+    )
+    monkeypatch.setattr("hhru_bot.resume_position.dismiss_cookie_banner", lambda _page: None)
+    select = MagicMock()
+    monkeypatch.setattr("hhru_bot.resume_position.select_catalog_leaf", select)
+    monkeypatch.setattr("hhru_bot.resume_position._dump_wizard_failure", lambda *_args: "dump.html")
+
+    minimum = MagicMock()
+    minimum_verify = MagicMock()
+    apply = MagicMock()
+    monkeypatch.setattr("hhru_bot.resume_position.save_position_wizard_minimum", minimum)
+    monkeypatch.setattr("hhru_bot.resume_position.verify_wizard_minimum_save", minimum_verify)
+    monkeypatch.setattr("hhru_bot.resume_position.apply_position", apply)
+
+    verify_calls: list[dict] = []
+
+    def fake_verify(_page, _resume, *, expected_title, expected_role_id, expected_role_label):
+        verify_calls.append(
+            {"title": expected_title, "role_id": expected_role_id, "label": expected_role_label}
+        )
+        return ResumeState(status="not_finished")
+
+    monkeypatch.setattr("hhru_bot.resume_position.verify_wizard_save", fake_verify)
+
+    args = _draft_position_args(tmp_path / "history.db")
+    args.title = "Программист, разработчик"
+    assert command.run(args) is False
+    out = capsys.readouterr().out
+    assert "[OK]" in out
+    assert "(uncertain)" not in out
+
+    # Состоявшееся сохранение подтверждается readback'ом, а не маскируется
+    # fallback'ом: ни заглушки, ни editor-фиксапа, ни повторного входа в визард.
+    minimum.assert_not_called()
+    minimum_verify.assert_not_called()
+    apply.assert_not_called()
+    select.assert_not_called()
+    assert verify_calls == [
+        {"title": "Программист, разработчик", "role_id": "96", "label": "Программист, разработчик"}
+    ]
+
+    row = History(tmp_path / "history.db").command_runs()[-1]
+    assert row["attempted"] == row["success"] == 1
+    assert row["failed"] == row["uncertain"] == row["skipped"] == 0
+
+
 def test_direct_save_is_never_attempted_in_dry_run(tmp_path: Path, monkeypatch, capsys) -> None:
     """#909/#913: dry-run строго немутирующ — прямой путь (как и фолбэк)
     не выполняется, wizard не открывается при явной --specialization."""

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -1025,10 +1025,13 @@ def test_landed_first_next_save_is_verified_not_masked_by_fallback(
         PositionValues(title="Программист, разработчик"),
         ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
     )
-    monkeypatch.setattr(
-        "hhru_bot.resume_position.open_position_form",
-        lambda _page, _resume, **_kwargs: flow,
-    )
+    open_calls: list[bool] = []
+
+    def fake_open(_page, _resume, **_kwargs):
+        open_calls.append(True)
+        return flow
+
+    monkeypatch.setattr("hhru_bot.resume_position.open_position_form", fake_open)
 
     # Модалка каталога не подтверждена ни разу — как в живом прогоне #899:
     # экран закрылся прямым save, без открытия «Уточните специальность».
@@ -1065,11 +1068,15 @@ def test_landed_first_next_save_is_verified_not_masked_by_fallback(
     assert "(uncertain)" not in out
 
     # Состоявшееся сохранение подтверждается readback'ом, а не маскируется
-    # fallback'ом: ни заглушки, ни editor-фиксапа, ни повторного входа в визард.
+    # fallback'ом: ни заглушки wizard-minimum, ни editor-фиксапа. Открытий
+    # формы ровно два — вход и обязательный pre-WRITE re-bind прямого пути
+    # (commands/resume_position.py:378); третий вызыв был бы реентерой
+    # fallback'а после состоявшегося save.
     minimum.assert_not_called()
     minimum_verify.assert_not_called()
     apply.assert_not_called()
     select.assert_not_called()
+    assert len(open_calls) == 2
     assert verify_calls == [
         {"title": "Программист, разработчик", "role_id": "96", "label": "Программист, разработчик"}
     ]

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -429,6 +429,10 @@ def test_save_position_wizard_screen_closed_by_first_next_is_not_chip_popular(mo
     monkeypatch.setattr(resume_position, "dismiss_cookie_banner", lambda _page: None)
     select = MagicMock()
     monkeypatch.setattr(resume_position, "select_catalog_leaf", select)
+    # При регрессии падению предшествует настоящий дамп на MagicMock-странице
+    # (write_text(MagicMock) → TypeError); стаб держит отказ чистым — как в
+    # соседнем тесте на ChipPopularUnavailable и в командном двойнике.
+    monkeypatch.setattr(resume_position, "_dump_wizard_failure", lambda *_args: "dump.html")
 
     resume_position.save_position_wizard(
         page,
@@ -440,10 +444,12 @@ def test_save_position_wizard_screen_closed_by_first_next_is_not_chip_popular(mo
     )
 
     # Сохранившийся save не диагностируется как chip-popular: ровно один NEXT,
-    # каталог не тронут, финальный wait_for_url не нужен; транзитный тик
-    # опроса (chip-экран до редиректа) действительно пройден.
+    # каталог не тронут, финальный wait_for_url не нужен. Несущие ассерты —
+    # запрет повторного NEXT (#900) и отсутствие финального wait; тик опроса
+    # проверяется фактом (.called ≥ 1: транзитный chip-экран пройден), а не
+    # точным числом — лишний poll в продакшне не меняет поведение.
     next_button.click.assert_called_once_with()
-    page.wait_for_timeout.assert_called_once()
+    assert page.wait_for_timeout.called
     select.assert_not_called()
     page.wait_for_url.assert_not_called()
 

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -386,6 +386,68 @@ def test_save_position_wizard_raises_chip_popular_unavailable_when_catalog_modal
     select.assert_not_called()
 
 
+def test_save_position_wizard_screen_closed_by_first_next_is_not_chip_popular(monkeypatch):
+    # #899 (регресс-страж): живой факт #893 (диагностика 2026-08-31,
+    # воспроизведена на двух резюме) и #900-инцидент — первый NEXT может сам
+    # сохранить специализацию и закрыть экран: hh.ru уводит URL с
+    # professional_role, а модалка каталога не открывается вовсе. Этот исход
+    # НЕ ChipPopularUnavailable: в ветке #892 исключение ставилось по виду
+    # chip-экрана и маскировало СОСТОЯВШЕЕСЯ сохранение, уводя fallback в
+    # демонтируемый экран с финальным (uncertain). #913: state-machine wait
+    # проверяет уход URL ПЕРВЫМ, поэтому состоявшийся save выходит чистым
+    # return, а вердикт делает только identity-bound readback вызывающего
+    # (verify_wizard_save).
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/profile/resume/professional_role?resume=resume-id"
+    position = MagicMock()
+    position.count.return_value = 1
+    position.input_value.return_value = ""
+    clear = MagicMock()
+    clear.count.return_value = 0
+    next_button = MagicMock()
+    next_button.count.return_value = 1
+    next_button.first = next_button
+    page.locator.side_effect = lambda selector: {
+        resume_position.WIZARD_POSITION: position,
+        resume_position.WIZARD_POSITION_CLEAR: clear,
+        resume_position.WIZARD_NEXT: next_button,
+    }[selector]
+
+    # Транзитный chip-экран: URL уходит не мгновенно по клику, а через один
+    # тик опроса (живой сценарий #899: чипы видны, экран демонтируется, затем
+    # редирект). Регрессия «диагноз по виду экрана» (#892) стреляла именно в
+    # этот зазор — уход URL обязан решать исход раньше любого детектора.
+    def click_side_effect():
+        return None
+
+    next_button.click.side_effect = click_side_effect
+    page.wait_for_timeout.side_effect = lambda _ms: setattr(
+        page, "url", "https://hh.ru/resume/resume-id"
+    )
+    monkeypatch.setattr(resume_position, "is_profession_modal_confirmed", lambda _page: False)
+    monkeypatch.setattr(resume_position, "dismiss_cookie_banner", lambda _page: None)
+    select = MagicMock()
+    monkeypatch.setattr(resume_position, "select_catalog_leaf", select)
+
+    resume_position.save_position_wizard(
+        page,
+        resume,
+        PositionValues(
+            title="Программист, разработчик", specializations=["Программист, разработчик"]
+        ),
+        role_id="96",
+    )
+
+    # Сохранившийся save не диагностируется как chip-popular: ровно один NEXT,
+    # каталог не тронут, финальный wait_for_url не нужен; транзитный тик
+    # опроса (chip-экран до редиректа) действительно пройден.
+    next_button.click.assert_called_once_with()
+    page.wait_for_timeout.assert_called_once()
+    select.assert_not_called()
+    page.wait_for_url.assert_not_called()
+
+
 @pytest.mark.parametrize("clear_count", [1, 0])
 def test_save_position_wizard_minimum_saves_any_placeholder_category_via_chip(clear_count):
     # #890: the wizard-minimum fallback does not care WHICH profession gets


### PR DESCRIPTION
Closes #899

## Контекст

#899 писалось против ветки PR #892: там `ChipPopularUnavailable`
ставился по ВИДУ chip-экрана (`chip.count() == 1`) после первого NEXT и
маскировал уже состоявшееся успешное сохранение — `verify_wizard_save`
не вызывалась, fallback падал в демонтируемый экран, команда рапортовала
`[FAIL] (uncertain)`.

После мерджа #914 этот код ушёл из main. Переоценка против актуального
main (25e0d617): **сценарий ишью недостижим**, продакшн-код не меняется.

## Доказательство кодом

- `resume_position.py:665-672` — state-machine wait после первого NEXT
  проверяет уход URL с визарда ПЕРВЫМ (каждые 500 мс, дедлайн 15 с):
  экран закрылся → чистый `return`, исключение не возникает. Живой
  коррелят состоявшегося save — именно уход URL (диагностика #893 от
  2026-08-31, воспроизведена на двух резюме; #900-инцидент).
- `commands/resume_position.py:420-427` — на этом выходе выполняется
  `verify_wizard_save` (то, что #899 требовал вызвать): identity-bound
  SSR-readback роли/экрана/карточки, дедлайн 30 с.
- `resume_position.py:678` — единственная точка raise
  `ChipPopularUnavailable` во всём коде; достижима только когда URL все
  15 с остаётся на визарде И модалки нет — по живым фактам это состояние
  «экран не закрыт, save не состоялся». Fallback по нему работает по
  живому экрану, финальный вердикт снова даёт `verify_wizard_save`
  (`commands/resume_position.py:450-456`) с точным `expected_role_id`.
- Детекция «по виду экрана» удалена физически:
  `WIZARD_POSITION_CHIP_POPULAR` в `save_position_wizard` не
  используется; селектор живёт только в `save_position_wizard_minimum`
  как позитивное ожидание.

Остаточный путь `[FAIL] (uncertain)` поверх реального успеха — только
Playwright-крах после `first_click_started`
(`commands/resume_position.py:468-473`), общий post-click grey-zone
(#465/#207), не механизм #899.

## Что в PR (только тесты)

- `test_save_position_wizard_screen_closed_by_first_next_is_not_chip_popular`
  (`tests/test_resume_position.py`) — первый NEXT закрывает экран, модалки
  нет, URL уходит тиком опроса (транзитный chip-экран): функция обязана
  вернуться без исключения; ровно один NEXT, каталог не тронут, финальный
  `wait_for_url` не нужен.
- `test_landed_first_next_save_is_verified_not_masked_by_fallback`
  (`tests/test_resume_edit_command_runs.py`) — командный уровень с
  НАСТОЯЩЕЙ `save_position_wizard` (не двойником): `[OK]` без
  `(uncertain)`, один вызов `verify_wizard_save` с ожидаемой ролью,
  `save_position_wizard_minimum`/`verify_wizard_minimum_save`/
  `apply_position` не вызывались, ledger `success=1 uncertain=0`.

## Mutation-проверка (стражи ловят возврат регрессии)

- **Мутация A**: удалена ветка ухода URL из wait → оба теста красные
  (исключение кидается и на закрывшемся экране).
- **Мутация B** (класс #892): chip-детект поставлен раньше проверки URL →
  оба теста красные (исключение в транзитном зазоре).
- Исходник после мутаций восстановлен (`git checkout --`), в PR только
  тесты.

## Проверки

- Полный pytest: зелёный (exit 0, live-категории не собираются).
- `ruff check` + `ruff format --check`: чисты.
- `scripts/check_pytest_budget.py`: 54.8 с из 240 с.
- CLI не менялся — `gen_cli_docs` не требуется.

## Живой прогон

Продакшн-код не меняется, поэтому в этом PR нет фикса для live-проверки.
Критерии приёмки КОНТРОЛЬНОГО прогона (устраивает оркестратор после
мерджа текущих фиксов; он же закрывает #899) опубликованы комментарием в
ишью: согласованность вердикта CLI с SSR-состоянием, один attempt, нет
fallback после состоявшегося save, честность chip-shape.

Refs #893 #914 #907 #900 #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)