### PR TITLE
refactor(resume-mutations): общее чтение resume_id из URL/карточки/SSR

### DIFF
--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -14,7 +14,6 @@ resume-card-link-<hash> (identity-bound); новый resume_id обязан от
 from __future__ import annotations
 
 import logging
-import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -39,13 +38,27 @@ from .negotiations_probe import parse_initial_state
 # copy-resume-only variant; the command layer already treats this shared
 # PageStateIndeterminate subtype as an expired-session failure.
 from .responses import NotAuthenticated
+
+# Имена `_card_hashes` и `_RESUME_HASH_RE` сохранены как тестируемый seam:
+# тесты monkeypatch'ат их в этом модуле, и вызовы copy_resume_on_hh обязаны
+# резолвиться через глобал этого модуля.
+from .resume_ids import (
+    RESUME_ID_FROM_PATH_RE as _RESUME_HASH_RE,
+)
+from .resume_ids import (
+    card_resume_id,
+    read_ssr_resume_items,
+    resume_card_locator,
+    resume_item_attrs,
+)
+from .resume_ids import (
+    page_card_hashes as _card_hashes,
+)
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
     RESUME_LIST_ACTION_MORE,
     RESUME_LIST_CARD,
-    RESUME_LIST_CARD_LINK_QA_PREFIX,
-    RESUME_LIST_CARD_LINK_TPL,
     RESUME_LIST_CARD_TITLE,
     RESUME_PROFILE_READY,
 )
@@ -61,8 +74,6 @@ PROFILE_STALL_SECONDS = 15.0
 PROFILE_ABSOLUTE_TIMEOUT_SECONDS = 300.0
 PROFILE_POLL_MS = 250
 MENU_CLICK_TIMEOUT_MS = 1_000
-
-_RESUME_HASH_RE = re.compile(r"/resume/([0-9a-f]{32,40})")
 
 
 def _monotonic() -> float:
@@ -318,16 +329,6 @@ def _reload_resumes_list(page: Page) -> str:
     return ""
 
 
-def _card_hashes(page: Page) -> set[str]:
-    """Хэши всех резюме в списке /applicant/resumes (для diff до/после)."""
-    hashes: set[str] = set()
-    for link in page.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
-        qa = link.get_attribute("data-qa") or ""
-        if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
-            hashes.add(qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :])
-    return hashes
-
-
 def _resume_lineage(page: Page) -> dict[str, ResumeLineage]:
     """Read hash/numeric parentage from the resume-list SSR state.
 
@@ -340,20 +341,12 @@ def _resume_lineage(page: Page) -> dict[str, ResumeLineage]:
     An empty mapping is an unavailable proof, never evidence that a relation
     is absent.  Callers retain the URL-bound fallback and otherwise fail closed.
     """
-    try:
-        state = parse_initial_state(page.content())
-    except (ValueError, AttributeError, PlaywrightError, PlaywrightTimeoutError):
-        return {}
-    if not isinstance(state, dict):
-        return {}
-    resumes = state.get("applicantResumes")
-    if not isinstance(resumes, list):
-        return {}
+    resumes, _ = read_ssr_resume_items(page)
 
     result: dict[str, ResumeLineage] = {}
     for item in resumes:
-        attrs = item.get("_attributes") if isinstance(item, dict) else None
-        if not isinstance(attrs, dict):
+        attrs = resume_item_attrs(item)
+        if attrs is None:
             continue
         resume_hash = attrs.get("hash")
         numeric_id = attrs.get("id")
