### PR TITLE
fix: distinguish unreadable resume quota

### DIFF
--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -54,7 +54,7 @@ from .resume_ids import (
 from .resume_ids import (
     page_card_hashes as _card_hashes,
 )
-from .resume_limits import RESUME_LIMIT_REASON, resume_limit_reason
+from .resume_limits import RESUME_QUOTA_UNREADABLE_REASON, resume_limit_reason
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -744,7 +744,7 @@ def copy_resume_on_hh(
         # Отсутствие действия при уже завершившемся client render — не stall и
         # не повод перезагружать страницу (например, достигнут лимит резюме).
         if (
-            failure.startswith(RESUME_LIMIT_REASON)
+            failure.startswith(RESUME_QUOTA_UNREADABLE_REASON)
             or failure.startswith("duplicate_action_missing:")
             or "неоднозначно" in failure
         ):

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -653,8 +653,21 @@ def create_resume_on_hh(
     except PlaywrightError as exc:
         # Отсутствие кнопки не доказывает лимит hh.ru: это также может быть
         # сбой чтения/гидрации. Классифицируем состояние строго fail-closed.
-        limit_reason = resume_limit_reason(page.locator(RESUME_CREATE_BUTTON))
+        create_button_locator = page.locator(RESUME_CREATE_BUTTON)
+        limit_reason = resume_limit_reason(create_button_locator)
         if limit_reason:
+            # Preserve the actionable Playwright diagnostic when the selector
+            # is ambiguous: strict count() failure is still unreadable quota,
+            # but hiding the exception makes selector drift unnecessarily hard
+            # to diagnose.
+            if create_button_locator.count() > 1:
+                return CreateResumeResult(
+                    False,
+                    reason=(
+                        f"{limit_reason} (кнопка создания неоднозначна: "
+                        f"{create_button_locator.count()} совпадений; ошибка: {exc})"
+                    ),
+                )
             return CreateResumeResult(False, reason=limit_reason)
         return CreateResumeResult(False, reason=f"список резюме не отрисовался: {exc}")
     # Дубль-гард (#304, Codex cycles 2/3) вынесен в resume_titles (#911):

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -651,9 +651,8 @@ def create_resume_on_hh(
     try:
         page.locator(RESUME_CREATE_BUTTON).first.wait_for(state="visible", timeout=15000)
     except PlaywrightError as exc:
-        # На лимите hh.ru кнопку не рендерит вовсе. Не маскировать этот
-        # наблюдаемый отказ под проблему гидрации/сети: создание без кнопки
-        # невозможно, поэтому остаёмся fail-closed.
+        # Отсутствие кнопки не доказывает лимит hh.ru: это также может быть
+        # сбой чтения/гидрации. Классифицируем состояние строго fail-closed.
         limit_reason = resume_limit_reason(page.locator(RESUME_CREATE_BUTTON))
         if limit_reason:
             return CreateResumeResult(False, reason=limit_reason)
@@ -670,9 +669,8 @@ def create_resume_on_hh(
     create_button, reason = _one(page, RESUME_CREATE_BUTTON, "кнопка создания резюме")
     if reason:
         return CreateResumeResult(False, reason=reason)
-    # count() подтверждает только наличие узла. При исчерпанном лимите hh.ru
-    # узел остаётся в DOM, но становится disabled; клик по нему даёт сетевую
-    # ошибку и скрывает настоящую причину.
+    # count()/disabled не являются явным маркером квоты: при сетевом сбое
+    # они дают те же значения. Не называем это исчерпанием без N/M-маркера.
     limit_reason = resume_limit_reason(create_button)
     if limit_reason:
         return CreateResumeResult(False, reason=limit_reason)

--- a/src/hhru_bot/resume_limits.py
+++ b/src/hhru_bot/resume_limits.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 
 from playwright.sync_api import Locator
 
-RESUME_LIMIT_REASON = "лимит резюме исчерпан; удалите ненужные резюме и повторите попытку"
+RESUME_QUOTA_UNREADABLE_REASON = "квоту прочитать не удалось — повторите попытку"
+RESUME_LIMIT_REASON = RESUME_QUOTA_UNREADABLE_REASON
 
 
 def resume_limit_reason(action: Locator) -> str:
-    """Return the quota failure when an action is absent or disabled.
+    """Return an unreadable-quota failure unless the action is unambiguous.
 
-    Callers must invoke this only after the relevant page has been hydrated.
-    Before that point an absent action is merely an indeterminate DOM state;
-    treating it as a quota would hide selector or loading failures.  More than
-    one action is likewise left to the caller's ambiguity check.
+    An absent or disabled action can be caused by a network/rendering failure.
+    An exhausted result must come from an explicit hh.ru quota marker with
+    parsed N/M values, never from this fallback.
     """
     count = action.count()
-    if count == 0:
-        return RESUME_LIMIT_REASON
-    if count == 1 and action.first.is_disabled():
-        return RESUME_LIMIT_REASON
+    if count != 1 or action.first.is_disabled():
+        return RESUME_QUOTA_UNREADABLE_REASON
     return ""

--- a/src/hhru_bot/resume_limits.py
+++ b/src/hhru_bot/resume_limits.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from playwright.sync_api import Locator
 
 RESUME_QUOTA_UNREADABLE_REASON = "квоту прочитать не удалось — повторите попытку"
-RESUME_LIMIT_REASON = RESUME_QUOTA_UNREADABLE_REASON
 
 
 def resume_limit_reason(action: Locator) -> str:

--- a/tests/test_copy_resume_browser.py
+++ b/tests/test_copy_resume_browser.py
@@ -430,14 +430,14 @@ def test_duplicate_button_missing_fails(monkeypatch):
     _patch_env(monkeypatch, page)
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
     assert not result.success
-    assert "лимит резюме исчерпан" in result.reason
-    # Client render подтверждён optional-маркером: отсутствие action — это не
-    # stall и не повод для recovery reload (возможен лимит резюме hh.ru).
+    assert "квоту прочитать не удалось" in result.reason
+    # Client render подтверждён optional-маркером, но отсутствие action не
+    # доказывает лимит: quota read мог завершиться сетевым/DOM-сбоем.
     assert page.reloads == []
     assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE)]
 
 
-def test_disabled_duplicate_button_reports_quota_without_retry(monkeypatch):
+def test_disabled_duplicate_button_reports_unreadable_quota_without_retry(monkeypatch):
     duplicate = StubLocator(None, DUP_SEL, count=1, scope="")
     duplicate._disabled = True
     page = StubPage(dup_locators={CARD_SEL: duplicate})
@@ -447,7 +447,7 @@ def test_disabled_duplicate_button_reports_quota_without_retry(monkeypatch):
 
     assert not result.success
     assert not result.uncertain
-    assert "лимит резюме исчерпан" in result.reason
+    assert "квоту прочитать не удалось" in result.reason
     assert page.reloads == []
     assert page.clicks == [(CARD_SEL, RESUME_LIST_ACTION_MORE)]
 
@@ -538,7 +538,7 @@ def test_recovered_hydration_error_does_not_poison_later_failure(monkeypatch):
     result = cr.copy_resume_on_hh(page, _resume(), dry_run=False)
 
     assert not result.success
-    assert "лимит резюме исчерпан" in result.reason
+    assert "квоту прочитать не удалось" in result.reason
     assert "hydration_error" not in result.reason
 
 

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -224,8 +224,8 @@ def _run(page, before_click=None):
         "<main>список резюме</main>",
     ],
 )
-def test_resume_limit_is_reported_before_create_click(monkeypatch, html):
-    """The list HTML exposes the hh.ru resume limit as disabled/missing button."""
+def test_unreadable_quota_is_reported_before_create_click(monkeypatch, html):
+    """Disabled/missing list action leaves the hh.ru quota unreadable."""
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
     page = HtmlCreateButtonPage(html)
 
@@ -233,19 +233,19 @@ def test_resume_limit_is_reported_before_create_click(monkeypatch, html):
 
     assert not result.success
     assert not result.uncertain
-    assert "лимит" in result.reason.lower()
-    assert "удал" in result.reason.lower()
+    assert "квоту прочитать не удалось" in result.reason
+    assert "исчерпан" not in result.reason
     assert RESUME_CREATE_BUTTON not in page.clicks
 
 
-def test_disabled_create_button_is_terminal_quota_failure(monkeypatch):
+def test_disabled_create_button_is_unreadable_quota_failure(monkeypatch):
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
     page = HtmlCreateButtonPage("<button data-qa='mainmenu_createResume' disabled>Создать</button>")
 
     result = _run(page)
 
     assert not result.success
-    assert result.reason.startswith("лимит резюме исчерпан")
+    assert result.reason.startswith("квоту прочитать не удалось")
     assert RESUME_CREATE_BUTTON not in page.clicks
 
 

--- a/tests/test_resume_limits.py
+++ b/tests/test_resume_limits.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hhru_bot.resume_limits import RESUME_LIMIT_REASON, resume_limit_reason
+from hhru_bot.resume_limits import RESUME_QUOTA_UNREADABLE_REASON, resume_limit_reason
 
 pytestmark = pytest.mark.unit
 
@@ -20,9 +20,11 @@ class _Locator:
         return self._disabled
 
 
-@pytest.mark.parametrize("locator", [_Locator(0), _Locator(1, disabled=True)])
-def test_absent_or_disabled_action_reports_quota(locator):
-    assert resume_limit_reason(locator) == RESUME_LIMIT_REASON
+@pytest.mark.parametrize("locator", [_Locator(0), _Locator(1, disabled=True), _Locator(2)])
+def test_unreadable_action_never_reports_exhausted_quota(locator):
+    reason = resume_limit_reason(locator)
+    assert reason == RESUME_QUOTA_UNREADABLE_REASON
+    assert "исчерпан" not in reason
 
 
 def test_enabled_action_has_no_quota_reason():
@@ -30,4 +32,4 @@ def test_enabled_action_has_no_quota_reason():
 
 
 def test_ambiguous_action_is_not_called_quota():
-    assert resume_limit_reason(_Locator(2, disabled=True)) == ""
+    assert resume_limit_reason(_Locator(2, disabled=True)) == RESUME_QUOTA_UNREADABLE_REASON


### PR DESCRIPTION
Closes #943
Closes #944

## Summary
- Treat missing, ambiguous, disabled, or otherwise unconfirmed create/copy action state as an unreadable quota, never as confirmed exhaustion.
- Enforce the quota proxy's strict `count() == 1` check and add regression coverage for absent, ambiguous, disabled, and hydration-failure paths.

## Review findings
- The #940 implementation classified an absent action (`count() == 0`) and a disabled action as exhausted without parsing an explicit hh.ru quota marker; that is the discriminator behind #943.
- The neighboring create/copy paths share this proxy. Their existing readback and hydration guards remain fail-closed; the affected quota branches now return `квоту прочитать не удалось — повторите попытку`.
- No confirmed live quota N/M marker or corresponding repository dump is available in this checkout, so this PR deliberately does not invent a selector or report exhaustion. An exhausted result must be added only after capturing and parsing a real hh.ru marker.
- Existing fixtures are reused for the surrounding list/readback behavior; failure cases assert the safety contract rather than inventing hh.ru markup.

## Verification
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest -q` (all tests passed)

Merge is intentionally left to the user.
