### PR TITLE
fix(resume-position): не кликать CANCEL после ухода с формы в dry-run (follow-up #963)

### DIFF
--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -367,6 +367,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 # дерево реально отрисовало. Отказ и здесь, и в боевом пути
                 # наступает до клика сохранения.
                 refusals: list[str] = []
+                left_the_form = False
                 if not wizard and plan.specializations:
                     from ..resume_position import validate_specializations_against_tree
 
@@ -375,11 +376,16 @@ def _run(args: argparse.Namespace, progress) -> bool:
                     # нажат, pending-правки отбрасываются; CANCEL под оверлеем
                     # открытой панели недостижим.
                     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
+                    # #963 follow-up: после навигации мы на /resume/{id} —
+                    # формы редактора и её CANCEL там нет; клик по нему валил
+                    # бы успешный dry-run по таймауту. Отмена уже произошла
+                    # самой навигацией, дублировать её кликом не нужно.
+                    left_the_form = True
                 if refusals:
                     for refusal in refusals:
                         print(f"[FAIL] {refusal}")
                     return True
-                if not wizard:
+                if not wizard and not left_the_form:
                     page.locator(CANCEL).click()
                 print("[INFO] Ничего не записано на hh.ru.")
                 return False

--- a/tests/test_resume_position_command.py
+++ b/tests/test_resume_position_command.py
@@ -65,7 +65,22 @@ def env(monkeypatch, tmp_path):
     clicks: list[str] = []
 
     class FakePage:
+        def __init__(self):
+            self._navigated = False
+
+        def mark_navigated(self):
+            # #963 follow-up: goto_hh уводит с формы редактора — CANCEL на
+            # целевой странице не существует, как и на живом DOM.
+            self._navigated = True
+
         def locator(self, selector):
+            if self._navigated and selector == hhru_bot.resume_position.CANCEL:
+                from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+                def click():
+                    raise PlaywrightTimeoutError("CANCEL vanished after navigation")
+
+                return SimpleNamespace(click=click)
             return SimpleNamespace(click=lambda: clicks.append(selector))
 
         def close(self):
@@ -231,6 +246,31 @@ def test_editor_dry_run_validates_specializations_against_tree(env, capsys, tmp_
     )
 
     assert env.validated == [["Инженер по тестированию"]]
+    assert "[INFO] Ничего не записано на hh.ru." in capsys.readouterr().out
+
+
+def test_editor_dry_run_with_specialization_skips_cancel_after_navigation(
+    env, capsys, tmp_path, monkeypatch
+):
+    """#963 follow-up: dry-run со spec-валидацией уходит с формы через goto_hh
+    (панель закрывается навигацией), после чего CANCEL на /resume/{id} не
+    существует — клик по нему валил бы dry-run по таймауту после УСПЕШНОЙ
+    сверки. Фейковая страница отражает живой DOM: после навигации клик по
+    CANCEL падает — команда обязана его не делать."""
+    monkeypatch.setattr(
+        hhru_bot.browser,
+        "goto_hh",
+        lambda page, url: page.mark_navigated(),
+    )
+    # Панель сверена, отказов нет: успешный dry-run обязан закончиться
+    # [INFO] без клика по исчезнувшей после навигации CANCEL.
+    assert (
+        cmd.run(
+            _args(tmp_path, title=None, specialization=["Инженер по тестированию"], dry_run=True)
+        )
+        is False
+    )
+
     assert "[INFO] Ничего не записано на hh.ru." in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Баг

С мерджа #963 (`9afa8790`) каждый успешный `resume-position --specialization … --dry-run` на резюме в editor-режиме падает после валидации: dry-run закрывает панель выбора специализаций уходом со страницы (`goto_hh` на `/resume/{id}` — сам приём корректен, submit не нажат), но дальше по не-wizard пути безусловно кликает CANCEL — а формы редактора и её CANCEL после навигации не существует. Итог: Playwright-таймаут вместо `[INFO] Ничего не записано на hh.ru.`

Находка cycle-review PR #968 (автопрогон, out-of-scope для того PR), исправляется здесь по прямому поручению пользователя. Моки #963 не ловили баг: `goto_hh` подменялся no-op'ом, а FakePage отвечал на любой клик успехом.

## Фикс

Флаг `left_the_form` в `commands/resume_position.py`: после `goto_hh` отмена уже произошла самой навигацией (pending-правки отбрасываются уходом), повторный клик не нужен — CANCEL кликается только если мы всё ещё на форме.

## Тест

Репродьюсер в `test_editor_dry_run_with_specialization_skips_cancel_after_navigation`: FakePage после `goto_hh` (переопределённого без no-op — он помечает страницу навигированной) отвечает на клик CANCEL PlaywrightTimeoutError, как живой DOM. На прежнем коде тест красный (команда падает → `[FAIL]` → `True`), после фикса — зелёный.

Живой прогон не требуется: паттерн UI-клика читается из DOM-структуры (CANCEL — элемент формы редактора, исчезающей при навигации), подтверждать мутацией нечего — dry-run по определению ничего не пишет.

## Проверки

Полный pytest одним проходом — зелёный; `ruff check` + `ruff format --check` — чисты.

Refs #950