@@ -394,54 +387,36 @@ def list_resume_cards(
 
     status_by_hash: dict[str, str] = {}
     searchable_by_hash: dict[str, bool] = {}
-    ssr_unavailable = False  # Флаг: SSR данные недоступны или некорректны
-    try:
-        state = parse_initial_state(page.content())
-    except (ValueError, AttributeError, PlaywrightError, PlaywrightTimeoutError):
-        # PlaywrightError/PlaywrightTimeoutError могут возникнуть при закрытии страницы,
-        # сбое renderer или деградации браузера. Помечаем SSR как недоступный.
-        state = None
-        ssr_unavailable = True
-
-    if not ssr_unavailable and not isinstance(state, dict):
-        # Valid JSON can still have the wrong top-level shape (for example an
-        # interstitial payload such as null or a list).
-        ssr_unavailable = True
-    elif not ssr_unavailable:
-        resumes = state.get("applicantResumes")
-        if not isinstance(resumes, list) or not resumes:
-            # applicantResumes отсутствует, пуст или имеет неправильный тип:
-            # пустой список неотличим от SSR, который не загрузился.
+    # Непустая reason — SSR не прочитан / не объект / секция отсутствует, пуста
+    # или не список (пустой список неотличим от SSR, который не загрузился).
+    resumes, ssr_reason = read_ssr_resume_items(page)
+    ssr_unavailable = bool(ssr_reason)
+    for item in resumes:
+        attrs = resume_item_attrs(item)
+        if attrs is None:
             ssr_unavailable = True
-        else:
-            for item in resumes:
-                attrs = item.get("_attributes") if isinstance(item, dict) else None
-                resume_hash = attrs.get("hash") if isinstance(attrs, dict) else None
-                status = attrs.get("status") if isinstance(attrs, dict) else None
-                if (
-                    not isinstance(resume_hash, str)
-                    or not resume_hash
-                    or not isinstance(status, str)
-                    or not status
-                ):
-                    # A partially valid SSR payload must not be presented as a
-                    # complete status read: callers need to know that status
-                    # data is unavailable or schema-drifted.
-                    ssr_unavailable = True
-                    continue
-                status_by_hash[resume_hash] = status
-                is_searchable = attrs.get("isSearchable")
-                if isinstance(is_searchable, bool):
-                    searchable_by_hash[resume_hash] = is_searchable
+            continue
+        resume_hash = attrs.get("hash")
+        status = attrs.get("status")
+        if (
+            not isinstance(resume_hash, str)
+            or not resume_hash
+            or not isinstance(status, str)
+            or not status
+        ):
+            # A partially valid SSR payload must not be presented as a
+            # complete status read: callers need to know that status
+            # data is unavailable or schema-drifted.
+            ssr_unavailable = True
+            continue
+        status_by_hash[resume_hash] = status
+        is_searchable = attrs.get("isSearchable")
+        if isinstance(is_searchable, bool):
+            searchable_by_hash[resume_hash] = is_searchable
 
     cards: list[ResumeCard] = []
     for card in cards_locator.all():
-        resume_id = ""
-        for link in card.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
-            qa = link.get_attribute("data-qa") or ""
-            if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
-                resume_id = qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :]
-                break
+        resume_id = card_resume_id(card)
         if not resume_id:
             # Codex adversarial review (PR #322): вложенный селектор ссылки-хэша
             # — второй, независимо дрейфующий локатор (RESUME_LIST_CARD уже
@@ -530,8 +505,8 @@ def resolve_numeric_resume_ids(page: Page) -> ResumeIdMapping | None:
     mapping: dict[str, str] = {}
     statuses: dict[str, str] = {}
     for item in resumes:
-        attrs = item.get("_attributes") if isinstance(item, dict) else None
-        if not isinstance(attrs, dict):
+        attrs = resume_item_attrs(item)
+        if attrs is None:
             continue
         resume_hash, numeric_id = attrs.get("hash"), attrs.get("id")
         if not resume_hash or numeric_id is None:
@@ -709,10 +684,9 @@ def copy_resume_on_hh(
     logger.info("Открываю список резюме: %s", RESUMES_LIST_URL)
     _goto_resumes_list(page)
 
-    link_sel = RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume.resume_id)
     duplicate = None
     for attempt in range(2):
