### PR TITLE
create-resume/resume-position: pre-flight сверка профессии с live-каталогом до мутации

### DIFF
--- a/src/hhru_bot/catalog_preflight.py
+++ b/src/hhru_bot/catalog_preflight.py
@@ -1,0 +1,119 @@
+"""Pre-flight сверка профессии с live-каталогом ДО мутирующего клика (#950).
+
+Боевой кейс 2026-09-03 («Хирург»): имена автоподсказок title-поля визарда и
+имена листов дерева — разные каталоги, и CLI узнавал об этом только после
+сожжённого боевого прогона. Модуль держит чистую сверку «запрос -> листы» и
+read-only browser-обёртку для create-resume: фильтр каталога поиска вакансий
+открывается и читается ДО входа в визард (id-пространство дерева модалки
+совпадает с каталогом поиска вакансий, #913), поэтому отказ «листа нет в
+каталоге» наступает до первого мутирующего клика и перечисляет листы, которые
+фильтр реально предлагает (принцип #836). Источник истины — live-каталог;
+полный офлайн-справочник собирает `hhru professional-roles --refresh`
+(кэш — только для диагностики/поиска, не для решения о записи).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from playwright.sync_api import Page
+
+from .create_resume import OTHER_ROLE_LABEL
+from .external_forms.detect import normalize
+from .professional_roles import search_professional_roles
+
+# #920 (боевой прогон «Логопед» 2026-09-02): фильтр дерева hh.ru НЕСТАБИЛЕН —
+# на один и тот же запрос боевой прогон получал ровно «Другое», а повтор тем же
+# кодом — точный лист. Пустой/вырожденный ответ фильтра переспрашивается один
+# раз (полный повтор fill + опроса), прежде чем стать отказом; при стабильном
+# отсутствии профессии повтор возвращает тот же результат, fail-closed не
+# ослабляется.
+_AREA_FILTER_ATTEMPTS = 2
+
+
+@dataclass(frozen=True)
+class LeafEvaluation:
+    """Результат сверки одного запроса с перечнем листов live-каталога.
+
+    ``exact`` — есть нормализованное точное совпадение; ``candidates`` —
+    ближайшие листы для отказа, ведущего к цели (перезапуск с первого раза
+    по реальному имени листа): и листы, содержащие запрос («Плотник» ->
+    «Столяр, плотник», направление гарда #920), и листы, содержащиеся в
+    запросе («Врач-хирург» -> «Врач», боевой кейс #950 — узкое имя есть в
+    подсказках, а в дереве только общее). Плейсхолдер «Другое» кандидатом
+    никогда не является — это вырожденный catch-all, выбор которого решается
+    явным флагом вызывающей команды, а не подбором.
+    """
+
+    value: str
+    exact: bool
+    candidates: tuple[str, ...]
+
+
+def evaluate_leaf(value: str, available: Iterable[str]) -> LeafEvaluation:
+    """Сверить запрос с перечнем листов: точное совпадение + подстрока-кандидаты."""
+    unique = list(dict.fromkeys(label.strip() for label in available if label.strip()))
+    query = normalize(value)
+    exact = bool(query) and any(normalize(label) == query for label in unique)
+    candidates = tuple(
+        label
+        for label in unique
+        if query
+        and normalize(label) != normalize(OTHER_ROLE_LABEL)
+        and (query in normalize(label) or normalize(label) in query)
+    )
+    return LeafEvaluation(value=value, exact=exact, candidates=candidates)
+
+
+def format_candidates(evaluation: LeafEvaluation) -> str:
+    """Человекочитаемый перечень альтернатив для отказа по листу."""
+    if evaluation.candidates:
+        return "ближайшие доступные листы: " + "; ".join(evaluation.candidates)
+    return "совпадений по подстроке не найдено"
+
+
+@dataclass(frozen=True)
+class PreflightOutcome:
+    """Итог pre-flight сверки: проход (возможно с предупреждением) или отказ."""
+
+    ok: bool
+    message: str
+
+
+def preflight_area(
+    page: Page, area: str, *, allow_unresolved_area: bool = False
+) -> PreflightOutcome:
+    """Read-only сверка ``--area`` с live-каталогом поиска вакансий до визарда.
+
+    Открывает фильтр профессий ``/search/vacancy`` (goto + ввод в поисковую
+    строку модалки, ничего не выбирается и не сохраняется — граница
+    «Чтение состояния») и проверяет, что фильтр по ``area`` отвечает
+    точным листом. Отказ перечисляет предложенные листы; вырождение фильтра
+    в пустоту/«Другое» переспрашивается (:data:`_AREA_FILTER_ATTEMPTS`).
+    ``allow_unresolved_area`` не отменяет чтение: при отсутствии листа это
+    проход с предупреждением, а не молчаливое согласие.
+    """
+    evaluation = LeafEvaluation(value=area, exact=False, candidates=())
+    offered: list[str] = []
+    for _ in range(_AREA_FILTER_ATTEMPTS):
+        roles = search_professional_roles(page, [area])
+        evaluation = evaluate_leaf(area, (role.label for role in roles))
+        if evaluation.exact:
+            return PreflightOutcome(True, "")
+        offered = [role.label for role in roles if role.label != OTHER_ROLE_LABEL]
+        if offered:
+            break
+        # Фильтр не вернул содержательных листов (пусто или только «Другое») —
+        # известная нестабильность #920; переспрашиваем, при повторе — отказ.
+    message = (
+        f"профессия «{area}» не найдена в live-каталоге поиска вакансий "
+        f"(сверка до входа в визард, #950); {format_candidates(evaluation)}. "
+        'Полный справочник: hhru professional-roles --refresh, затем --query "подстрока".'
+    )
+    if allow_unresolved_area:
+        return PreflightOutcome(True, f"{message} Будет выбрана роль-плейсхолдер «Другое» (id 40).")
+    return PreflightOutcome(
+        False,
+        f"{message} Повторите с точным именем листа или используйте --allow-unresolved-area.",
+    )

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -93,6 +93,23 @@ def run(args: argparse.Namespace):
             with launch_context(
                 config.storage_state_file, headless=args.headless, user_agent=config.user_agent
             ) as context:
+                page = context.new_page()
+                # #950: сверка area с live-каталогом поиска вакансий ДО входа в
+                # визард — отказ наступает до любого клика (первый NEXT может
+                # материализовать фантом-черновик, #936) и перечисляет листы,
+                # которые фильтр реально предлагает. Чтение read-only.
+                from ..catalog_preflight import preflight_area
+
+                outcome = preflight_area(
+                    page,
+                    args.area,
+                    allow_unresolved_area=getattr(args, "allow_unresolved_area", False),
+                )
+                if not outcome.ok:
+                    print(f"[FAIL] {outcome.message}")
+                    return True
+                if outcome.message:
+                    print(f"[WARN] {outcome.message}")
                 create_kwargs = {
                     "area": args.area,
                     "title": args.title,
@@ -101,7 +118,7 @@ def run(args: argparse.Namespace):
                 }
                 if getattr(args, "allow_unresolved_area", False):
                     create_kwargs["allow_unresolved_area"] = True
-                result = create_resume_on_hh(context.new_page(), **create_kwargs)
+                result = create_resume_on_hh(page, **create_kwargs)
         except BaseException as exc:
             if attempt is not None:
                 attempt.interrupt(exc)

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -139,7 +139,7 @@ def _click_save_and_wait(page) -> None:
 
 def _run(args: argparse.Namespace, progress) -> bool:
     from ..ai.llm_client import LLMClient
-    from ..browser import BrowserLaunchError, launch_context
+    from ..browser import HH_BASE_URL, BrowserLaunchError, goto_hh, launch_context
     from ..config import ConfigError, load_config_or_exit
     from ..resume_position import (
         CANCEL,
@@ -362,6 +362,23 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     queries=classification_queries,
                 )
             if args.dry_run:
+                # #950: dry-run editor-пути сверяет --specialization с живым
+                # деревом резюме ДО записи — отказ перечисляет листы, которые
+                # дерево реально отрисовало. Отказ и здесь, и в боевом пути
+                # наступает до клика сохранения.
+                refusals: list[str] = []
+                if not wizard and plan.specializations:
+                    from ..resume_position import validate_specializations_against_tree
+
+                    refusals = validate_specializations_against_tree(page, plan.specializations)
+                    # Панель выбора закрывается уходом со страницы: submit не
+                    # нажат, pending-правки отбрасываются; CANCEL под оверлеем
+                    # открытой панели недостижим.
+                    goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
+                if refusals:
+                    for refusal in refusals:
+                        print(f"[FAIL] {refusal}")
+                    return True
                 if not wizard:
                     page.locator(CANCEL).click()
                 print("[INFO] Ничего не записано на hh.ru.")

--- a/src/hhru_bot/professional_roles.py
+++ b/src/hhru_bot/professional_roles.py
@@ -633,12 +633,26 @@ def search_professional_roles(page: Page, queries: list[str]) -> list[Profession
 
 
 def resolve_explicit_role(page: Page, label: str) -> ProfessionalRole:
+    from .create_resume import OTHER_ROLE_LABEL
+
     roles = search_professional_roles(page, [label])
     matches = [role for role in roles if normalize(role.label) == normalize(label)]
     if len(matches) != 1:
+        # #950: отказ ведёт к цели — перечисляем, что фильтр реально предложил
+        # по запросу (принцип #836), чтобы перезапуск был точным с первого раза.
+        # «Другое» предложением не является: точный save по плейсхолдеру —
+        # отказ по дизайну (#913), а не повторная цель.
+        offered = list(
+            dict.fromkeys(
+                role.label
+                for role in roles
+                if role.label != OTHER_ROLE_LABEL and normalize(role.label) != normalize(label)
+            )
+        )
+        detail = f"; фильтр предлагает: {'; '.join(offered)}" if offered else ""
         raise RuntimeError(
             f"профессия «{label}» не найдена однозначно в live-каталоге поиска вакансий "
-            f"(совпадений: {len(matches)})"
+            f"(совпадений: {len(matches)}){detail}"
         )
     return matches[0]
 

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -30,6 +30,7 @@ from .browser import (
     require_authenticated_page,
     resume_identity_matches,
 )
+from .catalog_preflight import evaluate_leaf, format_candidates
 from .config import ResumeConfig
 from .create_resume import OTHER_ROLE_LABEL, select_wizard_catalog_leaf
 from .logging_setup import LOG_DIR
@@ -1043,6 +1044,74 @@ def _pick_specialization(page: Page, search: Locator, value: str) -> None:
     option.first.click()
 
 
+def _read_specialization_labels(page: Page) -> list[str]:
+    """Labels of the specialization rows currently rendered in the open modal."""
+    try:
+        texts = page.locator(SPECIALIZATION_OPTION).all_inner_texts()
+    except PlaywrightError:
+        # Перерендер дерева между итерациями опроса отсоединяет хэндлы — сигнал
+        # повторить чтение (тот же принцип, что batch-снимок дерева в
+        # select_wizard_catalog_leaf), а не финальная ошибка.
+        return []
+    return [" ".join(text.split()) for text in texts if text.strip()]
+
+
+def _poll_specialization_labels(page: Page) -> list[str]:
+    """Два равных подряд снимка отфильтрованного дерева — консистентное чтение.
+
+    search.fill() запускает асинхронный React-ре-рендер отфильтрованного
+    дерева (#822): одиночное чтение видит либо прежнее (нефильтрованное)
+    дерево, либо недостроенный пустой список. Решение принимается только по
+    стабильному снимку (тот же принцип, что _poll_suggestion_texts в
+    create_resume); дедлайн — inline ``_CONTROL_WAIT_TIMEOUT_MS``.
+    """
+    deadline = time.monotonic() + _CONTROL_WAIT_TIMEOUT_MS / 1000
+    previous: list[str] | None = None
+    while True:
+        labels = _read_specialization_labels(page)
+        if labels == previous:
+            return labels
+        previous = labels
+        if time.monotonic() >= deadline:
+            return labels
+        page.wait_for_timeout(250)
+
+
+def validate_specializations_against_tree(page: Page, values: list[str]) -> list[str]:
+    """Read-only dry-run сверка специализаций с живым деревом резюме (#950).
+
+    Открывает панель выбора специализаций (единственный read-only клик по
+    ADD — панель выбора, не DELETE и не submit), читает дерево, отфильтрованное
+    каждым значением, и возвращает отказы для значений, которые дерево не
+    рендерит точным листом; отказ перечисляет реально предложенные листы.
+    Выход из экрана — обязанность вызывающего (уход со страницы или CANCEL,
+    никогда не submit). Боевой путь валидирует сам факт клика по листу в
+    ``_pick_specialization`` — здесь та же строгость, перенесённая до записи.
+    """
+    if page.locator(SPECIALIZATION_ADD).count() != 1:
+        raise RuntimeError("селектор добавления специализации не подтверждён")
+    page.locator(SPECIALIZATION_ADD).click()
+    modal = page.locator(SPECIALIZATION_MODAL)
+    try:
+        modal.first.wait_for(state="visible", timeout=_CONTROL_WAIT_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        raise RuntimeError("панель выбора специализаций не открылась") from exc
+    search = page.locator(SPECIALIZATION_SEARCH)
+    if search.count() != 1:
+        raise RuntimeError("селектор панели специализаций не подтверждён")
+
+    refusals: list[str] = []
+    for value in values:
+        search.fill(value)
+        evaluation = evaluate_leaf(value, _poll_specialization_labels(page))
+        if not evaluation.exact:
+            refusals.append(
+                "специализация не найдена в дереве резюме "
+                f"(dry-run сверка до записи, #950): {value}; {format_candidates(evaluation)}"
+            )
+    return refusals
+
+
 def _set_specializations(page: Page, values: list[str], fallback_other: bool = False) -> None:
     """Replace specializations through the confirmed nested tree selector."""
     if page.locator(SPECIALIZATION_ADD).count() != 1:
@@ -1084,7 +1153,14 @@ def _set_specializations(page: Page, values: list[str], fallback_other: bool = F
                 )
                 _pick_specialization(page, search, OTHER_ROLE_LABEL)
             else:
-                raise RuntimeError(f"специализация не найдена в дереве резюме: {value}") from exc
+                # #950: панель ещё открыта — читаем, что дерево реально
+                # предлагает по запросу, чтобы отказ вёл к точному повтору
+                # (принцип #836), а не к перебору вслепую.
+                evaluation = evaluate_leaf(value, _poll_specialization_labels(page))
+                raise RuntimeError(
+                    f"специализация не найдена в дереве резюме: {value}; "
+                    f"{format_candidates(evaluation)}"
+                ) from exc
 
     submit.click()
     # Waiting for the option itself is insufficient: hh.ru keeps the panel

--- a/tests/test_catalog_preflight.py
+++ b/tests/test_catalog_preflight.py
@@ -1,0 +1,161 @@
+"""Чистая сверка листов и read-only pre-flight --area (#950)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import hhru_bot.catalog_preflight as module
+from hhru_bot.catalog_preflight import (
+    PreflightOutcome,
+    evaluate_leaf,
+    format_candidates,
+    preflight_area,
+)
+from hhru_bot.professional_roles import ProfessionalRole
+
+pytestmark = pytest.mark.unit
+
+
+def test_evaluate_leaf_accepts_normalized_exact_match():
+    evaluation = evaluate_leaf("  Врач ", ["Ассистент врача", "Врач", "Другое"])
+
+    assert evaluation.exact is True
+
+
+def test_evaluate_leaf_missing_leaf_collects_substring_candidates():
+    evaluation = evaluate_leaf("врач", ["Ассистент врача", "Ветеринарный врач", "Бухгалтер"])
+
+    assert evaluation.exact is False
+    assert evaluation.candidates == ("Ассистент врача", "Ветеринарный врач")
+
+
+def test_evaluate_leaf_matches_leaf_contained_in_query():
+    """Боевой кейс #950: запрос «Врач-хирург», а в дереве только общий «Врач»."""
+    evaluation = evaluate_leaf("Врач-хирург", ["Врач", "Ветеринарный врач"])
+
+    assert evaluation.exact is False
+    # «Ветеринарный врач» не совпадает с запросом ни по одной подстроке.
+    assert evaluation.candidates == ("Врач",)
+
+
+def test_evaluate_leaf_deduplicates_and_keeps_first_order():
+    evaluation = evaluate_leaf(
+        "менеджер",
+        [
+            "Менеджер по продажам, менеджер по работе с клиентами",
+            "Менеджер по продажам, менеджер по работе с клиентами",
+            "Менеджер по закупкам",
+        ],
+    )
+
+    assert evaluation.candidates == (
+        "Менеджер по продажам, менеджер по работе с клиентами",
+        "Менеджер по закупкам",
+    )
+
+
+def test_evaluate_leaf_never_offers_placeholder_as_candidate():
+    """«Другое» — вырожденный catch-all: перезапуск по нему невозможен (#913)."""
+    evaluation = evaluate_leaf("хирург", ["Другое", "Врач"])
+
+    assert evaluation.exact is False
+    assert "Другое" not in evaluation.candidates
+    assert evaluation.candidates == ()
+
+
+def test_evaluate_leaf_exact_placeholder_is_still_exact():
+    """Явный запрос «Другое» — точный лист: авто-отказ на нём был бы ложным."""
+    assert evaluate_leaf("другое", ["Другое"]).exact is True
+
+
+def test_format_candidates_lists_or_reports_empty():
+    listed = format_candidates(evaluate_leaf("врач", ["Врач", "Ассистент врача"]))
+    empty = format_candidates(evaluate_leaf("хирург", ["Другое"]))
+
+    assert listed == "ближайшие доступные листы: Врач; Ассистент врача"
+    assert empty == "совпадений по подстроке не найдено"
+
+
+def test_preflight_area_exact_leaf_passes_silently(monkeypatch):
+    seen: dict[str, object] = {}
+
+    def fake_search(page, queries):
+        seen["queries"] = queries
+        return [ProfessionalRole("148", "Врач", "Медицина")]
+
+    monkeypatch.setattr(module, "search_professional_roles", fake_search)
+
+    outcome = preflight_area(SimpleNamespace(), "Врач")
+
+    assert outcome == PreflightOutcome(True, "")
+    assert seen["queries"] == ["Врач"]
+
+
+def test_preflight_area_missing_leaf_refuses_with_candidates(monkeypatch):
+    monkeypatch.setattr(
+        module,
+        "search_professional_roles",
+        lambda page, queries: [
+            ProfessionalRole("148", "Врач", "Медицина"),
+            ProfessionalRole("149", "Ассистент врача", "Медицина"),
+            ProfessionalRole("40", "Другое", "Медицина"),
+        ],
+    )
+
+    outcome = preflight_area(SimpleNamespace(), "Врач-хирург")
+
+    assert outcome.ok is False
+    assert "не найдена в live-каталоге" in outcome.message
+    # «Ассистент врача» не содержится в запросе ни в одну сторону — в перечень
+    # попадает только лист «Врач», содержащийся в запросе целиком (#950).
+    assert "ближайшие доступные листы: Врач" in outcome.message
+    assert "Ассистент врача" not in outcome.message
+    assert "Другое" not in outcome.message
+    assert "--allow-unresolved-area" in outcome.message
+
+
+def test_preflight_area_placeholder_only_filter_retries_then_refuses(monkeypatch):
+    """Нестабильность фильтра #920: вырожденный ответ переспрашивается один раз."""
+    calls: list[list[str]] = []
+
+    def fake_search(page, queries):
+        calls.append(list(queries))
+        return [ProfessionalRole("40", "Другое", "Медицина")]
+
+    monkeypatch.setattr(module, "search_professional_roles", fake_search)
+
+    outcome = preflight_area(SimpleNamespace(), "Врач-хирург")
+
+    assert calls == [["Врач-хирург"], ["Врач-хирург"]]
+    assert outcome.ok is False
+    assert "совпадений по подстроке не найдено" in outcome.message
+
+
+def test_preflight_area_second_attempt_finds_leaf(monkeypatch):
+    responses: list[list[ProfessionalRole]] = [
+        [ProfessionalRole("40", "Другое", "Медицина")],
+        [ProfessionalRole("148", "Врач", "Медицина")],
+    ]
+
+    def fake_search(page, queries):
+        return responses.pop(0)
+
+    monkeypatch.setattr(module, "search_professional_roles", fake_search)
+
+    assert preflight_area(SimpleNamespace(), "Врач").ok is True
+
+
+def test_preflight_area_allow_unresolved_passes_with_warning(monkeypatch):
+    monkeypatch.setattr(
+        module,
+        "search_professional_roles",
+        lambda page, queries: [ProfessionalRole("148", "Врач", "Медицина")],
+    )
+
+    outcome = preflight_area(SimpleNamespace(), "Врач-хирург", allow_unresolved_area=True)
+
+    assert outcome.ok is True
+    assert "[WARN]" not in outcome.message
+    assert "«Другое» (id 40)" in outcome.message

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -12,6 +12,7 @@ import pytest
 import hhru_bot.browser
 import hhru_bot.commands.create_resume as cmd
 import hhru_bot.create_resume
+from hhru_bot.catalog_preflight import PreflightOutcome
 from hhru_bot.create_resume import CreateResumeResult
 from hhru_bot.history import History
 
@@ -28,6 +29,7 @@ def _args(tmp_path, **overrides):
         title="Backend developer",
         force=False,
         dry_run=False,
+        allow_unresolved_area=False,
     )
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -47,7 +49,15 @@ def env(monkeypatch, tmp_path):
     monkeypatch.setattr(hhru_bot.browser, "launch_context", launch)
     state = SimpleNamespace(result=CreateResumeResult(True, NEW_ID, "черновик создан"), calls=[])
 
-    def create(page, *, area, title, dry_run, before_click=None):
+    # #950: pre-flight сверка area с live-каталогом — на двойнике проход без
+    # предупреждения; конкретные refusal-сценарии — в тестах ниже и в
+    # test_catalog_preflight.py.
+    monkeypatch.setattr(
+        "hhru_bot.catalog_preflight.preflight_area",
+        lambda page, area, *, allow_unresolved_area=False: PreflightOutcome(True, ""),
+    )
+
+    def create(page, *, area, title, dry_run, before_click=None, allow_unresolved_area=False):
         state.calls.append((area, title, dry_run))
         if not dry_run and (state.result.success or state.result.uncertain):
             before_click()
@@ -63,6 +73,56 @@ def test_dry_run_is_default_and_does_not_prompt(env, tmp_path, capsys, monkeypat
     output = capsys.readouterr().out
     assert "[DRY-RUN]" in output
     assert env.calls == [("it", "Backend developer", True)]
+
+
+def test_preflight_refusal_blocks_wizard_in_live_run(env, tmp_path, capsys, monkeypatch):
+    """#950: отказ по area наступает до входа в визард — create не вызывается."""
+    monkeypatch.setattr(
+        "hhru_bot.catalog_preflight.preflight_area",
+        lambda page, area, *, allow_unresolved_area=False: PreflightOutcome(
+            False,
+            "профессия «Хирург» не найдена в live-каталоге; ближайшие доступные "
+            "листы: Врач. Повторите с точным именем листа.",
+        ),
+    )
+
+    assert cmd.run(_args(tmp_path, force=True)) is True
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "Хирург" in out
+    assert "Врач" in out
+    assert env.calls == []
+
+
+def test_preflight_refusal_blocks_dry_run_before_wizard(env, tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(
+        "hhru_bot.catalog_preflight.preflight_area",
+        lambda page, area, *, allow_unresolved_area=False: PreflightOutcome(
+            False, "профессия не найдена в live-каталоге"
+        ),
+    )
+
+    assert cmd.run(_args(tmp_path, dry_run=True)) is True
+
+    assert "[FAIL]" in capsys.readouterr().out
+    assert env.calls == []
+
+
+def test_preflight_allow_mode_passes_with_warning(env, tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(
+        "hhru_bot.catalog_preflight.preflight_area",
+        lambda page, area, *, allow_unresolved_area=False: PreflightOutcome(
+            True, "профессия не найдена; будет выбрана роль-плейсхолдер «Другое» (id 40)."
+        ),
+    )
+
+    assert cmd.run(_args(tmp_path, force=True, allow_unresolved_area=True)) is False
+
+    out = capsys.readouterr().out
+    assert "[WARN]" in out
+    assert "«Другое» (id 40)" in out
+    assert env.calls == [("it", "Backend developer", False)]
 
 
 def test_force_prints_yaml_but_does_not_modify_config(env, tmp_path, capsys):

--- a/tests/test_professional_roles.py
+++ b/tests/test_professional_roles.py
@@ -74,6 +74,23 @@ def test_resolve_explicit_role_rejects_duplicate_labels(monkeypatch):
         resolve_explicit_role(MagicMock(), "Аналитик")
 
 
+def test_resolve_explicit_role_missing_leaf_lists_offered_labels(monkeypatch):
+    """#950: отказ ведёт к цели — перечень листов, предложенных фильтром."""
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.search_professional_roles",
+        lambda page, queries: [
+            ProfessionalRole("148", "Врач", "Медицина"),
+            ProfessionalRole("40", "Другое", "Медицина"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="фильтр предлагает: Врач$") as exc_info:
+        resolve_explicit_role(MagicMock(), "Врач-хирург")
+
+    # «Другое» — плейсхолдер, а не повторная цель (#913): в перечне его нет.
+    assert "Другое" not in str(exc_info.value)
+
+
 def _catalog(*, fetched_at: datetime | None = None) -> VacancySearchRoleCatalog:
     return VacancySearchRoleCatalog(
         fetched_at=fetched_at or datetime(2026, 8, 24, tzinfo=UTC),

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -90,3 +90,57 @@ def test_resume_catalog_rejects_non_leaf_or_missing_specialization(monkeypatch, 
     finally:
         browser.close()
         playwright.stop()
+
+
+@pytest.mark.browser_unit
+def test_set_specializations_missing_leaf_refusal_lists_visible_candidates(monkeypatch):
+    """#950: отказ при отсутствии листа перечисляет, что дерево реально
+    отрисовало по фильтру, — перезапуск с первого раза, а не перебор."""
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    playwright, browser, page = _page()
+    try:
+        page.locator(resume_position.SPECIALIZATION_ADD).click()
+        with pytest.raises(RuntimeError) as exc_info:
+            resume_position._set_specializations(page, ["Менеджер"])
+        message = str(exc_info.value)
+        assert "специализация не найдена в дереве резюме: Менеджер" in message
+        assert "ближайшие доступные листы: " in message
+        assert "Менеджер по продажам, менеджер по работе с клиентами" in message
+    finally:
+        browser.close()
+        playwright.stop()
+
+
+@pytest.mark.browser_unit
+def test_validate_specializations_confirms_exact_leaf_without_submit(monkeypatch):
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    playwright, browser, page = _page()
+    try:
+        refusals = resume_position.validate_specializations_against_tree(
+            page, ["Водитель, экспедитор"]
+        )
+
+        assert refusals == []
+        # Панель не сабмитится: submit остаётся на месте, выбор не применён.
+        assert page.locator(resume_position.SPECIALIZATION_MODAL).is_visible()
+    finally:
+        browser.close()
+        playwright.stop()
+
+
+@pytest.mark.browser_unit
+def test_validate_specializations_refusal_lists_filtered_candidates(monkeypatch):
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    playwright, browser, page = _page()
+    try:
+        refusals = resume_position.validate_specializations_against_tree(
+            page, ["Менеджер", "Водитель, экспедитор"]
+        )
+
+        assert len(refusals) == 1
+        assert "Менеджер" in refusals[0]
+        assert "ближайшие доступные листы: " in refusals[0]
+        assert "Менеджер по продажам, менеджер по работе с клиентами" in refusals[0]
+    finally:
+        browser.close()
+        playwright.stop()

--- a/tests/test_resume_position_command.py
+++ b/tests/test_resume_position_command.py
@@ -81,6 +81,16 @@ def env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(hhru_bot.browser, "launch_context", fake_launch)
 
+    # #950: dry-run editor-пути валидирует --specialization по живому дереву —
+    # на двойнике проход; refusal-сценарии переопределяют в тестах ниже.
+    validated: list[list[str]] = []
+    monkeypatch.setattr(
+        hhru_bot.resume_position,
+        "validate_specializations_against_tree",
+        lambda page, values: (validated.append(list(values)), [])[1],
+    )
+    monkeypatch.setattr(hhru_bot.browser, "goto_hh", lambda page, url: None)
+
     # Editor-режим с текущим заголовком «QA»: ручной --title без LLM.
     flow = SimpleNamespace(
         kind="editor",
@@ -93,7 +103,7 @@ def env(monkeypatch, tmp_path):
         "open_position_form",
         lambda page, resume, enter_wizard=True: flow,
     )
-    return SimpleNamespace(clicks=clicks)
+    return SimpleNamespace(clicks=clicks, validated=validated)
 
 
 def test_duplicate_title_refused_before_save(env, capsys, tmp_path, monkeypatch):
@@ -209,3 +219,68 @@ def test_editor_dry_run_without_title_keeps_honest_none(env, capsys, tmp_path, m
     out = capsys.readouterr().out
     assert "title: None" in out
     assert "[INFO] Ничего не записано на hh.ru." in out
+
+
+def test_editor_dry_run_validates_specializations_against_tree(env, capsys, tmp_path):
+    """#950: dry-run editor-пути сверяет --specialization с живым деревом."""
+    assert (
+        cmd.run(
+            _args(tmp_path, title=None, specialization=["Инженер по тестированию"], dry_run=True)
+        )
+        is False
+    )
+
+    assert env.validated == [["Инженер по тестированию"]]
+    assert "[INFO] Ничего не записано на hh.ru." in capsys.readouterr().out
+
+
+def test_editor_dry_run_refuses_missing_specialization_before_any_click(
+    env, capsys, tmp_path, monkeypatch
+):
+    """Отказ перечисляет кандидатов и не доходит ни до CANCEL, ни до записи."""
+    monkeypatch.setattr(
+        hhru_bot.resume_position,
+        "validate_specializations_against_tree",
+        lambda page, values: [
+            "специализация не найдена в дереве резюме (dry-run сверка до записи, "
+            "#950): Врач-хирург; ближайшие доступные листы: Врач"
+        ],
+    )
+
+    assert (
+        cmd.run(_args(tmp_path, title=None, specialization=["Врач-хирург"], dry_run=True)) is True
+    )
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "Врач-хирург" in out
+    assert "Врач" in out
+    assert "[INFO] Ничего не записано" not in out
+    # Панель закрыта уходом со страницы; кликов по форме в dry-run нет.
+    assert env.clicks == []
+
+
+def test_editor_dry_run_skips_tree_validation_for_wizard_flow(env, capsys, tmp_path, monkeypatch):
+    """Wizard-поток не открывает editor-форму — его валидатором является
+    live-каталог поиска вакансий (resolve_explicit_role), не дерево резюме."""
+    flow = SimpleNamespace(
+        kind="wizard",
+        resume_id=RESUME_ID,
+        values=PositionValues(title="QA"),
+        state=SimpleNamespace(next_incomplete_screen_id="professional_role"),
+    )
+    monkeypatch.setattr(
+        hhru_bot.resume_position,
+        "open_position_form",
+        lambda page, resume, enter_wizard=True: flow,
+    )
+    monkeypatch.setattr("hhru_bot.resume_titles.account_duplicate_reason", lambda *a, **kw: "")
+    monkeypatch.setattr(
+        "hhru_bot.professional_roles.resolve_explicit_role",
+        lambda page, label: SimpleNamespace(role_id="148", label=label, category="Медицина"),
+    )
+
+    assert cmd.run(_args(tmp_path, title=None, specialization=["Инженер"], dry_run=True)) is False
+
+    assert env.validated == []
+    assert "[INFO] Ничего не записано на hh.ru." in capsys.readouterr().out


### PR DESCRIPTION
## Суть

Боевой кейс «Хирург» (#950, 2026-09-03): три боевых прогона ушли на то, что имена автоподсказок title-поля визарда и имена листов дерева — **разные каталоги**, и CLI узнавал об этом только отказом на живом визарде. Этот PR переносит сверку с live-каталогом **до первого мутирующего клика**, а отказ делает ведущим к цели: с перечнем листов, которые каталог реально предлагает.

## Изменения

- **`catalog_preflight.py` (новый)** — чистая сверка «запрос → листы»: точное нормализованное совпадение + кандидаты по подстроке в обе стороны («Плотник» → «Столяр, плотник» — направление гарда #920; «Врач-хирург» → «Врач» — боевой кейс #950). Плейсхолдер «Другое» (id 40) кандидатом **никогда** не предлагается — его выбор решается явным `--allow-unresolved-area`/`--fallback-other`, не подбором (#913).
- **`create-resume`** — `preflight_area()` перед входом в визард (в обоих режимах, включая `--dry-run`): read-only фильтр каталога поиска вакансий (`/search/vacancy`), ничего не выбирается и не сохраняется. Отказ — до любого клика (первый NEXT может материализовать фантом-черновик, #936). Вырождение фильтра в пустоту/«Другое» переспрашивается один раз — известная нестабильность фильтра hh.ru (#920). С `--allow-unresolved-area` отсутствие листа — проход с `[WARN]`, а не молчаливое согласие.
- **`resume-position`** —
  - dry-run editor-пути валидирует `--specialization` по живому дереву специализаций: панель открывается единственным read-only кликом по ADD (DELETE/submit не трогаются), значения сверяются по стабильному снимку отфильтрованного дерева (#822-гонка учтена — два равных подряд снимка), выход — уходом со страницы, никогда сабмитом;
  - боевой путь: отказ `_set_specializations` при отсутствующем листе обогащён кандидатами из уже открытой панели (тот же принцип #836), по-прежнему до клика сохранения;
  - `resolve_explicit_role` (wizard-путь) перечисляет предложения фильтра в отказе; «Другое» в перечне предложений не участвует.
- Полный офлайн-справочник остаётся за существующим `professional-roles --refresh` + `--query`; отказ create-resume подсказывает эту команду. Источник истины — live-каталог, кэш не участвует в решениях о записи.

## Тесты

- Новые: `tests/test_catalog_preflight.py` (юнит: точное совпадение, обе стороны подстроки, дедуп, «Другое»-исключение, retry на вырожденный фильтр, allow-режим) + browser_unit по фикстуре дерева (`validate_specializations_against_tree` — точный лист без сабмита, отказ с кандидатами; обогащённое сообщение `_set_specializations`).
- Проводка: create-resume (отказ до `create_resume_on_hh` в live и dry-run, `[WARN]` в allow-режиме), resume-position (валидация вызывается с планом, отказ → `[FAIL]` без единого клика, wizard-поток не трогается).
- Полный сюит: `pytest` — 3343 passed, 2 skipped; live-категории не собираются (addopts). `ruff check` + `ruff format --check` + `gen_cli_docs --check` — чисто.

## Живые проверки

- [x] Read-only, исполнено кодом PR (`PYTHONPATH=src`):
  - `create-resume --dry-run --area "Врач-хирург"` → `[FAIL] … не найдена в live-каталоге … (сверка до входа в визард, #950); совпадений по подстроке не найдено`, `attempted=0` — мутирующих кликов нет, визард не открывался (acceptance №1).
  - `create-resume --dry-run --area "Врач"` → preflight прошёл, `[DRY-RUN] … визард найден, клики не выполнены`.
  - `resume-position --resume python --specialization "Врач-хирург" --dry-run` → `[FAIL] специализация не найдена в дереве резюме (dry-run сверка до записи, #950)`, `attempted=0`; перечня нет — фильтр дерева по запросу пуст (согласуется с разведкой #950) (acceptance №2).
- [x] Боевой прогон (разрешён пользователем, один за раз): `create-resume --area "Врач" --title "Врач-хирург" --force` — **успех с первого раза**, `attempted=1 success=1 uncertain=0`, черновик подтверждён read-only `list-resumes` (acceptance №3). Показательно: автоподсказки hh.ru для «Врач» включают «Врач-хирург» (20 подсказок, ни одна не выбрана автоматически), а дерево каталога резолвит реальный лист «Врач» — ровно расхождение каталогов, из-за которого #950 жёг прогоны. Черновик остаётся на аккаунте (удаления запрещены) — цена прогона, согласована заранее.

## Риски / follow-ups

- Отказ create-resume в `--dry-run` теперь ненулевой exit code при отсутствующей области — ранее dry-run всегда «успешно» печатал план. Это и есть цель ишью (отказ до клика), но скрипты, полагавшиеся на «dry-run всегда 0», изменят поведение.
- Pre-flight create-resume сверяет **каталог поиска вакансий** (id-пространство дерева модалки совместимо, #913), а не сам экран каталога визарда: читать последний до мутации нельзя — он за первым NEXT (#936). Расхождение двух каталогов не наблюдалось, но при странном отказе первый подозреваемый — именно оно.
- Валидатор editor-дерева читает только отрисованные строки отфильтрованного списка: в боевых прогонах (#822/#867) отфильтрованные множества помещались в вьюпорт; если живой прогон покажет виртуализацию с обрезкой — добавить прокрутку по образцу `_tree_scroll` из `professional_roles`.
