### PR TITLE
fix(common): открытие common — published-redirect и гонка монтирования (#995)

### DIFF
--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -169,9 +169,56 @@ def open_common_form(page: Page, resume: ResumeConfig):
 def _open_common_screen(page: Page, resume_id: str):
     goto_hh(page, f"{HH_BASE_URL}{account_profile.RESUME_COMMON_PATH}?resume={resume_id}")
     require_authenticated_page(page)
+    # #995 (live 2026-09-06): редирект с /profile/resume?resume=… зависит от
+    # состояния резюме — у ЧЕРНОВИКА он ведёт на /profile/resume/common
+    # (визард), у ОПУБЛИКОВАННОГО — на /resume/{resume_id} (страница
+    # просмотра; визанда common у published не существует, а старый
+    # /applicant/resumes/edit/common отдаёт голый JSON). Дождаться
+    # разрешения редиректа, прежде чем судить о форме.
+    try:
+        page.wait_for_url(
+            lambda url: urlsplit(str(url)).path != account_profile.RESUME_COMMON_PATH,
+            wait_until="commit",
+            timeout=_COMMON_SCREEN_NAV_TIMEOUT_MS,
+        )
+    except PlaywrightError as exc:
+        try:
+            dump_page_html(page, "common_open_failure")
+        except Exception:  # noqa: BLE001 — диагностика не должна заменять исходную ошибку
+            pass
+        raise RuntimeError(
+            f"форма common не открылась: редирект с /profile/resume не разрешился "
+            f"за {_COMMON_SCREEN_NAV_TIMEOUT_MS // 1000}с ({page.url})"
+        ) from exc
+    if urlsplit(page.url).path == f"/resume/{resume_id}":
+        # Опубликованное резюме (#995): честная семантика вместо
+        # «форма common не открылась».
+        try:
+            dump_page_html(page, "common_open_failure")
+        except Exception:  # noqa: BLE001
+            pass
+        raise RuntimeError(
+            "экран common визарда существует только у черновиков: резюме "
+            "опубликовано, hh.ru редиректит на страницу просмотра — правки "
+            "common через визард невозможны"
+        )
+    # Гонка «DCL ≠ отрисовано»: SPA-экран монтируется после domcontentloaded —
+    # ждать монтирование (attached), а не судить по мгновенному count() (#995).
     editor = page.locator(FORM)
+    try:
+        editor.first.wait_for(state="attached", timeout=_WAIT_MS)
+    except PlaywrightError:
+        try:
+            dump_page_html(page, "common_open_failure")
+        except Exception:  # noqa: BLE001
+            pass
+        raise RuntimeError("форма common не открылась: экран не смонтировался") from None
     if editor.count() != 1:
-        raise RuntimeError("форма common не открылась")
+        try:
+            dump_page_html(page, "common_open_failure")
+        except Exception:  # noqa: BLE001
+            pass
+        raise RuntimeError("форма common не открылась: контейнер неоднозначен")
     route = urlsplit(page.url)
     if route.path != COMMON_SCREEN_PATH or parse_qs(route.query).get("resume") != [resume_id]:
         raise RuntimeError("форма common открыта не для запрошенного резюме")

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -166,6 +166,16 @@ def open_common_form(page: Page, resume: ResumeConfig):
     return _open_common_screen(page, resume.resume_id)
 
 
+def _dump_and_raise(page: Page, message: str, cause: BaseException | None = None):
+    """Дамп на отказе открытия common (#995): диагностика не должна
+    заменять исходную ошибку — упавший дамп не съедает отказ."""
+    try:
+        dump_page_html(page, "common_open_failure")
+    except Exception:  # noqa: BLE001 — см. докстринг
+        pass
+    raise RuntimeError(message) from cause
+
+
 def _open_common_screen(page: Page, resume_id: str):
     goto_hh(page, f"{HH_BASE_URL}{account_profile.RESUME_COMMON_PATH}?resume={resume_id}")
     require_authenticated_page(page)
@@ -182,43 +192,30 @@ def _open_common_screen(page: Page, resume_id: str):
             timeout=_COMMON_SCREEN_NAV_TIMEOUT_MS,
         )
     except PlaywrightError as exc:
-        try:
-            dump_page_html(page, "common_open_failure")
-        except Exception:  # noqa: BLE001 — диагностика не должна заменять исходную ошибку
-            pass
-        raise RuntimeError(
-            f"форма common не открылась: редирект с /profile/resume не разрешился "
-            f"за {_COMMON_SCREEN_NAV_TIMEOUT_MS // 1000}с ({page.url})"
-        ) from exc
+        _dump_and_raise(
+            page,
+            "форма common не открылась: редирект с /profile/resume не разрешился "
+            f"за {_COMMON_SCREEN_NAV_TIMEOUT_MS // 1000}с ({page.url})",
+            cause=exc,
+        )
     if urlsplit(page.url).path == f"/resume/{resume_id}":
         # Опубликованное резюме (#995): честная семантика вместо
         # «форма common не открылась».
