### PR TITLE
refactor(resume-mutations): unify resume limit detection

### DIFF
--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -54,7 +54,7 @@ from .resume_ids import (
 from .resume_ids import (
     page_card_hashes as _card_hashes,
 )
-from .resume_limits import resume_limit_reason
+from .resume_limits import RESUME_LIMIT_REASON, resume_limit_reason
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -300,6 +300,13 @@ def _wait_duplicate_action(
         if duplicate_count == 1:
             limit_reason = resume_limit_reason(duplicate)
             if limit_reason:
+                # A disabled menu item may be mounted briefly while Magritte
+                # finishes hydration.  Require a second, delayed reading;
+                # otherwise a transient disabled state would become a
+                # terminal quota verdict and skip the safe recovery path.
+                page.wait_for_timeout(PROFILE_POLL_MS)
+                if duplicate.count() != 1 or not resume_limit_reason(duplicate):
+                    continue
                 return None, limit_reason
             observer.confirm_ready()
             return duplicate.first, ""
@@ -737,7 +744,7 @@ def copy_resume_on_hh(
         # Отсутствие действия при уже завершившемся client render — не stall и
         # не повод перезагружать страницу (например, достигнут лимит резюме).
         if (
-            failure.startswith("лимит резюме исчерпан")
+            failure.startswith(RESUME_LIMIT_REASON)
             or failure.startswith("duplicate_action_missing:")
             or "неоднозначно" in failure
         ):

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -54,6 +54,7 @@ from .resume_ids import (
 from .resume_ids import (
     page_card_hashes as _card_hashes,
 )
+from .resume_limits import resume_limit_reason
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -297,6 +298,9 @@ def _wait_duplicate_action(
 
         duplicate_count = duplicate.count()
         if duplicate_count == 1:
+            limit_reason = resume_limit_reason(duplicate)
+            if limit_reason:
+                return None, limit_reason
             observer.confirm_ready()
             return duplicate.first, ""
         if duplicate_count > 1:
@@ -308,9 +312,20 @@ def _wait_duplicate_action(
 
         now = _monotonic()
         if now >= absolute_deadline:
+            if ready_seen:
+                limit_reason = resume_limit_reason(duplicate)
+                if limit_reason:
+                    return None, limit_reason
             return None, observer.failure_reason(absolute=True)
         if now - observer.last_progress_at >= PROFILE_STALL_SECONDS:
             if ready_seen:
+                # Once the profile-ready marker was seen, a persistently
+                # missing duplicate action is the quota signal documented by
+                # hh.ru, not a stalled profile.  Keep this check shared with
+                # create-resume, including disabled actions.
+                limit_reason = resume_limit_reason(duplicate)
+                if limit_reason:
+                    return None, limit_reason
                 return None, observer.failure_reason()
             return None, observer.failure_reason(stalled=True)
         page.wait_for_timeout(PROFILE_POLL_MS)
@@ -721,7 +736,11 @@ def copy_resume_on_hh(
 
         # Отсутствие действия при уже завершившемся client render — не stall и
         # не повод перезагружать страницу (например, достигнут лимит резюме).
-        if failure.startswith("duplicate_action_missing:") or "неоднозначно" in failure:
+        if (
+            failure.startswith("лимит резюме исчерпан")
+            or failure.startswith("duplicate_action_missing:")
+            or "неоднозначно" in failure
+        ):
             return CopyResumeResult(resume.id, False, reason=failure)
 
         if attempt == 1:

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -19,6 +19,7 @@ from .browser import (
 )
 from .external_forms.detect import normalize
 from .resume_ids import RESUME_ID_FROM_PATH_OR_QUERY_RE
+from .resume_limits import resume_limit_reason
 from .resume_titles import duplicate_title_reason, read_account_titles
 from .selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
@@ -40,10 +41,6 @@ logger = logging.getLogger("hhru_bot.create_resume")
 # задержки, но честный (не бесконечный) дедлайн на случай, если чекбокс
 # реально не переключился.
 _CHECKBOX_CONFIRM_TIMEOUT = 5.0
-_RESUME_LIMIT_REASON = (
-    "лимит резюме hh.ru (~20) достигнут или кнопка создания недоступна; "
-    "удалите ненужные резюме и повторите попытку"
-)
 # #913 (battle2, живой дамп): «Другое» — вырожденный catch-all лист каталога
 # с фиксированным id; id-пространство дерева совместимо с каталогом поиска
 # (подтверждено live: 96 <-> tree-selector-item-96). Автопринятие единственного
@@ -657,8 +654,9 @@ def create_resume_on_hh(
         # На лимите hh.ru кнопку не рендерит вовсе. Не маскировать этот
         # наблюдаемый отказ под проблему гидрации/сети: создание без кнопки
         # невозможно, поэтому остаёмся fail-closed.
-        if page.locator(RESUME_CREATE_BUTTON).count() == 0:
-            return CreateResumeResult(False, reason=_RESUME_LIMIT_REASON)
+        limit_reason = resume_limit_reason(page.locator(RESUME_CREATE_BUTTON))
+        if limit_reason:
+            return CreateResumeResult(False, reason=limit_reason)
         return CreateResumeResult(False, reason=f"список резюме не отрисовался: {exc}")
     # Дубль-гард (#304, Codex cycles 2/3) вынесен в resume_titles (#911):
     # должности в аккаунте уникальны, дубликат надо отклонять ДО клика —
@@ -675,8 +673,9 @@ def create_resume_on_hh(
     # count() подтверждает только наличие узла. При исчерпанном лимите hh.ru
     # узел остаётся в DOM, но становится disabled; клик по нему даёт сетевую
     # ошибку и скрывает настоящую причину.
-    if _require(create_button).is_disabled():
-        return CreateResumeResult(False, reason=_RESUME_LIMIT_REASON)
+    limit_reason = resume_limit_reason(create_button)
+    if limit_reason:
+        return CreateResumeResult(False, reason=limit_reason)
 
     if dry_run:
         goto_hh(page, CREATION_URL)

--- a/src/hhru_bot/resume_limits.py
+++ b/src/hhru_bot/resume_limits.py
@@ -1,0 +1,23 @@
+"""Shared pre-write detection of the hh.ru resume quota."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator
+
+RESUME_LIMIT_REASON = "лимит резюме исчерпан; удалите ненужные резюме и повторите попытку"
+
+
+def resume_limit_reason(action: Locator) -> str:
+    """Return the quota failure when an action is absent or disabled.
+
+    Callers must invoke this only after the relevant page has been hydrated.
+    Before that point an absent action is merely an indeterminate DOM state;
+    treating it as a quota would hide selector or loading failures.  More than
+    one action is likewise left to the caller's ambiguity check.
+    """
+    count = action.count()
+    if count == 0:
+        return RESUME_LIMIT_REASON
+    if count == 1 and action.first.is_disabled():
+        return RESUME_LIMIT_REASON
+    return ""

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -108,6 +108,7 @@ class StubLocator:
         one = StubLocator(self._page, self.selector, count=min(self._count, 1), scope=self._scope)
         one._count_after_wait = 1
         one._wait_ok = self._wait_ok
+        one._disabled = getattr(self, "_disabled", False)
         return one
 
     def all(self):
@@ -117,7 +118,7 @@ class StubLocator:
         return None
 
     def is_disabled(self):
-        return False
+        return getattr(self, "_disabled", False)
 
 
 class StubPage:
@@ -432,6 +433,21 @@ def test_duplicate_button_missing_fails(monkeypatch):
     assert "лимит резюме исчерпан" in result.reason
     # Client render подтверждён optional-маркером: отсутствие action — это не
     # stall и не повод для recovery reload (возможен лимит резюме hh.ru).
+    assert page.reloads == []
+    assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE)]
+
+
+def test_disabled_duplicate_button_reports_quota_without_retry(monkeypatch):
+    duplicate = StubLocator(None, DUP_SEL, count=1, scope="")
+    duplicate._disabled = True
+    page = StubPage(dup_locators={CARD_SEL: duplicate})
+    _patch_env(monkeypatch, page)
+
+    result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
+
+    assert not result.success
+    assert not result.uncertain
+    assert "лимит резюме исчерпан" in result.reason
     assert page.reloads == []
     assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE)]
 

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -116,6 +116,9 @@ class StubLocator:
     def get_attribute(self, name):
         return None
 
+    def is_disabled(self):
+        return False
+
 
 class StubPage:
     """Конфигурируемый минимум Page для copy_resume_on_hh.
@@ -426,8 +429,7 @@ def test_duplicate_button_missing_fails(monkeypatch):
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert not result.success
-    assert "Дублировать" in result.reason
-    assert result.reason.startswith("duplicate_action_missing:")
+    assert "лимит резюме исчерпан" in result.reason
     # Client render подтверждён optional-маркером: отсутствие action — это не
     # stall и не повод для recovery reload (возможен лимит резюме hh.ru).
     assert page.reloads == []
@@ -520,7 +522,7 @@ def test_recovered_hydration_error_does_not_poison_later_failure(monkeypatch):
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
 
     assert not result.success
-    assert result.reason.startswith("duplicate_action_missing:")
+    assert "лимит резюме исчерпан" in result.reason
     assert "hydration_error" not in result.reason
 
 

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -238,6 +238,17 @@ def test_resume_limit_is_reported_before_create_click(monkeypatch, html):
     assert RESUME_CREATE_BUTTON not in page.clicks
 
 
+def test_disabled_create_button_is_terminal_quota_failure(monkeypatch):
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+    page = HtmlCreateButtonPage("<button data-qa='mainmenu_createResume' disabled>Создать</button>")
+
+    result = _run(page)
+
+    assert not result.success
+    assert result.reason.startswith("лимит резюме исчерпан")
+    assert RESUME_CREATE_BUTTON not in page.clicks
+
+
 def test_active_create_button_keeps_existing_behavior(monkeypatch):
     """An enabled button still enters the existing wizard flow."""
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))

--- a/tests/test_resume_limits.py
+++ b/tests/test_resume_limits.py
@@ -1,0 +1,33 @@
+"""Shared resume-quota detection (#928)."""
+
+import pytest
+
+from hhru_bot.resume_limits import RESUME_LIMIT_REASON, resume_limit_reason
+
+pytestmark = pytest.mark.unit
+
+
+class _Locator:
+    def __init__(self, count, disabled=False):
+        self._count = count
+        self._disabled = disabled
+        self.first = self
+
+    def count(self):
+        return self._count
+
+    def is_disabled(self):
+        return self._disabled
+
+
+@pytest.mark.parametrize("locator", [_Locator(0), _Locator(1, disabled=True)])
+def test_absent_or_disabled_action_reports_quota(locator):
+    assert resume_limit_reason(locator) == RESUME_LIMIT_REASON
+
+
+def test_enabled_action_has_no_quota_reason():
+    assert resume_limit_reason(_Locator(1)) == ""
+
+
+def test_ambiguous_action_is_not_called_quota():
+    assert resume_limit_reason(_Locator(2, disabled=True)) == ""


### PR DESCRIPTION
Closes #928

## Summary
- вынес общий fail-closed детектор исчерпания лимита резюме для create/copy
- copy-resume больше не маскирует подтверждённое отсутствие/disabled действия под profile_stalled
- delete-resume не менялся: его путь не зависит от доступности создания/копирования

## Tests
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` (полный набор, 2 skipped)
- targeted resume limit/create/copy tests

## Risks / follow-up
- Обязательный live-прогон через оркестратора ещё не выполнен; код не запускает мутацию при детекте лимита.
- Живой прогон должен быть одним запуском, только создание черновика, без удаления/публикации.