-        card_locator = page.locator(f"{RESUME_LIST_CARD}:has({link_sel})")
+        card_locator = resume_card_locator(page, resume.resume_id)
         match_count = _wait_single_match_count(card_locator, timeout_ms=COPY_TIMEOUT_MS)
         if match_count == -1:
             return CopyResumeResult(

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -17,6 +17,7 @@ from .browser import (
     goto_hh,
 )
 from .external_forms.detect import normalize
+from .resume_ids import RESUME_ID_FROM_PATH_OR_QUERY_RE
 from .resume_titles import duplicate_title_reason, read_account_titles
 from .selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
@@ -30,12 +31,6 @@ from .selector_groups.resume_page import (
 )
 
 CREATION_URL = f"{HH_BASE_URL}{RESUME_CREATION_URL}"
-# hh.ru подтверждает сохранение ДВУМЯ формами URL: прямой страницей резюме
-# (/resume/{id}) и следующим шагом визарда, где id уходит в query-параметр
-# (/profile/resume/educations?resume={id}&hhtmFrom=...). Боевой прогон #778
-# наблюдал вторую: резюме создавалось, но ожидание первой формы падало по
-# таймауту и давало uncertain при фактическом успехе.
-_RESUME_ID_RE = re.compile(r"(?:/resume/|[?&]resume=)([0-9a-f]{32,40})(?:[/?#&]|$)")
 # #837: живой замер показал checked=True уже на первой проверке спустя
 # +100мс после клика — секундный запас на порядок больше наблюдавшейся
 # задержки, но честный (не бесконечный) дедлайн на случай, если чекбокс
@@ -395,12 +390,12 @@ def create_resume_on_hh(
         )
         if reason:
             return CreateResumeResult(False, reason=reason)
-        page.wait_for_url(_RESUME_ID_RE, wait_until="commit")
+        page.wait_for_url(RESUME_ID_FROM_PATH_OR_QUERY_RE, wait_until="commit")
     except PlaywrightError as exc:
         return CreateResumeResult(
             False, reason=f"ошибка после клика сохранения: {exc}", uncertain=True
         )
-    match = _RESUME_ID_RE.search(page.url)
+    match = RESUME_ID_FROM_PATH_OR_QUERY_RE.search(page.url)
     if not match:
         return CreateResumeResult(
             False, reason="новый resume_id не подтверждён после сохранения", uncertain=True

--- a/src/hhru_bot/delete_resume.py
+++ b/src/hhru_bot/delete_resume.py
@@ -15,9 +15,9 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page
 
 from .browser import RESUMES_FULL_LIST_URL, goto_hh, open_confirmed_resume
+from .resume_ids import resume_card_locator
 from .selector_groups.resume_list import (
     RESUME_LIST_CARD,
-    RESUME_LIST_CARD_LINK_TPL,
 )
 from .selector_groups.resume_page import (
     RESUME_DELETE_BUTTON,
@@ -105,10 +105,7 @@ def delete_resume_on_hh(
     """
     resume_id = resume.resume_id
     goto_hh(page, RESUMES_FULL_LIST_URL)
-    card_selector = (
-        f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"
-    )
-    card = page.locator(card_selector)
+    card = resume_card_locator(page, resume_id)
     if card.count() == 0:
         try:
             card.first.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
@@ -187,7 +184,7 @@ def delete_resume_on_hh(
             # Same commit-vs-hydration guard as above: after domcontentloaded the
             # React card may not be attached yet, so a bare count()==0 right after
             # the reload must not be treated as a permanent failure.
-            card = page.locator(card_selector)
+            card = resume_card_locator(page, resume_id)
             if card.count() == 0:
                 try:
                     card.first.wait_for(state="attached", timeout=DELETE_VERIFY_TIMEOUT_MS)
@@ -261,9 +258,7 @@ def delete_resume_on_hh(
                     True,
                 )
         _wait_resume_list_ready(page)
-        remaining = page.locator(
-            f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"
-        ).count()
+        remaining = resume_card_locator(page, resume_id).count()
     except Exception as exc:
         return DeleteResumeResult(
             resume_id, False, f"не удалось проверить результат удаления: {exc}", True

--- a/src/hhru_bot/resume_ids.py
+++ b/src/hhru_bot/resume_ids.py
@@ -1,0 +1,119 @@
+"""Чтение идентификаторов резюме: URL, карточка списка, SSR (#891).
+
+``create_resume``/``copy_resume``/``delete_resume`` исторически независимо
+решали одну задачу — «какой это resume_id и откуда он доказан» — параллельными
+regex (почти одинаковыми по смыслу, но с разными вариантами матчинга), тремя
+копиями обхода data-qa-ссылок карточек и двумя копиями обхода SSR
+``applicantResumes``. Модуль собирает сами ЧТЕНИЯ в одном месте.
+
+Граница модуля: только чтение идентификаторов. Решения об успехе/отказе,
+строгие проверки (``count != 1``, fail-closed причины, ``uncertain``) и их
+формулировки остаются у вызывающих модулей — рефакторинг #891 сознательно
+сохраняет наблюдаемое поведение и сообщения трёх боевых команд, поэтому
+таксономии ошибок (в том числе разные по строгости) сюда НЕ переезжают.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Locator, Page
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from .negotiations_probe import parse_initial_state
+from .selector_groups.resume_list import (
+    RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_QA_PREFIX,
+    RESUME_LIST_CARD_LINK_TPL,
+)
+
+# resume_id в PATH-форме URL: /resume/<hash>. Единственная форма, которую
+# признаёт copy-resume: URL после WRITE-клика там только КАНДИДАТ (SPA hh.ru
+# при клонировании часто не меняет URL вовсе), поэтому матч сам по себе ничего
+# не доказывает — финальное слово за diff'ом карточек списка
+# (copy_resume._reconcile_created_resume).
+RESUME_ID_FROM_PATH_RE = re.compile(r"/resume/([0-9a-f]{32,40})")
+
+# resume_id в ДВУХ формах URL, которыми hh.ru подтверждает сохранение (#778):
+# прямой страницей резюме (/resume/<id>) и следующим шагом визарда, где id
+# уходит в query-параметр (/profile/resume/educations?resume=<id>&hhtmFrom=...).
+# Боевой прогон #778 наблюдал вторую: резюме создавалось, но ожидание первой
+# формы падало по таймауту и давало uncertain при фактическом успехе. Эту
+# форму доверяет только create-resume (wait_for_url + search(page.url)).
+RESUME_ID_FROM_PATH_OR_QUERY_RE = re.compile(
+    r"(?:/resume/|[?&]resume=)([0-9a-f]{32,40})(?:[/?#&]|$)"
+)
+
+
+def card_resume_id(card: Locator) -> str:
+    """Прочитать resume_id из data-qa ссылки внутри одной карточки списка.
+
+    Хвост ``resume-card-link-<hash>`` — и есть resume_id (identity-bound,
+    #33). Пустая строка — ссылка-хэш не найдена или её data-qa без префикса:
+    вызывающий код обязан трактовать это как дрейф разметки, а не молча
+    пропускать карточку (тот же инвариант, что у ``list_resume_cards``, PR
+    #322: частичный список — не список).
+    """
+    for link in card.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
+        qa = link.get_attribute("data-qa") or ""
+        if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
+            return qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :]
+    return ""
+
+
+def page_card_hashes(page: Page) -> set[str]:
+    """Хэши всех резюме в списке (для diff карточек до/после мутации)."""
+    hashes: set[str] = set()
+    for link in page.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
+        qa = link.get_attribute("data-qa") or ""
+        if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
+            hashes.add(qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :])
+    return hashes
+
+
+def resume_card_locator(page: Page, resume_id: str) -> Locator:
+    """Identity-bound карточка списка: карточка, содержащая ссылку на resume_id.
+
+    Один конструктор селектора для copy-resume/delete-resume: привязка карточки
+    к конкретному резюме через ``resume-card-link-<hash>`` — общий источник
+    истины identity-проверки (#33) у обеих команд.
+    """
+    return page.locator(
+        f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=resume_id)})"
+    )
+
+
+def resume_item_attrs(item) -> dict | None:  # noqa: ANN001
+    """``_attributes`` одного элемента SSR ``applicantResumes``; ``None`` — невалиден.
+
+    Элемент без ``_attributes`` (или вовсе не dict) — частичный payload; что
+    с ним делать (skip / пометить список недоступным), решает вызывающий код.
+    """
+    attrs = item.get("_attributes") if isinstance(item, dict) else None
+    return attrs if isinstance(attrs, dict) else None
+
+
+def read_ssr_resume_items(page: Page) -> tuple[list, str]:
+    """Прочитать список ``applicantResumes`` из SSR-состояния страницы списка.
+
+    Возвращает ``(items, reason)``: непустая ``reason`` — SSR недоступен (шаблон
+    ``HH-Lux-InitialState`` не найден, JSON невалиден или не объект, секция
+    ``applicantResumes`` отсутствует, пуста или не список). Честно пустая секция
+    здесь тоже недоступность: пустой SSR неотличим от незагрузившегося
+    (``list_resume_cards``). Читающему родство клонов (``_resume_lineage``)
+    reason безразличен: пустое/нечитаемое — пустое доказательство, никогда не
+    доказательство отсутствия связи.
+    """
+    try:
+        state = parse_initial_state(page.content())
+    except (ValueError, AttributeError, PlaywrightError, PlaywrightTimeoutError) as exc:
+        return [], f"SSR-состояние не прочитано: {exc}"
+    if not isinstance(state, dict):
+        # parse_initial_state возвращает любой валидный JSON: null/массив/строка
+        # (schema-drift, интерстишл) — недоступность, не «резюме нет».
+        return [], f"SSR-состояние не объект ({type(state).__name__})"
+    resumes = state.get("applicantResumes")
+    if not isinstance(resumes, list) or not resumes:
+        return [], "секция applicantResumes отсутствует, пуста или не список"
+    return resumes, ""

