### PR TITLE
research(hhru-live): сверка якорей и close-контролов с живым DOM (#932)

### DIFF
--- a/extensions/hhru-live/README.md
+++ b/extensions/hhru-live/README.md
@@ -74,24 +74,22 @@ modal/dialog/toast/notification/cookie-баннеры, классифициру�
 до слушателя (см. #743). Полноценный агентский мост (Native Messaging) —
 второй этап #588, здесь его нет намеренно.
 
-## Что НЕ подтверждено живым DOM (честно)
+## Селекторы — статус проверки (#932, сверка с живым DOM 2026-09-05)
 
-Якоря классификации и close-маркеры — гипотезы, написанные по документации
-проекта (CLAUDE.md, #586) и структуре hh.ru, но **не снятые с живого DOM**:
+Формат — по образцу «Селекторы — статус проверки» из CLAUDE.md. Сверка
+строго read-only: анонимная главная через curl-дамп, залогиненный профиль —
+через живую вкладку (ценз видимых overlay + cross-check с реестром
+селекторов `selectors/reference-map.yaml`, все его записи `documented_live`).
 
-- фактические классы/aria-label/data-qa крестиков модалок и тостов hh.ru;
-- реальный DOM тоста «Резюме доставлено» (transient UI — см. #586, popup
-  исчез до снятия селекторов);
-- close-маркеры cookie-баннера hh.ru (частично подтверждено живым DOM
-  2026-09-02, анонимная главная: баннер включается state-классом
-  `cookie-policy-banner-enabled` на `<body>` — отсюда страж, что `html`/`body`
-  никогда не регистрируются как overlay; сам элемент баннера самоудаляется
-  до осмотра, его крестик не снят).
-
-Первая боевая проверка — вручную через этот MVP в своём Chrome; системная
-read-only сверка — вынесена в follow-up (#932). При расхождении симптом такой:
-окно репортится как `ambiguous`/не закрывается — сверить DOM вкладки (F12) и
-поправить якоря в `content.js`.
+| Якорь / контрол | Статус | Живое доказательство |
+|---|---|---|
+| Cookie-информер: `div[data-qa="cookies-policy-informer"]`, класс `wrapper--*` (без «cookie»), кнопка «Понятно» `data-qa="cookies-policy-informer-accept"` | подтверждено живым DOM (анонимный curl-дамп 2026-09-05) | информер НЕ ловится `[class*="cookie"]` → в `OVERLAY_SELECTORS` добавлен `[data-qa*="cookie"]`; «Понятно» — не close-маркер, dismiss вернёт `no_close_control`, согласие не кликается никогда |
+| State-класс баннера `cookie-policy-banner-enabled` на `<body>` | подтверждено живым DOM 2026-09-02 (анонимная главная) | страж html/body в `reportIfNewlyVisible` |
+| Крестики модалок: `data-qa="profile-modal-button-close"`, `photo-viewer-close`, `bloko-modal-close`, `editor-modal-close-icon`, `resume-delete-close` | подтверждено живым DOM (профиль 2026-09-05 + реестр селекторов, все `documented_live`) | реальные крестики — всегда data-qa `*-close`, БЕЗ aria-label «закрыть» и без глифа × (svg-иконка); рабочее плечо `findCloseControls` — `/close/` по data-qa |
+| Нотификации: контейнер `Bloko-Notification-Manager notification-manager` присутствует на странице всегда, даже пустой | подтверждено живым DOM (профиль 2026-09-05) | детектор репортит его как `notification`/`safe` с `no_close_control` — шум, но безопасный (клик невозможен); фильтрация пустых контейнеров — осознанно НЕ делалась (не якорь, а логика) |
+| Кнопка удаления в нотификациях: `[data-qa='notification-close'] button[aria-label='Удалить']` | подтверждено реестром селекторов (живой DOM более ранних прогонов) | aria-label не виден в textContent → `collectText` теперь включают `aria-label` потомков: такая нотификация попадёт в `dangerous` (/удалить/i), автозакрытие исключено |
+| Форма отклика: `form#RESPONSE_MODAL_FORM_ID`, `data-qa*="vacancy-response"`, task-question/task-body | **UNCONFIRMED** | клик «Откликнуться» создаёт тему отклика (инцидент 2026-08-16) — живой DOM модалки не снимался; закроет боевой apply второго этапа |
+| Тост «Резюме доставлено» / «Отклик отправлен» | **UNCONFIRMED** | transient UI (#586: popup исчез до снятия); ловить только перехватом сразу после боевого действия |
 
 Permissions минимальны: `storage` (журнал диагностики в `storage.session`,
 переживает рестарт MV3 service worker) + host hh.ru. Диагностика подключения

--- a/extensions/hhru-live/content.js
+++ b/extensions/hhru-live/content.js
@@ -21,7 +21,13 @@ const ACTION_ALLOWLIST = new Set(['list_overlays', 'dismiss_overlay', 'check_ele
 const OVERLAY_SELECTORS = [
   '[role="dialog"]', '[role="alertdialog"]', '[aria-modal="true"]',
   '[class*="modal"]', '[class*="popup"]', '[class*="toast"]',
-  '[class*="notification"]', '[class*="cookie"]'
+  '[class*="notification"]', '[class*="cookie"]',
+  // #932, live DOM 2026-09-05 (анонимная главная): информер cookies — это
+  // div[data-qa="cookies-policy-informer"] с классом wrapper--* («cookie» в
+  // классе НЕТ), так что [class*="cookie"] его не находит. Внутри — кнопка
+  // «Понятно» (data-qa="cookies-policy-informer-accept", НЕ close-маркер:
+  // dismiss вернёт no_close_control и не кликнет согласие).
+  '[data-qa*="cookie"]'
 ];
 // Danger anchors are matched against the overlay's own + descendant text.
 // Intentionally narrow: a miss keeps the overlay merely blocked (safe side);
@@ -46,10 +52,24 @@ const DANGEROUS_TEXT = [
 // dismissible (PR #935 review). The response form itself is covered by the
 // structural anchors below.
 const APPLY_TEXT = [/сопроводительн/i, /тестовое задание/i, /анкет/i];
+// Статус #932 (2026-09-05): структурные apply-якоря (RESPONSE_MODAL_FORM_ID,
+// vacancy-response data-qa) и APPLY_TEXT остаются ГИПОТЕЗАМИ — живая модалка
+// отклика не снималась, потому что клик «Откликнуться» создаёт тему отклика
+// (инцидент 2026-08-16); подтверждение возможно только в боевом apply
+// (второй этап). Close-маркеры и cookie-информер при этом подтверждены
+// живым DOM — см. README, таблицу статусов.
 const APPLY_QA = /vacancy-response/i;
 const APPLY_CLASS = /task-question|task-body/i;
 const APPLY_FORM_ID = /RESPONSE_MODAL_FORM_ID/;
 const CLOSE_LABEL = /закрыт|close|dismiss/i;
+// #932, live DOM 2026-09-05 (залогиненный профиль + реестр селекторов):
+// реальные крестики hh.ru — это data-qa с суффиксом -close
+// (profile-modal-button-close, photo-viewer-close, bloko-modal-close,
+// editor-modal-close-icon, resume-delete-close); aria-label «закрыть» и
+// глифы ×/✕ на них НЕ встречаются (иконка — svg без текста). Значит
+// рабочее плечо здесь — именно /close/ по data-qa/class; label- и
+// glyph-плечи остаются как совместимость с прочими библиотечными
+// модалками, живых опровержений нет.
 // A lone latin "x" is weaker evidence than ×/✕: decorative spans with a
 // data-qa attribute and an x glyph exist on real pages, and it must not be
 // clickable just because of the attribute (PR #935 review).
@@ -88,9 +108,19 @@ function classify(element) {
 // element.textContent already includes the subtree (descendants double up,
 // harmless for regex matching); the per-node loop keeps the js-harness stub,
 // whose textContent is per-node, working with the same code path.
+// #932 (live DOM 2026-09-05): aria-label тоже в скане — в реестре селекторов
+// зафиксирована живая hh.ru-нотификация, чей единственный close-контрол —
+// button[aria-label="Удалить"] ([data-qa='notification-close'] button) —
+// текстом «удалить» нигде не виден, и без этого такая нотификация
+// классифицировалась бы safe с кликабельным «удалением».
 function collectText(element) {
   const parts = [element.textContent || ''];
-  walkDescendants(element, (node) => parts.push(node.textContent || ''));
+  walkDescendants(element, (node) => {
+    parts.push(node.textContent || '');
+    // aria-label — часть видимого пользователю смысла кнопки, хотя в
+    // textContent не попадает никогда.
+    parts.push(node.getAttribute ? (node.getAttribute('aria-label') || '') : '');
+  });
   return parts.join(' ').trim().replace(/\s+/g, ' ');
 }
 


### PR DESCRIPTION
Closes #932

Строго read-only сверка якорей `extensions/hhru-live/content.js` с живым hh.ru (2026-09-05): анонимная главная — curl-дамп, залогиненный профиль — ценз видимых overlay в живой вкладке + cross-check с `selectors/reference-map.yaml`.

## Подтверждено живым DOM
- **Cookie-информер** — `div[data-qa="cookies-policy-informer"]`, класс `wrapper--*` (без «cookie»): селектор `[class*="cookie"]` его **не находил** → добавлен `[data-qa*="cookie"]`. Кнопка «Понятно» (`cookies-policy-informer-accept`) — не close-маркер: dismiss честно вернёт `no_close_control`, согласие не кликается никогда (задокументированный fail-closed trade-off не актуален — в тексте нет «подтвердите»).
- **Крестики модалок** — всегда `data-qa="*-close"` (`profile-modal-button-close`, `photo-viewer-close`, `bloko-modal-close`, `editor-modal-close-icon`, `resume-delete-close`), БЕЗ aria-label «закрыть» и без глифа × (svg без текста). Рабочее плечо `findCloseControls` — `/close/` по data-qa; label/glyph-плечи оставлены как совместимость.
- **Нотификации**: пустой `Bloko-Notification-Manager` присутствует всегда и репортится как safe-шум (клик невозможен) — задокументировано, не чинилось.
- **Опасный кейс закрыт**: в реестре есть живая нотификация с единственным close-контролом `button[aria-label='Удалить']` — aria-label не виден в textContent, и она классифицировалась бы `safe`. `collectText` теперь включает aria-label → `/удалить/i` → `dangerous`.

## Честно UNCONFIRMED (README)
Модалка отклика (`RESPONSE_MODAL_FORM_ID`, `vacancy-response`) и тосты «Резюме доставлено»/«Отклик отправлен» — подтверждение возможно только боевым apply второго этапа (клик «Откликнуться» создаёт тему отклика, инцидент 2026-08-16).

## Проверки
`node --check` OK, `pytest tests/test_page_state.py` 20 passed (контракт «единственный control.click()» не тронут), изменения — только значения якорей, логика не менялась.