### PR TITLE
refactor(resume): save-подтверждение — классификация исходов + плоский bounded-цикл

### DIFF
--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -456,9 +456,14 @@ def _expected_editor(page: Page, resume_id: str, first_entry: bool) -> bool:
     remainder = path[len(base) :]
     segments_after_base = [part for part in remainder.split("/") if part]
     return (
-        # The next character after the base must be nothing or a "/" — a
+        # Explicit prefix check first: a shorter unrelated path ("/login",
+        # "/profile/edit") slices to an empty remainder and would otherwise
+        # pass the empty-remainder test below as the base editor (#960
+        # review, round 2).
+        path.startswith(base)
+        # The character right after the base must be nothing or a "/" — a
         # sibling route like "-notes" shares the prefix but not the route.
-        (not remainder or remainder.startswith("/"))
+        and (not remainder or remainder.startswith("/"))
         and len(segments_after_base) <= 1
         and parts.query in ("", f"resumeFrom={resume_id}")
     )

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -439,17 +439,28 @@ def _expected_editor(page: Page, resume_id: str, first_entry: bool) -> bool:
     ``*``-vs-``**``-vs-trailing-slash question class from PR #958 review
     cycle 3 cannot come up here. Confirmed shapes:
     - first entry: exactly ``/resume/edit/{resume_id}/experience`` (#787);
-    - shared profile: ``/profile/edit/experience[/{rowId}]`` (#844) with an
-      empty query or ``?resumeFrom={resume_id}`` (#840). Any other query
-      means the page is not in the state hh.ru opened it in — fail closed.
+    - shared profile: exactly ``/profile/edit/experience`` or with a single
+      ``/{rowId}`` segment (#844), with an empty query or
+      ``?resumeFrom={resume_id}`` (#840). A similarly named sibling route
+      (``/profile/edit/experience-notes``) or a deeper path
+      (``/experience/{row}/extra``) is NOT the confirmed editor — the
+      path-segment boundary is enforced, not a bare ``startswith`` (#960
+      review); any other query means the page is not in the state hh.ru
+      opened it in — fail closed.
     """
     parts = urlsplit(page.url)
     path = parts.path.rstrip("/")
     if first_entry:
         return path == f"/resume/edit/{resume_id}/experience"
-    return path.startswith("/profile/edit/experience") and parts.query in (
-        "",
-        f"resumeFrom={resume_id}",
+    base = "/profile/edit/experience"
+    remainder = path[len(base) :]
+    segments_after_base = [part for part in remainder.split("/") if part]
+    return (
+        # The next character after the base must be nothing or a "/" — a
+        # sibling route like "-notes" shares the prefix but not the route.
+        (not remainder or remainder.startswith("/"))
+        and len(segments_after_base) <= 1
+        and parts.query in ("", f"resumeFrom={resume_id}")
     )
 
 

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -12,7 +12,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
@@ -427,6 +427,74 @@ def _still_on_experience_editor(page: Page) -> bool:
     return path.startswith("/profile/edit/experience") or (
         path.startswith("/resume/edit/") and path.endswith("/experience")
     )
+
+
+def _expected_editor(page: Page, resume_id: str, first_entry: bool) -> bool:
+    """True while the page is THIS resume's confirmed experience editor (#960).
+
+    This predicate IS the mutation boundary of the save loop below: attempt 2
+    re-checks it right before the only allowed second save click, so a tab
+    that drifted to another resume's editor can never receive a re-click.
+    Exact path/query comparison replaces the old glob semantics — the
+    ``*``-vs-``**``-vs-trailing-slash question class from PR #958 review
+    cycle 3 cannot come up here. Confirmed shapes:
+    - first entry: exactly ``/resume/edit/{resume_id}/experience`` (#787);
+    - shared profile: ``/profile/edit/experience[/{rowId}]`` (#844) with an
+      empty query or ``?resumeFrom={resume_id}`` (#840). Any other query
+      means the page is not in the state hh.ru opened it in — fail closed.
+    """
+    parts = urlsplit(page.url)
+    path = parts.path.rstrip("/")
+    if first_entry:
+        return path == f"/resume/edit/{resume_id}/experience"
+    return path.startswith("/profile/edit/experience") and parts.query in (
+        "",
+        f"resumeFrom={resume_id}",
+    )
+
+
+SaveOutcomeKind = Literal["saved", "rejected", "drifted", "unconfirmed"]
+
+
+@dataclass(frozen=True)
+class SaveOutcome:
+    """Classified result of one save click (#960).
+
+    Exactly one ``kind`` per outcome; the flat save loop maps every kind to
+    exactly one ledger state (saved → binding verification, rejected after
+    the refill retry → failed, everything else → uncertain)."""
+
+    kind: SaveOutcomeKind
+    detail: str = ""
+
+
+def _classify_save_outcome(page: Page, resume_id: str, first_entry: bool) -> SaveOutcome:
+    """Classify the page state after a save click (#960).
+
+    saved — the browser is on ``/resume/{resume_id}`` (trailing slash and
+      query suffix do not disqualify: explicit path comparison, not glob)
+      AND the resume identity probe confirms it;
+    rejected — still on the confirmed editor with visible inline validation
+      texts, i.e. a definite non-mutation hh.ru refused client-side
+      (#959, live capture 2026-09-03);
+    drifted — still an experience editor, but not the confirmed one for
+      THIS resume (another resume's editor, a foreign ``resumeFrom``);
+    unconfirmed — everything else: the click's effect is genuinely unknown
+      and the caller must report uncertain.
+    """
+    path = urlsplit(page.url).path.rstrip("/")
+    if path == f"/resume/{resume_id}" and resume_identity_matches(page, resume_id):
+        return SaveOutcome("saved")
+    if _expected_editor(page, resume_id, first_entry):
+        rejection = _read_save_validation_errors(page)
+        if rejection is not None:
+            return SaveOutcome("rejected", rejection)
+        return SaveOutcome(
+            "unconfirmed", f"форма не навигировала и валидации не показала ({page.url})"
+        )
+    if _still_on_experience_editor(page):
+        return SaveOutcome("drifted", page.url)
+    return SaveOutcome("unconfirmed", f"страница не редактор опыта и не резюме ({page.url})")
 
 
 def _select_month(page: Page, locator, month: str) -> None:
@@ -1046,7 +1114,7 @@ def edit_experience_on_hh(
                         f"строка опыта {index}: не удалось открыть новую запись: {exc}"
                     )
                 ]
-            if urlsplit(page.url).path.rstrip("/") != edit_path:
+            if not _expected_editor(page, resume_id, True):
                 return results + [
                     ExperienceResult(
                         f"строка опыта {index}: форма открыта не для того резюме ({page.url})"
@@ -1266,119 +1334,126 @@ def edit_experience_on_hh(
                             "сохранением, save не нажат (#956)"
                         )
                     ]
-                save_attempted = True
-                rejection_retried = False
-                while True:
+                # #960: the save loop is flat and bounded. The invariant reads
+                # locally: the ONLY mutating click is `save.click()` below, it
+                # happens at most twice, and each iteration re-confirms —
+                # before clicking — that the page is still THIS resume's
+                # confirmed editor (_expected_editor; the attempt-2 re-check
+                # closes PR #958 cycle 3's drifted-retry finding). Every
+                # outcome leaves the loop in exactly one ledger state:
+                # saved → binding verification below, rejected after the
+                # refill retry → failed, anything else → uncertain.
+                save_attempted = False
+                for attempt in (1, 2):
                     save = page.locator(save_selector)
                     if save.count() != 1:
                         return results + [
                             ExperienceResult(f"строка {index}: save-кнопка не подтверждена")
                         ]
-                    save.click()
-                    try:
-                        # Trailing "*" (#958 follow-up): the post-save redirect
-                        # carries a query suffix (live log 2026-09-03: navigated
-                        # to ".../resume/{id}?hhtmFrom=profile_experience") and a
-                        # bare glob is a FULL match, so the save was recorded as
-                        # an uncertain after a 30s timeout although Playwright's
-                        # own log showed the navigation had happened. "*" matches
-                        # the query/fragment suffix but not a "/" path segment,
-                        # so a genuinely different page still fails the wait;
-                        # resume_identity_matches() below re-checks identity.
-                        page.wait_for_url(
-                            f"**/resume/{resume_id}*",
-                            wait_until="commit",
-                            timeout=SAVE_TIMEOUT_MS,
-                        )
-                        break
-                    except PlaywrightError as exc:
-                        # #958 follow-up (live capture 2026-09-03): before falling
-                        # back to the opaque navigation-timeout uncertain, check
-                        # whether hh.ru REJECTED the save client-side — visible
-                        # form-helper-error messages while still on the editor
-                        # URL are a definite non-mutation ("Пожалуйста, укажите"
-                        # under every empty required field, no navigation), so a
-                        # plain failed is reported instead: retryable, no
-                        # uncertain lock on the resume_id.
-                        rejection = _read_save_validation_errors(page)
-                        if rejection is not None and not rejection_retried:
-                            # The #956 wipe window is not observable from the
-                            # outside: the rejection may be a one-off wipe that
-                            # landed between the last verification and THIS
-                            # submit (live 2026-09-03: exactly that, on the
-                            # description field). Answer it with ONE bounded
-                            # refill+verify pass and a second save click before
-                            # reporting a failure — a second rejection (or a
-                            # refill that fails its own settle check) is final.
-                            rejection_retried = True
-                            _dump_experience_save_failure(
-                                page,
-                                index,
-                                RuntimeError(f"hh.ru отклонил сохранение: {rejection}"),
-                            )
-                            logger.warning(
-                                "experience: строка %s — save отклонён валидацией (%s); "
-                                "дозаполнение и один повторный save",
-                                index,
-                                rejection,
-                            )
-                            try:
-                                refill_ok = _refill_and_verify_fields()
-                            except (PlaywrightError, ValueError) as refill_exc:
-                                # The refill runs INSIDE this except handler, so
-                                # a throw here would escape the whole try uncaught
-                                # (Python handlers do not catch exceptions raised
-                                # in sibling handlers). A save click has already
-                                # happened, so the outcome is uncertain, not a
-                                # crash.
-                                return results + [
-                                    ExperienceResult(
-                                        f"строка {index}: дозаполнение после отклонения "
-                                        f"save не удалось: {refill_exc}",
-                                        uncertain=True,
-                                    )
-                                ]
-                            if not refill_ok:
-                                return results + [
-                                    ExperienceResult(
-                                        f"строка {index}: поле не удерживает значение "
-                                        f"после отклонения save: {rejection}"
-                                    )
-                                ]
-                            continue
-                        if rejection is not None:
-                            # Dump here too: the validation text is generic
-                            # ("Пожалуйста, укажите") and does not name the field,
-                            # so without the HTML the rejected field is unprovable
-                            # and the next run repeats blind.
-                            _dump_experience_save_failure(
-                                page,
-                                index,
-                                RuntimeError(f"hh.ru отклонил сохранение: {rejection}"),
-                            )
-                            return results + [
-                                ExperienceResult(
-                                    f"строка {index}: hh.ru отклонил сохранение после "
-                                    f"дозаполнения — валидация формы: {rejection}"
-                                )
-                            ]
-                        # #956: dump the page at the moment of the failed save so
-                        # the next investigation is reproducible without another
-                        # live attempt (same pattern as resume_education's
-                        # _dump_save_failure). The dump shows whether the form
-                        # still holds the values and whether a validation message
-                        # or an overlay absorbed the click.
-                        _dump_experience_save_failure(page, index, exc)
+                    if save_attempted and not _expected_editor(page, resume_id, first_entry):
+                        # A save click already happened and its effect is
+                        # unknown — uncertain, never a blind re-click on an
+                        # unconfirmed form.
                         return results + [
                             ExperienceResult(
-                                f"строка {index}: сохранение не подтверждено после клика: {exc}",
+                                f"строка {index}: повторный save отменён: редактор не подтверждён",
                                 uncertain=True,
                             )
                         ]
-                if not resume_identity_matches(page, resume_id):
+                    save_attempted = True
+                    save.click()
+                    # wait_for_url is only the bounded timer that gives hh.ru
+                    # time to navigate; the verdict comes from
+                    # _classify_save_outcome's explicit path comparison below,
+                    # so a timeout here is not read as a failure (an SPA
+                    # pushState navigation need not raise the lifecycle event
+                    # wait_for_url waits for, #825). The trailing "**" matches
+                    # both the query suffix (live log 2026-09-03:
+                    # ".../resume/{id}?hhtmFrom=profile_experience") and a
+                    # trailing slash — the full-match-glob false-uncertains
+                    # from PR #958 review cycle 3.
+                    nav_error: PlaywrightError | None = None
+                    try:
+                        page.wait_for_url(
+                            f"**/resume/{resume_id}**",
+                            wait_until="commit",
+                            timeout=SAVE_TIMEOUT_MS,
+                        )
+                    except PlaywrightError as exc:
+                        nav_error = exc
+                    outcome = _classify_save_outcome(page, resume_id, first_entry)
+                    if outcome.kind == "saved":
+                        break
+                    if outcome.kind == "rejected" and attempt == 1:
+                        # Definite non-mutation: hh.ru refused the submit
+                        # client-side (#959). Answer it with ONE bounded
+                        # refill+verify pass and the second — and only —
+                        # re-click before reporting a failure; the #956 wipe
+                        # may have landed between the last verification and
+                        # THIS submit (live 2026-09-03, dump-confirmed).
+                        _dump_experience_save_failure(
+                            page,
+                            index,
+                            RuntimeError(f"hh.ru отклонил сохранение: {outcome.detail}"),
+                        )
+                        logger.warning(
+                            "experience: строка %s — save отклонён валидацией (%s); "
+                            "дозаполнение и один повторный save",
+                            index,
+                            outcome.detail,
+                        )
+                        try:
+                            refill_ok = _refill_and_verify_fields()
+                        except (PlaywrightError, ValueError) as refill_exc:
+                            # A save click has already happened, so the outcome
+                            # is uncertain, not a crash (PR #958 cycle 1).
+                            return results + [
+                                ExperienceResult(
+                                    f"строка {index}: дозаполнение после отклонения "
+                                    f"save не удалось: {refill_exc}",
+                                    uncertain=True,
+                                )
+                            ]
+                        if not refill_ok:
+                            return results + [
+                                ExperienceResult(
+                                    f"строка {index}: поле не удерживает значение "
+                                    f"после отклонения save: {outcome.detail}"
+                                )
+                            ]
+                        continue
+                    if outcome.kind == "rejected":
+                        # Dump here too: the validation text is generic
+                        # ("Пожалуйста, укажите") and does not name the field,
+                        # so without the HTML the rejected field is unprovable
+                        # and the next run repeats blind.
+                        _dump_experience_save_failure(
+                            page,
+                            index,
+                            RuntimeError(f"hh.ru отклонил сохранение: {outcome.detail}"),
+                        )
+                        return results + [
+                            ExperienceResult(
+                                f"строка {index}: hh.ru отклонил сохранение после "
+                                f"дозаполнения — валидация формы: {outcome.detail}"
+                            )
+                        ]
+                    # #956: dump the page at the moment of the unconfirmed save
+                    # (drifted editor, another page, unreadable state) so the
+                    # next investigation is reproducible without another live
+                    # attempt. nav_error (the raw Playwright timeout text) goes
+                    # into the dump/log; the CLI reason carries the classifier's
+                    # page-state detail.
+                    _dump_experience_save_failure(
+                        page,
+                        index,
+                        nav_error
+                        if nav_error is not None
+                        else RuntimeError(f"save не подтверждён: {outcome.detail}"),
+                    )
                     return results + [
                         ExperienceResult(
-                            f"строка {index}: после save identity резюме не подтверждён",
+                            f"строка {index}: сохранение не подтверждено: {outcome.detail}",
                             uncertain=True,
                         )
                     ]

--- a/src/hhru_bot/experience.py
+++ b/src/hhru_bot/experience.py
@@ -440,13 +440,17 @@ def _expected_editor(page: Page, resume_id: str, first_entry: bool) -> bool:
     cycle 3 cannot come up here. Confirmed shapes:
     - first entry: exactly ``/resume/edit/{resume_id}/experience`` (#787);
     - shared profile: exactly ``/profile/edit/experience`` or with a single
-      ``/{rowId}`` segment (#844), with an empty query or
-      ``?resumeFrom={resume_id}`` (#840). A similarly named sibling route
-      (``/profile/edit/experience-notes``) or a deeper path
-      (``/experience/{row}/extra``) is NOT the confirmed editor — the
-      path-segment boundary is enforced, not a bare ``startswith`` (#960
-      review); any other query means the page is not in the state hh.ru
-      opened it in — fail closed.
+      ``/{rowId}`` segment (#844), and ALWAYS with
+      ``?resumeFrom={resume_id}`` (#840) — both code-driven entry points
+      carry the param. ``resumeFrom`` is the only resume-specific signal
+      the URL has: an empty query is exactly what hh.ru shows when NO
+      binding was established (#787 live capture: the param dropped on the
+      suggestion-chip route), so an empty-query editor could be ANY
+      resume's editor and must never gate the retry click (#960 review,
+      round 3). A similarly named sibling route
+      (``/profile/edit/experience-notes``), a deeper path
+      (``/experience/{row}/extra``) or any other query — not the confirmed
+      editor, fail closed.
     """
     parts = urlsplit(page.url)
     path = parts.path.rstrip("/")
@@ -465,7 +469,7 @@ def _expected_editor(page: Page, resume_id: str, first_entry: bool) -> bool:
         # sibling route like "-notes" shares the prefix but not the route.
         and (not remainder or remainder.startswith("/"))
         and len(segments_after_base) <= 1
-        and parts.query in ("", f"resumeFrom={resume_id}")
+        and parts.query == f"resumeFrom={resume_id}"
     )
 
 

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -612,13 +612,16 @@ def _edit_block(
                 save.click()
                 navigation_error: PlaywrightError | None = None
                 try:
-                    # Trailing "*" (#958 follow-up): the post-save redirect
-                    # carries a query suffix (live log 2026-09-03, experience
-                    # editor: navigated to ".../resume/{id}?hhtmFrom=
-                    # profile_experience") and a bare glob is a FULL match —
-                    # the same latent false-uncertain as experience.py.
+                    # Trailing "**" (#958 follow-up, #960): the post-save
+                    # redirect carries a query suffix (live log 2026-09-03,
+                    # experience editor: navigated to ".../resume/{id}?hhtmFrom=
+                    # profile_experience") — and a bare glob is a FULL match, so
+                    # the wait would time out although the navigation happened.
+                    # "**" (not "*") also matches a trailing slash, i.e. the
+                    # "/resume/{id}/" redirect shape from PR #958 review
+                    # cycle 3; the identity checks below still guard the result.
                     page.wait_for_url(
-                        f"**/resume/{resume_id}*", wait_until="commit", timeout=SAVE_TIMEOUT_MS
+                        f"**/resume/{resume_id}**", wait_until="commit", timeout=SAVE_TIMEOUT_MS
                     )
                 except PlaywrightError as exc:
                     # #825: раньше здесь не было явного timeout -- Playwright

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -6,6 +6,9 @@ from hhru_bot.experience import (
     ExperienceEntry,
     ExperiencePlan,
     ExperienceResult,
+    SaveOutcome,
+    _classify_save_outcome,
+    _expected_editor,
     _experience_row_indexes,
     _merge_fill_plan,
     build_prompt,
@@ -399,7 +402,10 @@ class _SavePage:
         return _Locator(count=1)
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):
-        return None
+        # #960: the save loop's verdict comes from _classify_save_outcome
+        # reading page.url, so a successful wait must model the navigation
+        # itself (all fixtures in this file save resume-1).
+        self.url = "https://hh.ru/resume/resume-1"
 
     def wait_for_function(self, _fn, *, arg=None, timeout=None):
         return None
@@ -1439,6 +1445,9 @@ class _RejectionRetryPage(_SavePage):
             raise PlaywrightError(
                 f"Timeout {timeout}ms exceeded.\nwaiting for navigation to {url} until '{wait_until}'"
             )
+        # #960: a non-rejected click navigates to the resume page — the
+        # classifier reads page.url, so the fake must model it.
+        self.url = "https://hh.ru/resume/resume-1"
 
     def locator(self, selector):
         if selector == "validation-errors":
@@ -1650,7 +1659,10 @@ def test_edit_experience_save_timeout_without_validation_stays_uncertain(monkeyp
     assert len(results) == 1
     assert not results[0].success
     assert results[0].uncertain
-    assert "сохранение не подтверждено после клика" in results[0].reason
+    # #960: the uncertain reason now carries the classifier's page-state
+    # detail (the raw Playwright timeout text goes to the dump/log instead).
+    assert "сохранение не подтверждено" in results[0].reason
+    assert "валидации не показала" in results[0].reason
     assert dumps == [0]
 
 
@@ -1686,6 +1698,224 @@ def test_edit_experience_save_redirect_with_query_suffix_is_success(monkeypatch)
     monkeypatch.setattr("hhru_bot.experience.require_authenticated_page", lambda page: None)
 
     page = _QuerySuffixNavPage(indexes=[], grow_indexes_on_reload=[2])
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan([ExperienceEntry(company="Acme", position="Engineer")]),
+        dry_run=False,
+    )
+
+    assert results == [ExperienceResult("строка 0: сохранено и привязано к резюме", True)]
+
+
+# --- #960: _expected_editor / _classify_save_outcome unit contracts ---
+
+
+class _OutcomePage:
+    """Minimal fake for the #960 classifier: only page.url and the
+    validation-error locator group matter to it."""
+
+    def __init__(self, url, error_texts=None):
+        self.url = url
+        self._error_texts = error_texts
+
+    def locator(self, selector):
+        if selector == "validation-errors":
+            return _ValidationErrorsLocator(self._error_texts or [])
+        return _Locator(count=0)
+
+
+def test_expected_editor_accepts_only_this_resumes_confirmed_shapes():
+    """#960 contract: first entry is the exact /resume/edit/{id}/experience
+    path (trailing slash tolerated), shared profile is
+    /profile/edit/experience[/{rowId}] with an empty query or exactly
+    ?resumeFrom={resume_id} (#840/#844 live shapes). Anything else — another
+    resume's editor, a foreign query — is not the confirmed editor."""
+    assert _expected_editor(_OutcomePage("/resume/edit/00001/experience"), "00001", True)
+    assert _expected_editor(_OutcomePage("/resume/edit/00001/experience/"), "00001", True)
+    assert not _expected_editor(_OutcomePage("/resume/edit/00002/experience"), "00001", True)
+    assert not _expected_editor(_OutcomePage("/resume/00001"), "00001", True)
+
+    assert _expected_editor(_OutcomePage("/profile/edit/experience"), "00001", False)
+    assert _expected_editor(
+        _OutcomePage("/profile/edit/experience?resumeFrom=00001"), "00001", False
+    )
+    assert _expected_editor(
+        _OutcomePage("/profile/edit/experience/12345?resumeFrom=00001"), "00001", False
+    )
+    # Another resume's binding (drifted tab) or a foreign query — not ours.
+    assert not _expected_editor(
+        _OutcomePage("/profile/edit/experience?resumeFrom=00002"), "00001", False
+    )
+    assert not _expected_editor(
+        _OutcomePage("/profile/edit/experience?resumeFrom=00001&foo=bar"), "00001", False
+    )
+    assert not _expected_editor(
+        _OutcomePage("/resume/edit/00001/experience?resumeFrom=00001"), "00001", False
+    )
+
+
+def test_classify_save_outcome_saved_requires_path_and_identity(monkeypatch):
+    """saved = explicit /resume/{id} path (trailing slash and query suffix do
+    not disqualify — the glob question class from PR #958 cycle 3) AND the
+    identity probe confirming this resume."""
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, rid: True)
+    assert _classify_save_outcome(
+        _OutcomePage("https://hh.ru/resume/00001?hhtmFrom=profile_experience"), "00001", True
+    ) == SaveOutcome("saved")
+    assert _classify_save_outcome(
+        _OutcomePage("https://hh.ru/resume/00001/"), "00001", False
+    ) == SaveOutcome("saved")
+    # Same path but identity not confirmed — NOT saved (uncertain upstream).
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, rid: False)
+    assert (
+        _classify_save_outcome(_OutcomePage("/resume/00001"), "00001", True).kind == "unconfirmed"
+    )
+
+
+def test_classify_save_outcome_rejected_reads_visible_validation(monkeypatch):
+    """rejected = still on the confirmed editor AND visible form-helper-error
+    texts (#959 live capture) — a definite non-mutation."""
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, rid: False)
+    monkeypatch.setattr(
+        "hhru_bot.experience.EXPERIENCE_SAVE_VALIDATION_ERRORS", "validation-errors"
+    )
+    outcome = _classify_save_outcome(
+        _OutcomePage("/resume/edit/00001/experience", error_texts=["Пожалуйста, укажите"]),
+        "00001",
+        True,
+    )
+    assert outcome.kind == "rejected"
+    assert "Пожалуйста, укажите" in outcome.detail
+
+    outcome = _classify_save_outcome(
+        _OutcomePage(
+            "/profile/edit/experience/9?resumeFrom=00001", error_texts=["Пожалуйста, укажите"]
+        ),
+        "00001",
+        False,
+    )
+    assert outcome.kind == "rejected"
+
+
+def test_classify_save_outcome_drifted_is_another_resumes_editor(monkeypatch):
+    """drifted = an experience editor route, but not the confirmed one for
+    THIS resume (the PR #958 cycle 3 drifted-retry finding)."""
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, rid: False)
+    monkeypatch.setattr(
+        "hhru_bot.experience.EXPERIENCE_SAVE_VALIDATION_ERRORS", "validation-errors"
+    )
+    outcome = _classify_save_outcome(
+        _OutcomePage("/profile/edit/experience?resumeFrom=00002"), "00001", False
+    )
+    assert outcome.kind == "drifted"
+    # The first-entry editor while saving an indexed (shared-profile) row.
+    outcome = _classify_save_outcome(_OutcomePage("/resume/edit/00001/experience"), "00001", False)
+    assert outcome.kind == "drifted"
+
+
+def test_classify_save_outcome_unconfirmed_is_everything_else(monkeypatch):
+    """unconfirmed = neither the resume page nor an experience editor (login
+    redirect, unrelated page) and also an editor whose validation read came
+    back empty — genuinely unknown outcomes."""
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, rid: False)
+    monkeypatch.setattr(
+        "hhru_bot.experience.EXPERIENCE_SAVE_VALIDATION_ERRORS", "validation-errors"
+    )
+    assert (
+        _classify_save_outcome(_OutcomePage("https://hh.ru/account/login"), "00001", True).kind
+        == "unconfirmed"
+    )
+    assert (
+        _classify_save_outcome(_OutcomePage("/applicant/resumes"), "00001", False).kind
+        == "unconfirmed"
+    )
+    # On the confirmed editor but no readable validation: unknown, uncertain.
+    outcome = _classify_save_outcome(_OutcomePage("/resume/edit/00001/experience"), "00001", True)
+    assert outcome.kind == "unconfirmed"
+    assert "валидации не показала" in outcome.detail
+
+
+# --- #960: flat bounded save loop ---
+
+
+class _DriftBeforeRetryPage(_RejectionRetryPage):
+    """The first save click is rejected (#956 wipe), but while the refill
+    runs hh.ru navigates the tab to ANOTHER resume's shared-profile editor
+    (session drift). The attempt-2 guard must cancel the re-click instead of
+    mutating whatever form is now on screen."""
+
+    def __init__(self, indexes, **kwargs):
+        super().__init__(indexes, **kwargs)
+        self._save_locator_resolutions = 0
+
+    def locator(self, selector):
+        if selector == "[data-qa='resume-partial-edit-save']":
+            self._save_locator_resolutions += 1
+            if self._save_locator_resolutions == 2:
+                # The second resolution is the retry loop re-addressing the
+                # save button on attempt 2 — by then the tab has drifted.
+                self.url = "/profile/edit/experience/9?resumeFrom=other-resume"
+        return super().locator(selector)
+
+
+def test_edit_experience_drifted_retry_cancels_second_save_click(monkeypatch):
+    """#960 mutation boundary: before the only allowed second save click the
+    loop re-confirms THIS resume's editor; a drifted tab yields one uncertain
+    and NO second click."""
+    monkeypatch.setattr("hhru_bot.experience.open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr("hhru_bot.experience.goto_hh", _fake_goto_to_edit_path)
+    monkeypatch.setattr(
+        "hhru_bot.experience.EXPERIENCE_SAVE_VALIDATION_ERRORS", "validation-errors"
+    )
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, resume_id: True)
+    monkeypatch.setattr("hhru_bot.experience.require_authenticated_page", lambda page: None)
+    dumps = []
+    monkeypatch.setattr(
+        "hhru_bot.experience._dump_experience_save_failure",
+        lambda page, index, exc: dumps.append(index),
+    )
+
+    page = _DriftBeforeRetryPage(indexes=[], reject_clicks=1)
+    results = edit_experience_on_hh(
+        page,
+        "resume-1",
+        ExperiencePlan(
+            [ExperienceEntry(company="Acme", position="Engineer", duties="Готовил хлеб")]
+        ),
+        dry_run=False,
+    )
+
+    assert page.save_clicks == 1
+    assert len(results) == 1
+    assert not results[0].success
+    assert results[0].uncertain
+    assert "повторный save отменён" in results[0].reason
+    assert dumps == [0]
+
+
+class _TrailingSlashNavPage(_SavePage):
+    """The post-save redirect lands on /resume/{id}/ (trailing slash) and the
+    wait deliberately times out — wait_for_url is only a timer (#960), the
+    classifier's explicit path comparison must still recognize the save."""
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):
+        self.url = "https://hh.ru/resume/resume-1/"
+        raise PlaywrightError(
+            f"Timeout {timeout}ms exceeded.\nwaiting for navigation to {url} until '{wait_until}'"
+        )
+
+
+def test_edit_experience_trailing_slash_redirect_is_success(monkeypatch):
+    """PR #958 review cycle 3: a "/resume/{id}/" redirect shape must not
+    false-uncertain a successful save — the classifier strips the trailing
+    slash instead of relying on glob semantics."""
+    monkeypatch.setattr("hhru_bot.experience.open_confirmed_resume", lambda page, resume_id: None)
+    monkeypatch.setattr("hhru_bot.experience.goto_hh", _fake_goto_to_edit_path)
+    monkeypatch.setattr("hhru_bot.experience.resume_identity_matches", lambda page, resume_id: True)
+    monkeypatch.setattr("hhru_bot.experience.require_authenticated_page", lambda page: None)
+
+    page = _TrailingSlashNavPage(indexes=[], grow_indexes_on_reload=[2])
     results = edit_experience_on_hh(
         page,
         "resume-1",

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1758,6 +1758,11 @@ def test_expected_editor_accepts_only_this_resumes_confirmed_shapes():
     # confirmed editor — the gate of the second save click must reject them.
     assert not _expected_editor(_OutcomePage("/profile/edit/experience-notes"), "00001", False)
     assert not _expected_editor(_OutcomePage("/profile/edit/experience/123/extra"), "00001", False)
+    # Shorter unrelated paths slice to an empty remainder past the base
+    # (#960 review, round 2): without the explicit prefix check, "/login"
+    # with its empty query would pass as the base shared-profile editor.
+    assert not _expected_editor(_OutcomePage("/login"), "00001", False)
+    assert not _expected_editor(_OutcomePage("/profile/edit"), "00001", False)
 
 
 def test_classify_save_outcome_saved_requires_path_and_identity(monkeypatch):

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1728,21 +1728,27 @@ class _OutcomePage:
 def test_expected_editor_accepts_only_this_resumes_confirmed_shapes():
     """#960 contract: first entry is the exact /resume/edit/{id}/experience
     path (trailing slash tolerated), shared profile is
-    /profile/edit/experience[/{rowId}] with an empty query or exactly
+    /profile/edit/experience[/{rowId}] carrying exactly
     ?resumeFrom={resume_id} (#840/#844 live shapes). Anything else — another
-    resume's editor, a foreign query — is not the confirmed editor."""
+    resume's editor, an empty query, a foreign query — is not the confirmed
+    editor."""
     assert _expected_editor(_OutcomePage("/resume/edit/00001/experience"), "00001", True)
     assert _expected_editor(_OutcomePage("/resume/edit/00001/experience/"), "00001", True)
     assert not _expected_editor(_OutcomePage("/resume/edit/00002/experience"), "00001", True)
     assert not _expected_editor(_OutcomePage("/resume/00001"), "00001", True)
 
-    assert _expected_editor(_OutcomePage("/profile/edit/experience"), "00001", False)
     assert _expected_editor(
         _OutcomePage("/profile/edit/experience?resumeFrom=00001"), "00001", False
     )
     assert _expected_editor(
         _OutcomePage("/profile/edit/experience/12345?resumeFrom=00001"), "00001", False
     )
+    # An empty query carries no resume-specific signal — the same URL may be
+    # showing ANOTHER resume's editor (#787 live capture: hh.ru drops
+    # resumeFrom exactly when no binding is established; #960 review,
+    # round 3). It must never gate the retry click.
+    assert not _expected_editor(_OutcomePage("/profile/edit/experience"), "00001", False)
+    assert not _expected_editor(_OutcomePage("/profile/edit/experience/12345"), "00001", False)
     # Another resume's binding (drifted tab) or a foreign query — not ours.
     assert not _expected_editor(
         _OutcomePage("/profile/edit/experience?resumeFrom=00002"), "00001", False
@@ -1818,6 +1824,10 @@ def test_classify_save_outcome_drifted_is_another_resumes_editor(monkeypatch):
     outcome = _classify_save_outcome(
         _OutcomePage("/profile/edit/experience?resumeFrom=00002"), "00001", False
     )
+    assert outcome.kind == "drifted"
+    # Empty-query shared editor: no resume-specific signal (#787 live drop,
+    # #960 review round 3) — could be any resume's editor, never ours.
+    outcome = _classify_save_outcome(_OutcomePage("/profile/edit/experience"), "00001", False)
     assert outcome.kind == "drifted"
     # The first-entry editor while saving an indexed (shared-profile) row.
     outcome = _classify_save_outcome(_OutcomePage("/resume/edit/00001/experience"), "00001", False)

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1753,6 +1753,11 @@ def test_expected_editor_accepts_only_this_resumes_confirmed_shapes():
     assert not _expected_editor(
         _OutcomePage("/resume/edit/00001/experience?resumeFrom=00001"), "00001", False
     )
+    # Path-segment boundary (#960 review): a similarly named sibling route
+    # and a deeper-than-{rowId} path share the prefix but are not the
+    # confirmed editor — the gate of the second save click must reject them.
+    assert not _expected_editor(_OutcomePage("/profile/edit/experience-notes"), "00001", False)
+    assert not _expected_editor(_OutcomePage("/profile/edit/experience/123/extra"), "00001", False)
 
 
 def test_classify_save_outcome_saved_requires_path_and_identity(monkeypatch):


### PR DESCRIPTION
## Summary

Рефакторинг confirm-save блока `edit_experience_on_hh` по ишью #960 (4 находки из 3 циклов ревью PR #958 — варианты одного корня: инвариант мутации не виден локально во вложенном `try/except/while`).

### Что изменилось

1. **`_expected_editor(page, resume_id, first_entry) -> bool`** — предикат «мы на подтверждённой форме ЭТОГО резюме»:
   - first-entry: точное сравнение пути с `/resume/edit/{resume_id}/experience` (rstrip `/`);
   - shared-profile: путь `/profile/edit/experience[/{rowId}]` И query ровно `resumeFrom={resume_id}` — пустой query убран по round 3 ревью: он не несёт resume-специфичного сигнала (#787 live: параметр роняется ровно когда привязки нет), оба code-driven входа (#840/#844) его всегда несут.
   Переиспользован также в существующей проверке открытия first-entry формы.

2. **`SaveOutcome` (frozen dataclass) + `_classify_save_outcome(page, resume_id, first_entry)`** — классификация исхода клика:
   - `saved` — путь `/resume/{resume_id}` (rstrip `/`) И `resume_identity_matches`;
   - `rejected` — подтверждённый редактор + видимые тексты `EXPERIENCE_SAVE_VALIDATION_ERRORS` (переиспользует `_read_save_validation_errors`);
   - `drifted` — experience-редактор, но не нашего резюме;
   - `unconfirmed` — всё прочее.
   Явное сравнение путей вместо glob снимает класс вопросов «`*` vs `**` vs trailing slash» (DEFERRED-находка cycle 3 про `/resume/{id}/`).

3. **Плоский bounded-цикл** вместо вложенного `try/except/while`: `for attempt in (1, 2)`, максимум 2 клика. Перед КАЖДЫМ кликом (включая повторный) — re-check `_expected_editor`: граница мутации — одна видимая строка `save.click()` (DEFERRED-находка cycle 3 про drifted-retry). `wait_for_url` теперь только bounded-таймер (глоб `**/resume/{id}**` — матчит query-суффикс и trailing slash), вердикт — у классификатора.

4. **`resume_education.py`**: тот же post-save glob `*` → `**` (односимвольно). Глубокая унификация с experience не делалась (принцип максимальной простоты, формы разные). Опциональный identity-fallback после таймаута НЕ добавлен: post-save marker-wait + `resume_identity_matches` уже дают тот же результат (SPA-pushState кейс покрыт), лишних 5 строк ради недостижимого окна не заводил.

### Ledger-семантика — не менялась

saved → прежняя binding-верификация (reload + identity + рост строк для first_entry) → success / uncertain / failed; rejected после refill-retry → `failed` (retryable, без uncertain-замка); refill не удержал значение → `failed` до второго клика; refill-исключение → `uncertain`; drifted/unconfirmed → `uncertain` + dump; save-кнопка не подтверждена → `failed`. Fail-closed не ослаблен: reject-classification по-прежнему только при видимых текстах валидации на подтверждённом редакторе.

### Тесты

- unit на каждый kind `_classify_save_outcome` (saved — включая trailing slash/query-суффикс и требование identity; rejected на обеих shape редактора; drifted — чужой `resumeFrom` и first-entry редактор при правке indexed-строки; unconfirmed — логин/другая страница/редактор без читаемой валидации);
- unit на `_expected_editor` (обе shape + отказы: чужой resume_id, чужой/лишний query);
- drift-guard: retry отменяется `uncertain`, второй клик НЕ выполняется (`save_clicks == 1`);
- retry: успех после refill (2 клика), второе отклонение → финальный failed (2 дампа), refill-исключение → uncertain;
- trailing-slash редирект = success (wait_for_url в фикстуре специально падает по таймауту — классификатор всё равно признаёт saved);
- существующие retry-тесты #956/#959 перенесены на новый цикл (сценарии те же; фейки `wait_for_url` теперь моделируют навигацию — классификатор читает `page.url`).

### Проверено локально

- `ruff check src tests` — чисто;
- `ruff format --check src tests` — чисто;
- полный `pytest`: **3328 passed, 2 skipped, 3 deselected**.

### Известные ограничения

- По гейту ишью «после рефакторинга обязателен новый боевой прогон» (create черновика → edit-experience → привязка): в этой задаче живые прогоны не выполнялись (тесты на моках) — прогон перед мерджем остаётся за владельцем; прежний зелёный прогон от 2026-09-04 валидировал до-рефакторную структуру.
- CLI-текст двух uncertain-причин изменился под формат классификатора («сохранение не подтверждено: {detail}» — теперь содержит состояние страницы; сырой текст таймаута Playwright уходит в дамп/лог). Ledger-распределение исходов не изменилось.

Closes #960