--- a/src/hhru_bot/resume_ids.py
+++ b/src/hhru_bot/resume_ids.py
@@ -24,6 +24,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from .negotiations_probe import parse_initial_state
 from .selector_groups.resume_list import (
     RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_PREFIX,
     RESUME_LIST_CARD_LINK_QA_PREFIX,
     RESUME_LIST_CARD_LINK_TPL,
 )
@@ -55,7 +56,7 @@ def card_resume_id(card: Locator) -> str:
     пропускать карточку (тот же инвариант, что у ``list_resume_cards``, PR
     #322: частичный список — не список).
     """
-    for link in card.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
+    for link in card.locator(RESUME_LIST_CARD_LINK_PREFIX).all():
         qa = link.get_attribute("data-qa") or ""
         if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
             return qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :]
@@ -65,7 +66,7 @@ def card_resume_id(card: Locator) -> str:
 def page_card_hashes(page: Page) -> set[str]:
     """Хэши всех резюме в списке (для diff карточек до/после мутации)."""
     hashes: set[str] = set()
-    for link in page.locator(f"[data-qa^='{RESUME_LIST_CARD_LINK_QA_PREFIX}']").all():
+    for link in page.locator(RESUME_LIST_CARD_LINK_PREFIX).all():
         qa = link.get_attribute("data-qa") or ""
         if qa.startswith(RESUME_LIST_CARD_LINK_QA_PREFIX):
             hashes.add(qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :])

--- a/src/hhru_bot/resume_titles.py
+++ b/src/hhru_bot/resume_titles.py
@@ -18,10 +18,9 @@ from playwright.sync_api import Page
 
 from .browser import RESUMES_FULL_LIST_URL, goto_hh
 from .external_forms.detect import normalize
+from .resume_ids import card_resume_id
 from .selector_groups.resume_list import (
     RESUME_LIST_CARD,
-    RESUME_LIST_CARD_LINK_PREFIX,
-    RESUME_LIST_CARD_LINK_QA_PREFIX,
     RESUME_LIST_CARD_TITLE,
 )
 from .selector_groups.resume_page import RESUME_CREATE_BUTTON
@@ -70,15 +69,10 @@ def read_account_titles(page: Page) -> tuple[list[AccountTitle], str]:
             return [], ""
         entries: list[AccountTitle] = []
         for card in cards.all():
-            # Счёт строго до чтения: get_attribute/inner_text по отсутствующему
-            # элементу в реальном Playwright ждёт его весь таймаут и кидает
-            # TimeoutError, а не возвращает None — причина отказа должна
-            # формироваться по count()==0, а не падать 30-секундным ожиданием.
-            link = card.locator(RESUME_LIST_CARD_LINK_PREFIX)
-            link_qa = ""
-            if link.count() >= 1:
-                link_qa = link.first.get_attribute("data-qa") or ""
-            resume_id = link_qa[len(RESUME_LIST_CARD_LINK_QA_PREFIX) :] if link_qa else ""
+            # Чтение resume_id через общий ридер (#891): .all() не ждёт элемент,
+            # так что «счёт строго до чтения» здесь соблюдён самим снапшотом
+            # ссылок — get_attribute берётся только с реально найденных узлов.
+            resume_id = card_resume_id(card)
             if not resume_id:
                 return [], (
                     "карточка резюме без resume_id (ссылка-хэш не найдена — дрейф разметки); "

--- a/src/hhru_bot/resume_titles.py
+++ b/src/hhru_bot/resume_titles.py
@@ -69,9 +69,12 @@ def read_account_titles(page: Page) -> tuple[list[AccountTitle], str]:
             return [], ""
         entries: list[AccountTitle] = []
         for card in cards.all():
-            # Чтение resume_id через общий ридер (#891): .all() не ждёт элемент,
-            # так что «счёт строго до чтения» здесь соблюдён самим снапшотом
-            # ссылок — get_attribute берётся только с реально найденных узлов.
+            # Чтение resume_id через общий ридер (#891): снапшот .all() убирает
+            # ожидание на ПОИСК ссылок («счёт строго до чтения» — без retry-гонки
+            # между count() и перечислением). Само чтение атрибута авто-ждёт и
+            # при детаче между .all() и get_attribute кидает TimeoutError — это
+            # покрывает внешний except PlaywrightError ниже, не снимать его как
+            # якобы избыточный.
             resume_id = card_resume_id(card)
             if not resume_id:
                 return [], (

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -739,9 +739,9 @@ def test_no_navigation_with_matching_parent_lineage_succeeds(monkeypatch):
 
 
 def test_resume_lineage_reads_server_clone_relation(monkeypatch):
+    # SSR-чтение переехало в resume_ids (#891), поэтому шов патчится там.
     monkeypatch.setattr(
-        cr,
-        "parse_initial_state",
+        "hhru_bot.resume_ids.parse_initial_state",
         lambda html: {
             "applicantResumes": [
                 {
@@ -761,7 +761,7 @@ def test_resume_lineage_reads_server_clone_relation(monkeypatch):
 
 
 def test_resume_lineage_malformed_state_is_unavailable(monkeypatch):
-    monkeypatch.setattr(cr, "parse_initial_state", lambda html: ["interstitial"])
+    monkeypatch.setattr("hhru_bot.resume_ids.parse_initial_state", lambda html: ["interstitial"])
 
     assert cr._resume_lineage(SimpleNamespace(content=lambda: "<html>")) == {}
 

--- a/tests/test_resume_ids.py
+++ b/tests/test_resume_ids.py
@@ -1,0 +1,197 @@
+"""Тесты общего модуля чтения идентификаторов резюме (resume_ids, #891).
+
+Модуль — только чтения (URL regex / data-qa карточки / SSR applicantResumes),
+поэтому все тесты идут на фейках без браузера. Регресс-цель рефакторинга #891:
+три мутационные команды (create/copy/delete-resume) читают identity из одного
+места, и каждое чтение возвращает «не доказано» (пустая строка/причина), а не
+догадку, когда источник недоступен.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hhru_bot.resume_ids import (
+    RESUME_ID_FROM_PATH_OR_QUERY_RE,
+    RESUME_ID_FROM_PATH_RE,
+    card_resume_id,
+    page_card_hashes,
+    read_ssr_resume_items,
+    resume_card_locator,
+    resume_item_attrs,
+)
+from hhru_bot.selector_groups.resume_list import (
+    RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_TPL,
+)
+
+pytestmark = pytest.mark.unit
+
+# Очевидно поддельные resume_id (хвосты фикстур проекта), не реальные хэши.
+ID_A = "a" * 38
+ID_B = "b" * 38
+
+
+class _Link:
+    def __init__(self, qa: str | None):
+        self._qa = qa
+
+    def get_attribute(self, name: str) -> str | None:
+        return self._qa
+
+
+class _LinksLocator:
+    """Локатор ссылок внутри карточки: снапшот .all(), как настоящий Playwright."""
+
+    def __init__(self, qas: list[str | None]):
+        self._qas = qas
+
+    def all(self) -> list[_Link]:
+        return [_Link(qa) for qa in self._qas]
+
+
+class _Card:
+    def __init__(self, qas: list[str | None]):
+        self._qas = qas
+
+    def locator(self, selector: str) -> _LinksLocator:
+        assert selector.startswith("[data-qa^='resume-card-link-'"), selector
+        return _LinksLocator(self._qas)
+
+
+class _HashesPage:
+    def __init__(self, qas: list[str | None]):
+        self._qas = qas
+
+    def locator(self, selector: str) -> _LinksLocator:
+        assert selector.startswith("[data-qa^='resume-card-link-'"), selector
+        return _LinksLocator(self._qas)
+
+
+class _SelectorPage:
+    """Фиксирует селектор, переданный в page.locator."""
+
+    def __init__(self) -> None:
+        self.selectors: list[str] = []
+
+    def locator(self, selector: str):
+        self.selectors.append(selector)
+        raise AssertionError("локатор не должен использоваться в этом тесте")
+
+
+def test_path_regex_reads_resume_url():
+    match = RESUME_ID_FROM_PATH_RE.search(f"https://hh.ru/resume/{ID_A}?hhtmFrom=resume")
+    assert match is not None
+    assert match.group(1) == ID_A
+
+
+def test_path_regex_rejects_query_form():
+    # Разница двух regex (#891): PATH-форма НЕ признаёт query-подтверждение
+    # визарда — это семантика copy-resume, где URL только кандидат.
+    assert RESUME_ID_FROM_PATH_RE.search(f"https://hh.ru/applicant/resumes?resume={ID_A}") is None
+
+
+def test_path_or_query_regex_reads_both_confirmation_forms():
+    # /resume/<id> — прямая страница (#304)...
+    path_url = f"https://hh.ru/resume/{ID_A}"
+    # ...и ?resume=<id> — следующий шаг визарда, боевой прогон #778.
+    query_urls = [
+        f"https://hh.ru/profile/resume/educations?resume={ID_A}&hhtmFrom=wizard",
+        f"https://hh.ru/profile/resume/educations?hhtmFrom=wizard&resume={ID_A}",
+        f"https://hh.ru/profile/resume/educations?resume={ID_A}",
+    ]
+    for url in [path_url, *query_urls]:
+        match = RESUME_ID_FROM_PATH_OR_QUERY_RE.search(url)
+        assert match is not None, url
+        assert match.group(1) == ID_A
+
+
+def test_path_or_query_regex_ignores_partial_or_foreign_ids():
+    # Не hex-хвост (короткий) и чужой query-параметр — не идентификатор.
+    assert RESUME_ID_FROM_PATH_OR_QUERY_RE.search("https://hh.ru/resume/abc123") is None
+    assert RESUME_ID_FROM_PATH_OR_QUERY_RE.search("https://hh.ru/x?resumey=1") is None
+
+
+def test_card_resume_id_reads_link_tail():
+    assert card_resume_id(_Card([f"resume-card-link-{ID_A}"])) == ID_A
+
+
+def test_card_resume_id_skips_foreign_links_and_returns_empty():
+    # Ссылки без префикса — дрейф разметки: «не доказано» (пустая строка),
+    # а не частичный id.
+    assert card_resume_id(_Card(["broken-link-no-prefix", f"resume-card-link-{ID_A}"])) == ID_A
+    assert card_resume_id(_Card([])) == ""
+    assert card_resume_id(_Card(["resume-card-link-"])) == ""
+    assert card_resume_id(_Card([None])) == ""
+
+
+def test_page_card_hashes_collects_unique_ids():
+    qas = [f"resume-card-link-{ID_A}", f"resume-card-link-{ID_B}", f"resume-card-link-{ID_A}"]
+    assert page_card_hashes(_HashesPage(qas)) == {ID_A, ID_B}
+
+
+def test_page_card_hashes_ignores_foreign_links():
+    assert page_card_hashes(_HashesPage(["vacancy-link-42", None])) == set()
+
+
+def test_resume_card_locator_builds_identity_bound_selector():
+    page = _SelectorPage()
+    with pytest.raises(AssertionError):
+        resume_card_locator(page, ID_A)
+    expected = f"{RESUME_LIST_CARD}:has({RESUME_LIST_CARD_LINK_TPL.format(resume_id=ID_A)})"
+    assert page.selectors == [expected]
+
+
+def test_resume_item_attrs_reads_attributes_or_none():
+    assert resume_item_attrs({"_attributes": {"hash": ID_A}}) == {"hash": ID_A}
+    assert resume_item_attrs({"other": 1}) is None
+    assert resume_item_attrs("не dict") is None
+
+
+def _ssr_html(payload: str) -> str:
+    return f"<html><template id='HH-Lux-InitialState'>{payload}</template></html>"
+
+
+def test_read_ssr_resume_items_reads_section():
+    payload = json.dumps(
+        {
+            "applicantResumes": [
+                {"_attributes": {"hash": ID_A, "id": 101}},
+                {"_attributes": {"hash": ID_B, "id": 102, "parentResumeId": 101}},
+            ]
+        }
+    )
+    items, reason = read_ssr_resume_items(SimpleNamespace(content=lambda: _ssr_html(payload)))
+    assert reason == ""
+    assert [item["_attributes"]["hash"] for item in items] == [ID_A, ID_B]
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html>proxy check</html>",  # шаблона нет
+        _ssr_html("null"),  # валидный JSON не-объект (интерстишл)
+        _ssr_html("[1,2]"),
+        _ssr_html(json.dumps({"other": 1})),  # секции нет
+        _ssr_html(json.dumps({"applicantResumes": {}})),  # не список
+        _ssr_html(json.dumps({"applicantResumes": []})),  # пустая секция
+    ],
+)
+def test_read_ssr_resume_items_reports_unavailable_not_empty(html):
+    # Fail-closed контракт: недоступность возвращается причиной, никогда —
+    # «пустой список за подтверждённый факт».
+    items, reason = read_ssr_resume_items(SimpleNamespace(content=lambda: html))
+    assert items == []
+    assert reason != ""
+
+
+def test_read_ssr_resume_items_survives_parse_errors():
+    def _boom() -> str:
+        raise ValueError("invalid JSON")
+
+    items, reason = read_ssr_resume_items(SimpleNamespace(content=_boom))
+    assert items == []
+    assert reason != ""

