### PR TITLE
feat(resume): детекция баннера ошибки на /resume/{id} — внятный отказ вместо таймаутов

### DIFF
--- a/src/hhru_bot/about.py
+++ b/src/hhru_bot/about.py
@@ -17,7 +17,13 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, goto_hh, open_hydrated_resume_editor
+from .browser import (
+    HH_BASE_URL,
+    RESUME_UNAVAILABLE_REASON,
+    goto_hh,
+    has_resume_error_banner,
+    open_hydrated_resume_editor,
+)
 from .selector_groups import resume_page
 
 if TYPE_CHECKING:
@@ -134,6 +140,11 @@ def open_about_editor(page: Page, resume: ResumeConfig) -> str:
     the trigger to become visible before the strict count check.
     """
     goto_hh(page, resume.resume_url)
+    # #972: сбойный экран /resume/{id} — доменная ошибка модуля (команда
+    # ловит только AboutGenerationError), внятный отказ вместо ухода в
+    # edit-route и таймаута. Pre-mutation.
+    if has_resume_error_banner(page):
+        raise AboutGenerationError(RESUME_UNAVAILABLE_REASON)
     trigger = page.locator(resume_page.RESUME_EDIT_ABOUT_BUTTON)
     try:
         trigger.wait_for(state="visible", timeout=10_000)

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -87,6 +87,17 @@ class NotAuthenticated(PageStateIndeterminate):
     """The current page does not prove that the hh.ru session is valid."""
 
 
+class ResumeUnavailable(RuntimeError):
+    """hh.ru показал сбойный экран на /resume/{id} (#972).
+
+    Подтверждённое состояние страницы, а не неопределённость: сессия жива
+    (страница отрендерена под логином), но запрошенное резюме недоступно.
+    Pre-mutation терминальный сигнал (обычный failed/retry): клика не было,
+    поэтому исход принципиально не ``uncertain`` (#176) и не
+    ``NotAuthenticated`` — сессия действительна.
+    """
+
+
 class ThrottledChannelDetected(PlaywrightTimeoutError):
     """goto_hh timed out AFTER the server answered the navigation request.
 
@@ -242,6 +253,9 @@ def open_confirmed_resume(page: Page, resume_id: str) -> None:
         raise ValueError("resume_id is required")
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
     require_authenticated_page(page)
+    # #972: до identity-чека — сбойный экран держит URL /resume/{id}, поэтому
+    # resume_identity_matches его пропускает, а мутация падает таймаутом.
+    require_available_resume(page)
     if not resume_identity_matches(page, resume_id):
         raise ValueError("identity резюме не подтверждён")
 
@@ -493,6 +507,56 @@ def has_login_form(page: Page) -> bool:
     маркер: cookie есть, а сервер не отверг сессию формой входа.
     """
     return page.locator(LOGIN_FORM).count() > 0
+
+
+# Подтверждено живым DOM за логином 2026-09-05 (issue #972, read-only live-замер
+# tests/test_resume_error_banner_live.py, дамп
+# data/logs/972_resume_error_banner_000000.html): несуществующее/удалённое
+# резюме по прямому URL /resume/{id} рендерит сбойный экран
+# <div class="attention attention_bad">Произошла ошибка. Возникли неполадки,
+# но мы уже работаем над их устранением.</div> — data-qa на баннере НЕТ (как у
+# error boundary «Problem fetching content», #802), поэтому стабильный
+# bloko-класс + точный текст — двойной признак, отсекающий другие
+# attention_bad-баннеры на этой же странице. Экран тот же и для полностью
+# несуществующего id, и для удалённого резюме (скриншот владельца из #972).
+RESUME_ERROR_BANNER = "div.attention.attention_bad"
+RESUME_ERROR_BANNER_TEXT = "Произошла ошибка"
+# Формулировка по #972: констатирует наблюдаемый факт (баннер) и называет
+# вероятную причину, НЕ утверждая «удалено» — баннер является общим сбойным
+# экраном hh.ru. Без сверки со списком резюме.
+RESUME_UNAVAILABLE_REASON = (
+    "резюме недоступно: hh.ru показал баннер ошибки "
+    "(наиболее вероятная причина — резюме удалено владельцем; "
+    "баннер — общий сбойный экран hh.ru, удаление не доказано)"
+)
+
+
+def has_resume_error_banner(page: Page) -> bool:
+    """Сбойный экран hh.ru на /resume/{id}: видимый баннер ошибки (#972).
+
+    Ошибка чтения селектора — не доказательство отсутствия баннера: детектор
+    молчит, вызывающий путь продолжает свой обычный fail-closed (его
+    «кнопка/форма не найдена» останется прежним отказом). Намеренно
+    позитивный сигнал, как у ``has_login_form``. AttributeError — для
+    unit-факов без ``filter`` (паттерн ``detect_antibot_on_page``).
+    """
+    try:
+        return (
+            page.locator(RESUME_ERROR_BANNER).filter(has_text=RESUME_ERROR_BANNER_TEXT).count() > 0
+        )
+    except (AttributeError, PlaywrightError):
+        return False
+
+
+def require_available_resume(page: Page) -> None:
+    """Терминальный pre-mutation отказ, если страница резюме — сбойный экран.
+
+    Вызывается сразу после навигации на /resume/{id} и проверки сессии, до
+    любого клика/поиска формы: URL при баннере остаётся /resume/{id}, поэтому
+    identity-проверки его не отсекают.
+    """
+    if has_resume_error_banner(page):
+        raise ResumeUnavailable(RESUME_UNAVAILABLE_REASON)
 
 
 # #825: hh.ru рендерит информер о cookie-политике на каждой свежей навигации

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -534,6 +534,10 @@ RESUME_UNAVAILABLE_REASON = (
 def has_resume_error_banner(page: Page) -> bool:
     """Сбойный экран hh.ru на /resume/{id}: видимый баннер ошибки (#972).
 
+    ``visible=True`` — гвард от скрытых (display:none) копий attention_bad
+    того же текста на живой странице резюме, по образцу
+    ``detect_antibot_on_page`` (dormant-шаблон не должен давать отказ
+    «резюме недоступно»; на снятом live-экране баннер один и видимый).
     Ошибка чтения селектора — не доказательство отсутствия баннера: детектор
     молчит, вызывающий путь продолжает свой обычный fail-closed (его
     «кнопка/форма не найдена» останется прежним отказом). Намеренно
@@ -542,7 +546,10 @@ def has_resume_error_banner(page: Page) -> bool:
     """
     try:
         return (
-            page.locator(RESUME_ERROR_BANNER).filter(has_text=RESUME_ERROR_BANNER_TEXT).count() > 0
+            page.locator(RESUME_ERROR_BANNER)
+            .filter(has_text=RESUME_ERROR_BANNER_TEXT, visible=True)
+            .count()
+            > 0
         )
     except (AttributeError, PlaywrightError):
         return False

--- a/src/hhru_bot/bump.py
+++ b/src/hhru_bot/bump.py
@@ -8,7 +8,13 @@ from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from . import selectors as sel
-from .browser import HH_BASE_URL, goto_hh, has_login_form
+from .browser import (
+    HH_BASE_URL,
+    RESUME_UNAVAILABLE_REASON,
+    goto_hh,
+    has_login_form,
+    has_resume_error_banner,
+)
 from .config import ResumeConfig, is_resume_url_placeholder
 
 logger = logging.getLogger("hhru_bot.bump")
@@ -60,6 +66,11 @@ def bump_resume(page: Page, resume: ResumeConfig, dry_run: bool) -> BumpResult:
             False,
             "Сессия недействительна: страница содержит форму входа. Выполните login.",
         )
+    # #972: сбойный экран /resume/{id} — внятный отказ вместо таймаута на
+    # поиске кнопки поднятия. Ранний выход до действия: acted=False (#163),
+    # в actions не пишется, обычный failed/retry.
+    if has_resume_error_banner(page):
+        return BumpResult(resume.id, False, RESUME_UNAVAILABLE_REASON)
 
     # #139: гонка рендера — раньше hint читался сразу через count() > 0, без
     # ожидания. Непрогрузившаяся страница резюме давала 0 совпадений (не

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -21,7 +21,7 @@ from playwright.sync_api import Error as PlaywrightError
 from . import commands as _commands_pkg
 from .accounts import AccountError, resolve_account_paths
 from .apply.antibot import AntiBotChallengeDetected
-from .browser import BrowserLaunchError, ThrottledChannelDetected
+from .browser import BrowserLaunchError, ResumeUnavailable, ThrottledChannelDetected
 from .exit_codes import CommandExitCode
 from .logging_setup import setup_logging
 from .write_lock import WriteLockBusy, acquire_write_lock
@@ -449,6 +449,14 @@ def _execute(args: argparse.Namespace) -> None:
     except AntiBotChallengeDetected as exc:
         # #344: terminal apply/run state.  Do not render a traceback or continue
         # with another vacancy/resume (or bump in the combined ``run`` command).
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        sys.exit(1)
+    except ResumeUnavailable as exc:
+        # #972 (PR #974 follow-up): пути, где детектор баннера бросает
+        # исключение (open_position_form, open_confirmed_resume →
+        # edit-experience/publish/delete), раньше доходили до generic
+        # except Exception → re-raise → сырой traceback. Тот же контракт, что
+        # у AntiBotChallengeDetected: [FAIL]-отказ, exit 1, без traceback.
         print(f"[FAIL] {exc}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:

--- a/src/hhru_bot/resume_education.py
+++ b/src/hhru_bot/resume_education.py
@@ -28,6 +28,7 @@ from .browser import (
     labelled_field,
     open_hydrated_resume_editor,
     require_authenticated_page,
+    require_available_resume,
     resume_identity_matches,
 )
 from .config_sections.education import EducationRecord
@@ -798,6 +799,9 @@ def edit_education_on_hh(
         raise ValueError("resume_url не содержит однозначный resume_id")
     resume_id = path_parts[1]
     goto_hh(page, resume_url)
+    # #972: сбойный экран /resume/{id} держит URL — внятный отказ вместо
+    # таймаута на поиске секций образования. Pre-mutation, failed/retry.
+    require_available_resume(page)
     results = []
     if section in ("primary", "both"):
         results.append(

--- a/src/hhru_bot/resume_photo.py
+++ b/src/hhru_bot/resume_photo.py
@@ -41,9 +41,11 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 from .browser import (
+    RESUME_UNAVAILABLE_REASON,
     dismiss_cookie_banner,
     dump_page_html,
     goto_hh,
+    has_resume_error_banner,
     require_authenticated_page,
     wait_for_react_hydration,
 )
@@ -187,6 +189,10 @@ def upload_photo_on_hh(
     goto_hh(page, resume.resume_url)
     require_authenticated_page(page)
     dismiss_cookie_banner(page)
+    # #972: сбойный экран /resume/{id} — внятный отказ вместо таймаута на
+    # ожидании блока аватара. Pre-mutation (файл никуда не передан).
+    if has_resume_error_banner(page):
+        return UploadPhotoResult(reason=RESUME_UNAVAILABLE_REASON, photo_present=None)
     avatar = page.locator(RESUME_AVATAR_BLOCK).first
     try:
         # SPA-страница: блок аватара появляется после гидратации React
@@ -787,6 +793,10 @@ def select_photo_on_hh(
     goto_hh(page, resume.resume_url)
     require_authenticated_page(page)
     dismiss_cookie_banner(page)
+    # #972: сбойный экран /resume/{id} — внятный отказ вместо таймаута на
+    # ожидании блока аватара. Pre-mutation (карандаш/галерея не тронуты).
+    if has_resume_error_banner(page):
+        return SelectPhotoResult(reason=RESUME_UNAVAILABLE_REASON)
     avatar = page.locator(RESUME_AVATAR_BLOCK).first
     try:
         avatar.wait_for(state="visible", timeout=_AVATAR_WAIT_TIMEOUT_MS)

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -28,6 +28,7 @@ from .browser import (
     goto_hh,
     open_hydrated_resume_editor,
     require_authenticated_page,
+    require_available_resume,
     resume_identity_matches,
 )
 from .catalog_preflight import evaluate_leaf, format_candidates
@@ -491,6 +492,9 @@ def open_position_form(
     """
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     require_authenticated_page(page)
+    # #972: сбойный экран держит URL /resume/{id} и прошёл бы identity-чек,
+    # уводя команду в таймауты. Pre-mutation отказ (команда печатает [FAIL]).
+    require_available_resume(page)
     if _is_wizard_path(getattr(page, "url", "")):
         if not enter_wizard:
             # state.title is the only title source on this read-only path:

--- a/src/hhru_bot/resume_sections.py
+++ b/src/hhru_bot/resume_sections.py
@@ -14,10 +14,12 @@ from playwright.sync_api import Locator, Page
 
 from .browser import (
     HH_BASE_URL,
+    RESUME_UNAVAILABLE_REASON,
     PageStateIndeterminate,
     goto_hh,
     has_auth_cookie,
     has_login_form,
+    has_resume_error_banner,
     labelled_field,
     open_hydrated_resume_editor,
 )
@@ -371,6 +373,10 @@ def apply_plan(page: Page, resume_id: str, plan: ResumeSectionsPlan, *, dry_run:
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
     if has_login_form(page):
         return ["hh.ru показал форму входа"]
+    # #972: сбойный экран /resume/{id} — внятный отказ вместо таймаута на
+    # поиске триггеров секций. Pre-mutation, обычный failed/retry.
+    if has_resume_error_banner(page):
+        return [RESUME_UNAVAILABLE_REASON]
     errors = list(plan.skipped)
     errors += _apply_rows(
         page,

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -16,9 +16,11 @@ from playwright.sync_api import Page
 
 from .browser import (
     HH_BASE_URL,
+    RESUME_UNAVAILABLE_REASON,
     goto_hh,
     has_auth_cookie,
     has_login_form,
+    has_resume_error_banner,
     open_hydrated_resume_editor,
 )
 from .config import ResumeConfig
@@ -317,6 +319,10 @@ def edit_skills_on_hh(
     goto_hh(page, f"{HH_BASE_URL}/resume/{resume.resume_id}")
     if not has_auth_cookie(page) or has_login_form(page):
         return SkillsResult(False, reason="сессия hh.ru не подтверждена")
+    # #972: сбойный экран /resume/{id} — внятный отказ вместо таймаута на
+    # открытии редактора навыков. Pre-mutation, в actions не пишется.
+    if has_resume_error_banner(page):
+        return SkillsResult(False, reason=RESUME_UNAVAILABLE_REASON)
     edit_path = f"/resume/edit/{resume.resume_id}/keySkills"
     trigger = page.locator(resume_page.RESUME_SKILLS_EDIT_BUTTON)
     first_entry = trigger.count() == 0

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -12,10 +12,16 @@ from hhru_bot.about import (
     generate_about,
     open_about_editor,
 )
+from hhru_bot.browser import RESUME_ERROR_BANNER
 from hhru_bot.commands.about import draft_prefix
 from hhru_bot.config import bare_resume
 
 pytestmark = pytest.mark.unit
+
+# #972: open_about_editor до триггера читает баннер-детектор сбойного экрана
+# (div.attention.attention_bad + has_text). Пустой локатор = «баннера нет».
+_EMPTY_BANNER = MagicMock(name="empty_banner")
+_EMPTY_BANNER.filter.return_value.count.return_value = 0
 
 
 class Response:
@@ -108,6 +114,7 @@ def test_open_about_editor_retries_pre_hydration_noop_click(monkeypatch):
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -132,6 +139,7 @@ def test_open_about_editor_waits_for_hidden_but_present_field(monkeypatch):
     field.wait_for.return_value = None
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -160,6 +168,7 @@ def test_open_about_editor_accepts_draft_edit_route(monkeypatch):
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -184,6 +193,7 @@ def test_open_about_editor_accepts_draft_edit_route_with_query(monkeypatch):
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -208,6 +218,7 @@ def test_open_about_editor_rejects_wrong_route_with_empty_resume_id(monkeypatch)
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -234,6 +245,7 @@ def test_open_about_editor_still_fails_closed_on_unexpected_route(monkeypatch):
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -264,6 +276,7 @@ def test_open_about_editor_uses_edit_route_when_button_missing(monkeypatch):
         page.url = url
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -290,6 +303,7 @@ def test_open_about_editor_propagates_non_timeout_error(monkeypatch):
     )
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
     }[selector]
     monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)
@@ -315,6 +329,7 @@ def test_open_about_editor_edit_route_rejects_wrong_resume(monkeypatch):
         page.url = "https://hh.ru/resume/edit/other-id/about"
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
     }[selector]
     monkeypatch.setattr(about_module, "goto_hh", goto_side_effect)
@@ -341,6 +356,7 @@ def test_open_about_editor_edit_route_fails_closed_when_editor_absent(monkeypatc
         page.url = url
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
         about_module.resume_page.RESUME_ABOUT_EDITOR: field,
     }[selector]
@@ -359,6 +375,7 @@ def test_open_about_editor_fails_fast_when_button_ambiguous(monkeypatch):
     trigger.wait_for.return_value = None
 
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         about_module.resume_page.RESUME_EDIT_ABOUT_BUTTON: trigger,
     }[selector]
     monkeypatch.setattr(about_module, "goto_hh", lambda *_args, **_kwargs: None)

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -331,6 +331,9 @@ def test_open_confirmed_resume_checks_auth_and_identity(monkeypatch):
     page = MagicMock(name="Page")
     page.url = "https://hh.ru/resume/123"
     page.context.cookies.return_value = [{"name": "hhtoken"}]
+    # #972: баннер-детектор (locator→filter→count) на живой странице — int;
+    # без этой настройки MagicMock-цепочка вернула бы MagicMock, упав в `> 0`.
+    page.locator.return_value.filter.return_value.count.return_value = 0
     monkeypatch.setattr(browser, "goto_hh", lambda page, url: None)
     monkeypatch.setattr(browser, "has_login_form", lambda page: False)
     open_confirmed_resume(page, "123")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -690,6 +690,30 @@ def test_antibot_terminal_state_prints_fail_without_traceback(monkeypatch, capsy
     logging.getLogger("hhru_bot").handlers.clear()
 
 
+def test_resume_unavailable_prints_fail_without_traceback(monkeypatch, capsys):
+    """#972: сбойный экран hh.ru вместо страницы резюме — тот же контракт, что
+    у AntiBotChallengeDetected: [FAIL]-отказ, exit 1, без traceback. До
+    cli-ветки ResumeUnavailable улетал в generic except Exception → re-raise
+    (сырой traceback на путях open_position_form/open_confirmed_resume)."""
+    from hhru_bot.browser import RESUME_UNAVAILABLE_REASON, ResumeUnavailable
+
+    def _unavailable(_args: argparse.Namespace) -> bool:
+        raise ResumeUnavailable(RESUME_UNAVAILABLE_REASON)
+
+    import hhru_bot.commands.whoami as whoami_module
+
+    monkeypatch.setattr(whoami_module, "run", _unavailable)
+    with pytest.raises(SystemExit) as exc_info:
+        main(["whoami"])
+
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "[FAIL] резюме недоступно" in stderr
+    assert "удалено владельцем" in stderr
+    assert "Traceback" not in stderr
+    logging.getLogger("hhru_bot").handlers.clear()
+
+
 def test_network_connection_failure_prints_environment_without_traceback(monkeypatch, capsys):
     """#747: сетевой сбой соединения (нет доступа до hh.ru — прокси/GFW/etc,
     причина не устанавливается) должен получать тот же структурированный

--- a/tests/test_resume_error_banner.py
+++ b/tests/test_resume_error_banner.py
@@ -73,16 +73,24 @@ def _attention_bad_nodes(html: str) -> list[_DOMNode]:
 
 
 class _ClassTextLocator:
-    """Локатор ровно под паттерн детектора: ``.filter(has_text=...)`` + count.
+    """Локатор ровно под паттерн детектора: ``.filter(has_text=, visible=)`` + count.
 
     Playwright-семантика has_text — подстрока в тексте элемента; здесь то же
     (inner_text узла включает его прямых потомков, как у реального браузера).
+    ``visible`` — no-op, как у FakeLocator в ``_fakes``: html.parser не знает
+    CSS display, все узлы фикстуры считаются видимыми (скрытые копии баннера
+    отсекает реальный Playwright-фильтр, а не этот фейк).
     """
 
     def __init__(self, nodes: list[_DOMNode]):
         self._nodes = nodes
 
-    def filter(self, *, has_text: str | None = None) -> _ClassTextLocator:
+    def filter(
+        self,
+        *,
+        has_text: str | None = None,
+        visible: bool | None = None,  # noqa: ARG002
+    ) -> _ClassTextLocator:
         if has_text is None:
             return self
         return _ClassTextLocator([n for n in self._nodes if has_text in n.inner_text()])

--- a/tests/test_resume_error_banner.py
+++ b/tests/test_resume_error_banner.py
@@ -1,0 +1,287 @@
+"""#972: детекция баннера ошибки на /resume/{id} — внятный отказ вместо таймаутов.
+
+HTML-фикстура — скелет живого сбойного экрана, снятого read-only замером
+2026-09-05 (tests/test_resume_error_banner_live.py, дамп
+data/logs/972_resume_error_banner_000000.html): несуществующее/удалённое
+резюме рендерит <div class="attention attention_bad">Произошла ошибка...</div>
+без data-qa. Все тесты без браузера: детерминированный фейк Page поверх
+html.parser (паттерн ``_fakes``), селектор — ``div.attention.attention_bad``
++ точный текст (двойной признак, отсекающий другие attention_bad-баннеры).
+
+Семантика (#972 п.3): детекция — pre-mutation отказ (обычный failed/retry),
+не uncertain и не запись в actions; существующие ранние выходы (#163) не
+меняются.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Error as PlaywrightError
+
+from _fakes import _DOMNode, _parse_root
+from hhru_bot import browser as browser_module
+from hhru_bot.about import AboutGenerationError, open_about_editor
+from hhru_bot.browser import (
+    RESUME_ERROR_BANNER,
+    RESUME_UNAVAILABLE_REASON,
+    ResumeUnavailable,
+    has_resume_error_banner,
+    open_confirmed_resume,
+    require_available_resume,
+)
+from hhru_bot.bump import bump_resume
+from hhru_bot.config import ResumeConfig, SearchFilters
+from hhru_bot.resume_education import EducationPlan, edit_education_on_hh
+from hhru_bot.resume_position import open_position_form
+from hhru_bot.resume_sections import apply_plan as apply_sections_plan
+from hhru_bot.skills import edit_skills_on_hh
+
+pytestmark = pytest.mark.integration
+
+# Скелет живого DOM сбойного экрана (без шапки/футера — только main-контейнер
+# баннера, снятый замером #972; вложенность и классы дословные).
+BANNER_HTML = """
+<main class="main-content main-content_broad-spacing">
+  <div class="bloko-columns-wrapper">
+    <div class="row-content">
+      <div class="bloko-column bloko-column_xs-4 bloko-column_s-8 bloko-column_m-12 bloko-column_l-16">
+        <div class="attention attention_bad">Произошла ошибка. Возникли неполадки, но мы уже работаем над их устранением.</div>
+      </div>
+    </div>
+  </div>
+</main>
+"""
+BANNER_TEXT_FULL = "Произошла ошибка. Возникли неполадки, но мы уже работаем над их устранением."
+# Очевидно поддельный id (38 hex, правило #828).
+RESUME_ID = "0" * 38
+RESUME_URL = f"https://hh.ru/resume/{RESUME_ID}"
+
+
+def _attention_bad_nodes(html: str) -> list[_DOMNode]:
+    """Все div.attention.attention_bad фикстуры (селектор детектора #972)."""
+    found: list[_DOMNode] = []
+
+    def walk(node: _DOMNode) -> None:
+        for child in node.children:
+            classes = child.attrs.get("class", "").split()
+            if child.tag == "div" and "attention" in classes and "attention_bad" in classes:
+                found.append(child)
+            walk(child)
+
+    walk(_parse_root(html))
+    return found
+
+
+class _ClassTextLocator:
+    """Локатор ровно под паттерн детектора: ``.filter(has_text=...)`` + count.
+
+    Playwright-семантика has_text — подстрока в тексте элемента; здесь то же
+    (inner_text узла включает его прямых потомков, как у реального браузера).
+    """
+
+    def __init__(self, nodes: list[_DOMNode]):
+        self._nodes = nodes
+
+    def filter(self, *, has_text: str | None = None) -> _ClassTextLocator:
+        if has_text is None:
+            return self
+        return _ClassTextLocator([n for n in self._nodes if has_text in n.inner_text()])
+
+    def count(self) -> int:
+        return len(self._nodes)
+
+
+class _FakeContext:
+    def cookies(self) -> list[dict[str, str]]:
+        return [{"name": "hhtoken", "value": "fake"}]
+
+
+class FakeBannerPage:
+    """Page сбойного экрана: goto, пустая форма входа, баннер по селектору #972."""
+
+    def __init__(self, html: str = BANNER_HTML, *, locator_error: bool = False):
+        self._html = html
+        self.url = RESUME_URL
+        self.goto_calls: list[str] = []
+        self.context = _FakeContext()
+        self._locator_error = locator_error
+
+    def goto(self, url: str, *, wait_until: str = "load") -> None:  # noqa: ARG002
+        self.goto_calls.append(url)
+
+    def content(self) -> str:
+        return self._html
+
+    def locator(self, selector: str) -> _ClassTextLocator:
+        if self._locator_error:
+            raise PlaywrightError("page is closed")
+        if selector == RESUME_ERROR_BANNER:
+            return _ClassTextLocator(_attention_bad_nodes(self._html))
+        # LOGIN_FORM и прочие селекторы точек применения после детекции не
+        # читаются; форма входа обязана быть пустой (сессия жива, #972).
+        if selector == browser_module.LOGIN_FORM:
+            return _ClassTextLocator([])
+        return _ClassTextLocator([])
+
+
+def _resume() -> ResumeConfig:
+    return ResumeConfig(
+        id="r1",
+        resume_url=RESUME_URL,
+        search=SearchFilters(text="python", area=1),
+    )
+
+
+# --- Детектор ---------------------------------------------------------------
+
+
+def test_banner_detected_on_live_dom_skeleton():
+    """Позитив: снятый живой скелет распознаётся детектором."""
+    assert has_resume_error_banner(FakeBannerPage()) is True
+
+
+def test_other_attention_bad_text_is_not_the_banner():
+    """Двойной признак: attention_bad с ДРУГИМ текстом — не наш баннер.
+
+    ``attention attention_bad`` — общий класс предупреждений hh.ru; класс без
+    текста ложно срабатывал бы на чужих баннерах той же страницы.
+    """
+    html = '<div class="attention attention_bad">Проверьте правильность данных</div>'
+
+    assert has_resume_error_banner(FakeBannerPage(html)) is False
+
+
+def test_error_text_without_attention_class_is_not_the_banner():
+    """Текст баннера в элементе без класса attention_bad — не детект."""
+    html = f"<div>{BANNER_TEXT_FULL}</div>"
+
+    assert has_resume_error_banner(FakeBannerPage(html)) is False
+
+
+def test_regular_resume_page_is_not_the_banner():
+    """Страница живого резюме (без баннера) не детектируется."""
+    html = """
+    <main><div data-qa="resume-block-title-position">Python-разработчик</div></main>
+    """
+
+    assert has_resume_error_banner(FakeBannerPage(html)) is False
+
+
+def test_locator_error_keeps_detector_silent():
+    """Ошибка чтения селектора — не доказательство баннера: детектор молчит,
+    вызывающий путь сохраняет свой обычный fail-closed отказ."""
+    assert has_resume_error_banner(FakeBannerPage(locator_error=True)) is False
+
+
+# --- Инвариант семантики отказа ----------------------------------------------
+
+
+def test_require_available_resume_message_states_fact_and_probable_cause():
+    """Формулировка #972 п.2: факт (баннер) констатируется, причина —
+    вероятная, «удалено» НЕ утверждается (баннер — общий сбойный экран)."""
+    with pytest.raises(ResumeUnavailable) as exc_info:
+        require_available_resume(FakeBannerPage())
+
+    message = str(exc_info.value)
+    assert "резюме недоступно" in message
+    assert "баннер ошибки" in message
+    assert "удалено владельцем" in message
+    assert "не доказано" in message
+
+
+def test_require_available_resume_passes_without_banner():
+    require_available_resume(
+        FakeBannerPage("<main><div data-qa='resume-block-title-position'>x</div></main>")
+    )
+
+
+def test_resume_unavailable_is_not_indeterminate_and_not_auth():
+    """#972 п.3: отказ — pre-mutation failed/retry, НЕ PageStateIndeterminate
+    (состояние подтверждено) и не авторизационный класс (сессия жива)."""
+    assert issubclass(ResumeUnavailable, RuntimeError)
+    assert not issubclass(ResumeUnavailable, browser_module.PageStateIndeterminate)
+    assert not issubclass(ResumeUnavailable, browser_module.NotAuthenticated)
+
+
+# --- Точки применения: ранний отказ вместо таймаута --------------------------
+
+
+def test_open_confirmed_resume_fails_fast_on_banner():
+    """open_confirmed_resume (пути experience edit/read): ResumeUnavailable
+    до identity-чека — сбойный экран держит URL /resume/{id} и прошёл бы его."""
+    with pytest.raises(ResumeUnavailable, match="резюме недоступно"):
+        open_confirmed_resume(FakeBannerPage(), RESUME_ID)
+
+
+def test_bump_reports_unavailable_resume_before_button_search():
+    """bump: внятный отказ вместо «кнопка поднятия не найдена»; acted=False и
+    uncertain=False — клика не было, actions/пауза не нужны (#163/#176)."""
+    page = FakeBannerPage()
+
+    result = bump_resume(page, _resume(), dry_run=False)
+
+    assert result.success is False
+    assert result.reason == RESUME_UNAVAILABLE_REASON
+    assert result.acted is False
+    assert result.uncertain is False
+
+
+def test_open_position_form_raises_resume_unavailable():
+    """resume-position (editor/wizard вход): терминальный отказ до выбора flow."""
+    with pytest.raises(ResumeUnavailable, match="резюме недоступно"):
+        open_position_form(FakeBannerPage(), _resume())
+
+
+def test_edit_skills_reports_unavailable_resume():
+    from hhru_bot.skills import Skill
+
+    result = edit_skills_on_hh(
+        FakeBannerPage(), _resume(), (Skill("Python", "basic"),), dry_run=True, mode="append"
+    )
+
+    assert result.success is False
+    assert result.reason == RESUME_UNAVAILABLE_REASON
+
+
+def test_edit_education_raises_resume_unavailable():
+    with pytest.raises(ResumeUnavailable, match="резюме недоступно"):
+        edit_education_on_hh(
+            FakeBannerPage(), RESUME_URL, EducationPlan(), section="primary", dry_run=True
+        )
+
+
+def test_sections_apply_plan_reports_unavailable_resume():
+    """attestations/recommendations: отказ в errors-списке, триггеры не ищутся."""
+    from hhru_bot.resume_sections import ResumeSectionsPlan
+
+    errors = apply_sections_plan(FakeBannerPage(), RESUME_ID, ResumeSectionsPlan(), dry_run=True)
+
+    assert errors == [RESUME_UNAVAILABLE_REASON]
+
+
+def test_about_editor_raises_domain_error_on_banner():
+    """edit-about: доменная AboutGenerationError (команда ловит только её)."""
+    with pytest.raises(AboutGenerationError, match="резюме недоступно"):
+        open_about_editor(FakeBannerPage(), _resume())
+
+
+def test_upload_photo_reports_unavailable_resume():
+    from pathlib import Path
+
+    from hhru_bot.resume_photo import PhotoFile, upload_photo_on_hh
+
+    photo = PhotoFile(path=Path("/tmp/x.jpg"), size_bytes=10, kind="jpeg")
+    result = upload_photo_on_hh(FakeBannerPage(), _resume(), photo, True)
+
+    assert result.success is False
+    assert result.reason == RESUME_UNAVAILABLE_REASON
+    assert result.photo_present is None
+
+
+def test_select_photo_reports_unavailable_resume():
+    from hhru_bot.resume_photo import select_photo_on_hh
+
+    result = select_photo_on_hh(FakeBannerPage(), _resume(), "123", True)
+
+    assert result.success is False
+    assert result.reason == RESUME_UNAVAILABLE_REASON

--- a/tests/test_resume_error_banner_live.py
+++ b/tests/test_resume_error_banner_live.py
@@ -1,0 +1,129 @@
+"""Live-замер #972: DOM баннера ошибки на /resume/{несуществующий id}.
+
+Read-only по построению: единственное действие — навигация на URL резюме,
+которого нет в аккаунте. Никакие кнопки не нажимаются, формы не открываются,
+сохранение невозможно — страница сбойного экрана не содержит мутирующих
+контролов вообще.
+
+Опциональный прогон (маркер live_read исключён из обычной сюиты):
+
+    HHRU_LIVE_CONFIG=/путь/к/config.yaml \
+        pytest -m live_read tests/test_resume_error_banner_live.py -q -s
+
+Что снимает (issue #972):
+1. Полный HTML сбойного экрана — дамп в data/logs/, селектор извлекается
+   чтением дампа, не угадыванием. Скриншот владельца (2026-09-05) — первичное
+   доказательство текста баннера «Произошла ошибка. Возникли неполадки, но
+   мы уже работаем над их устранением.».
+2. Структуру окружения баннера: тег/id/class/data-qa/role всех элементов,
+   содержащих текст баннера, их предков и соседей — источник стабильного
+   селектора (data-qa если есть; иначе текстовый/ARIA-паттерн, как у
+   ``_ENTRY_NOT_FOUND_TEXT`` в resume_education.py).
+
+Целевой resume_id по умолчанию — заведомо несуществующий (38 нулей:
+очевидно поддельный, правило #828). Опционально переопределяется env
+``HHRU_LIVE_RESUME_ID`` — для повторения замера на конкретном id
+(например, удалённом резюме) без хардкода реальных значений в репо.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.browser import HH_BASE_URL, goto_hh, launch_context
+from hhru_bot.config import load_config
+
+_LIVE_CONFIG = os.environ.get("HHRU_LIVE_CONFIG")
+
+pytestmark = [
+    pytest.mark.live_read,
+    pytest.mark.skipif(
+        not _LIVE_CONFIG,
+        reason="требуется явный opt-in HHRU_LIVE_CONFIG=<config.yaml с сессией>",
+    ),
+]
+
+LOG_DIR = Path(__file__).resolve().parents[1] / "data" / "logs"
+# 38 нулей: правильная длина hex-id резюме hh.ru, очевидно поддельное значение.
+NONEXISTENT_RESUME_ID = "0" * 38
+BANNER_TEXT = "Произошла ошибка"
+
+# JS-снимок структуры вокруг баннера: сам элемент с текстом, его предки и
+# прямые дети — с тегом, атрибутами и обрезанным outerHTML. Чтение DOM, не
+# внутренний API hh.ru.
+_BANNER_STRUCTURE_JS = """(needle) => {
+  const out = [];
+  const seen = new Set();
+  const describe = (el, depth) => {
+    if (!el || el.nodeType !== 1 || seen.has(el)) return;
+    seen.add(el);
+    const attrs = {};
+    for (const attr of el.attributes || []) attrs[attr.name] = attr.value;
+    out.push({
+      depth,
+      tag: el.tagName.toLowerCase(),
+      id: el.id || null,
+      dataQa: el.getAttribute('data-qa'),
+      role: el.getAttribute('role'),
+      ariaLive: el.getAttribute('aria-live'),
+      className: (el.className && el.className.toString
+        ? el.className.toString().slice(0, 160) : null),
+      text: (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 200),
+      outerHTML: el.outerHTML.replace(/\\s+/g, ' ').slice(0, 400),
+      attrs,
+    });
+  };
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const roots = [];
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if ((node.textContent || '').includes(needle)) {
+      roots.push(node.parentElement);
+    }
+  }
+  for (const root of roots || []) {
+    describe(root, 0);
+    let depth = 1;
+    for (let el = root && root.parentElement; el && depth <= 4; el = el.parentElement) {
+      describe(el, -depth);
+      depth += 1;
+    }
+    for (const child of (root ? root.querySelectorAll('*') : [])) {
+      describe(child, 1);
+    }
+  }
+  return {url: location.href, title: document.title, elements: out};
+}"""
+
+
+def test_capture_resume_error_banner_dom():
+    assert _LIVE_CONFIG is not None  # skipif выше гарантирует явный opt-in
+    config = load_config(_LIVE_CONFIG)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    resume_id = os.environ.get("HHRU_LIVE_RESUME_ID", NONEXISTENT_RESUME_ID)
+
+    with launch_context(
+        config.storage_state_file, headless=True, user_agent=config.user_agent
+    ) as context:
+        page = context.new_page()
+        goto_hh(page, f"{HH_BASE_URL}/resume/{resume_id}")
+        # Сбойный экран — серверная страница; даём возможной клиентской
+        # догрузке устояться, чтобы дамп не был преждевременным срезом.
+        page.wait_for_timeout(2_000)
+
+        html = page.content()
+        (LOG_DIR / f"972_resume_error_banner_{resume_id[:6]}.html").write_text(
+            html, encoding="utf-8"
+        )
+        structure = page.evaluate(_BANNER_STRUCTURE_JS, BANNER_TEXT)
+
+        print(f"[MEASURE #972] url={structure['url']} title={structure['title']!r}")
+        print(f"[MEASURE #972] body text: {page.locator('body').inner_text()[:400]!r}")
+        print(f"[MEASURE #972] banner elements found: {len(structure['elements'])}")
+        for element in structure["elements"]:
+            print(f"[MEASURE #972]   {element}")
+        print(f"[MEASURE #972] дамп: {LOG_DIR / f'972_resume_error_banner_{resume_id[:6]}.html'}")
+        # Одна read-only навигация; см. докстринг — мутирующих действий нет.

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -125,6 +125,7 @@ def test_open_position_form_reads_draft_wizard_title(monkeypatch):
     page.locator.side_effect = lambda selector: position
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     flow = resume_position.open_position_form(page, resume)
 
@@ -144,6 +145,7 @@ def test_open_position_form_can_inspect_wizard_without_entering_chip_screen(monk
     )
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     flow = resume_position.open_position_form(page, resume, enter_wizard=False)
 
@@ -178,6 +180,7 @@ def test_open_position_form_routes_profile_state_to_identity_bound_wizard(monkey
 
     monkeypatch.setattr(resume_position, "goto_hh", goto)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     flow = resume_position.open_position_form(page, resume)
 
@@ -196,6 +199,7 @@ def test_open_position_form_rejects_wrong_wizard_resume(monkeypatch):
     page.url = "https://hh.ru/profile/resume/professional_role?resume=other-id"
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     with pytest.raises(RuntimeError, match="не для того резюме"):
         resume_position.open_position_form(page, resume)
@@ -216,6 +220,7 @@ def test_open_position_form_rejects_ambiguous_wizard_entry_card(monkeypatch):
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     with pytest.raises(RuntimeError, match="карточка выбора профессии неоднозначна: 2"):
         resume_position.open_position_form(page, resume)
@@ -239,6 +244,7 @@ def test_open_position_form_retries_ssr_card_until_hydrated(monkeypatch):
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     flow = resume_position.open_position_form(page, resume)
 
@@ -268,6 +274,7 @@ def test_open_position_form_reloads_once_after_stalled_ssr_card(monkeypatch):
     monkeypatch.setattr(resume_position, "WIZARD_TRANSITION_ATTEMPTS", 2)
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
 
     flow = resume_position.open_position_form(page, resume)
 
@@ -613,6 +620,7 @@ def test_verify_wizard_minimum_save_returns_once_professional_role_clears(monkey
     page = MagicMock()
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda _page, _resume_id: True)
     states = [
         ResumeState(status="not_finished", next_incomplete_screen_id="professional_role"),
@@ -633,6 +641,7 @@ def test_verify_wizard_minimum_save_times_out_while_professional_role_persists(m
     state = ResumeState(status="not_finished", next_incomplete_screen_id="professional_role")
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: state)
     monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 31]))
@@ -1335,6 +1344,7 @@ def test_open_position_form_retries_pre_hydration_noop_click(monkeypatch):
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1376,6 +1386,7 @@ def test_open_position_form_rejects_form_on_wrong_resume_route(monkeypatch):
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1416,6 +1427,7 @@ def test_open_position_form_accepts_correct_edit_route_on_first_attempt(monkeypa
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1450,6 +1462,7 @@ def test_open_position_form_rejects_already_mounted_form_on_wrong_route(monkeypa
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1482,6 +1495,7 @@ def test_verify_wizard_save_polls_until_professional_role_clears(monkeypatch):
     )
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: next(states))
     monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 1]))
@@ -1518,6 +1532,7 @@ def test_verify_wizard_save_polls_until_resume_card_title_matches(monkeypatch):
     )
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: state)
     monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 1]))
@@ -1554,6 +1569,7 @@ def test_open_position_form_accepts_edit_route_with_query(monkeypatch):
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1586,6 +1602,7 @@ def test_open_position_form_rejects_wrong_route_with_empty_resume_id(monkeypatch
     }[selector]
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(
         resume_position,
@@ -1609,6 +1626,7 @@ def test_verify_wizard_save_never_accepts_persistent_professional_role(monkeypat
     state = ResumeState(status="not_finished", next_incomplete_screen_id="professional_role")
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: state)
     monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 31]))
@@ -1633,6 +1651,7 @@ def test_verify_wizard_save_rejects_wrong_server_role(monkeypatch):
     )
     monkeypatch.setattr(resume_position, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_position, "require_authenticated_page", lambda _page: None)
+    monkeypatch.setattr(resume_position, "require_available_resume", lambda _page: None)
     monkeypatch.setattr(resume_position, "resume_identity_matches", lambda *_args: True)
     monkeypatch.setattr(resume_position, "parse_resume_state", lambda *_args: state)
     monkeypatch.setattr(resume_position.time, "monotonic", MagicMock(side_effect=[0, 0, 31]))

--- a/tests/test_resume_sections.py
+++ b/tests/test_resume_sections.py
@@ -8,11 +8,17 @@ import pytest
 from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.resume_sections as resume_sections
+from hhru_bot.browser import RESUME_ERROR_BANNER
 from hhru_bot.config import ConfigError
 from hhru_bot.config_sections.resume_sections import parse_resume_sections
 from hhru_bot.resume_sections import Recommendation, ResumeSectionsPlan, apply_plan, parse_plan
 
 pytestmark = pytest.mark.unit
+
+# #972: apply_plan до триггеров читает баннер-детектор сбойного экрана
+# (div.attention.attention_bad + has_text). Пустой локатор = «баннера нет».
+_EMPTY_BANNER = MagicMock(name="empty_banner")
+_EMPTY_BANNER.filter.return_value.count.return_value = 0
 
 
 def test_config_rejects_unconfirmed_blocks() -> None:
@@ -77,6 +83,9 @@ def test_recommendation_text_is_rejected_before_opening_editor(monkeypatch) -> N
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.return_value = trigger
+    # #972: баннер-детектор apply_plan читает locator(BANNER).filter(...).count()
+    # через тот же return_value — настраиваем int-ответ «баннера нет».
+    trigger.filter.return_value.count.return_value = 0
     monkeypatch.setattr(resume_sections, "goto_hh", lambda *_args: None)
     monkeypatch.setattr(resume_sections, "has_auth_cookie", lambda _page: True)
     monkeypatch.setattr(resume_sections, "has_login_form", lambda _page: False)
@@ -102,6 +111,7 @@ def test_recommendation_dry_run_cancels_partial_editor(monkeypatch) -> None:
     partial_cancel.count.return_value = 1
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_attestations,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: trigger,
         "[data-qa='resume-partial-edit-cancel']": partial_cancel,
@@ -135,6 +145,7 @@ def test_save_wait_timeout_is_recorded_as_row_error_not_raised(monkeypatch) -> N
     save.wait_for.side_effect = PlaywrightError("timeout waiting for editor to close")
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: trigger,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_recommendations,
         f"[data-qa='{resume_sections.ATTESTATION_FIELDS[0]}']": ready,
@@ -172,6 +183,7 @@ def test_save_click_error_is_recorded_as_row_error_not_raised(monkeypatch) -> No
     save.click.side_effect = PlaywrightError("element is not attached to the DOM")
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: trigger,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_recommendations,
         f"[data-qa='{resume_sections.ATTESTATION_FIELDS[0]}']": ready,
@@ -209,6 +221,7 @@ def test_cancel_click_error_is_recorded_as_row_error_not_raised(monkeypatch) -> 
     partial_cancel.click.side_effect = PlaywrightError("element is not attached to the DOM")
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_attestations,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: trigger,
         "[data-qa='resume-partial-edit-cancel']": partial_cancel,
@@ -244,6 +257,7 @@ def test_save_confirmation_does_not_rely_on_url_already_matched(monkeypatch) -> 
     save.count.return_value = 1
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_attestations,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: trigger,
         "input[name='company']": ready,
@@ -282,6 +296,7 @@ def test_unconfirmed_save_stops_block_instead_of_clicking_next_row(monkeypatch) 
     save.wait_for.side_effect = PlaywrightError("timeout waiting for editor to close")
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: trigger,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_recommendations,
         f"[data-qa='{resume_sections.ATTESTATION_FIELDS[0]}']": ready,
@@ -323,6 +338,7 @@ def test_ambiguous_save_button_stops_block_instead_of_leaving_editor_open(monkey
     ambiguous_save.count.return_value = 2
     ready = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: trigger,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_recommendations,
         f"[data-qa='{resume_sections.ATTESTATION_FIELDS[0]}']": ready,
@@ -417,6 +433,7 @@ def test_empty_section_opens_first_row_via_resume_scoped_route(
     cancel = MagicMock()
     cancel.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_rows,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_rows,
         resume_sections.EMPTY_SECTION_MARKERS["attestations"]: empty_marker,
@@ -469,6 +486,7 @@ def test_both_empty_sections_reset_to_resume_before_each_block(monkeypatch) -> N
     cancel = MagicMock()
     cancel.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_rows,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_rows,
         resume_sections.EMPTY_SECTION_MARKERS["attestations"]: empty_marker,
@@ -517,6 +535,7 @@ def test_empty_section_requires_unique_live_marker(monkeypatch, marker_count) ->
     marker = MagicMock()
     marker.count.return_value = marker_count
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_rows,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_rows,
         resume_sections.EMPTY_SECTION_MARKERS["attestations"]: marker,
@@ -547,6 +566,7 @@ def test_empty_section_route_guard_rejects_other_resume(monkeypatch) -> None:
     marker = MagicMock()
     marker.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         resume_sections.RESUME_EDIT_BUTTON["attestations"]: no_rows,
         resume_sections.RESUME_EDIT_BUTTON["recommendations"]: no_rows,
         resume_sections.EMPTY_SECTION_MARKERS["attestations"]: marker,

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 import hhru_bot.skills as skills_module
+from hhru_bot.browser import RESUME_ERROR_BANNER
 from hhru_bot.config import bare_resume
 from hhru_bot.skills import (
     Skill,
@@ -18,6 +19,12 @@ from hhru_bot.skills import (
 )
 
 pytestmark = pytest.mark.unit
+
+# #972: edit_skills_on_hh до открытия редактора читает баннер-детектор
+# сбойного экрана (div.attention.attention_bad + has_text). Пустой локатор
+# = «баннера нет».
+_EMPTY_BANNER = MagicMock(name="empty_banner")
+_EMPTY_BANNER.filter.return_value.count.return_value = 0
 
 
 def test_parse_skill_plan_accepts_fenced_json_and_levels() -> None:
@@ -71,6 +78,7 @@ def test_edit_skills_retries_pre_hydration_noop_click(monkeypatch) -> None:
 
     trigger.click.side_effect = click_side_effect
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -107,6 +115,7 @@ def test_edit_skills_does_not_retry_after_navigation_to_editor(monkeypatch) -> N
 
     editor.wait_for.side_effect = navigate_then_timeout
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
     }[selector]
@@ -140,6 +149,7 @@ def test_edit_skills_rejects_editor_on_wrong_resume_route(monkeypatch) -> None:
     editor.wait_for.return_value = None
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -178,6 +188,7 @@ def test_edit_skills_accepts_correct_edit_route_on_first_attempt(monkeypatch) ->
     editor.wait_for.return_value = None
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -255,6 +266,7 @@ def test_edit_skills_reports_only_chips_observed_after_save(monkeypatch) -> None
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -309,6 +321,7 @@ def test_edit_skills_waits_for_each_chip_before_next_addition(monkeypatch) -> No
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: suggestion,
@@ -373,6 +386,7 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -423,6 +437,7 @@ def test_edit_skills_marks_rejected_chip_as_uncertain(monkeypatch) -> None:
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -470,6 +485,7 @@ def test_edit_skills_post_save_wait_timeout_falls_through_to_strict_read(monkeyp
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -519,6 +535,7 @@ def test_edit_skills_normalizes_internal_whitespace_in_observed_chips(monkeypatc
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -565,6 +582,7 @@ def test_edit_skills_accepts_edit_route_with_query(monkeypatch) -> None:
     editor.wait_for.return_value = None
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -594,6 +612,7 @@ def test_edit_skills_rejects_wrong_route_with_empty_resume_id(monkeypatch) -> No
     editor.wait_for.return_value = None
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -636,6 +655,7 @@ def test_edit_skills_dedups_existing_chip_with_internal_whitespace(monkeypatch) 
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -678,6 +698,7 @@ def test_edit_skills_opens_editor_via_resume_scoped_route_on_empty_resume(monkey
     editor.wait_for.return_value = None
     cancel = MagicMock()
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
@@ -714,6 +735,7 @@ def test_edit_skills_navigation_timeout_on_empty_resume_returns_failure(monkeypa
     trigger = MagicMock()
     trigger.count.return_value = 0
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
     }[selector]
     goto_attempt = 0
@@ -747,6 +769,7 @@ def test_edit_skills_wrong_route_after_navigation_on_empty_resume_returns_failur
     trigger = MagicMock()
     trigger.count.return_value = 0
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
     }[selector]
     monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
@@ -774,6 +797,7 @@ def test_edit_skills_editor_wait_timeout_on_empty_resume_returns_failure(monkeyp
     editor = MagicMock()
     editor.wait_for.side_effect = PlaywrightTimeoutError("editor hidden")
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_INPUT: editor,
     }[selector]
@@ -809,6 +833,7 @@ def test_confirm_skill_levels_clicks_matching_radio_and_saves() -> None:
     save = MagicMock()
     save.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         "input[name='SeleniumСредний']": radio,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
     }[selector]
@@ -836,6 +861,7 @@ def test_confirm_skill_levels_skips_missing_radio_without_failing() -> None:
     save = MagicMock()
     save.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         "input[name='SeleniumСредний']": missing_radio,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
     }[selector]
@@ -865,6 +891,7 @@ def test_confirm_skill_levels_skips_radio_when_count_raises() -> None:
     save = MagicMock()
     save.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         'input[name="Ruby\'QuoteСредний"]': broken_radio,
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
     }.get(selector, broken_radio)
@@ -919,6 +946,7 @@ def test_edit_skills_handles_levels_wizard_step_for_new_skill(monkeypatch) -> No
         if selector == "input[name='SeleniumСредний']":
             return levels_radio
         return {
+            RESUME_ERROR_BANNER: _EMPTY_BANNER,
             skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
             skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
             skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
@@ -971,6 +999,7 @@ def test_edit_skills_marks_level_mismatch_as_uncertain_not_ok(monkeypatch) -> No
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
         skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),


### PR DESCRIPTION
feat(resume): детекция баннера ошибки на /resume/{id} — внятный отказ вместо таймаутов

Closes #972

## Что изменилось

Несуществующее/удалённое резюме по прямому URL `/resume/{id}` рендерит сбойный
экран hh.ru — только баннер «Произошла ошибка. Возникли неполадки, но мы уже
работаем над их устранением.», без data-qa. CLI этот экран не различал:
`bump` отвечал «кнопка поднятия резюме не найдена на странице», edit-команды и
`resume-position` падали Playwright-таймаутами.

## Селектор — с живого DOM (read-only)

Снят live_read-замером за логином 2026-09-05 (`tests/test_resume_error_banner_live.py`,
конфиг основного репо, одна read-only навигация; дамп —
`data/logs/972_resume_error_banner_000000.html`):

```html
<main class="main-content main-content_broad-spacing">
  <div class="bloko-columns-wrapper">
    <div class="row-content">
      <div class="bloko-column ...">
        <div class="attention attention_bad">Произошла ошибка. ...</div>
```

- **data-qa на баннере нет** (как у error boundary «Problem fetching content», #802) —
  стабильный bloko-класс `div.attention.attention_bad` + точный текст — **двойной
  признак**, отсекающий другие attention_bad-предупреждения той же страницы.
- Экран идентичен для полностью несуществующего id (38 нулей, очевидно
  поддельный — #828) и для удалённого резюме (скриншот владельца из #972).
- Шапка (чаты/резюме/отклики) рендерится — сессия жива: семантика «резюме
  недоступно, сессия ок» подтверждена живым замером.
- Селектор без `[data-qa` → референс-каталог `selectors/` не затрагивается
  (прецедент: `_DELETE_CONFIRM_DIALOG`, `_ENTRY_NOT_FOUND_TEXT`); пометка
  подтверждения — комментарий у константы в `browser.py`.

## Реализация

- `browser.py` (семейство `PAGE_STATE`/`NotAuthenticated`): `RESUME_ERROR_BANNER`/
  `RESUME_UNAVAILABLE_REASON`, `has_resume_error_banner()` (ошибка чтения селектора —
  не доказательство баннера: детектор молчит, путь сохраняет свой fail-closed),
  `require_available_resume()`, исключение `ResumeUnavailable` — **pre-mutation
  failed/retry**: не `uncertain` (#176, клика не было) и не `NotAuthenticated`
  (сессия действительна). `open_confirmed_resume` проверяет баннер **до**
  identity-чека — сбойный экран держит URL `/resume/{id}` и прошёл бы его.
- Точки применения (все пути, открывающие `/resume/{id}` напрямую до мутации):
  `bump` (BumpResult, acted=False — #163 сохранён), `resume-position`
  (`open_position_form`), edit-опыта (`open_confirmed_resume` — edit+read),
  edit-образования, edit-навыков, edit-about (доменная `AboutGenerationError` —
  команда ловит только её), attestations/recommendations, `upload-photo`,
  `select-photo`. Каждая точка — 2–4 строки рядом с существующим auth-чеком.
- **Не тронуты**: post-mutation readback'ы (`verify_wizard_save`,
  `verify_wizard_minimum_save`, `_readback_photo_persisted`, readback
  `_select_and_assign`, copy-resume) — там uncertain-семантика, детекция баннера
  после мутации не имеет права переквалифицировать исход в обычный failed.
  `edit-languages` `/resume/{id}` не открывает (профиль языков —
  `/applicant/profile/me`) — детекция неприменима.
- Сообщение (по #972 п.2, без сверки со списком резюме): «резюме недоступно:
  hh.ru показал баннер ошибки (наиболее вероятная причина — резюме удалено
  владельцем; баннер — общий сбойный экран hh.ru, удаление не доказано)».

## Тесты

- `tests/test_resume_error_banner.py` (17): HTML-фикстура — дословный скелет
  снятого живого DOM; позитив, негативы двойного признака (чужой текст в
  attention_bad / текст без класса), молчание при ошибке селектора, инварианты
  класса исключения, формулировка сообщения, все 9 точек применения
  (отказ без клика/uncertain).
- `tests/test_resume_error_banner_live.py` (live_read, вне обычной сюиты):
  канал повторного снятия селектора; id по умолчанию — 38 нулей,
  переопределяется `HHRU_LIVE_RESUME_ID` без хардкода реальных id.
- Существующие двойники расширены баннерным селектором (словари локаторов в
  test_about/test_skills/test_resume_sections, гейт-патчи test_resume_position,
  одна настройка цепочки в test_browser_navigation) — семантика тестов не менялась.

## Проверки

- `python3 -m pytest -q -n 4 --dist worksteal` — **3409 passed, 2 skipped**
  (скипы — Windows-only, не связаны).
- `ruff check src tests scripts` + `ruff format --check` — чисто.
- `scripts/selector_contracts.py check` (296), `scripts/sync_plugin_manifests.py
  --check`, `scripts/check_plugin_refs.py`, `scripts/gen_cli_docs.py --check` — чисто.
- Live-подтверждение селектора: выполнено (read-only, см. выше); мутирующих
  прогонов не было — фича детекции read-only.

## Риски и следствия

- `has_text`-фильтр — подстрока: баннер детектируется и при изменении второй
  фразы hh.ru, но смена первой («Произошла ошибка») ослепит детектор — вернёт
  прежнее поведение (таймаут/«не найдена»), не ложный отказ. Симптом регрессии —
  явный текст баннера в `[FAIL]` пропадает; лечится повторным live-замером.
- `require_available_resume` в `open_confirmed_resume`/`open_position_form`
  поднимает новое исключение: команды печатают его через существующий широкий
  `except Exception → [FAIL]` без записи в actions (pre-mutation).