-        try:
-            dump_page_html(page, "common_open_failure")
-        except Exception:  # noqa: BLE001
-            pass
-        raise RuntimeError(
+        _dump_and_raise(
+            page,
             "экран common визарда существует только у черновиков: резюме "
             "опубликовано, hh.ru редиректит на страницу просмотра — правки "
-            "common через визард невозможны"
+            "common через визард невозможны",
         )
     # Гонка «DCL ≠ отрисовано»: SPA-экран монтируется после domcontentloaded —
     # ждать монтирование (attached), а не судить по мгновенному count() (#995).
     editor = page.locator(FORM)
     try:
         editor.first.wait_for(state="attached", timeout=_WAIT_MS)
-    except PlaywrightError:
-        try:
-            dump_page_html(page, "common_open_failure")
-        except Exception:  # noqa: BLE001
-            pass
-        raise RuntimeError("форма common не открылась: экран не смонтировался") from None
+    except PlaywrightError as exc:
+        _dump_and_raise(page, "форма common не открылась: экран не смонтировался", cause=exc)
     if editor.count() != 1:
-        try:
-            dump_page_html(page, "common_open_failure")
-        except Exception:  # noqa: BLE001
-            pass
-        raise RuntimeError("форма common не открылась: контейнер неоднозначен")
+        _dump_and_raise(page, "форма common не открылась: контейнер неоднозначен")
     route = urlsplit(page.url)
     if route.path != COMMON_SCREEN_PATH or parse_qs(route.query).get("resume") != [resume_id]:
         raise RuntimeError("форма common открыта не для запрошенного резюме")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.common as common
 from hhru_bot.common import (
@@ -532,8 +533,16 @@ def _confirm_page(monkeypatch, **overrides):
     save = field(common.SAVE, value=None)
     if values["click_error"]:
         save.first.click.side_effect = PlaywrightError("pointer intercepted")
-    if values["nav_error"] is not None:
-        page.wait_for_url.side_effect = values["nav_error"]
+
+    # wait_for_url уважает предикат (как реальный API): навигация-ошибка
+    # рождается только когда предикат НЕ удовлетворён текущим url (#995:
+    # один и тот же page.wait_for_url используют и _open_common_screen,
+    # и confirm/save с разными предикатами).
+    def _wait_for_url(predicate, *, wait_until=None, timeout=None):
+        if not predicate(page.url) and values["nav_error"] is not None:
+            raise values["nav_error"]
+
+    page.wait_for_url.side_effect = _wait_for_url
 
     def locate(selector):
         if selector not in locators:
@@ -553,7 +562,7 @@ def test_confirm_common_screen_clicks_next_and_requires_url_change(monkeypatch):
     assert result.success and result.acted and not result.uncertain
     before_click.assert_called_once_with()
     save.first.click.assert_called_once_with()
-    page.wait_for_url.assert_called_once()
+    assert page.wait_for_url.call_count == 2  # #995: один — _open_common_screen
 
 
 def test_confirm_common_screen_refuses_before_click_on_missing_prefill(monkeypatch):
@@ -564,7 +573,8 @@ def test_confirm_common_screen_refuses_before_click_on_missing_prefill(monkeypat
     assert "first_name" in result.reason
     before_click.assert_not_called()
     save.first.click.assert_not_called()
-    page.wait_for_url.assert_not_called()
+    # #995: единственный вызов — легитимный wait_for_url в _open_common_screen
+    assert page.wait_for_url.call_count == 1
 
 
 def test_confirm_common_screen_click_error_still_succeeds_on_url_change(monkeypatch):
@@ -801,6 +811,58 @@ class _WizardShapePage:
         return MagicMock()
 
 
+# --- #995: открытие экрана common (published-redirect и гонка монтирования) ---
+
+
+class _OpenScreenPage:
+    """Страница в момент открытия common: URL управляется тестом,
+    wait_for_url моделирует редирект hh.ru (live 2026-09-06: у черновика —
+    на /profile/resume/common, у опубликованного — на /resume/{hash})."""
+
+    def __init__(self, final_path, form_attached=True):
+
+        self.url = "https://hh.ru/profile/resume?resume=00001"
+        self._final_path = final_path
+        self._form_attached = form_attached
+        self.locators: dict = {}
+
+    def resolve_redirect(self):
+        self.url = f"https://hh.ru{self._final_path}"
+
+    def wait_for_url(self, predicate, *, wait_until=None, timeout=None):
+        from playwright.sync_api import Error as PlaywrightError
+
+        self.resolve_redirect()
+        if not predicate(self.url):
+            raise PlaywrightError("Navigation timeout")
+
+    def locator(self, selector):
+        from hhru_bot.selector_groups import account_profile as ap
+
+        loc = self.locators.get(selector)
+        if loc is None:
+            from unittest.mock import MagicMock
+
+            loc = MagicMock()
+            loc.count.return_value = 1
+            if selector == ap.RESUME_COMMON_FORM:
+                loc.first.wait_for.side_effect = (
+                    None if self._form_attached else PlaywrightError("not attached")
+                )
+            loc.first.inner_text.return_value = "x"
+            loc.first.input_value.return_value = "x"
+            loc.first.is_checked.return_value = True
+            self.locators[selector] = loc
+        return loc
+
+    def get_by_label(self, label, *, exact=False):
+        from unittest.mock import MagicMock
+
+        m = MagicMock()
+        m.count.return_value = 0
+        return m
+
+
 def _hydrated(monkeypatch, ok):
     """Гейт гидрации под контролем теста; возвращает список селекторов."""
     calls = []
@@ -887,3 +949,70 @@ def test_wizard_read_work_ticket_from_container(monkeypatch):
     """read_common на wizard-shape читает трудовую книжку из контейнера."""
     result = common._read_common(_WizardShapePage())
     assert result.work_ticket == "Да"
+
+
+def test_open_common_published_resume_refuses_honestly(monkeypatch):
+    """#995: у опубликованного резюме hh.ru редиректит на /resume/{hash} —
+    честный отказ «визанд только у черновиков» + дамп, а не «форма не
+    открылась»."""
+    page = _OpenScreenPage(f"/resume/{'0' * 32}")
+    dump = MagicMock()
+    monkeypatch.setattr(common, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "require_authenticated_page", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    try:
+        common._open_common_screen(page, "0" * 32)
+        raised = None
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None and "только у черновиков" in str(raised)
+    dump.assert_called_once()
+
+
+def test_open_common_redirect_timeout_dumps(monkeypatch):
+    """Редирект не разрешился за бюджет: отказ с URL + дамп (#995)."""
+    page = _OpenScreenPage("/profile/resume")
+    from playwright.sync_api import Error as PlaywrightError
+
+    page.wait_for_url = lambda *a, **k: (_ for _ in ()).throw(PlaywrightError("timeout"))
+    dump = MagicMock()
+    monkeypatch.setattr(common, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "require_authenticated_page", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    try:
+        common._open_common_screen(page, "0" * 32)
+        raised = None
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None and "редирект" in str(raised)
+    dump.assert_called_once()
+
+
+def test_open_common_draft_waits_for_spa_mount(monkeypatch):
+    """Черновик: редирект на /profile/resume/common, экран монтируется позже
+    DCL — wait_for(attached) вместо мгновенного count() (#995)."""
+    page = _OpenScreenPage(f"/profile/resume/common?resume={'0' * 32}")
+    monkeypatch.setattr(common, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "require_authenticated_page", lambda *_a, **_k: None)
+    editor = common._open_common_screen(page, "0" * 32)
+    # attached (монтирование, #995) + visible (финальное ожидание из #869)
+    assert [c.kwargs["state"] for c in editor.first.wait_for.call_args_list] == [
+        "attached",
+        "visible",
+    ]
+
+
+def test_open_common_unmounted_screen_dumps(monkeypatch):
+    """Форма не смонтировалась за бюджет: внятный отказ + дамп (#995)."""
+    page = _OpenScreenPage(f"/profile/resume/common?resume={'0' * 32}", form_attached=False)
+    dump = MagicMock()
+    monkeypatch.setattr(common, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "require_authenticated_page", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    try:
+        common._open_common_screen(page, "0" * 32)
+        raised = None
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None and "не смонтировался" in str(raised)
+    dump.assert_called_once()


### PR DESCRIPTION
Closes #995

## Живой диагноз (read-only IAB 2026-09-06)
- `/profile/resume?resume={published}` (marketing) **мгновенно редиректит на `/resume/{hash}`** — таймлайн 12с, форма `resume-profile-screen_common` не появляется ни разу. Гонки нет.
- Старый `/applicant/resumes/edit/common?resume={published}` — голый JSON (мёртв).
- У черновика тот же URL открывает `/profile/resume/common` нормально.
- **Вывод: визанд common существует только у черновиков.** Прежний код судил по мгновенному `count()` после DCL и падал безликим «форма common не открылась» без дампа.

## Фикс (`_open_common_screen`)
1. `wait_for_url` до выхода из `/profile/resume` (30с) — разрешение редиректа; таймаут → дамп `common_open_failure` + причина с URL.
2. Финал `/resume/{resume_id}` → **опубликованное**: дамп + «экран common визанда существует только у черновиков…» — честная семантика вместо вводящей в заблуждение ошибки.
3. Черновик: `wait_for(state="attached")` вместо мгновенного `count()` (гонка «DCL ≠ отрисовано»); не смонтировался / неоднозначен → дамп + уточнённая причина.
4. Identity-чек `?resume=` сохранён.

## Acceptance (живой, read-only)
- **Черновик** (Дворник-бригадир): `common --show` **зелёный** — таблица 13 полей, `[OK]`, read-only.
- **Опубликованный** (marketing): `[FAIL] … экран common визанда существует только у черновиков…` + дамп `common_open_failure_*.html` — ровно ожидаемое поведение.

Полный pytest зелёный (4 новых теста), ruff чист.