--- a/tests/test_resume_ids.py
+++ b/tests/test_resume_ids.py
@@ -25,6 +25,7 @@ from hhru_bot.resume_ids import (
 )
 from hhru_bot.selector_groups.resume_list import (
     RESUME_LIST_CARD,
+    RESUME_LIST_CARD_LINK_PREFIX,
     RESUME_LIST_CARD_LINK_TPL,
 )
 
@@ -58,7 +59,9 @@ class _Card:
         self._qas = qas
 
     def locator(self, selector: str) -> _LinksLocator:
-        assert selector.startswith("[data-qa^='resume-card-link-'"), selector
+        # Ридер обязан строить селектор из генерируемой константы реестра, а не
+        # из собственного литерала (правило «можно сгенерировать — не хардкодить»).
+        assert selector == RESUME_LIST_CARD_LINK_PREFIX, selector
         return _LinksLocator(self._qas)
 
 
@@ -67,7 +70,7 @@ class _HashesPage:
         self._qas = qas
 
     def locator(self, selector: str) -> _LinksLocator:
-        assert selector.startswith("[data-qa^='resume-card-link-'"), selector
+        assert selector == RESUME_LIST_CARD_LINK_PREFIX, selector
         return _LinksLocator(self._qas)
 
 

--- a/tests/test_resume_titles.py
+++ b/tests/test_resume_titles.py
@@ -197,6 +197,11 @@ class _OneNode:
     def count(self) -> int:
         return 1
 
