### PR TITLE
fix(edit-languages): опции языка/уровня — portal-попап вне dialog (#975)

### DIFF
--- a/src/hhru_bot/languages.py
+++ b/src/hhru_bot/languages.py
@@ -325,7 +325,10 @@ def _choose_language(page, form, name: str) -> None:
     if selector.count() != 1:
         raise PlaywrightError("поле выбора языка не найдено однозначно")
     selector.click()
-    _click_portal_option(page.get_by_role("option", name=name, exact=True).last)
+    _click_portal_option(
+        page.get_by_role("option", name=name, exact=True).last,
+        strict_label=f"языка '{name}'",
+    )
 
 
 def _choose_degree(page, form, level: str) -> None:

--- a/src/hhru_bot/languages.py
+++ b/src/hhru_bot/languages.py
@@ -31,6 +31,7 @@ _LANGUAGE_PROFILE_PATH = "/applicant/profile/me"
 _LANGUAGE_PROFILE_READY_SELECTOR = f"{resume_page.RESUME_LANGUAGE_CARD}:visible, {LOGIN_FORM}"
 _ADD_HYDRATION_TIMEOUT_MS = 15_000
 _ADD_FORM_TIMEOUT_MS = 15_000
+_OPTION_TIMEOUT_MS = 15_000
 _ADD_CLICK_ATTEMPTS = 2
 
 
@@ -305,13 +306,26 @@ def edit_languages_on_hh(
         )
 
 
+def _click_portal_option(option, strict_label: str | None = None) -> None:
+    # #975 (live 2026-09-05): клик по активатору открывает magritte-попап,
+    # который рендерится в портале ВНЕ диалога role=dialog — опция внутри
+    # dialog.get_by_role("option") не появляется никогда (30s timeout).
+    # Паттерн experience._select_month / #826: опция адресуется page-wide и
+    # ждёт видимости после клика (commit не значит отрисовано); ожидание до
+    # строгого count() принципиально — без него count может увидеть 0 опций
+    # ещё не отрисованного попапа.
+    option.wait_for(state="visible", timeout=_OPTION_TIMEOUT_MS)
+    if strict_label is not None and option.count() != 1:
+        raise PlaywrightError(f"опция {strict_label} не найдена однозначно")
+    option.click()
+
+
 def _choose_language(page, form, name: str) -> None:
     selector = form.locator(resume_page.RESUME_LANGUAGE_FORM_LANGUAGE_SELECT)
     if selector.count() != 1:
         raise PlaywrightError("поле выбора языка не найдено однозначно")
     selector.click()
-    dialog = page.get_by_role("dialog", name="Язык").last
-    dialog.get_by_role("option", name=name, exact=True).click()
+    _click_portal_option(page.get_by_role("option", name=name, exact=True).last)
 
 
 def _choose_degree(page, form, level: str) -> None:
@@ -319,11 +333,8 @@ def _choose_degree(page, form, level: str) -> None:
     if selector.count() != 1:
         raise PlaywrightError("поле выбора уровня не найдено однозначно")
     selector.click()
-    dialog = page.get_by_role("dialog", name="Язык").last
-    option = dialog.locator(resume_page.RESUME_LANGUAGE_DEGREE_OPTION.format(level.lower()))
-    if option.count() != 1:
-        raise PlaywrightError(f"опция уровня '{level}' не найдена однозначно")
-    option.click()
+    option = page.locator(resume_page.RESUME_LANGUAGE_DEGREE_OPTION.format(level.lower()))
+    _click_portal_option(option, strict_label=f"уровня '{level}'")
 
 
 def _language_save_button(dialog):

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -173,6 +173,15 @@ class _StrictLastLocator:
         return self._dialog
 
 
+def _portal_option():
+    """#975: magritte-опции языка/уровня адресуются page-wide (portal-попап
+    вне dialog), а не через dialog.locator — мок для locator-side_effect."""
+    option = MagicMock()
+    option.count.return_value = 1
+    option.wait_for.return_value = None
+    return option
+
+
 def test_add_language_flow_uses_last_as_a_property_not_a_call(monkeypatch) -> None:
     """#265 code-review round 1 (Codex/claude): page.get_by_role(...).last()
     called Locator.last as a method; it is a property on the real API, and
@@ -208,6 +217,8 @@ def test_add_language_flow_uses_last_as_a_property_not_a_call(monkeypatch) -> No
             return card
         if selector == resume_page.RESUME_LANGUAGE_ADD_BUTTON:
             return add_button
+        if "magritte-select-option-" in selector:
+            return _portal_option()
         return MagicMock()
 
     page.locator.side_effect = locator_side_effect
@@ -391,6 +402,8 @@ def test_dialog_hidden_is_not_trusted_as_proof_of_persistence(monkeypatch) -> No
             return card
         if selector == resume_page.RESUME_LANGUAGE_ADD_BUTTON:
             return add_button
+        if "magritte-select-option-" in selector:
+            return _portal_option()
         return MagicMock()
 
     page.locator.side_effect = locator_side_effect
@@ -464,6 +477,8 @@ def _page_with_language_section(add_button, form_locator):
             return add_button
         if selector == resume_page.RESUME_LANGUAGE_ADD_FORM:
             return form_locator
+        if "magritte-select-option-" in selector:
+            return _portal_option()
         return MagicMock()
 
     page.locator.side_effect = locator
@@ -519,6 +534,8 @@ def test_lost_first_add_click_is_retried_and_succeeds(monkeypatch):
             return add_button
         if selector == rp.RESUME_LANGUAGE_ADD_FORM:
             return form_locator
+        if "magritte-select-option-" in selector:
+            return _portal_option()
         return MagicMock()
 
     page.locator.side_effect = locator

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -167,6 +167,9 @@ class _StrictLastLocator:
 
     def __init__(self, dialog: MagicMock) -> None:
         self._dialog = dialog
+        # #975 review: page-wide language option now passes the strict
+        # count() guard in _click_portal_option — satisfy it by default.
+        dialog.count.return_value = 1
 
     @property
     def last(self) -> MagicMock:


### PR DESCRIPTION
## Что случилось

После hydration-фикса #975 (4648850a) живой прогон `edit-languages --language "Таджикский=C2" --force` падал на шаг дальше — форма открывалась, но опция языка не находилась:

```
[FAIL] ... Locator.click: Timeout 30000ms exceeded.
Call log:
  - waiting for get_by_role("dialog", name="Язык").last.get_by_role("option", name="Таджикский", exact=True)
```

RUN `d54241b1` (fail до мутации, записи на hh.ru не было).

## Причина

Magritte-попап комбобокса рендерится в **портале вне `role=dialog`** — опция внутри `dialog.get_by_role("option")` не появляется никогда. Тот же портал-механизм, что у `experience._select_month` и #826.

## Фикс

- Опции языка/уровня адресуются page-wide с явным `wait_for(state="visible")` после клика по активатору (паттерн «commit не значит отрисовано»); ожидание до строгого `count()!=1` принципиально — без него count видит 0 опций не отрисованного попапа.
- Общий шаг вынесен в локальный `_click_portal_option()` (общий хелпер в `browser.py` запрещён CLAUDE.md — таймауты законно разные).
- Тесты: мок `_portal_option()` + перехват `magritte-select-option-` в locator-side_effect (18/18 зелёные), ruff check/format чистые.

## Живой прогон

Боевой `edit-languages --force` после фикса: `[OK] Таджикский [C2]`, success=1, post-save readback подтвердил строку в карточке языков.

Closes #975
