### PR TITLE
fix(edit-languages): hydration gate + add-form click retry (#975)

### DIFF
--- a/src/hhru_bot/languages.py
+++ b/src/hhru_bot/languages.py
@@ -14,13 +14,24 @@ from urllib.parse import urlsplit
 
 from playwright.sync_api import Error as PlaywrightError
 
-from .browser import HH_BASE_URL, LOGIN_FORM, goto_hh, has_auth_cookie, has_login_form
+from .browser import (
+    HH_BASE_URL,
+    LOGIN_FORM,
+    dump_page_html,
+    goto_hh,
+    has_auth_cookie,
+    has_login_form,
+    wait_for_react_hydration,
+)
 from .config import ResumeConfig
 from .selector_groups import resume_page
 
 CEFR_LEVELS = frozenset(("A1", "A2", "B1", "B2", "C1", "C2"))
 _LANGUAGE_PROFILE_PATH = "/applicant/profile/me"
 _LANGUAGE_PROFILE_READY_SELECTOR = f"{resume_page.RESUME_LANGUAGE_CARD}:visible, {LOGIN_FORM}"
+_ADD_HYDRATION_TIMEOUT_MS = 15_000
+_ADD_FORM_TIMEOUT_MS = 15_000
+_ADD_CLICK_ATTEMPTS = 2
 
 
 @dataclass(frozen=True)
@@ -141,6 +152,39 @@ def _open_language_profile(page):
     return card
 
 
+def _open_add_form(page) -> None:
+    """Open the add-language form, surviving the hydration click window (#975).
+
+    Бои 2026-09-05 (#975): кнопка «Добавить язык» видима из SSR задолго до
+    гидрации (окно #858 — на холодном контексте CLI заметно дольше, чем в
+    тёплом браузере), клик в это окно молча теряется, и ожидание формы
+    падало по таймауту без какого-либо следа. Теперь перед кликом ждём
+    React-привязку кнопки, а пропавший клик повторяем: два клика подряд
+    безопасны, потому что после РЕАЛЬНО открытия модалки повторный клик
+    упрётся в оверлей и даст PlaywrightError, а не вторую модалку.
+    Провал обеих попыток — дамп страницы и внятная причина вместо
+    безликого таймаута.
+    """
+    add_button = page.locator(resume_page.RESUME_LANGUAGE_ADD_BUTTON)
+    form = page.locator(resume_page.RESUME_LANGUAGE_ADD_FORM).first
+    errors: list[str] = []
+    for attempt in range(1, _ADD_CLICK_ATTEMPTS + 1):
+        wait_for_react_hydration(
+            page, resume_page.RESUME_LANGUAGE_ADD_BUTTON, timeout_ms=_ADD_HYDRATION_TIMEOUT_MS
+        )
+        try:
+            add_button.click()
+            form.wait_for(state="visible", timeout=_ADD_FORM_TIMEOUT_MS)
+            return
+        except PlaywrightError as exc:
+            errors.append(f"попытка {attempt}: {exc}")
+    dump_path = dump_page_html(page, "language_add_form_timeout")
+    reason = f"форма добавления языка не открылась после {len(errors)} кликов ({'; '.join(errors)})"
+    if dump_path is not None:
+        reason += f"; дамп: {dump_path}"
+    raise RuntimeError(reason)
+
+
 def read_existing_languages(card) -> tuple[str, ...]:
     """Read the language names already on the (already-confirmed) card."""
     return tuple(
@@ -223,14 +267,9 @@ def edit_languages_on_hh(
         for item in additions:
             # unconfirmed (above) already proved every item.level is non-None.
             assert item.level is not None
-            add_button.click()
-            # The visible profile card may still be SSR-only when Add is
-            # clicked.  Wait for the hydrated form itself before inspecting
-            # the dialog or its fields; commit/visibility of the card does
-            # not prove that the React modal has rendered yet.
-            page.locator(resume_page.RESUME_LANGUAGE_ADD_FORM).first.wait_for(
-                state="visible", timeout=15_000
-            )
+            # Гидрация + ретрай клика внутри (#975): первый клик может уйти
+            # в SSR-кнопку и молча потеряться.
+            _open_add_form(page)
             dialog = page.get_by_role("dialog", name="Язык").last
             dialog.wait_for(state="visible", timeout=15_000)
             form = dialog.locator(resume_page.RESUME_LANGUAGE_ADD_FORM)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -444,3 +444,128 @@ def test_existing_languages_are_read_from_cell_text_not_split_on_comma(monkeypat
 
     assert not result.success
     assert "пустого раздела" in result.reason
+
+
+def _page_with_language_section(add_button, form_locator):
+    """MagicMock page whose strict count() guards mirror the live selectors."""
+    from hhru_bot.selector_groups import resume_page
+
+    page = MagicMock()
+    page.url = "https://hh.ru/applicant/profile/me"
+    card = MagicMock()
+    card.count.return_value = 1
+    card.locator.return_value.all.return_value = []
+    add_button.count.return_value = 1
+
+    def locator(selector):
+        if selector == resume_page.RESUME_LANGUAGE_CARD:
+            return card
+        if selector == resume_page.RESUME_LANGUAGE_ADD_BUTTON:
+            return add_button
+        if selector == resume_page.RESUME_LANGUAGE_ADD_FORM:
+            return form_locator
+        return MagicMock()
+
+    page.locator.side_effect = locator
+    return page
+
+
+def _happy_dialog_chain(monkeypatch):
+    dialog = MagicMock()
+    form = MagicMock()
+    form.locator.return_value.count.return_value = 1
+    form.count.return_value = 1
+    dialog.locator.return_value = form
+    page_get_by_role = _StrictLastLocator(dialog)
+    return dialog, page_get_by_role
+
+
+def test_lost_first_add_click_is_retried_and_succeeds(monkeypatch):
+    """#975: the add button is visible from SSR long before hydration; a click
+    inside that window is silently lost and the form never opens. The first
+    attempt must be retried (after a hydration wait), not fail the run."""
+    from hhru_bot.selector_groups import resume_page as rp
+
+    resume = type("Resume", (), {"resume_id": "abc", "id": "abc"})()
+    add_button = MagicMock()
+    form_locator = MagicMock()
+    # First attempt: the click is lost (form never becomes visible),
+    # second attempt: the form opens.
+    form_locator.first.wait_for.side_effect = [
+        PlaywrightError("Timeout 15000ms exceeded"),
+        None,
+    ]
+    added_row = MagicMock()
+    added_row.locator.return_value.first.inner_text.return_value = "English"
+    add_button.count.return_value = 1
+
+    def make_card():
+        card = MagicMock()
+        card.count.return_value = 1
+        card.first.wait_for.return_value = None
+        # rows before the save: none; after: the saved language
+        card.locator.return_value.all.side_effect = lambda: (
+            [] if add_button.click.call_count < 2 else [added_row]
+        )
+        return card
+
+    page = MagicMock()
+    page.url = "https://hh.ru/applicant/profile/me"
+
+    def locator(selector):
+        if selector == rp.RESUME_LANGUAGE_CARD:
+            return make_card()
+        if selector == rp.RESUME_LANGUAGE_ADD_BUTTON:
+            return add_button
+        if selector == rp.RESUME_LANGUAGE_ADD_FORM:
+            return form_locator
+        return MagicMock()
+
+    page.locator.side_effect = locator
+    dialog, get_by_role = _happy_dialog_chain(monkeypatch)
+    page.get_by_role.return_value = get_by_role
+    monkeypatch.setattr(languages, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(languages, "has_auth_cookie", lambda _p: True)
+    monkeypatch.setattr(languages, "has_login_form", lambda _p: False)
+    hydration_calls = []
+    monkeypatch.setattr(
+        languages,
+        "wait_for_react_hydration",
+        lambda _page, _sel, *, timeout_ms: hydration_calls.append(timeout_ms) or True,
+    )
+
+    result = edit_languages_on_hh(
+        page, resume, (Language("English", "B2"),), dry_run=False, mode="append"
+    )
+
+    assert result.success, result.reason
+    assert result.acted is True
+    assert add_button.click.call_count == 2
+    assert len(hydration_calls) == 2
+
+
+def test_add_form_never_opens_reports_reason_and_dump(monkeypatch):
+    """#975: both click attempts lost -> fail with a specific reason and a
+    page dump, not a bare locator timeout wrapped in a generic message."""
+    resume = type("Resume", (), {"resume_id": "abc", "id": "abc"})()
+    add_button = MagicMock()
+    form_locator = MagicMock()
+    form_locator.first.wait_for.side_effect = PlaywrightError("Timeout 15000ms exceeded")
+    page = _page_with_language_section(add_button, form_locator)
+    monkeypatch.setattr(languages, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(languages, "has_auth_cookie", lambda _p: True)
+    monkeypatch.setattr(languages, "has_login_form", lambda _p: False)
+    monkeypatch.setattr(languages, "wait_for_react_hydration", lambda *_a, **_k: True)
+    dump_path = MagicMock()
+    monkeypatch.setattr(languages, "dump_page_html", lambda _page, stem: dump_path)
+
+    result = edit_languages_on_hh(
+        page, resume, (Language("English", "B2"),), dry_run=False, mode="append"
+    )
+
+    assert not result.success
+    assert result.acted is False
+    assert "форма добавления языка не открылась" in result.reason
+    assert str(dump_path) in result.reason
+    assert "попытка 2" in result.reason
+    assert add_button.click.call_count == 2


### PR DESCRIPTION
Closes #975

## Причина
Прогоны 4f6f2d83/45692beb (2026-09-05): клик по «Добавить язык» уходил в SSR-кнопку до гидрации (окно #858 — на холодном контексте Playwright-сессии заметно дольше, чем в тёплом браузере), событие молча терялось, ожидание `profile-language-add-form` падало по таймауту 15с, наружу выходила безликая обёртка «сохранение языка не подтверждено» без дампа.

Read-only probe живого профиля (2026-09-05): селекторы `profile-language-add` / `profile-language-add-form` / `profile-languages-editor-modal` на `/applicant/profile/me` актуальны, форма по клику в гидратированном состоянии открывается мгновенно — DOM-drift исключён, виновато окно гидрации.

## Фикс (`languages.py`)
- новый `_open_add_form(page)`: перед кликом — `wait_for_react_hydration` кнопки (15с), затем click + ожидание формы; пропавший клик ретраится (2 попытки); повторный клик при уже открытой модалке безопасно даёт PlaywrightError (оверхлей), а не вторую модалку;
- провал обеих попыток — `dump_page_html(page, "language_add_form_timeout")` и причина вида «форма добавления языка не открылась после 2 кликов (попытка 1: …; попытка 2: …); дамп: …» вместо обёртки locator-timeout.

## Тесты
- потерянный первый клик → ретрай открывает форму → success, click.call_count == 2, гидрация ждала перед каждым кликом;
- оба клика потеряны → fail с внятной причиной, дампом, `acted=False`.

`pytest tests/` зелёный, `selector_contracts check` OK (296).

## Acceptance
Боевой прогон `edit-languages --language "Таджикский=C2" --force` — после явного разрешения (галочка ниже).

- [ ] боевой прогон зелёный (readback строки «Таджикский» на карточке языков)