+    def all(self) -> list[_OneNode]:
+        # card_resume_id (#891) читает ссылки снапшотом .all(), как список
+        # карточек: двойник возвращает сам себя единственным совпадением.
+        return [self]
+
     def get_attribute(self, name: str) -> str | None:
         if self._raise_read:
             raise PlaywrightError("detached by rerender")


### PR DESCRIPTION
Closes #891

## Что сделано

Новый модуль `src/hhru_bot/resume_ids.py` — общий дом чтения идентификаторов резюме, которые `create_resume.py`/`copy_resume.py`/`delete_resume.py`/`resume_titles.py` исторически дублировали независимо. Граница модуля: **только чтения**; решения об успехе/отказе, строгие проверки и формулировки причин остаются у вызывающих командных модулей.

| Чтение | Было | Стало |
|---|---|---|
| resume_id в URL | `create_resume._RESUME_ID_RE` (path+query, #778) и `copy_resume._RESUME_HASH_RE` (только path) | `RESUME_ID_FROM_PATH_RE` / `RESUME_ID_FROM_PATH_OR_QUERY_RE` рядом, с комментариями о разной семантике доверия |
| хэш из data-qa карточки | 3 копии обхода `resume-card-link-*` (copy x2, resume_titles) | `card_resume_id` / `page_card_hashes` |
| identity-bound карточка | f-строка `RESUME_LIST_CARD:has(...)` в copy и delete | `resume_card_locator` |
| SSR `applicantResumes` | 2 копии parse+нормализации недоступности (copy: `_resume_lineage`, `list_resume_cards`) | `read_ssr_resume_items` + `resume_item_attrs` (3-й вызывающий, `resolve_numeric_resume_ids`, использует только attrs-идиому — его логи не тронуты) |

Тестовый seam сохранён: `cr._card_hashes`/`cr._resume_lineage`/`cr._wait_resume_list_ready`/`cr._monotonic` остаются глобалами `copy_resume` и monkeypatch'атся существующими тестами без изменения семантики (только шов `parse_initial_state` для `_resume_lineage` переехал в `hhru_bot.resume_ids`).

## Сознательно НЕ объединено (сохранение поведения, п. «Что не предлагается» ишью)

- **(a) Лимит резюме**: create проверяет два признака (`count()==0` + `is_disabled()`), copy — только отсутствие «Дублировать». Унификация = изменение причин отказа на боевой команде; по правилу проекта такой фикс требует живого прогона (#890). Здесь только фиксация факта в докстринге/коммит-месседже — кандидат в отдельное ишью.
- **(b) Гидратация/recovery reload**: таймауты законно разные на каждом экране; общая обёртка была бы тонким проходом без инварианта — это осознанное решение уже зафиксировано в CLAUDE.md («общего хелпера в browser.py намеренно нет»). Двойное `_wait_resume_list_ready` оставлено как есть (разные state/исключения — наблюдаемое поведение).
- **(c) Таксономии ошибок**: боевые, разные по строгости; унификация меняла бы сообщения.
- **(d) Readback клона**: иерархия «URL-кандидат → diff списка → lineage» осталась в `copy_resume` — это его задача, не чтения.

## Тесты

- Новые `tests/test_resume_ids.py` (18 юнит-тестов, фейки без браузера): обе regex-семантики (включая отрицательные), чтение хэшей карточек, селектор identity-карточки, SSR-недоступность (не прочитан / не объект / секция отсутствует, пуста, не список / ошибки парсера).
- Правки существующих: `_OneNode` в `test_resume_titles.py` получил `.all()` (ридер читает ссылки снапшотом, как `list_resume_cards`); два теста lineage патчат `hhru_bot.resume_ids.parse_initial_state`.
- Полный прогон: **3175 passed, 2 skipped**. `ruff check` + `ruff format --check` — чисто. `gen_cli_docs --check` — синхронизирован.

## Риски

- Милый edge в `read_account_titles`: раньше читалась только ПЕРВАЯ ссылка карточки, теперь — первая с корректным префиксом. Отличие проявляется только при дрейфе разметки («чужая» ссылка перед настоящей), где чтение настоящего id корректнее отказа; genuinely-пустой id по-прежнему fail-closed.
- Живой прогон не требовался (чистый рефакторинг чтений на моках; боевые пути кликов не тронуты).

## Известные последующие шаги

- Унификация обработки лимита резюме (a) — отдельное ишью с live-проверкой (см. #890: `profile_stalled` маскирует лимит в copy-пути).

🤖 Generated with [Claude Code](https://claude.com/claude-code)