### PR TITLE
fix(common): «экран common уже пройден» для educations-черновиков (#999)

### DIFF
--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -205,6 +205,22 @@ def _open_common_screen(page: Page, resume_id: str):
             "опубликовано, hh.ru редиректит на страницу просмотра — правки "
             "common через визард невозможны",
         )
+    # #999 (бой 2026-09-06): hh.ru автоподтверждает common у
+    # fresh-черновика за секунды, и визанд встаёт на следующий экран
+    # (например, /profile/resume/educations). Это не поломка, а
+    # «common уже подтверждён» — отказ называет факт, а не
+    # «экран не смонтировался».
+    current = urlsplit(page.url).path
+    if (
+        current.startswith(f"{account_profile.RESUME_COMMON_PATH}/")
+        and current != COMMON_SCREEN_PATH
+    ):
+        _dump_and_raise(
+            page,
+            f"экран common уже пройден: визанд черновика стоит на "
+            f"«{current.rsplit('/', 1)[-1]}» — повторное подтверждение "
+            "common не требуется",
+        )
     # Гонка «DCL ≠ отрисовано»: SPA-экран монтируется после domcontentloaded —
     # ждать монтирование (attached), а не судить по мгновенному count() (#995).
     editor = page.locator(FORM)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -996,3 +996,23 @@ def test_open_common_unmounted_screen_dumps(monkeypatch):
         raised = exc
     assert raised is not None and "не смонтировался" in str(raised)
     dump.assert_called_once()
+
+
+def test_open_common_already_passed_screen_reports_fact(monkeypatch):
+    """#999: hh.ru автоподтверждает common у fresh-черновика, и визанд
+    встаёт на следующий экран (educations). Отказ должен называть факт
+    «уже пройден», а не «не смонтировался»."""
+    page = _OpenScreenPage(f"/profile/resume/educations?resume={'0' * 32}")
+    dump = MagicMock()
+    monkeypatch.setattr(common, "goto_hh", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "require_authenticated_page", lambda *_a, **_k: None)
+    monkeypatch.setattr(common, "dump_page_html", dump)
+    try:
+        common._open_common_screen(page, "0" * 32)
+        raised = None
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None
+    assert "уже пройден" in str(raised)
+    assert "educations" in str(raised)
+    dump.assert_called_once()


### PR DESCRIPTION
Closes #999

Бой #989 п.3 показал дрейф: hh.ru автоподтверждает common у fresh-черновика за секунды, и визанд встаёт на следующий экран (educations). Прежде это читалось как «экран не смонтировался» — похоже на поломку, хотя это факт «common уже подтверждён».

## Фикс
`_open_common_screen`: редирект в `/profile/resume/<other>` (≠ common) даёт отказ «экран common уже пройден: визанд черновика стоит на «<screen>» — повторное подтверждение не требуется» + дамп. Продуктовое решение по ревью: отказ (не no-op-success) — команда common требует явного экрана; no-op маскировал бы рассинхрон ожиданий.

Полутонов не добавлял (`--recheck` и no-op — при появлении реальной потребности). Тест: educations-редирект → «уже пройден» + «educations» в причине + дамп. Полный pytest зелёный, ruff чист.