### PR TITLE
fix(common): гидрационный гейт SAVE перед NEXT-кликом (#991)

### DIFF
--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -535,14 +535,15 @@ def save_common(
 ) -> CommonResult:
     apply_common(page, values)
     save = _strict(page, SAVE, "кнопка сохранения common")
-    if before_click:
-        before_click()
     # #991: #990 сделал исход честным, но корневая причина боевых uncertain
     # (#982/#986) — NEXT-клик до гидратации SPA (#858; живой аналог измерен в
     # #840: активатор месяца гидрируется СЕКУНДЫ, клик в этом окне теряется).
     # Гейт: до клика ждём React-привязку SAVE; две попытки без гидрации —
     # клик не отправлялся вовсе, это честный failed (мутации точно не было),
-    # а не uncertain.
+    # а не uncertain. Гейт — pre-click проверка (ревью #992: как launch_context/
+    # «форма не найдена» из #476), поэтому стоит ДО before_click: резерв
+    # uncertain-маркера не должен висеть всё 30с-окно ожидания гидрации,
+    # в котором клик структурно невозможен.
     hydrated = False
     for _attempt in range(2):
         if wait_for_react_hydration(page, SAVE, timeout_ms=_SAVE_HYDRATION_TIMEOUT_MS):
@@ -560,6 +561,8 @@ def save_common(
             f"SAVE не гидратирован за {2 * _SAVE_HYDRATION_TIMEOUT_MS // 1000}с — "
             "клик не отправлялся (мутации нет)",
         )
+    if before_click:
+        before_click()
     # #989: тот же защищённый клик, что у confirm_common_screen (#986,
     # паттерн #913): исход решает wait_for_url (уход с
     # /profile/resume/common, бюджет 30с), падение click() при состоявшемся

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -26,6 +26,7 @@ from .browser import (
     labelled_field,
     optional_labelled_field,
     require_authenticated_page,
+    wait_for_react_hydration,
 )
 from .config import ResumeConfig
 from .selector_groups import account_profile
@@ -75,6 +76,9 @@ COMMON_SCREEN_PATH = "/profile/resume/common"
 # wait_for_url, а не сам click().
 _COMMON_SCREEN_NAV_TIMEOUT_MS = 30_000
 _WAIT_MS = 5_000
+# #991: окно гидратации SAVE перед NEXT-кликом (одно ожидание). Две попытки
+# подряд в save_common дают суммарные ~30с — сопоставимо с бюджетом навигации.
+_SAVE_HYDRATION_TIMEOUT_MS = 15_000
 
 # Поля, без которых hh.ru не пускает черновик дальше к публикации (#982).
 # Авто-режим сохраняет предзаполненное только когда все они непусты.
@@ -533,16 +537,39 @@ def save_common(
     save = _strict(page, SAVE, "кнопка сохранения common")
     if before_click:
         before_click()
-    # #989: два боевых uncertain показали, что NEXT-клик до гидратации SPA
-    # проглатывается (visible ≠ гидратирован), а ожидание скрытия формы за 5с
-    # окно медленной гидратации не покрывает в принципе. Тот же защищённый
-    # клик, что у confirm_common_screen (#986, паттерн #913): исход решает
-    # wait_for_url (уход с /profile/resume/common, бюджет 30с), падение
-    # click() при состоявшемся переходе — не ошибка.
+    # #991: #990 сделал исход честным, но корневая причина боевых uncertain
+    # (#982/#986) — NEXT-клик до гидратации SPA (#858; живой аналог измерен в
+    # #840: активатор месяца гидрируется СЕКУНДЫ, клик в этом окне теряется).
+    # Гейт: до клика ждём React-привязку SAVE; две попытки без гидрации —
+    # клик не отправлялся вовсе, это честный failed (мутации точно не было),
+    # а не uncertain.
+    hydrated = False
+    for _attempt in range(2):
+        if wait_for_react_hydration(page, SAVE, timeout_ms=_SAVE_HYDRATION_TIMEOUT_MS):
+            hydrated = True
+            break
+    if not hydrated:
+        # Дамп покажет, жива ли форма и есть ли form-helper-error — иначе
+        # «не гидратирован» неотличим от «страница умерла».
+        try:
+            dump_page_html(page, "common_save_failure")
+        except Exception:  # noqa: BLE001 — диагностика не должна маскировать исход
+            pass
+        return CommonResult(
+            False,
+            f"SAVE не гидратирован за {2 * _SAVE_HYDRATION_TIMEOUT_MS // 1000}с — "
+            "клик не отправлялся (мутации нет)",
+        )
+    # #989: тот же защищённый клик, что у confirm_common_screen (#986,
+    # паттерн #913): исход решает wait_for_url (уход с
+    # /profile/resume/common, бюджет 30с), падение click() при состоявшемся
+    # переходе — не ошибка. Текст падения клика сохраняется в reason при
+    # неуспехе (ревью #990: иначе «дошёл ли клик» недиагностируемо).
+    click_error: str | None = None
     try:
         save.click()
-    except PlaywrightError:
-        pass
+    except PlaywrightError as exc:
+        click_error = str(exc)
     try:
         page.wait_for_url(
             lambda url: urlsplit(str(url)).path != COMMON_SCREEN_PATH,
@@ -552,10 +579,15 @@ def save_common(
     except PlaywrightError as exc:
         # Клик мог уйти на hh.ru (#176) — дампим экран: в нём виден
         # text form-helper-error, которым hh.ru объясняет отказ валидации,
-        # и это единственная диагностика этого исхода (#989).
+        # и это единственная диагностика этого исхода (#989). Пустой дамп
+        # по ошибкам валидации = потерянный клик (#991) — см. дискриминатор
+        # в #991 для следующей итерации.
         try:
             dump_page_html(page, "common_save_failure")
         except Exception:  # noqa: BLE001 — диагностика не должна заменять исходную ошибку
             pass
-        return CommonResult(False, f"сохранение common не подтверждено: {exc}", True, True)
+        reason = f"сохранение common не подтверждено: {exc}; гидрация SAVE: ок"
+        if click_error is not None:
+            reason += f"; ошибка клика: {click_error[:300]}"
+        return CommonResult(False, reason, True, True)
     return CommonResult(True, "поля common сохранены", True)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -627,3 +627,76 @@ def test_save_common_dump_failure_does_not_mask_uncertain(monkeypatch):
     result = common.save_common(page, common.CommonValues())
     assert not result.success and result.acted and result.uncertain
     assert "сохранение common не подтверждено" in result.reason
+
+
+# --- #991: гидрационный гейт SAVE перед NEXT-кликом ---------------------------
+
+
+def _hydration(monkeypatch, sequence):
+    """Мок wait_for_react_hydration, отдающий значения из sequence по порядку."""
+    calls = []
+
+    def fake(page, selector, *, timeout_ms):
+        calls.append(timeout_ms)
+        return sequence.pop(0) if sequence else False
+
+    monkeypatch.setattr(common, "wait_for_react_hydration", fake)
+    return calls
+
+
+def test_save_common_hydrated_immediately_clicks_once(monkeypatch):
+    """Гидрация с первой попытки: клик один, исход не изменился (#990)."""
+    page, save, _locators = _confirm_page(monkeypatch)
+    calls = _hydration(monkeypatch, [True])
+    result = common.save_common(page, common.CommonValues())
+    assert result.success and result.acted and not result.uncertain
+    assert calls == [common._SAVE_HYDRATION_TIMEOUT_MS]
+    save.first.click.assert_called_once_with()
+
+
+def test_save_common_second_hydration_attempt_clicks(monkeypatch):
+    """Первая попытка гидрации не удалась — клик НЕ отправлялся; вторая
+    удалась → ровно один клик, success."""
+    page, save, _locators = _confirm_page(monkeypatch)
+    _hydration(monkeypatch, [False, True])
+    result = common.save_common(page, common.CommonValues())
+    assert result.success and result.acted
+    save.first.click.assert_called_once_with()
+
+
+def test_save_common_never_hydrated_fails_closed_without_click(monkeypatch):
+    """Гидрации нет за обе попытки: клик не отправлялся — честный failed
+    (acted=False, не uncertain), дамп страницы, факт в reason."""
+    page, save, _locators = _confirm_page(monkeypatch)
+    calls = _hydration(monkeypatch, [False, False])
+    dump = MagicMock()
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    result = common.save_common(page, common.CommonValues())
+    assert not result.success
+    assert result.acted is False and result.uncertain is False
+    save.first.click.assert_not_called()
+    assert len(calls) == 2
+    dump.assert_called_once_with(page, "common_save_failure")
+    assert "гидратирован" in result.reason
+    assert "клик не отправлялся" in result.reason
+
+
+def test_save_common_uncertain_reason_carries_hydration_and_click_error(monkeypatch):
+    """Гидрация ок, переход не случился: uncertain + в reason и факт гидрации,
+    и текст исключения клика (ревью #990: иначе «дошёл ли клик» неизвестно)."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    page, save, _locators = _confirm_page(monkeypatch, click_error=True)
+    monkeypatch.setattr(
+        common,
+        "wait_for_react_hydration",
+        lambda page, selector, *, timeout_ms: True,
+    )
+    page.wait_for_url.side_effect = PlaywrightError("Navigation timeout")
+    dump = MagicMock()
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    result = common.save_common(page, common.CommonValues())
+    assert not result.success and result.acted and result.uncertain
+    assert "гидрация SAVE: ок" in result.reason
+    assert "pointer intercepted" in result.reason
+    dump.assert_called_once_with(page, "common_save_failure")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -700,3 +700,14 @@ def test_save_common_uncertain_reason_carries_hydration_and_click_error(monkeypa
     assert "гидрация SAVE: ок" in result.reason
     assert "pointer intercepted" in result.reason
     dump.assert_called_once_with(page, "common_save_failure")
+
+
+def test_save_common_hydration_gate_precedes_before_click(monkeypatch):
+    """Гейт-отказ — pre-click состояние (#476, ревью #992): before_click
+    (резерв uncertain-маркера) не вызывается вовсе, клик не отправлялся."""
+    page, _save, _locators = _confirm_page(monkeypatch)
+    _hydration(monkeypatch, [False, False])
+    before_click = MagicMock()
+    result = common.save_common(page, common.CommonValues(), before_click=before_click)
+    assert not result.success and not result.acted and not result.uncertain
+    before_click.assert_not_called()


### PR DESCRIPTION
Closes #991

Корень двух боевых uncertain `save_common` (#982/#986) — NEXT-клик до гидратации SPA (#858; окно измерено живьём в #840 на идентичном magritte-активаторе — секунды). PR #990 сделал исход честным, этот — устраняет причину.

## Изменения (`save_common`)
- **Гидрационный гейт**: `wait_for_react_hydration(page, SAVE, 15с)`, максимум 2 попытки; клик не отправляется, пока кнопка не гидратирована.
- **Матрица исходов**:
  | гидрация | nav | результат |
  |---|---|---|
  | ок (1-2 попытки) | ок | success (как #990) |
  | ок | нет | uncertain + дамп; reason += факт гидрации + текст click-исключения (ревью #990) |
  | нет ×2 | клика не было | **failed, acted=False** (мутация точно невозможна — не uncertain) + дамп |
- Бюджеты: 2×15с гидрации + 30с навигации — сопоставимы, честный таймаут сохранён.

## Тесты
4 новых (`tests/test_common.py`): гидрация сразу → 1 клик; False→True → 1 клик; никогда → failed без клика + дамп + «клик не отправлялся» в reason; гидрация ок + nav_error → uncertain, reason содержит «гидрация SAVE: ок» и текст click-исключения.

Полный pytest зелёный, ruff чист.

## После мерджа
Боевой прогон авто-режима `common` (п.3 #989) — по авторизации владельца; его дамп закрывает дискриминатор #991: `form-helper-error` ⇢ валидация (чинить префилл), пусто ⇢ потерянный клик был, гейт его теперь предотвращает.