### PR TITLE
feat(create-resume): readback-вердикт готовности черновика (статусная модель #978)

### DIFF
--- a/src/hhru_bot/commands/_common.py
+++ b/src/hhru_bot/commands/_common.py
@@ -523,6 +523,11 @@ class DurableMutationAttempt:
             getattr(result, "reason", None),
             reason_code=status,
         )
+        # #978 (ревью PR #980): после финализации попытка закрыта навсегда —
+        # исключение в диагностическом readback, который вызывающий код
+        # выполняет ПОСЛЕ finish, не должно попадать в interrupt() и
+        # перезаписывать доказанный успех как uncertain.
+        self.action_id = None
 
     def interrupt(self, exc: BaseException) -> None:
         if self.action_id is None:

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -133,8 +133,33 @@ def run(args: argparse.Namespace):
             print(f"[DRY-RUN] Создание резюме: area={args.area}, title={args.title}")
             print(f"[INFO] {result.reason}")
         else:
-            detail = f" {result.reason}." if result.placeholder_role else ""
-            print(f"[OK] Черновик резюме создан.{detail} Новый resume_id: {result.new_resume_id}")
+            # #978: вердикт статусной модели вместо безусловного «создан» —
+            # молчаливый success в состоянии «Дополнить» исчезает как класс.
+            from ..create_resume import (
+                READINESS_DRAFT_STARTED,
+                READINESS_READY_TO_PUBLISH,
+            )
+
+            if result.readiness == READINESS_READY_TO_PUBLISH:
+                verdict = "[OK] Готово к публикации: незавершённых шагов нет."
+            elif result.readiness == READINESS_DRAFT_STARTED:
+                verdict = (
+                    "[OK] Черновик начат: незавершённый шаг "
+                    f"nextIncompleteScreenId={result.next_incomplete_screen_id} — "
+                    "publish-resume откажет до заполнения этого экрана."
+                )
+            else:
+                verdict = (
+                    "[WARN] Черновик создан, но readback статуса не удался — "
+                    "готовность к публикации не подтверждена; проверьте "
+                    "publish-resume --dry-run."
+                )
+            print(f"{verdict} Новый resume_id: {result.new_resume_id}")
+            if result.placeholder_role:
+                print(
+                    "[WARN] Профессия НЕ установлена — назначена роль-плейсхолдер "
+                    "«Другое» (id 40); замените её вручную через «Дополнить»."
+                )
             print(format_config_snippet(result.new_resume_id))
         return False
 

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import argparse
 
-from ..create_resume import READINESS_DRAFT_STARTED, READINESS_READY_TO_PUBLISH
+from ..create_resume import (
+    READINESS_UNKNOWN,
+    apply_draft_readback,
+)
 from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 from .copy_resume import confirm_write, format_config_snippet
 
@@ -120,12 +123,18 @@ def run(args: argparse.Namespace):
                 if getattr(args, "allow_unresolved_area", False):
                     create_kwargs["allow_unresolved_area"] = True
                 result = create_resume_on_hh(page, **create_kwargs)
+                # #978 (ревью PR #980): attempt финализируется ДО readback'а —
+                # вердикт строго диагностический, прерывание в нём не
+                # превращает доказанное создание в uncertain и не держит
+                # command_runs-lease на время навигации readback.
+                if attempt is not None:
+                    attempt.finish(result)
+                if result.success and not dry_run:
+                    result = apply_draft_readback(page, result)
         except BaseException as exc:
             if attempt is not None:
                 attempt.interrupt(exc)
             raise
-        if attempt is not None:
-            attempt.finish(result)
         if not result.success:
             prefix = "[FAIL] (uncertain)" if result.uncertain else "[FAIL]"
             print(f"{prefix} {result.reason}")
@@ -134,28 +143,11 @@ def run(args: argparse.Namespace):
             print(f"[DRY-RUN] Создание резюме: area={args.area}, title={args.title}")
             print(f"[INFO] {result.reason}")
         else:
-            # #978: вердикт статусной модели вместо безусловного «создан» —
-            # молчаливый success в состоянии «Дополнить» исчезает как класс.
-            if result.readiness == READINESS_READY_TO_PUBLISH:
-                verdict = "[OK] Готово к публикации: незавершённых шагов нет."
-            elif result.readiness == READINESS_DRAFT_STARTED:
-                verdict = (
-                    "[OK] Черновик начат: незавершённый шаг "
-                    f"nextIncompleteScreenId={result.next_incomplete_screen_id} — "
-                    "publish-resume откажет до заполнения этого экрана."
-                )
-            else:
-                verdict = (
-                    "[WARN] Черновик создан, но readback статуса не удался — "
-                    "готовность к публикации не подтверждена; проверьте "
-                    "publish-resume --dry-run."
-                )
-            print(f"{verdict} Новый resume_id: {result.new_resume_id}")
-            if result.placeholder_role:
-                print(
-                    "[WARN] Профессия НЕ установлена — назначена роль-плейсхолдер "
-                    "«Другое» (id 40); замените её вручную через «Дополнить»."
-                )
+            # #978: вердикт статной модели вместо безусловного «создан». Текст
+            # единственный — reason, составленный в draft_verdict_result; CLI
+            # выбирает только префикс (ревью PR #980: без второго каталога).
+            prefix = "[WARN]" if result.readiness == READINESS_UNKNOWN else "[OK]"
+            print(f"{prefix} {result.reason} Новый resume_id: {result.new_resume_id}")
             print(format_config_snippet(result.new_resume_id))
         return False
 

--- a/src/hhru_bot/commands/create_resume.py
+++ b/src/hhru_bot/commands/create_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ..create_resume import READINESS_DRAFT_STARTED, READINESS_READY_TO_PUBLISH
 from ._common import ApplyProgress, DurableMutationAttempt, run_supervised_command
 from .copy_resume import confirm_write, format_config_snippet
 
