### PR TITLE
fix(common): защищённый NEXT-клик + дамп экрана в save_common (#989)

### DIFF
--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -533,9 +533,29 @@ def save_common(
     save = _strict(page, SAVE, "кнопка сохранения common")
     if before_click:
         before_click()
+    # #989: два боевых uncertain показали, что NEXT-клик до гидратации SPA
+    # проглатывается (visible ≠ гидратирован), а ожидание скрытия формы за 5с
+    # окно медленной гидратации не покрывает в принципе. Тот же защищённый
+    # клик, что у confirm_common_screen (#986, паттерн #913): исход решает
+    # wait_for_url (уход с /profile/resume/common, бюджет 30с), падение
+    # click() при состоявшемся переходе — не ошибка.
     try:
         save.click()
-        page.locator(FORM).first.wait_for(state="hidden", timeout=_WAIT_MS)
-    except Exception as exc:  # click may have reached hh.ru: caller records uncertain
+    except PlaywrightError:
+        pass
+    try:
+        page.wait_for_url(
+            lambda url: urlsplit(str(url)).path != COMMON_SCREEN_PATH,
+            wait_until="commit",
+            timeout=_COMMON_SCREEN_NAV_TIMEOUT_MS,
+        )
+    except PlaywrightError as exc:
+        # Клик мог дойти (клик мог уйти, #176) — дампим экран: в нём виден
+        # text form-helper-error, которым hh.ru объясняет отказ валидации,
+        # и это единственная диагностика этого исхода (#989).
+        try:
+            dump_page_html(page, "common_save_failure")
+        except Exception:  # noqa: BLE001 — диагностика не должна заменять исходную ошибку
+            pass
         return CommonResult(False, f"сохранение common не подтверждено: {exc}", True, True)
     return CommonResult(True, "поля common сохранены", True)

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -550,7 +550,7 @@ def save_common(
             timeout=_COMMON_SCREEN_NAV_TIMEOUT_MS,
         )
     except PlaywrightError as exc:
-        # Клик мог дойти (клик мог уйти, #176) — дампим экран: в нём виден
+        # Клик мог уйти на hh.ru (#176) — дампим экран: в нём виден
         # text form-helper-error, которым hh.ru объясняет отказ валидации,
         # и это единственная диагностика этого исхода (#989).
         try:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -582,3 +582,48 @@ def test_confirm_common_screen_no_navigation_is_uncertain(monkeypatch):
     result = common.confirm_common_screen(page, "00001")
     assert not result.success and result.acted and result.uncertain
     assert "переход с экрана common не подтверждён" in result.reason
+
+
+# --- #989: защищённый NEXT-клик + дамп экрана в save_common -------------------
+
+
+def test_save_common_succeeds_on_url_change(monkeypatch):
+    page, save, _locators = _confirm_page(monkeypatch)
+    monkeypatch.setattr(common, "dump_page_html", MagicMock())
+    result = common.save_common(page, common.CommonValues(), before_click=MagicMock())
+    assert result.success and result.acted and not result.uncertain
+    save.first.click.assert_called_once_with()
+    page.wait_for_url.assert_called_once()
+    common.dump_page_html.assert_not_called()
+
+
+def test_save_common_click_error_still_succeeds_on_url_change(monkeypatch):
+    # Паттерн #913: click() может упасть при состоявшемся переходе — исход
+    # решает wait_for_url, а не сам клик.
+    page, _save, _locators = _confirm_page(monkeypatch, click_error=True)
+    result = common.save_common(page, common.CommonValues())
+    assert result.success and result.acted
+
+
+def test_save_common_no_navigation_is_uncertain_and_dumps_screen(monkeypatch):
+    from playwright.sync_api import Error as PlaywrightError
+
+    page, _save, _locators = _confirm_page(monkeypatch, nav_error=PlaywrightError("timeout"))
+    dump = MagicMock()
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    result = common.save_common(page, common.CommonValues())
+    assert not result.success and result.acted and result.uncertain
+    assert "сохранение common не подтверждено" in result.reason
+    dump.assert_called_once_with(page, "common_save_failure")
+
+
+def test_save_common_dump_failure_does_not_mask_uncertain(monkeypatch):
+    from playwright.sync_api import Error as PlaywrightError
+
+    page, _save, _locators = _confirm_page(monkeypatch, nav_error=PlaywrightError("timeout"))
+    monkeypatch.setattr(
+        common, "dump_page_html", MagicMock(side_effect=RuntimeError("dump crashed"))
+    )
+    result = common.save_common(page, common.CommonValues())
+    assert not result.success and result.acted and result.uncertain
+    assert "сохранение common не подтверждено" in result.reason


### PR DESCRIPTION
## Суть

Два боевых uncertain-отказа `save_common` (прогоны #982 и #986, оба 2026-09-06)
показали один и тот же класс проблемы: NEXT-клик по «Сохранить и продолжить»
проглатывается до гидратации React SPA (`visible ≠ гидратирован`), а ожидание
скрытия формы за 5с это окно не покрывает в принципе. Read-only перепроверки
оба раза доказали отсутствие мутации (`nextIncompleteScreenId=common`).

## Изменения (`src/hhru_bot/common.py::save_common`)

- **Защищённый клик вместо ожидания скрытия** — тот же паттерн, что у
  `confirm_common_screen` из #986 (и `resume_position` #913): исход решает
  `wait_for_url` (уход с `/profile/resume/common`, `wait_until="commit"`,
  бюджет 30с через уже существующую `_COMMON_SCREEN_NAV_TIMEOUT_MS`), падение
  `click()` при состоявшемся переходе — не ошибка.
- **Дамп экрана при uncertain** (#989 п.1): неподтверждённый переход →
  `dump_page_html(page, "common_save_failure")` (best-effort, как у
  `read_common`) — в дампе видны тексты `form-helper-error`, которыми hh.ru
  объясняет отказ валидации; сейчас этот исход недиагностируем.

## Тесты

4 новых в `tests/test_common.py` (двойник `_confirm_page` переиспользован):
успех по смене URL; успех при упавшем click(); непереход → uncertain + дамп;
краш дампа не маскирует uncertain. Полная сюита `pytest -q -n 4 --dist
worksteal` зелёная, `ruff check` + `ruff format --check` чисты.

## Что НЕ входит

- Живой боевой прогон авто-режима common (п.3 ишью, закрытие #982) — мутация
  на hh.ru, отдельно по согласованию после мерджа.
- `confirm_common_screen` не тронут: его uncertain-ветка диагностически
  покрывается readback'ом create-пайплайна.

Closes #989
