### PR TITLE
test(hhru-live): relay popup→background→hh.ru исполняется харнестом (#931)

### DIFF
--- a/extensions/hhru-live/README.md
+++ b/extensions/hhru-live/README.md
@@ -73,6 +73,13 @@ modal/dialog/toast/notification/cookie-баннеры, классифициру�
 вкладку) → `content.js`. content.js принимает команды только от своего же
 расширения (`sender.id === chrome.runtime.id`).
 
+С #931 relay исполняется тестами по-настоящему: `run_background_scenario.js`
+(стаб chrome.tabs/storage.session) покрывает пересылку в hh.ru-таб и обе
+доменные ошибки (`no_hhru_tab`, `content_script_unreachable`), отказ чужому
+sender и действию вне allowlist, а также сохранность diagnostics-пути
+(`overlay_detected` → storage.session); ветки чужого происхождения — по
+образцу sender-validation #743.
+
 Канал `chrome.runtime.connect({name: "hhru-agent"})` по-прежнему **не
 достижим никем**: ни content.js, ни popup.js его не открывают, `background.js`
 регистрирует только `chrome.runtime.onConnect` (не `onConnectExternal`), в

--- a/tests/js_harness/run_background_scenario.js
+++ b/tests/js_harness/run_background_scenario.js
@@ -1,0 +1,191 @@
+// Executes extensions/hhru-live/background.js inside a vm context and runs
+// ONE named relay scenario (argv[2]) from the registry below, printing a
+// JSON verdict on stdout. Issue #931: the popup -> relay -> hh.ru-tab path
+// was previously covered only by grep guards — this runner exercises the
+// real listener with a chrome.tabs/storage stub, the same way
+// run_command_scenario.js exercises content.js.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const backgroundJsPath = path.join(__dirname, '..', '..', 'extensions', 'hhru-live', 'background.js');
+const source = fs.readFileSync(backgroundJsPath, 'utf8');
+
+// chrome stub with tabs + storage.session (unlike dom_stub.makeChrome, which
+// only models what content.js needs). lastError is modelled the way MV3
+// actually delivers it: set synchronously before the sendMessage callback.
+function makeEnv({ activeTab, tabReply, tabError }) {
+  const sent = { toTab: [], toStorage: null };
+  const chrome = {
+    runtime: {
+      id: 'hhru-live-test-extension',
+      lastError: null,
+      sendMessage: () => {},
+      onMessage: { addListener: (fn) => chrome.runtime._listeners.push(fn) },
+      onConnect: { addListener: () => {} },
+      _listeners: [],
+    },
+    tabs: {
+      query: (_opts, cb) => cb(activeTab ? [activeTab] : []),
+      sendMessage: (_tabId, message, cb) => {
+        sent.toTab.push({ tabId: _tabId, message });
+        if (tabError) {
+          chrome.runtime.lastError = { message: tabError };
+        }
+        cb(tabReply ?? null);
+        chrome.runtime.lastError = null;
+      },
+    },
+    storage: {
+      session: {
+        get: (key) => Promise.resolve(sent.storageGet ?? {}),
+        set: (data) => {
+          sent.toStorage = data;
+          return Promise.resolve();
+        },
+      },
+    },
+  };
+  return { chrome, sent };
+}
+
+function deliver(chrome, message, sender) {
+  return new Promise((resolve) => {
+    chrome.runtime._listeners.forEach((fn) => fn(message, sender, resolve));
+  });
+}
+
+const OWN = 'hhru-live-test-extension';
+const hhruSender = { id: OWN, tab: { id: 7, url: 'https://hh.ru/applicant/profile/me' } };
+
+const SCENARIOS = {
+  // The happy relay path: an allowlisted command from the popup travels to
+  // the active hh.ru tab and the content script's response comes back
+  // untouched.
+  relay_forwards_to_hhru_tab: async () => {
+    const overlays = [{ id: 'overlay-1', type: 'modal', disposition: 'safe', closeControls: 1 }];
+    const { chrome, sent } = makeEnv({
+      activeTab: { id: 7, url: 'https://hh.ru/applicant/profile/me' },
+      tabReply: { ok: true, overlays },
+    });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'agent_command', action: 'list_overlays' }, { id: OWN });
+    return {
+      response,
+      sentToTabCount: sent.toTab.length,
+      sentAction: sent.toTab[0]?.message.action ?? null,
+      sentTabId: sent.toTab[0]?.tabId ?? null,
+      tabReplyPreserved: response?.overlays === overlays || response?.overlays?.[0]?.id === 'overlay-1',
+    };
+  },
+
+  // No hh.ru tab focused (or the active tab is a foreign origin): the relay
+  // must refuse WITHOUT touching any tab.
+  relay_no_hhru_tab: async () => {
+    const { chrome, sent } = makeEnv({
+      activeTab: { id: 3, url: 'https://example.com/page' },
+    });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'agent_command', action: 'list_overlays' }, { id: OWN });
+    return {
+      error: response?.error ?? null,
+      sentToTabCount: sent.toTab.length,
+    };
+  },
+
+  // The tab is hh.ru but the content script is not there (freshly navigated,
+  // extension just reloaded): MV3 reports it via runtime.lastError.
+  relay_content_script_unreachable: async () => {
+    const { chrome, sent } = makeEnv({
+      activeTab: { id: 7, url: 'https://hh.ru/' },
+      tabError: 'Could not establish connection. Receiving end does not exist.',
+    });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'agent_command', action: 'check_element', selector: '[data-qa="x"]' }, { id: OWN });
+    return {
+      error: response?.error ?? null,
+      sentToTabCount: sent.toTab.length,
+    };
+  },
+
+  // A command from another extension (sender.id mismatch) is rejected before
+  // any tab lookup happens.
+  relay_rejects_foreign_sender: async () => {
+    const { chrome, sent } = makeEnv({
+      activeTab: { id: 7, url: 'https://hh.ru/' },
+      tabReply: { ok: true },
+    });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'agent_command', action: 'list_overlays' }, { id: 'some-other-extension' });
+    return {
+      error: response?.error ?? null,
+      sentToTabCount: sent.toTab.length,
+    };
+  },
+
+  // An action outside the relay allowlist never reaches the tab (content.js
+  // would reject it anyway — fail-closed twice).
+  relay_rejects_unknown_action: async () => {
+    const { chrome, sent } = makeEnv({
+      activeTab: { id: 7, url: 'https://hh.ru/' },
+      tabReply: { ok: true },
+    });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'agent_command', action: 'close_all_windows' }, { id: OWN });
+    return {
+      error: response?.error ?? null,
+      sentToTabCount: sent.toTab.length,
+    };
+  },
+
+  // Diagnostics from a real hh.ru tab (connected / overlay_detected) still
+  // land in storage.session — the relay must not have broken the
+  // detection-storage path (#644) when the command path was added (#930).
+  diagnostics_stored: async () => {
+    const { chrome, sent } = makeEnv({ activeTab: null });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, {
+      kind: 'overlay_detected',
+      observedAt: '2026-09-05T00:00:00Z',
+      overlay: { id: 'overlay-1', type: 'toast', disposition: 'safe' },
+    }, hhruSender);
+    return {
+      responseOk: response?.ok ?? null,
+      storedReports: sent.toStorage?.recentReports?.length ?? 0,
+      storedKind: sent.toStorage?.recentReports?.[0]?.kind ?? null,
+    };
+  },
+
+  // A diagnostics message from a NON-hh.ru origin is rejected even though it
+  // claims to be an overlay report (isTrustedSender gate, #743 pattern).
+  diagnostics_foreign_origin_rejected: async () => {
+    const { chrome, sent } = makeEnv({ activeTab: null });
+    vm.runInContext(source, vm.createContext({ chrome }));
+    const response = await deliver(chrome, { kind: 'overlay_detected', overlay: {} }, {
+      id: OWN,
+      tab: { id: 3, url: 'https://example.com/' },
+    });
+    return {
+      error: response?.error ?? null,
+      storedReports: sent.toStorage?.recentReports?.length ?? 0,
+    };
+  },
+};
+
+async function main() {
+  const name = process.argv[2];
+  const scenario = SCENARIOS[name];
+  if (!scenario) {
+    process.stderr.write(`unknown scenario: ${name}; available: ${Object.keys(SCENARIOS).join(', ')}\n`);
+    process.exit(1);
+  }
+  const result = await scenario();
+  process.stdout.write(JSON.stringify({ scenario: name, ...result }));
+}
+
+main().catch((err) => {
+  process.stderr.write(String((err && err.stack) || err));
+  process.exit(1);
+});

