### PR TITLE
fix(resume-position): near-miss отказ возвращает перечень кандидатов (#950), стёртый #964

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -1071,11 +1071,13 @@ def _pick_specialization(page: Page, search: Locator, value: str) -> None:
             # затёр бы валидную близкую специализацию (#954). Счётчик —
             # точный SPECIALIZATION_OPTION (число листьев), а не все дети
             # контейнера: заголовки групп не «варианты» (ревью PR #964).
+            # Отказ перечисляет реально отрисованные листы (принцип #836,
+            # канал #950): перезапуск с первого раза, а не перебор вслепую.
+            evaluation = evaluate_leaf(value, _poll_specialization_labels(page))
             option_count = page.locator(SPECIALIZATION_OPTION).count()
             raise RuntimeError(
                 f"результат фильтра непуст (совпадений: {option_count}), но точного "
-                f"листа «{value}» среди них нет — передайте точное имя листа из "
-                "live-каталога (составные имена вида «Столяр, плотник»)"
+                f"листа «{value}» среди них нет — {format_candidates(evaluation)}"
             ) from exc
         raise SpecializationTreeIndeterminate(
             f"дерево специализаций не отрисовалось за "

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -1073,11 +1073,22 @@ def _pick_specialization(page: Page, search: Locator, value: str) -> None:
             # контейнера: заголовки групп не «варианты» (ревью PR #964).
             # Отказ перечисляет реально отрисованные листы (принцип #836,
             # канал #950): перезапуск с первого раза, а не перебор вслепую.
+            # Хвост формируется отдельно от format_candidates (ревью PR
+            # #968): при расхождении семантик DOM-фильтра и substring-
+            # эвристики_candidates пуст, и «совпадений по подстроке не
+            # найдено» противоречило бы «результат фильтра непуст» — вместо
+            # этого предлагаем перечитать видимое дерево командой.
             evaluation = evaluate_leaf(value, _poll_specialization_labels(page))
             option_count = page.locator(SPECIALIZATION_OPTION).count()
+            tail = (
+                "ближайшие доступные листы: " + "; ".join(evaluation.candidates)
+                if evaluation.candidates
+                else "точных имён нет в выводе — перечитайте live-каталог "
+                "(search --dry-run) и передайте лист дословно"
+            )
             raise RuntimeError(
                 f"результат фильтра непуст (совпадений: {option_count}), но точного "
-                f"листа «{value}» среди них нет — {format_candidates(evaluation)}"
+                f"листа «{value}» среди них нет — {tail}"
             ) from exc
         raise SpecializationTreeIndeterminate(
             f"дерево специализаций не отрисовалось за "

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -1075,7 +1075,7 @@ def _pick_specialization(page: Page, search: Locator, value: str) -> None:
             # канал #950): перезапуск с первого раза, а не перебор вслепую.
             # Хвост формируется отдельно от format_candidates (ревью PR
             # #968): при расхождении семантик DOM-фильтра и substring-
-            # эвристики_candidates пуст, и «совпадений по подстроке не
+            # эвристики candidates пуст, и «совпадений по подстроке не
             # найдено» противоречило бы «результат фильтра непуст» — вместо
             # этого предлагаем перечитать видимое дерево командой.
             evaluation = evaluate_leaf(value, _poll_specialization_labels(page))

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -1033,17 +1033,25 @@ def test_set_specializations_no_fallback_on_near_miss_filter():
     """#954: непустой результат фильтра без точного совпадения (неточное имя
     листа — имена каталога составные, «Столяр, плотник») — НЕ пустой фильтр;
     «Другое» не подставляется даже с флагом: плейсхолдер затёр бы валидную
-    близкую специализацию. Счётчик в сообщении — число листьев
-    (SPECIALIZATION_OPTION), не всех детей контейнера (ревью PR #964)."""
+    близкую специализацию. Счётчик — число листьев (SPECIALIZATION_OPTION),
+    не всех детей контейнера (ревью PR #964); отказ перечисляет реально
+    отрисованные листы (канал #950, принцип #836)."""
     from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
     page = MagicMock()
     option = _mock_specialization_locators(
-        page, option_data_qa=[], container_children=3, rendered_options=2
+        page,
+        option_data_qa=[],
+        container_children=3,
+        rendered_options=2,
+        rendered_labels=[
+            "Учитель, преподаватель, педагог",
+            "Учитель начальных классов",
+        ],
     )
     option.first.wait_for.side_effect = PlaywrightTimeoutError("Timeout 5000ms exceeded.")
 
-    with pytest.raises(RuntimeError, match=r"результат фильтра непуст \(совпадений: 2\)"):
+    with pytest.raises(RuntimeError, match=r"совпадений: 2\).+ближайшие доступные листы"):
         resume_position._set_specializations(page, ["Учитель"], fallback_other=True)
 
     search = page.locator(resume_position.SPECIALIZATION_SEARCH)
@@ -1138,7 +1146,12 @@ def test_set_specializations_no_fallback_on_nontimeout_wait_error(monkeypatch):
 
 
 def _mock_specialization_locators(
-    page, *, option_data_qa, container_children: int | None = 0, rendered_options: int | None = None
+    page,
+    *,
+    option_data_qa,
+    container_children: int | None = 0,
+    rendered_options: int | None = None,
+    rendered_labels: list[str] | None = None,
 ):
     """Common scaffolding for _set_specializations tests below.
 
@@ -1169,10 +1182,12 @@ def _mock_specialization_locators(
     option_tree.filter.return_value = option
     # Unfiltered count of rendered leaves, read by the near-miss branch
     # (review PR #964): distinct from option_data_qa, which models the
-    # exact-label-filtered subset.
+    # exact-label-filtered subset. all_inner_texts feeds the refusal's
+    # candidate listing (_poll_specialization_labels -> evaluate_leaf).
     option_tree.count.return_value = (
         len(option_data_qa) if rendered_options is None else rendered_options
     )
+    option_tree.all_inner_texts.return_value = rendered_labels or []
     container = MagicMock()
     container.count.return_value = 0 if container_children is None else 1
     container.first.locator.return_value.count.return_value = container_children or 0

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -1059,6 +1059,28 @@ def test_set_specializations_no_fallback_on_near_miss_filter():
     option.first.click.assert_not_called()
 
 
+def test_set_specializations_near_miss_without_substring_candidates():
+    """Ревью PR #968: расхождение семантик — DOM-фильтр отрисовал листья,
+    substring-эвристика кандидатов не нашла (rendered_labels=[]). Хвост
+    отказа не противоречит «результат фильтра непуст»: вместо format_candidates
+    с «совпадений по подстроке не найдено» — указание перечитать каталог."""
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    page = MagicMock()
+    option = _mock_specialization_locators(
+        page, option_data_qa=[], container_children=3, rendered_options=2, rendered_labels=[]
+    )
+    option.first.wait_for.side_effect = PlaywrightTimeoutError("Timeout 5000ms exceeded.")
+
+    with pytest.raises(RuntimeError, match=r"совпадений: 2\).+перечитайте live-каталог"):
+        resume_position._set_specializations(page, ["Менеджер"], fallback_other=True)
+        pytest.fail("near-miss должен отказать, а не подставлять «Другое»")
+
+    search = page.locator(resume_position.SPECIALIZATION_SEARCH)
+    assert [call.args[0] for call in search.fill.call_args_list] == ["Менеджер"]
+    option.first.click.assert_not_called()
+
+
 def test_set_specializations_fallback_does_not_mask_ambiguity():
     """#950: совпадение отрендерилось, но под двумя id — подлинная
     неоднозначность; фоллбэк её не маскирует (fail-closed)."""

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -106,9 +106,12 @@ def test_resume_catalog_rejects_non_leaf_or_missing_specialization(
 
 @pytest.mark.browser_unit
 def test_set_specializations_missing_leaf_refusal_lists_visible_candidates(monkeypatch):
-    """#950/#954: отказ при неточном листе называет число отрисованных
-    совпадений и требует точное имя из live-каталога, — перезапуск с первого
-    раза, а не перебор (контракт сообщения — #964)."""
+    """#950/#954: near-miss (фильтр отрисовал листы, точного нет) отказывается,
+    называя число совпадений и перечисляя реально отрисованных кандидатов, —
+    перезапуск с первого раза, а не перебор. Формулировка «результат фильтра
+    непуст…» — новая семантика #954: непустой фильтр не «лист отсутствует»,
+    фоллбэк «Другое» на нём не срабатывает; перечисление кандидатов сохранено
+    (#836, контракт сообщения — #964)."""
     monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
     playwright, browser, page = _page()
     try:
@@ -118,7 +121,8 @@ def test_set_specializations_missing_leaf_refusal_lists_visible_candidates(monke
         message = str(exc_info.value)
         assert "результат фильтра непуст" in message
         assert "точного листа «Менеджер» среди них нет" in message
-        assert "передайте точное имя листа из live-каталога" in message
+        assert "ближайшие доступные листы: " in message
+        assert "Менеджер по продажам, менеджер по работе с клиентами" in message
     finally:
         browser.close()
         playwright.stop()


### PR DESCRIPTION
## Что сломалось

Мердж #964 (daa26691) сломал `tests/test_resume_position_catalog_fixture.py::test_set_specializations_missing_leaf_refusal_lists_visible_candidates` — main красный с 12:05, блокирует мерджи #962/#967.

## Разбор по дизайну empty-state (#954)

Сценарий теста — **near-miss**: запрос «Менеджер», фильтр отрисовывает 4 листа («Менеджер по продажам…»), точного листа нет. Поведенчески #964 прав: near-miss — не «лист отсутствует» (LeafMissing теперь только позитивно пустой контейнер), и фоллбэк «Другое» на нём не срабатывает. Но мердж #964 **стёр канал #950**: near-miss стал выходить коротким отказом «результат фильтра непуст (совпадений: N)» **без перечисления** реально отрисованных листов — а отказ обязан вести к точному повтору с первого раза (принцип #836), не к перебору вслепую.

## Фикс (код, не только тест)

Near-miss ветка `_pick_specialization` перед отказом читает дерево тем же `_poll_specialization_labels → evaluate_leaf → format_candidates`, что и catch-блок `SpecializationLeafMissing`; отказ стал «результат фильтра непуст (совпадений: N), но точного листа «X» среди них нет — ближайшие доступные листы: …». Счётчик — листья (`SPECIALIZATION_OPTION`), не все дети контейнера (ревью #964).

Семантика #954 не ослаблена: `SpecializationLeafMissing` — только позитивно пустой контейнер дерева; «Другое» на near-miss не подставляется; `SpecializationTreeIndeterminate` (контейнер не прикреплён) — fail-closed без записи.

Тест обновлён под новую формулировку **с** сохранением проверки перечня кандидатов; мок-хелпер получил `rendered_labels` (кандидаты отказа) в дополнение к `rendered_options` (счётчик).

## Проверки

- полный `pytest -q` одним проходом — зелёный (включая ранее красный тест);
- `ruff check` + `ruff format --check` — чисты.

Refs #954