@@ -135,11 +136,6 @@ def run(args: argparse.Namespace):
         else:
             # #978: вердикт статусной модели вместо безусловного «создан» —
             # молчаливый success в состоянии «Дополнить» исчезает как класс.
-            from ..create_resume import (
-                READINESS_DRAFT_STARTED,
-                READINESS_READY_TO_PUBLISH,
-            )
-
             if result.readiness == READINESS_READY_TO_PUBLISH:
                 verdict = "[OK] Готово к публикации: незавершённых шагов нет."
             elif result.readiness == READINESS_DRAFT_STARTED:

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -14,6 +14,7 @@ from playwright.sync_api import Locator, Page
 from .browser import (
     HH_BASE_URL,
     RESUMES_FULL_LIST_URL,
+    NotAuthenticated,
     dismiss_cookie_banner,
     goto_hh,
     open_confirmed_resume,
@@ -21,7 +22,7 @@ from .browser import (
 from .external_forms.detect import normalize
 from .resume_ids import RESUME_ID_FROM_PATH_OR_QUERY_RE
 from .resume_limits import resume_limit_reason
-from .resume_state import parse_resume_state
+from .resume_state import ResumeState, is_published, parse_resume_state
 from .resume_titles import duplicate_title_reason, read_account_titles
 from .selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
@@ -63,6 +64,7 @@ OTHER_ROLE_LABEL = "Другое"
 # разбора «Дополнить» по DOM-тексту нет и быть не должно.
 READINESS_READY_TO_PUBLISH = "ready_to_publish"  # незавершённых шагов нет
 READINESS_DRAFT_STARTED = "draft_started"  # есть nextIncompleteScreenId
+READINESS_ALREADY_PUBLISHED = "already_published"  # автопубликация #900
 READINESS_UNKNOWN = "unknown"  # readback не удался; готовность НЕ доказана
 
 # #920 этап 2 (живая диагностика 2026-09-02): на ПЕРВОМ экране визарда поле
@@ -696,38 +698,72 @@ def _is_unresolved_area_reason(reason: str) -> bool:
     )
 
 
-def read_draft_readiness(page: Page, resume_id: str) -> tuple[str, str | None, str]:
-    """Read-only readback статуса только что материализованного черновика (#978).
+def _classify_readiness(state: ResumeState) -> tuple[str, str | None, str]:
+    """Вердикт по спарсенному state — полный publish-гейт, не один сигнал.
 
-    Открывает страницу резюме и читает тот же identity-bound bootstrap-сигнал
-    ``nextIncompleteScreenId``, по которому publish-resume гейтит клик (#225).
-    Возвращает ``(READINESS_*, next_incomplete_screen_id | None, деталь-причина)``;
-    любая ошибка чтения — READINESS_UNKNOWN: черновик уже материализован, но
-    готовность к публикации НЕ доказана, и заявлять «готово» нельзя (fail-closed).
+    Ревью PR #980: «Готово к публикации» обязано значить то же, что и для
+    publish-resume: подтверждённый status, отсутствие nextIncompleteScreenId
+    И canPublishOrUpdate=true. Неполное состояние — honest unknown, а не
+    оптимистичное ready (fail-closed).
     """
-    try:
-        open_confirmed_resume(page, resume_id)
-        state = parse_resume_state(page.content(), resume_id)
-    except Exception as exc:  # noqa: BLE001 — readback диагностический: любая ошибка = unknown
-        return READINESS_UNKNOWN, None, str(exc)
-    # «Запись есть, но status не подтверждён» — unknown, а не оптимистичное
-    # ready: publish-resume точно так же требует подтверждённого статуса,
-    # и заявлять готовность из неполного state нельзя (fail-closed, ревью PR #980).
     if state.status is None:
-        return READINESS_UNKNOWN, None, "status резюме не найден в bootstrap разметке"
+        return READINESS_UNKNOWN, None, "status резюме не подтверждён в bootstrap разметке"
     if state.next_incomplete_screen_id:
         return READINESS_DRAFT_STARTED, state.next_incomplete_screen_id, ""
+    if is_published(state):
+        # #900: закрытие последнего незавершённого экрана публикует резюме
+        # АВТОМАТИЧЕСКИ — «готово к публикации» для уже опубликованного
+        # резюме было бы неверным вердиктом.
+        return READINESS_ALREADY_PUBLISHED, None, ""
+    if state.can_publish_or_update is not True:
+        return (
+            READINESS_UNKNOWN,
+            None,
+            f"canPublishOrUpdate={state.can_publish_or_update} не подтверждён",
+        )
     return READINESS_READY_TO_PUBLISH, None, ""
 
 
-def _success_result(
-    page: Page,
-    new_resume_id: str,
+def read_draft_readiness(page: Page, resume_id: str) -> tuple[str, str | None, str]:
+    """Read-only readback статуса только что материализованного черновика (#978).
+
+    Сначала дешёвый parse ТЕКУЩЕЙ страницы: после финального NEXT она уже
+    стоит на identity-bound URL и несёт тот же bootstrap (wizard-экраны тем же
+    способом читает verify_wizard_save в resume_position.py); полная навигация
+    через open_confirmed_resume — только если записи для resume_id на текущей
+    странице нет. Возвращает ``(READINESS_*, next_incomplete_screen_id | None,
+    деталь-причина)``; любая ошибка чтения — READINESS_UNKNOWN: черновик уже
+    материализован, но готовность к публикации НЕ доказана, и заявлять «готово»
+    нельзя (fail-closed). NotAuthenticated пробрасывается наверх: типизированную
+    классификацию SESSION_EXPIRED даёт run_supervised_command, а не молчаливый
+    unknown с советом, который сам упадёт по той же причине.
+    """
+    try:
+        state = parse_resume_state(page.content(), resume_id)
+    except Exception:  # noqa: BLE001 — parse-first: текущая страница записи может не нести
+        state = ResumeState()
+    if state.status is None and state.next_incomplete_screen_id is None:
+        try:
+            open_confirmed_resume(page, resume_id)
+            state = parse_resume_state(page.content(), resume_id)
+        except NotAuthenticated:
+            raise
+        except Exception as exc:  # noqa: BLE001 — readback диагностический: любая ошибка = unknown
+            return READINESS_UNKNOWN, None, str(exc)
+    return _classify_readiness(state)
+
+
+def draft_verdict_result(
+    readiness: str,
+    next_incomplete_screen_id: str | None,
+    detail: str,
     *,
-    placeholder_role: bool,
+    new_resume_id: str,
+    placeholder_role: bool = False,
 ) -> CreateResumeResult:
-    """Хвост успешного создания: readback статуса + вердикт статусной модели #978."""
-    readiness, next_incomplete, readback_detail = read_draft_readiness(page, new_resume_id)
+    """Единый каталог формулировок вердиктов #978 (ревью PR #980): и CLI, и
+    actions-строка получают один и тот же текст reason — второго каталога в
+    команде нет, детали readback не теряются между слоями."""
     placeholder_note = (
         f" Профессия НЕ установлена — назначена роль-плейсхолдер «{OTHER_ROLE_LABEL}» "
         f"(id {OTHER_ROLE_ID}), замените её на реальную вручную через «Дополнить»."
@@ -736,17 +772,22 @@ def _success_result(
     )
     if readiness == READINESS_DRAFT_STARTED:
         reason = (
-            f"черновик начат: незавершённый шаг nextIncompleteScreenId="
-            f"{next_incomplete} — publish-resume откажет до заполнения экрана "
-            f"{next_incomplete}.{placeholder_note}"
+            f"Черновик начат: незавершённый шаг nextIncompleteScreenId="
+            f"{next_incomplete_screen_id} — publish-resume откажет до заполнения экрана "
+            f"{next_incomplete_screen_id}.{placeholder_note}"
         )
     elif readiness == READINESS_READY_TO_PUBLISH:
-        reason = f"готово к публикации: незавершённых шагов нет.{placeholder_note}"
+        reason = f"Готово к публикации: незавершённых шагов нет.{placeholder_note}"
+    elif readiness == READINESS_ALREADY_PUBLISHED:
+        reason = (
+            "Резюме уже опубликовано (автопубликация при закрытии последнего экрана "
+            f"визарда, #900) — publish-resume не требуется.{placeholder_note}"
+        )
     else:
         reason = (
-            f"черновик материализован, но readback статуса не удался: {readback_detail}. "
-            f"Готовность к публикации не подтверждена — проверьте publish-resume --dry-run."
-            f"{placeholder_note}"
+            "Черновик материализован, но readback статуса не удался: "
+            f"{detail or 'причина неизвестна'}. Готовность к публикации не "
+            f"подтверждена — проверьте publish-resume --dry-run.{placeholder_note}"
         )
     return CreateResumeResult(
         True,
@@ -754,7 +795,25 @@ def _success_result(
         reason=reason,
         placeholder_role=placeholder_role,
         readiness=readiness,
-        next_incomplete_screen_id=next_incomplete,
+        next_incomplete_screen_id=next_incomplete_screen_id,
+    )
+
+
+def apply_draft_readback(page: Page, result: CreateResumeResult) -> CreateResumeResult:
+    """Наложить readback-вердикт на успешный результат создания (#978).
+
+    Вызывающий код обязан вызвать это ПОСЛЕ DurableMutationAttempt.finish
+    (ревью PR #980, finding 1): readback строго диагностический — прерывание
+    здесь не превращает доказанное создание в uncertain и не держит
+    command_runs-lease на время навигации.
+    """
+    readiness, next_incomplete, detail = read_draft_readiness(page, result.new_resume_id)
+    return draft_verdict_result(
+        readiness,
+        next_incomplete,
+        detail,
+        new_resume_id=result.new_resume_id,
+        placeholder_role=result.placeholder_role,
     )
 
 
@@ -962,5 +1021,14 @@ def create_resume_on_hh(
             False, reason="новый resume_id не подтверждён после сохранения", uncertain=True
         )
     # #978: молчаливый success в состоянии «Дополнить» исчезает как класс —
-    # оба успешных пути (обычный и placeholder) заканчиваются readback'ом.
-    return _success_result(page, match.group(1), placeholder_role=placeholder_role)
+    # вердикт накладывает вызывающий код через apply_draft_readback ПОСЛЕ
+    # финализации attempt (ревью PR #980: readback диагностический и не
+    # выполняется внутри DurableMutationAttempt-seam).
+    if placeholder_role:
+        return CreateResumeResult(
+            True,
+            new_resume_id=match.group(1),
+            reason="черновик создан",
+            placeholder_role=True,
+        )
+    return CreateResumeResult(True, new_resume_id=match.group(1), reason="черновик создан")

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -16,10 +16,12 @@ from .browser import (
     RESUMES_FULL_LIST_URL,
     dismiss_cookie_banner,
     goto_hh,
+    open_confirmed_resume,
 )
 from .external_forms.detect import normalize
 from .resume_ids import RESUME_ID_FROM_PATH_OR_QUERY_RE
 from .resume_limits import resume_limit_reason
+from .resume_state import parse_resume_state
 from .resume_titles import duplicate_title_reason, read_account_titles
 from .selector_groups.resume_page import (
     RESUME_CREATE_BUTTON,
@@ -52,6 +54,16 @@ OTHER_ROLE_ID = "40"
 # плейсхолдером, черновик материализуется, профессию владелец меняет вручную
 # через «Дополнить»).
 OTHER_ROLE_LABEL = "Другое"
+
+# #978 (решение владельца): статусная модель результата create-resume.
+# «Черновик создан» без вердикта о готовности исчезает как класс — команда
+# обязана заканчивать readback'ом и возвращать один из этих вердиктов.
+# Источник истины один — nextIncompleteScreenId из identity-bound bootstrap,
+# тот же сигнал, по которому гейтит publish-resume (#225); параллельного
+# разбора «Дополнить» по DOM-тексту нет и быть не должно.
+READINESS_READY_TO_PUBLISH = "ready_to_publish"  # незавершённых шагов нет
+READINESS_DRAFT_STARTED = "draft_started"  # есть nextIncompleteScreenId
+READINESS_UNKNOWN = "unknown"  # readback не удался; готовность НЕ доказана
 
 # #920 этап 2 (живая диагностика 2026-09-02): на ПЕРВОМ экране визарда поле
 # должности — combobox с подсказками автодополнения hh.ru; попап открывается
@@ -89,6 +101,10 @@ class CreateResumeResult:
     # роль закрыта плейсхолдером. Поле вместо снифа подстроки reason
     # (cycle 7): потребителю нужен структурированный факт, а не парсинг текста.
     placeholder_role: bool = False
+    # #978: вердикт статусной модели (READINESS_*). Пустая строка — только у
+    # результатов, не дошедших до материализации черновика (dry-run, отказы).
+    readiness: str = ""
+    next_incomplete_screen_id: str | None = None
 
 
 def _one(page: Page, selector: str, label: str) -> tuple[Locator | None, str]:
@@ -680,12 +696,62 @@ def _is_unresolved_area_reason(reason: str) -> bool:
     )
 
 
-def _placeholder_role_success_reason() -> str:
-    """Итог [OK] для флагового пути: роль закрыта плейсхолдером, не профессией."""
-    return (
-        "черновик создан; профессия НЕ установлена — назначена "
-        f"роль-плейсхолдер «{OTHER_ROLE_LABEL}» (id {OTHER_ROLE_ID}), "
-        "замените её на реальную вручную через «Дополнить»"
+def read_draft_readiness(page: Page, resume_id: str) -> tuple[str, str | None, str]:
+    """Read-only readback статуса только что материализованного черновика (#978).
+
+    Открывает страницу резюме и читает тот же identity-bound bootstrap-сигнал
+    ``nextIncompleteScreenId``, по которому publish-resume гейтит клик (#225).
+    Возвращает ``(READINESS_*, next_incomplete_screen_id | None, деталь-причина)``;
+    любая ошибка чтения — READINESS_UNKNOWN: черновик уже материализован, но
+    готовность к публикации НЕ доказана, и заявлять «готово» нельзя (fail-closed).
+    """
+    try:
+        open_confirmed_resume(page, resume_id)
+        state = parse_resume_state(page.content(), resume_id)
+    except Exception as exc:  # noqa: BLE001 — readback диагностический: любая ошибка = unknown
+        return READINESS_UNKNOWN, None, str(exc)
+    if state.status is None and state.next_incomplete_screen_id is None:
+        return READINESS_UNKNOWN, None, "состояние резюме не найдено в bootstrap разметке"
+    if state.next_incomplete_screen_id:
+        return READINESS_DRAFT_STARTED, state.next_incomplete_screen_id, ""
+    return READINESS_READY_TO_PUBLISH, None, ""
+
+
+def _success_result(
+    page: Page,
+    new_resume_id: str,
+    *,
+    placeholder_role: bool,
+) -> CreateResumeResult:
+    """Хвост успешного создания: readback статуса + вердикт статусной модели #978."""
+    readiness, next_incomplete, readback_detail = read_draft_readiness(page, new_resume_id)
+    placeholder_note = (
+        f" Профессия НЕ установлена — назначена роль-плейсхолдер «{OTHER_ROLE_LABEL}» "
+        f"(id {OTHER_ROLE_ID}), замените её на реальную вручную через «Дополнить»."
+        if placeholder_role
+        else ""
+    )
+    if readiness == READINESS_DRAFT_STARTED:
+        reason = (
+            f"черновик начат: незавершённый шаг nextIncompleteScreenId="
+            f"{next_incomplete} — publish-resume откажет до заполнения экрана "
+            f"{next_incomplete}.{placeholder_note}"
+        )
+    elif readiness == READINESS_READY_TO_PUBLISH:
+        reason = f"готово к публикации: незавершённых шагов нет.{placeholder_note}"
+    else:
+        reason = (
+            f"черновик материализован, но readback статуса не удался: {readback_detail}. "
+            f"Готовность к публикации не подтверждена — проверьте publish-resume --dry-run."
+            f"{placeholder_note}"
+        )
+    return CreateResumeResult(
+        True,
+        new_resume_id=new_resume_id,
+        reason=reason,
+        placeholder_role=placeholder_role,
+        readiness=readiness,
+        next_incomplete_screen_id=next_incomplete,
     )
 
 
@@ -892,11 +958,6 @@ def create_resume_on_hh(
         return CreateResumeResult(
             False, reason="новый resume_id не подтверждён после сохранения", uncertain=True
         )
-    if placeholder_role:
-        return CreateResumeResult(
-            True,
-            new_resume_id=match.group(1),
-            reason=_placeholder_role_success_reason(),
-            placeholder_role=True,
-        )
-    return CreateResumeResult(True, new_resume_id=match.group(1), reason="черновик создан")
+    # #978: молчаливый success в состоянии «Дополнить» исчезает как класс —
+    # оба успешных пути (обычный и placeholder) заканчиваются readback'ом.
+    return _success_result(page, match.group(1), placeholder_role=placeholder_role)

--- a/src/hhru_bot/create_resume.py
+++ b/src/hhru_bot/create_resume.py
@@ -710,8 +710,11 @@ def read_draft_readiness(page: Page, resume_id: str) -> tuple[str, str | None, s
         state = parse_resume_state(page.content(), resume_id)
     except Exception as exc:  # noqa: BLE001 — readback диагностический: любая ошибка = unknown
         return READINESS_UNKNOWN, None, str(exc)
-    if state.status is None and state.next_incomplete_screen_id is None:
-        return READINESS_UNKNOWN, None, "состояние резюме не найдено в bootstrap разметке"
+    # «Запись есть, но status не подтверждён» — unknown, а не оптимистичное
+    # ready: publish-resume точно так же требует подтверждённого статуса,
+    # и заявлять готовность из неполного state нельзя (fail-closed, ревью PR #980).
+    if state.status is None:
+        return READINESS_UNKNOWN, None, "status резюме не найден в bootstrap разметке"
     if state.next_incomplete_screen_id:
         return READINESS_DRAFT_STARTED, state.next_incomplete_screen_id, ""
     return READINESS_READY_TO_PUBLISH, None, ""

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -11,6 +11,7 @@ NEXT, выбор leaf — мутацию не совершает, и ошибк�
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -1842,3 +1843,114 @@ def test_pre_next_failure_does_not_warn_about_phantom_draft(monkeypatch):
     assert not result.success
     assert not result.uncertain
     assert "черновик" not in result.reason
+
+
+# --- #978: readback-вердикт статусной модели после материализации ------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+# Живой черновик #910: nextIncompleteScreenId=common (то же состояние, что у
+# резюме-свидетеля d7f3e582 из #978).
+READBACK_DRAFT_ID = "00007" + "0" * 34
+READBACK_COMMON_MARKUP = (FIXTURES_DIR / "resume_position_state_common_title_910.html").read_text(
+    encoding="utf-8"
+)
+
+
+class ReadbackPage(CheckboxWrapperPage):
+    """Страница после успешного финального NEXT: readback читает bootstrap."""
+
+    def __init__(self, markup):
+        super().__init__()
+        self._markup = markup
+
+    def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
+        if not isinstance(url, str):
+            self.url = (
+                f"https://hh.ru/profile/resume/educations?resume={READBACK_DRAFT_ID}"
+                "&hhtmFrom=my_resumes&hhtmFromLabel=create_resume_header"
+            )
+        return None
+
+    def content(self):
+        return self._markup
+
+
+def _patch_readback(monkeypatch):
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+
+    def _open(page, resume_id):
+        page.url = f"https://hh.ru/resume/{resume_id}"
+
+    monkeypatch.setattr(create, "open_confirmed_resume", _open)
+
+
+def test_success_ends_with_draft_started_verdict_when_common_incomplete(monkeypatch):
+    """Боевой кейс #978: черновик материализован, экран common не заполнен —
+    молчаливого success больше нет, вердикт «черновик начат»."""
+    _patch_readback(monkeypatch)
+    page = ReadbackPage(READBACK_COMMON_MARKUP)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_DRAFT_STARTED
+    assert result.next_incomplete_screen_id == "common"
+    assert "nextIncompleteScreenId=common" in result.reason
+    assert "publish-resume откажет" in result.reason
+
+
+def test_success_ends_with_ready_verdict_when_no_incomplete_step(monkeypatch):
+    _patch_readback(monkeypatch)
+    markup = '{"resume":{"hash":"' + READBACK_DRAFT_ID + '","status":"not_finished"}}'
+    page = ReadbackPage(markup)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_READY_TO_PUBLISH
+    assert result.next_incomplete_screen_id is None
+
+
+def test_readback_failure_is_unknown_but_draft_still_created(monkeypatch):
+    """Readback не удался — готовность НЕ доказана (fail-closed unknown),
+    но материализация черновика уже факт: success не отзывается."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+
+    def _broken_open(page, resume_id):
+        raise RuntimeError("сессия отвергнута при readback")
+
+    monkeypatch.setattr(create, "open_confirmed_resume", _broken_open)
+    page = ReadbackPage(READBACK_COMMON_MARKUP)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_UNKNOWN
+    assert "readback" in result.reason
+
+
+def test_placeholder_path_keeps_placeholder_flag_with_verdict(monkeypatch):
+    """Флаговый путь #936 (#978): плейсхолдер-предупреждение сохраняется и
+    объединяется с вердиктом readback."""
+    _patch_readback(monkeypatch)
+    page = ReadbackPage(READBACK_COMMON_MARKUP)
+
+    result = create._success_result(page, READBACK_DRAFT_ID, placeholder_role=True)
+
+    assert result.success
+    assert result.placeholder_role is True
+    assert result.readiness == create.READINESS_DRAFT_STARTED
+    assert "плейсхолдер" in result.reason
+    assert "nextIncompleteScreenId=common" in result.reason
+
+
+def test_readback_without_resume_record_is_unknown(monkeypatch):
+    """Bootstrap без записи этого резюме — не «готово», а честный unknown."""
+    _patch_readback(monkeypatch)
+    page = ReadbackPage("<html>пустая страница</html>")
+
+    readiness, next_incomplete, detail = create.read_draft_readiness(page, READBACK_DRAFT_ID)
+
+    assert readiness == create.READINESS_UNKNOWN
+    assert next_incomplete is None
+    assert detail

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -1954,3 +1954,17 @@ def test_readback_without_resume_record_is_unknown(monkeypatch):
     assert readiness == create.READINESS_UNKNOWN
     assert next_incomplete is None
     assert detail
+
+
+def test_record_without_status_is_unknown_not_optimistic_ready(monkeypatch):
+    """Ревью PR #980: «запись есть, status не подтверждён» — unknown, а не
+    ready_to_publish: заявлять готовность из неполного state нельзя."""
+    _patch_readback(monkeypatch)
+    markup = '{"resume":{"hash":"' + READBACK_DRAFT_ID + '"}}'
+    page = ReadbackPage(markup)
+
+    result = _run(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_UNKNOWN
+    assert "status" in result.reason

--- a/tests/test_create_resume_browser.py
+++ b/tests/test_create_resume_browser.py
@@ -1849,7 +1849,7 @@ def test_pre_next_failure_does_not_warn_about_phantom_draft(monkeypatch):
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 # Живой черновик #910: nextIncompleteScreenId=common (то же состояние, что у
-# резюме-свидетеля d7f3e582 из #978).
+# резюме-свидетеля «01234567…» из #978).
 READBACK_DRAFT_ID = "00007" + "0" * 34
 READBACK_COMMON_MARKUP = (FIXTURES_DIR / "resume_position_state_common_title_910.html").read_text(
     encoding="utf-8"
@@ -1859,9 +1859,11 @@ READBACK_COMMON_MARKUP = (FIXTURES_DIR / "resume_position_state_common_title_910
 class ReadbackPage(CheckboxWrapperPage):
     """Страница после успешного финального NEXT: readback читает bootstrap."""
 
-    def __init__(self, markup):
+    def __init__(self, markup, *, after_navigation_markup=None):
         super().__init__()
         self._markup = markup
+        self._after_navigation_markup = after_navigation_markup
+        self.navigated_urls: list[str] = []
 
     def wait_for_url(self, url, *, wait_until=None, timeout=None):  # noqa: ARG002
         if not isinstance(url, str):
@@ -1872,16 +1874,32 @@ class ReadbackPage(CheckboxWrapperPage):
         return None
 
     def content(self):
+        if self._after_navigation_markup is not None and self.navigated_urls:
+            return self._after_navigation_markup
         return self._markup
 
 
 def _patch_readback(monkeypatch):
+    """Навигация readback без реального браузера: open_confirmed_resume пишет URL.
+
+    Parse-first (ревью PR #980): при записи в текущем контенте вызова
+    навигации не будет вовсе — это проверяет отдельный тест ниже.
+    """
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
 
     def _open(page, resume_id):
+        page.navigated_urls.append(f"https://hh.ru/resume/{resume_id}")
         page.url = f"https://hh.ru/resume/{resume_id}"
 
     monkeypatch.setattr(create, "open_confirmed_resume", _open)
+
+
+def _run_with_readback(page, before_click=None, **kwargs):
+    """Как вызывающий код команды: create → attempt.finish → apply_draft_readback."""
+    result = _run(page, before_click=before_click, **kwargs)
+    if result.success:
+        result = create.apply_draft_readback(page, result)
+    return result
 
 
 def test_success_ends_with_draft_started_verdict_when_common_incomplete(monkeypatch):
@@ -1890,7 +1908,7 @@ def test_success_ends_with_draft_started_verdict_when_common_incomplete(monkeypa
     _patch_readback(monkeypatch)
     page = ReadbackPage(READBACK_COMMON_MARKUP)
 
-    result = _run(page, before_click=lambda: None)
+    result = _run_with_readback(page, before_click=lambda: None)
 
     assert result.success, result.reason
     assert result.readiness == create.READINESS_DRAFT_STARTED
@@ -1899,16 +1917,76 @@ def test_success_ends_with_draft_started_verdict_when_common_incomplete(monkeypa
     assert "publish-resume откажет" in result.reason
 
 
+def test_parse_first_skips_navigation_when_current_page_carries_state(monkeypatch):
+    """Ревью PR #980: страница после финального NEXT уже несёт bootstrap —
+    полная навигация не выполняется (дешевле и уже окна прерывания/lease)."""
+    _patch_readback(monkeypatch)
+    page = ReadbackPage(READBACK_COMMON_MARKUP)
+
+    _run_with_readback(page, before_click=lambda: None)
+
+    assert page.navigated_urls == []
+
+
+def test_readback_falls_back_to_resume_page_when_current_page_has_no_record(monkeypatch):
+    """Нет записи в текущем контенте — readback навигирует на /resume/{id}
+    (identity-подтверждённый маршрут), а не читает пустую страницу."""
+    _patch_readback(monkeypatch)
+    page = ReadbackPage(
+        "<html>wizard без bootstrap записи</html>",
+        after_navigation_markup=READBACK_COMMON_MARKUP,
+    )
+
+    result = _run_with_readback(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert page.navigated_urls == [f"https://hh.ru/resume/{READBACK_DRAFT_ID}"]
+    assert result.readiness == create.READINESS_DRAFT_STARTED
+
+
 def test_success_ends_with_ready_verdict_when_no_incomplete_step(monkeypatch):
     _patch_readback(monkeypatch)
-    markup = '{"resume":{"hash":"' + READBACK_DRAFT_ID + '","status":"not_finished"}}'
+    markup = (
+        '{"resume":{"hash":"' + READBACK_DRAFT_ID + '","status":"not_finished",'
+        '"canPublishOrUpdate":true}}'
+    )
     page = ReadbackPage(markup)
 
-    result = _run(page, before_click=lambda: None)
+    result = _run_with_readback(page, before_click=lambda: None)
 
     assert result.success, result.reason
     assert result.readiness == create.READINESS_READY_TO_PUBLISH
     assert result.next_incomplete_screen_id is None
+
+
+def test_ready_verdict_requires_confirmed_can_publish_or_update(monkeypatch):
+    """Ревью PR #980: «Готово к публикации» = полный publish-гейт, не один
+    nextIncompleteScreenId — canPublishOrUpdate не подтверждён => unknown."""
+    _patch_readback(monkeypatch)
+    markup = '{"resume":{"hash":"' + READBACK_DRAFT_ID + '","status":"not_finished"}}'
+    page = ReadbackPage(markup)
+
+    result = _run_with_readback(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_UNKNOWN
+    assert "canPublishOrUpdate" in result.reason
+
+
+def test_auto_published_draft_gets_dedicated_verdict(monkeypatch):
+    """#900: закрытие последнего экрана публикует резюме автоматически —
+    это отдельный вердикт, а не «готово к публикации»."""
+    _patch_readback(monkeypatch)
+    markup = (
+        '{"resume":{"hash":"' + READBACK_DRAFT_ID + '","status":"finished","isSearchable":true}}'
+    )
+    page = ReadbackPage(markup)
+
+    result = _run_with_readback(page, before_click=lambda: None)
+
+    assert result.success, result.reason
+    assert result.readiness == create.READINESS_ALREADY_PUBLISHED
+    assert "опубликовано" in result.reason
 
 
 def test_readback_failure_is_unknown_but_draft_still_created(monkeypatch):
@@ -1917,16 +1995,31 @@ def test_readback_failure_is_unknown_but_draft_still_created(monkeypatch):
     monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
 
     def _broken_open(page, resume_id):
-        raise RuntimeError("сессия отвергнута при readback")
+        raise RuntimeError("навигация readback не удалась")
 
     monkeypatch.setattr(create, "open_confirmed_resume", _broken_open)
-    page = ReadbackPage(READBACK_COMMON_MARKUP)
+    page = ReadbackPage("<html>пустая страница</html>")
 
-    result = _run(page, before_click=lambda: None)
+    result = _run_with_readback(page, before_click=lambda: None)
 
     assert result.success, result.reason
     assert result.readiness == create.READINESS_UNKNOWN
     assert "readback" in result.reason
+
+
+def test_readback_reraises_not_authenticated_for_session_expired_handler(monkeypatch):
+    """Ревью PR #980: NotAuthenticated из readback не глотается в unknown —
+    её ловит типизированный SESSION_EXPIRED-хендлер run_supervised_command."""
+    monkeypatch.setattr(create, "goto_hh", lambda page, url: page.goto(url))
+
+    def _expired_open(page, resume_id):
+        raise create.NotAuthenticated("сессия истекла")
+
+    monkeypatch.setattr(create, "open_confirmed_resume", _expired_open)
+    page = ReadbackPage("<html>пустая страница</html>")
+
+    with pytest.raises(create.NotAuthenticated):
+        create.read_draft_readiness(page, READBACK_DRAFT_ID)
 
 
 def test_placeholder_path_keeps_placeholder_flag_with_verdict(monkeypatch):
@@ -1934,8 +2027,11 @@ def test_placeholder_path_keeps_placeholder_flag_with_verdict(monkeypatch):
     объединяется с вердиктом readback."""
     _patch_readback(monkeypatch)
     page = ReadbackPage(READBACK_COMMON_MARKUP)
+    created = create.CreateResumeResult(
+        True, new_resume_id=READBACK_DRAFT_ID, reason="черновик создан", placeholder_role=True
+    )
 
-    result = create._success_result(page, READBACK_DRAFT_ID, placeholder_role=True)
+    result = create.apply_draft_readback(page, created)
 
     assert result.success
     assert result.placeholder_role is True
@@ -1963,7 +2059,7 @@ def test_record_without_status_is_unknown_not_optimistic_ready(monkeypatch):
     markup = '{"resume":{"hash":"' + READBACK_DRAFT_ID + '"}}'
     page = ReadbackPage(markup)
 
-    result = _run(page, before_click=lambda: None)
+    result = _run_with_readback(page, before_click=lambda: None)
 
     assert result.success, result.reason
     assert result.readiness == create.READINESS_UNKNOWN

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -217,3 +217,50 @@ def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):
     assert "uncertain" in output
     # No browser call was attempted -- the guard fires before _body runs.
     assert env.calls == []
+
+
+# --- #978: вердикты статусной модели в выводе команды ------------------------
+
+
+def _force_output(env, tmp_path, capsys, **fields):
+    from hhru_bot.create_resume import CreateResumeResult as Result
+
+    env.result = Result(True, NEW_ID, "reason", **fields)
+    cmd.run(_args(tmp_path, force=True))
+    return capsys.readouterr().out
+
+
+def test_draft_started_verdict_is_printed(env, tmp_path, capsys):
+    out = _force_output(
+        env, tmp_path, capsys, readiness="draft_started", next_incomplete_screen_id="common"
+    )
+    assert "Черновик начат" in out
+    assert "nextIncompleteScreenId=common" in out
+    assert "publish-resume откажет" in out
+    assert f"Новый resume_id: {NEW_ID}" in out
+
+
+def test_ready_to_publish_verdict_is_printed(env, tmp_path, capsys):
+    out = _force_output(env, tmp_path, capsys, readiness="ready_to_publish")
+    assert "Готово к публикации" in out
+    assert "Черновик начат" not in out
+
+
+def test_unknown_readback_warns_instead_of_claiming_ready(env, tmp_path, capsys):
+    out = _force_output(env, tmp_path, capsys, readiness="unknown")
+    assert "[WARN]" in out
+    assert "не подтверждена" in out
+    assert "Готово к публикации" not in out
+
+
+def test_placeholder_warning_survives_with_verdict(env, tmp_path, capsys):
+    out = _force_output(
+        env,
+        tmp_path,
+        capsys,
+        readiness="draft_started",
+        next_incomplete_screen_id="common",
+        placeholder_role=True,
+    )
+    assert "плейсхолдер" in out
+    assert "Черновик начат" in out

--- a/tests/test_create_resume_command.py
+++ b/tests/test_create_resume_command.py
@@ -222,43 +222,63 @@ def test_unresolved_uncertain_blocks_retry(env, tmp_path, capsys):
 # --- #978: вердикты статусной модели в выводе команды ------------------------
 
 
-def _force_output(env, tmp_path, capsys, **fields):
-    from hhru_bot.create_resume import CreateResumeResult as Result
+def _force_output(env, tmp_path, capsys, monkeypatch, readiness, **verdict_kwargs):
+    """Прогон команды с замоканным readback: вердикт целиком в reason
+    (единый каталог draft_verdict_result), CLI выбирает только префикс."""
+    import hhru_bot.commands.create_resume as command_module
+    from hhru_bot.create_resume import draft_verdict_result
 
-    env.result = Result(True, NEW_ID, "reason", **fields)
+    monkeypatch.setattr(command_module, "apply_draft_readback", lambda page, result: result)
+    env.result = draft_verdict_result(
+        readiness,
+        verdict_kwargs.get("next_incomplete_screen_id"),
+        verdict_kwargs.get("detail", ""),
+        new_resume_id=NEW_ID,
+        placeholder_role=verdict_kwargs.get("placeholder_role", False),
+    )
     cmd.run(_args(tmp_path, force=True))
     return capsys.readouterr().out
 
 
-def test_draft_started_verdict_is_printed(env, tmp_path, capsys):
+def test_draft_started_verdict_is_printed(env, tmp_path, capsys, monkeypatch):
     out = _force_output(
-        env, tmp_path, capsys, readiness="draft_started", next_incomplete_screen_id="common"
+        env, tmp_path, capsys, monkeypatch, "draft_started", next_incomplete_screen_id="common"
     )
-    assert "Черновик начат" in out
+    assert "[OK] Черновик начат" in out
     assert "nextIncompleteScreenId=common" in out
     assert "publish-resume откажет" in out
     assert f"Новый resume_id: {NEW_ID}" in out
 
 
-def test_ready_to_publish_verdict_is_printed(env, tmp_path, capsys):
-    out = _force_output(env, tmp_path, capsys, readiness="ready_to_publish")
-    assert "Готово к публикации" in out
+def test_ready_to_publish_verdict_is_printed(env, tmp_path, capsys, monkeypatch):
+    out = _force_output(env, tmp_path, capsys, monkeypatch, "ready_to_publish")
+    assert "[OK] Готово к публикации" in out
     assert "Черновик начат" not in out
 
 
-def test_unknown_readback_warns_instead_of_claiming_ready(env, tmp_path, capsys):
-    out = _force_output(env, tmp_path, capsys, readiness="unknown")
+def test_already_published_verdict_is_printed(env, tmp_path, capsys, monkeypatch):
+    out = _force_output(env, tmp_path, capsys, monkeypatch, "already_published")
+    assert "уже опубликовано" in out
+    assert "Готово к публикации:" not in out
+
+
+def test_unknown_readback_warns_with_failure_detail(env, tmp_path, capsys, monkeypatch):
+    """Ревью PR #980: [WARN] печатает result.reason ЦЕЛИКОМ — деталь readback
+    (почему именно не удался) доходит до терминала, а не только в history."""
+    out = _force_output(env, tmp_path, capsys, monkeypatch, "unknown", detail="timeout навигации")
     assert "[WARN]" in out
+    assert "timeout навигации" in out
     assert "не подтверждена" in out
     assert "Готово к публикации" not in out
 
 
-def test_placeholder_warning_survives_with_verdict(env, tmp_path, capsys):
+def test_placeholder_warning_survives_inside_verdict_reason(env, tmp_path, capsys, monkeypatch):
     out = _force_output(
         env,
         tmp_path,
         capsys,
-        readiness="draft_started",
+        monkeypatch,
+        "draft_started",
         next_incomplete_screen_id="common",
         placeholder_role=True,
     )


### PR DESCRIPTION
## Что

`create-resume` больше не завершается молчаливым success в состоянии «Дополнить». По статусной модели из решения владельца команда после материализации черновика делает read-only readback его статуса и возвращает один из трёх вердиктов:

- **«Черновик начат»** (`draft_started`) — резюме материализовано, но есть незаполненный обязательный экран: в выводе `nextIncompleteScreenId=<экран>` и явное предупреждение, что `publish-resume` откажет до заполнения.
- **«Готово к публикации»** (`ready_to_publish`) — незавершённых шагов нет, `publish-resume` пройдёт без отказа.
- **unknown** — readback не удался (сессия/навигация/bootstrap без записи): `[WARN]`, готовность НЕ заявляется (fail-closed). Материализация черновика при этом уже доказанный факт — success сохраняется.

Источник истины один — `nextIncompleteScreenId` из identity-bound bootstrap (`parse_resume_state`), тот же сигнал, по которому гейтит `publish-resume` (#225). Никакого параллельного разбора текста «Дополнить» по DOM.

## Как

- `create_resume.read_draft_readiness(page, resume_id)`: `open_confirmed_resume` + `parse_resume_state`, любые ошибки чтения → `READINESS_UNKNOWN`.
- `CreateResumeResult` расширен полями `readiness` / `next_incomplete_screen_id` (структурный факт вместо парсинга reason, тот же принцип что `placeholder_role`).
- Оба успешных пути (обычный и placeholder-«Другое» #936) заканчиваются readback'ом; предупреждение о плейсхолдере сохраняется и объединяется с вердиктом.
- Вывод команды: `[OK] Готово к публикации: …` / `[OK] Черновик начат: … nextIncompleteScreenId=common — publish-resume откажет …` / `[WARN] …`.

## Тесты

- `tests/test_create_resume_browser.py`: 5 новых — draft_started по живой фикстуре #910 (`nextIncompleteScreenId=common`), ready, unknown при сбое readback, unknown при bootstrap без записи, placeholder+вердикт.
- `tests/test_create_resume_command.py`: 4 новых — печать каждого вердикта + сохранность плейсхолдер-предупреждения.
- Полный сюит под xdist — зелёный; `ruff check` + `ruff format --check` — чисто; `gen_cli_docs --check` — синхронизирован (аргументы не менялись).

## Живая сверка (read-only)

`publish-resume --dry-run --resume d7f3e582…` (свидетель из ишью, прогон сегодня): `nextIncompleteScreenId=common` — сигнал читается, readback использует тот же парсер и ту же навигацию. Боевой прогон самого `create-resume --force` (мутация) не выполнялся — требуется согласование; после мерджа предложу его как проверку.

## Границы / follow-up

- Заполнение экрана common (`--common-from` / профиль) — отдельный шаг «перевода из статуса 1 в статус 2» из решения владельца; здесь намеренно не реализовано (нужен источник данных, подтверждённый живым DOM, без выдумывания значений). Декомпозиция — отдельно, как и сказано в ишью.
- `publish-resume --dry-run` не тронут.

Closes #978