--- a/tests/test_hhru_live_behavior.py
+++ b/tests/test_hhru_live_behavior.py
@@ -331,3 +331,55 @@ def test_hhru_live_policy_core_remote_work_not_dangerous():
     safe."""
     scenario = _run_policy_scenario("remote_work_not_dangerous")
     assert scenario["disposition"] == "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Транспорт agent-канала (issue #931): popup -> background relay -> активная
+# hh.ru-вкладка. Сценарии исполняют background.js по-настоящему через
+# tests/js_harness/run_background_scenario.js <name> (стаб chrome.tabs/
+# storage.session; до этого relay был покрыт только grep-гвардами).
+# ---------------------------------------------------------------------------
+
+BACKGROUND_RUNNER = REPO_ROOT / "tests" / "js_harness" / "run_background_scenario.js"
+
+
+def _run_background_scenario(name: str) -> dict:
+    return _run_node_scenario(BACKGROUND_RUNNER, [name])
+
+
+def test_hhru_live_relay_forwards_allowlisted_command_to_hhru_tab():
+    scenario = _run_background_scenario("relay_forwards_to_hhru_tab")
+    assert scenario["response"]["ok"] is True
+    assert scenario["sentToTabCount"] == 1
+    assert scenario["sentAction"] == "list_overlays"
+    assert scenario["tabReplyPreserved"]
+
+
+def test_hhru_live_relay_refuses_without_hhru_tab():
+    scenario = _run_background_scenario("relay_no_hhru_tab")
+    assert scenario["error"] == "no_hhru_tab"
+    assert scenario["sentToTabCount"] == 0
+
+
+def test_hhru_live_relay_reports_content_script_unreachable():
+    scenario = _run_background_scenario("relay_content_script_unreachable")
+    assert scenario["error"] == "content_script_unreachable"
+
+
+def test_hhru_live_relay_rejects_foreign_sender_and_unknown_action():
+    foreign = _run_background_scenario("relay_rejects_foreign_sender")
+    assert foreign["error"] == "sender_not_allowed"
+    assert foreign["sentToTabCount"] == 0
+    unknown = _run_background_scenario("relay_rejects_unknown_action")
+    assert unknown["error"] == "action_not_allowed"
+    assert unknown["sentToTabCount"] == 0
+
+
+def test_hhru_live_relay_keeps_diagnostics_storage_path():
+    stored = _run_background_scenario("diagnostics_stored")
+    assert stored["responseOk"] is True
+    assert stored["storedReports"] == 1
+    assert stored["storedKind"] == "overlay_detected"
+    foreign = _run_background_scenario("diagnostics_foreign_origin_rejected")
+    assert foreign["error"] == "sender_not_allowed"
+    assert foreign["storedReports"] == 0

--- a/tests/test_page_state.py
+++ b/tests/test_page_state.py
@@ -347,7 +347,9 @@ def test_hhru_live_relay_is_exercised_by_background_scenario_runner():
 
     runner = Path(__file__).parents[1] / "tests" / "js_harness" / "run_background_scenario.js"
     source = runner.read_text()
-    background = (Path(__file__).parents[1] / "extensions" / "hhru-live" / "background.js").read_text()
+    background = (
+        Path(__file__).parents[1] / "extensions" / "hhru-live" / "background.js"
+    ).read_text()
     # Сценарии раннера по имени; ошибки релея они проверяют по факту ответа.
     for scenario in (
         "relay_no_hhru_tab",
@@ -357,5 +359,10 @@ def test_hhru_live_relay_is_exercised_by_background_scenario_runner():
         "diagnostics_stored",
     ):
         assert scenario in source, f"раннер обязан покрывать сценарий {scenario}"
-    for error in ("no_hhru_tab", "content_script_unreachable", "sender_not_allowed", "action_not_allowed"):
+    for error in (
+        "no_hhru_tab",
+        "content_script_unreachable",
+        "sender_not_allowed",
+        "action_not_allowed",
+    ):
         assert error in background, f"background.js должен содержать {error}"

--- a/tests/test_page_state.py
+++ b/tests/test_page_state.py
@@ -335,3 +335,27 @@ def test_hhru_live_extension_readme_does_not_overclaim_external_reachability():
     readme = (root / "README.md").read_text()
     assert "reachable only from an **external** caller" not in readme
     assert "#743" in readme
+
+
+def test_hhru_live_relay_is_exercised_by_background_scenario_runner():
+    """Issue #931: relay popup -> background -> hh.ru-вкладка должен не только
+    существовать (grep-гварды выше), но и исполняться харнестом — раннер
+    background-сценариев обязан покрывать обе доменные ошибки релея
+    (no_hhru_tab, content_script_unreachable), иначе удаление веток релея
+    пройдёт мимо тестов."""
+    from pathlib import Path
+
+    runner = Path(__file__).parents[1] / "tests" / "js_harness" / "run_background_scenario.js"
+    source = runner.read_text()
+    background = (Path(__file__).parents[1] / "extensions" / "hhru-live" / "background.js").read_text()
+    # Сценарии раннера по имени; ошибки релея они проверяют по факту ответа.
+    for scenario in (
+        "relay_no_hhru_tab",
+        "relay_content_script_unreachable",
+        "relay_rejects_foreign_sender",
+        "relay_rejects_unknown_action",
+        "diagnostics_stored",
+    ):
+        assert scenario in source, f"раннер обязан покрывать сценарий {scenario}"
+    for error in ("no_hhru_tab", "content_script_unreachable", "sender_not_allowed", "action_not_allowed"):
+        assert error in background, f"background.js должен содержать {error}"


### PR DESCRIPTION
Closes #931

Аудит показал: сам транспорт (background.js relay `agent_command`, allowlist-зеркало, sender-гейты, popup-таблица с dismiss только для safe, diagnostics-журнал, permissions без изменений) уже реализован MVP #935 и покрыт grep-гвардами. Единственная щель по тексту ишью — пункт «опционально vm-сценарий background.js с chrome.tabs-стабом»: **ни один тест не исполнял background.js**, все relay-ветки проверялись только поиском по тексту.

## Что добавлено (только тесты + README, код не тронут)
- **`tests/js_harness/run_background_scenario.js`** — исполняет background.js в vm со стабом chrome (runtime + tabs + storage.session; lastError моделируется как в MV3 — синхронно перед callback). 7 сценариев:
  | Сценарий | Вердикт |
  |---|---|
  | `relay_forwards_to_hhru_tab` | команда уходит в hh.ru-таб от `sender.id = chrome.runtime.id`, ответ content возвращается нетронутым |
  | `relay_no_hhru_tab` | `no_hhru_tab`, в таб никто не стучался |
  | `relay_content_script_unreachable` | честный `content_script_unreachable` через lastError |
  | `relay_rejects_foreign_sender` | `sender_not_allowed` до всякого tabs.query |
  | `relay_rejects_unknown_action` | `action_not_allowed` до всякого tabs.query |
  | `diagnostics_stored` | `overlay_detected` по-прежнему пишется в storage.session |
  | `diagnostics_foreign_origin_rejected` | не-hh.ru origin → `sender_not_allowed`, ничего не сохранено (паттерн #743) |
- **5 pytest-обёрток** в test_hhru_live_behavior.py через существующий `_run_node_scenario`.
- **Гвард** в test_page_state.py: раннер обязан покрывать 5 relay-сценариев — ветки релея нельзя удалить незаметно.
- README: раздел транспорта дополнен.

## Проверки
`node --check` OK; test_page_state + test_hhru_live_behavior полностью зелёные. `tests/test_selector_metrics.py::test_bundle_matches_json_schema_and_golden` падает и на чистом main (предсуществующее, к расширению отношения не имеет).

Permissions не расширены (`["storage"]`-гвард держит), externally_connectable/Native Messaging — вне скоупа по тексту ишью (второй этап).