### PR TITLE
fix(roles): решение по факту, а не по aria-атрибутам; recovery от клина дерева (#1004)

### DIFF
--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -693,6 +693,38 @@ def rendered_controls_census(page: Page) -> list[dict]:
     return page.evaluate(_CENSUS_JS)
 
 
+def wait_for_named_control_hydration(
+    page: Page, name: str, *, timeout_ms: int, roles: tuple[str, ...] = ("button", "checkbox")
+) -> bool:
+    """Гидрация контрола с доступимым именем `name` (кнопки без data-qa).
+
+    #858/#1004: SSR-контролы видны до того, как React привяжет обработчики;
+    wait_for_react_hydration требует CSS-селектор, а тогглы вроде «Фильтры»
+    адресуются только ролью и текстом. Критерий тот же: __reactFiber и
+    __reactProps на самом элементе.
+    """
+    try:
+        page.wait_for_function(
+            """([names, roleList]) => {
+                const wanted = names.trim();
+                const sel = roleList.map((r) => `[role="${r}"], ${r}`).join(',');
+                for (const el of document.querySelectorAll(sel)) {
+                    if ((el.innerText || '').trim() !== wanted
+                        && (el.getAttribute('aria-label') || '') !== wanted) continue;
+                    const keys = Object.keys(el);
+                    if (keys.some((k) => k.startsWith('__reactFiber'))
+                        && keys.some((k) => k.startsWith('__reactProps'))) return true;
+                }
+                return false;
+            }""",
+            arg=[name, list(roles)],
+            timeout=timeout_ms,
+        )
+    except PlaywrightError:
+        return False
+    return True
+
+
 _SUBTREE_CENSUS_JS = r"""(root) => {
   const sel = 'input, textarea, select, button, a[href], label, ' +
     '[role="button"], [role="combobox"], [role="checkbox"], [role="radio"], [data-qa]';

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -470,6 +470,9 @@ def _set_tree(page: Page, trigger_selector: str, values: list[str], label: str) 
     # Keep the state probe independent from the option's compound data-qa
     # selector; hh.ru has used both a plain item class and the tree-item class
     # on selected rows across these pickers.
+    # #1004 (live IAB 2026-09-06): aria-selected строк tree-selector идёт в
+    # одну ногу с чекбоксом (замер в каталоге ролей: true при выборе, false
+    # при снятии) — читаем предвыбор по нему.
     selected = modal.locator("[aria-selected='true'][data-qa*='tree-selector-child-']")
     selected_ids = {
         selected.nth(index).get_attribute("data-qa") for index in range(selected.count())
@@ -662,6 +665,12 @@ def _set_many(page, field, values: list[str], labels: dict[str, str]) -> None:
     # A checkbox collection is returned by the exact labelled binding.  Set
     # the requested state explicitly, so repeated application is idempotent
     # and stale selections are removed rather than silently retained.
+    # #1004 (live IAB 2026-09-06): magritte в открытом попапе честно и
+    # мгновенно переключает aria-selected в обе стороны (замер на «Формате
+    # работы» редактора позиции: «Удалённо»=true на открытии, клик «Гибрид»
+    # даёт true тут же, повторный клик снимает) — решение о клике по
+    # атрибуту допустимо, но итог сверяется фактом ниже: потерянный клик
+    # (#858) не должен молча оставить полувыбранный набор.
     field.click()
     popup = page.locator(RESUME_POSITION_DROPDOWN)
     popup.wait_for(state="visible", timeout=_WAIT_MS)
@@ -680,6 +689,14 @@ def _set_many(page, field, values: list[str], labels: dict[str, str]) -> None:
             raise RuntimeError(f"вариант формы не найден: {value}")
         if option.first.get_attribute("aria-selected") != "true":
             option.first.click()
+    for index in range(options.count()):
+        option = options.nth(index)
+        text = option.inner_text().strip()
+        selected = option.get_attribute("aria-selected") == "true"
+        if selected and text not in wanted:
+            raise RuntimeError(f"лишний вариант остался выбранным в форме common: {text!r}")
+        if not selected and text in wanted:
+            raise RuntimeError(f"форма common не выбрала вариант: {text!r}")
     page.mouse.click(0, 0)
     popup.wait_for(state="hidden", timeout=_WAIT_MS)
 

--- a/src/hhru_bot/professional_roles.py
+++ b/src/hhru_bot/professional_roles.py
@@ -16,6 +16,7 @@ tree (#913).
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import tempfile
@@ -27,8 +28,10 @@ from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
-from .browser import HH_BASE_URL, goto_hh
+from .browser import HH_BASE_URL, goto_hh, wait_for_named_control_hydration
 from .external_forms.detect import normalize
+
+logger = logging.getLogger(__name__)
 
 SEARCH_URL = f"{HH_BASE_URL}/search/vacancy"
 FILTER_TRIGGER = "[data-qa='search-filter-professional-role-trigger']"
@@ -39,6 +42,12 @@ _ROLE_ID_RE = re.compile(r"(?:^|\s)tree-selector-input-(\d+)(?:\s|$)")
 _CATEGORY_ID_RE = re.compile(r"(?:^|\s)tree-selector-input-category-(\d+)(?:\s|$)")
 _WAIT_MS = 15_000
 _MAX_SCROLL_STEPS = 200
+# #1004: ожидание факта «leaf-строки появились/исчезли» после клика по шеврону.
+_LEAF_ATTACH_TIMEOUT_MS = 5_000
+_COLLAPSE_POLL_MS = 100
+_COLLAPSE_ATTEMPTS = 3
+# #858/#1004: окно гидрации тоггла «Фильтры» (SSR-кнопка видима до React).
+_FILTERS_HYDRATION_TIMEOUT_MS = 15_000
 
 CACHE_SCHEMA_VERSION = 1
 CACHE_SOURCE = SEARCH_URL
@@ -273,9 +282,23 @@ def _collect_category_roles(
     tree_item = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
     if tree_item.count() != 1:
         raise RuntimeError(f"строка категории «{category.label}» неоднозначна")
-    if tree_item.get_attribute("aria-expanded") != "true":
+    # #1004 (live IAB 2026-09-06): aria-expanded на дереве ролей обновляется
+    # честно в обе стороны, но решение принимаем по ФАКТУ — отрисованным
+    # leaf-строкам: атрибут мог протухнуть к моменту решения (класс #840),
+    # а клик по уже раскрытой категории схлопнул бы её. Атрибут — подсказка,
+    # строки — доказательство; после клика факт дожидаетсяся, иначе честный
+    # отказ с состоянием атрибута.
+    leaves = dialog.locator("[role='treeitem'][aria-level='2']")
+    if tree_item.get_attribute("aria-expanded") != "true" or leaves.count() == 0:
         chevron.click()
-        page.wait_for_timeout(100)
+        try:
+            leaves.first.wait_for(state="attached", timeout=_LEAF_ATTACH_TIMEOUT_MS)
+        except PlaywrightError as exc:
+            raise RuntimeError(
+                f"категория «{category.label}» не раскрылась: leaf-строки не появились "
+                f"после клика по шеврону (aria-expanded="
+                f"{tree_item.get_attribute('aria-expanded')!r})"
+            ) from exc
 
     by_id: dict[str, ProfessionalRole] = {}
     seen_leaf = False
@@ -301,19 +324,75 @@ def _collect_category_roles(
     else:
         raise RuntimeError(f"обход профессий категории «{category.label}» не достиг конца")
 
-    # Collapse through the chevron (never the checkbox) to keep the next
-    # category traversal bounded and to leave the modal unsubmitted.
-    chevron = _find_category(page, dialog, category.category_id)
-    tree_item = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
-    if tree_item.count() == 1 and tree_item.get_attribute("aria-expanded") == "true":
-        chevron.click()
-        page.wait_for_timeout(100)
+    # Collapse — bookkeeping после сбора: факт состояния дерева — aria-expanded
+    # (клик щёлкает его честно, замер 2026-09-06), а строки виртуализатор может
+    # НЕ размонтировать — см. _collapse_category.
+    try:
+        _collapse_category(page, dialog, category, leaves)
+    except TreeVirtualizationWedge as exc:
+        raise TreeVirtualizationWedge(str(exc), list(by_id.values())) from exc
     if not by_id:
         raise RuntimeError(f"категория «{category.label}» не вернула leaf-профессии")
     return list(by_id.values())
 
 
+class TreeVirtualizationWedge(RuntimeError):
+    """Дерево каталога заклинило: состояние щёлкает, список не перерисовывается.
+
+    Живой дрилл 2026-09-06 («Маркетинг, реклама, PR»): клик по шеврону честно
+    переводит категорию в aria-expanded=false, но виртуализатор hh.ru не
+    размонтирует leaf-строки; следующие раскрытия только ДОБАВЛЯЮТ строки.
+    Единственное известное лечение — переоткрыть диалог. Носит уже собранные
+    роли категории, чтобы переоткрытие не теряло данные.
+    """
+
+    def __init__(self, message: str, roles: list[ProfessionalRole]):
+        super().__init__(message)
+        self.roles = roles
+
+
+def _collapse_category(page: Page, dialog, category: ProfessionalRoleCategory, leaves) -> None:
+    """Свернуть категорию и проверить факт по aria-expanded (#1004).
+
+    Строки после клика — не доказательство: при клине виртуализатора они
+    остаются «призраками» (см. TreeVirtualizationWedge). aria-expanded при
+    этом состояние щёлкает честно в обоих направлениях (замер IAB 2026-09-06).
+    """
+    tree_item = None
+    for _attempt in range(_COLLAPSE_ATTEMPTS):
+        chevron = _find_category(page, dialog, category.category_id)
+        tree_item = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
+        if tree_item.count() != 1:
+            raise RuntimeError(
+                f"строка категории «{category.label}» потеряна при схлопывании"
+            )
+        if tree_item.get_attribute("aria-expanded") != "true":
+            if leaves.count() == 0:
+                return
+            raise TreeVirtualizationWedge(
+                f"категория «{category.label}» свернута, но {leaves.count()} "
+                "leaf-строк осталось в DOM — виртуализатор не размонтирует список",
+                [],
+            )
+        chevron.click()
+        page.wait_for_timeout(_COLLAPSE_POLL_MS)
+    raise RuntimeError(
+        f"категория «{category.label}» не сворачивается за {_COLLAPSE_ATTEMPTS} попытки: "
+        f"aria-expanded={tree_item.get_attribute('aria-expanded')!r}"
+    )
+
+
 def _open_filters_if_needed(page: Page) -> None:
+    # #858/#1004: SSR-тоггл «Фильтры» виден до того, как React привязал к нему
+    # обработчики; is_visible() — не кликабельность (клик в окне гидрации
+    # теряется, #840). Гейт: гидрация тоггла до первого решения по контролам.
+    if not wait_for_named_control_hydration(
+        page, "Фильтры", timeout_ms=_FILTERS_HYDRATION_TIMEOUT_MS
+    ):
+        raise RuntimeError(
+            "страница поиска вакансий не гидратировалась: тоггл «Фильтры» без "
+            "React-привязок — клик был бы потерян"
+        )
     trigger = page.locator(FILTER_TRIGGER)
     # Desktop cycles through collapsed -> quick filters -> full filters; the
     # compact in-app layout opens the full panel in one click.
@@ -369,7 +448,22 @@ def collect_vacancy_search_role_catalog(page: Page) -> VacancySearchRoleCatalog:
     categories = _collect_categories(page, dialog)
     seen_by_id: dict[str, ProfessionalRole] = {}
     for category in categories:
-        for role in _collect_category_roles(page, dialog, category):
+        try:
+            roles = _collect_category_roles(page, dialog, category)
+        except TreeVirtualizationWedge as exc:
+            # #1004: клин виртуализатора лечится только переоткрытием диалога.
+            # Роли заклинившей категории уже собраны (исключение их несёт).
+            logger.warning(
+                "каталог ролей: после «%s» дерево заклинило (%s) — переоткрываю "
+                "диалог, собранные роли сохранены",
+                category.label,
+                exc,
+            )
+            roles = exc.roles
+            dialog, search = _open_vacancy_search_catalog_dialog(page)
+            search.fill("")
+            _wait_for_tree(page, dialog)
+        for role in roles:
             previous = seen_by_id.get(role.role_id)
             if previous is not None:
                 if normalize(previous.label) != normalize(role.label):

--- a/src/hhru_bot/professional_roles.py
+++ b/src/hhru_bot/professional_roles.py
@@ -363,9 +363,7 @@ def _collapse_category(page: Page, dialog, category: ProfessionalRoleCategory, l
         chevron = _find_category(page, dialog, category.category_id)
         tree_item = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
         if tree_item.count() != 1:
-            raise RuntimeError(
-                f"строка категории «{category.label}» потеряна при схлопывании"
-            )
+            raise RuntimeError(f"строка категории «{category.label}» потеряна при схлопывании")
         if tree_item.get_attribute("aria-expanded") != "true":
             if leaves.count() == 0:
                 return

--- a/src/hhru_bot/professional_roles.py
+++ b/src/hhru_bot/professional_roles.py
@@ -46,6 +46,10 @@ _MAX_SCROLL_STEPS = 200
 _LEAF_ATTACH_TIMEOUT_MS = 5_000
 _COLLAPSE_POLL_MS = 100
 _COLLAPSE_ATTEMPTS = 3
+# Ревью #1008: быстрый, но не мгновенный размонтирующий рендер не должен
+# классифицироваться как клин (ложный клин = полный reload страницы). Настоящий
+# клин (дрилл 2026-09-06) не размонтирует строки ВОВСЕ — в окно не уложится.
+_WEDGE_GRACE_STEPS = 20  # 20 × _COLLAPSE_POLL_MS = 2 c
 # #858/#1004: окно гидрации тоггла «Фильтры» (SSR-кнопка видима до React).
 _FILTERS_HYDRATION_TIMEOUT_MS = 15_000
 
@@ -359,14 +363,19 @@ def _collapse_category(page: Page, dialog, category: ProfessionalRoleCategory, l
     этом состояние щёлкает честно в обоих направлениях (замер IAB 2026-09-06).
     """
     tree_item = None
-    for _attempt in range(_COLLAPSE_ATTEMPTS):
+    for _ in range(_COLLAPSE_ATTEMPTS):
         chevron = _find_category(page, dialog, category.category_id)
         tree_item = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
         if tree_item.count() != 1:
             raise RuntimeError(f"строка категории «{category.label}» потеряна при схлопывании")
         if tree_item.get_attribute("aria-expanded") != "true":
-            if leaves.count() == 0:
-                return
+            # Ревью #1008: один цикл попытки (~300 мс) — слишком узкое окно для
+            # медленного, но нормального размонтирования. Ограда ниже отличает
+            # «медленно» от «клина»: клин уходит целиком в таймаут окна.
+            for _ in range(_WEDGE_GRACE_STEPS):
+                if leaves.count() == 0:
+                    return
+                page.wait_for_timeout(_COLLAPSE_POLL_MS)
             raise TreeVirtualizationWedge(
                 f"категория «{category.label}» свернута, но {leaves.count()} "
                 "leaf-строк осталось в DOM — виртуализатор не размонтирует список",

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -798,9 +798,5 @@ def test_wait_for_named_control_hydration_truth_table():
         def wait_for_function(self, _js, *, arg, timeout):  # noqa: ARG002
             raise PlaywrightError("Timeout 15000ms exceeded")
 
-    assert browser.wait_for_named_control_hydration(
-        OkPage(), "Фильтры", timeout_ms=15_000
-    )
-    assert not browser.wait_for_named_control_hydration(
-        TimeoutPage(), "Фильтры", timeout_ms=15_000
-    )
+    assert browser.wait_for_named_control_hydration(OkPage(), "Фильтры", timeout_ms=15_000)
+    assert not browser.wait_for_named_control_hydration(TimeoutPage(), "Фильтры", timeout_ms=15_000)

--- a/tests/test_browser_navigation.py
+++ b/tests/test_browser_navigation.py
@@ -784,3 +784,23 @@ def test_dump_page_html_survives_census_failure(monkeypatch, tmp_path):
     page.evaluate.side_effect = RuntimeError("census crashed")
     dump = browser.dump_page_html(page, "census_failure_check")
     assert dump is not None and dump.exists()
+
+
+def test_wait_for_named_control_hydration_truth_table():
+    """#858/#1004: True только когда React-привязки найдены; таймаут — False."""
+    from playwright.sync_api import Error as PlaywrightError
+
+    class OkPage:
+        def wait_for_function(self, _js, *, arg, timeout):  # noqa: ARG002
+            assert arg == ["Фильтры", ["button", "checkbox"]]
+
+    class TimeoutPage:
+        def wait_for_function(self, _js, *, arg, timeout):  # noqa: ARG002
+            raise PlaywrightError("Timeout 15000ms exceeded")
+
+    assert browser.wait_for_named_control_hydration(
+        OkPage(), "Фильтры", timeout_ms=15_000
+    )
+    assert not browser.wait_for_named_control_hydration(
+        TimeoutPage(), "Фильтры", timeout_ms=15_000
+    )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1016,3 +1016,99 @@ def test_open_common_already_passed_screen_reports_fact(monkeypatch):
     assert "уже пройден" in str(raised)
     assert "educations" in str(raised)
     dump.assert_called_once()
+
+
+# --- #1004: потерянный клик в попапе common не проходит молча -----------------
+
+
+class _PopupOption:
+    def __init__(self, text, selected, stuck=False):
+        self.text = text
+        self._selected = selected
+        self.stuck = stuck  # клик теряется: атрибут не меняется (#858-класс)
+        self.clicks = 0
+
+    def inner_text(self):
+        return self.text
+
+    def get_attribute(self, name):  # noqa: ARG002
+        return "true" if self._selected else "false"
+
+    def click(self):
+        self.clicks += 1
+        if not self.stuck:
+            self._selected = not self._selected
+
+
+class _PopupOptions:
+    def __init__(self, options):
+        self.options = options
+
+    def count(self):
+        return len(self.options)
+
+    def nth(self, index):
+        return self.options[index]
+
+
+class _SetManyPage:
+    def __init__(self, options):
+        self.options = options
+        self.field = MagicMock()
+        self.field.evaluate.return_value = "DIV"
+        self.popup = MagicMock()
+
+        def _get_by_role(_role, *, name=None, exact=True):  # noqa: ARG002
+            if name is None:
+                return _PopupOptions(options)
+
+            class _Named:
+                first = next(o for o in options if o.text == name)
+
+                @staticmethod
+                def count():
+                    return sum(1 for o in options if o.text == name)
+
+            return _Named()
+
+        self.popup.get_by_role.side_effect = _get_by_role
+        self.mouse = MagicMock()
+
+    def locator(self, _selector):
+        return self.popup
+
+
+def _run_set_many(page, values):
+    common._set_many(page, page.field, values, common.WORK_FORMAT_LABELS)
+
+
+def test_set_many_verifies_final_selection_fact():
+    """Оба клика прошли: желаемый выбран, лишний снят — проверка факта молчит."""
+    options = [
+        _PopupOption("Удалённо", selected=False),
+        _PopupOption("Офис", selected=True),
+    ]
+    _run_set_many(_SetManyPage(options), ["remote"])
+    assert options[0]._selected is True
+    assert options[1]._selected is False
+
+
+def test_set_many_lost_click_on_wanted_option_fails_honestly():
+    """Клик по желаемому варианту потерян — раньше было бы молча; теперь
+    честный отказ с текстом варианта."""
+    options = [
+        _PopupOption("Удалённо", selected=False, stuck=True),
+        _PopupOption("Офис", selected=False),
+    ]
+    with pytest.raises(RuntimeError, match="не выбрала вариант: 'Удалённо'"):
+        _run_set_many(_SetManyPage(options), ["remote"])
+
+
+def test_set_many_lost_click_on_unwanted_option_fails_honestly():
+    """Лишний предвыбор не снялся (клик потерян) — честный отказ."""
+    options = [
+        _PopupOption("Удалённо", selected=False),
+        _PopupOption("Офис", selected=True, stuck=True),
+    ]
+    with pytest.raises(RuntimeError, match="лишний вариант остался выбранным.*'Офис'"):
+        _run_set_many(_SetManyPage(options), ["remote"])

--- a/tests/test_professional_roles.py
+++ b/tests/test_professional_roles.py
@@ -244,3 +244,344 @@ def test_tree_input_parser_rejects_category_rows():
     item.locator.return_value = tree_item
 
     assert professional_roles_module._role_from_tree_input(item, category="ИТ") is None
+
+
+# --- #1004: решение по факту leaf-строк, а не по aria-expanded ----------------
+
+
+class _LeafRow:
+    def locator(self, _selector):
+        return _RoleInput()
+
+
+class _Leaves:
+    """Живой счётчик leaf-строк: клик по шеврону меняет состояние."""
+
+    def __init__(self):
+        self._n = 0
+
+    def count(self):
+        return self._n
+
+    @property
+    def first(self):
+        return self
+
+    def all(self):
+        return [_LeafRow() for _ in range(self._n)]
+
+    def wait_for(self, *, state, timeout):  # noqa: ARG002
+        if self._n == 0:
+            raise professional_roles_module.PlaywrightError("leaf-строки не появились")
+        return None
+
+
+class _TreeItem:
+    def __init__(self, expanded):
+        self._expanded = expanded
+
+    def count(self):
+        return 1
+
+    def get_attribute(self, name):  # noqa: ARG002
+        return self._expanded
+
+
+class _Chevron:
+    """Клик тогглит состояние дерева (aria-expanded) и строки; ghost=True
+    повторяет клин виртуализатора: aria щёлкает, строки не размонтируются."""
+
+    def __init__(self, tree_item, leaves, ghost=False):
+        self._tree_item = tree_item
+        self._leaves = leaves
+        self.ghost = ghost
+        self.clicks = 0
+
+    def locator(self, _xpath):
+        return self._tree_item
+
+    def click(self):
+        self.clicks += 1
+        if self._tree_item._expanded == "true":
+            self._tree_item._expanded = "false"
+            if not self.ghost:
+                self._leaves._n = 0
+        else:
+            self._tree_item._expanded = "true"
+            self._leaves._n = 4
+
+
+class _LyingAttrChevron(_Chevron):
+    """Атрибут протух ("true" при свёрнутом дереве): первый клик раскрывает
+    по факту и делает атрибут честным, дальше — обычный тоггл."""
+
+    def __init__(self, tree_item, leaves):
+        super().__init__(tree_item, leaves)
+        self.recovered = False
+
+    def click(self):
+        if not self.recovered:
+            self.clicks += 1
+            self.recovered = True
+            self._tree_item._expanded = "true"
+            self._leaves._n = 4
+        else:
+            super().click()
+
+
+class _Dialog:
+    def __init__(self, leaves):
+        self._leaves = leaves
+
+    def locator(self, selector):  # noqa: ARG002
+        return self._leaves
+
+
+class _RoleInput:
+    def count(self):
+        return 1
+
+
+def _run_collect(category_label="ИТ"):
+    leaves = _Leaves()
+    chevron = _Chevron(_TreeItem("false"), leaves)
+    dialog = _Dialog(leaves)
+    page = MagicMock()
+    return chevron, leaves, dialog, page
+
+
+def test_collect_category_expands_and_collapses_by_leaf_fact(monkeypatch):
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    category = ProfessionalRoleCategory("11", "ИТ")
+    chevron, leaves, dialog, page = _run_collect()
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+    monkeypatch.setattr(professional_roles_module, "_tree_scroll", lambda *_a: True)
+    monkeypatch.setattr(
+        professional_roles_module,
+        "_role_from_tree_input",
+        lambda _input, category: ProfessionalRole("96", "Программист", category),
+    )
+
+    roles = professional_roles_module._collect_category_roles(page, dialog, category)
+
+    assert [r.role_id for r in roles] == ["96"]
+    assert chevron.clicks == 2  # раскрытие + схлопывание
+    assert leaves.count() == 0  # схлопнута по факту
+
+
+def test_collect_category_skips_click_when_leaves_already_attached(monkeypatch):
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    category = ProfessionalRoleCategory("11", "ИТ")
+    leaves = _Leaves()
+    leaves._n = 4  # категория уже раскрыта: строки на месте
+    chevron = _Chevron(_TreeItem("true"), leaves)
+    dialog = _Dialog(leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+    monkeypatch.setattr(professional_roles_module, "_tree_scroll", lambda *_a: True)
+    monkeypatch.setattr(
+        professional_roles_module,
+        "_role_from_tree_input",
+        lambda _input, category: ProfessionalRole("96", "Программист", category),
+    )
+
+    professional_roles_module._collect_category_roles(MagicMock(), dialog, category)
+
+    assert chevron.clicks == 1  # только схлопывание в конце
+
+
+def test_collect_category_click_recovers_stale_true_attribute(monkeypatch):
+    """aria-expanded="true" при нуле строк — протухший атрибут: клик был,
+    факт дождался строк (класс #840)."""
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    category = ProfessionalRoleCategory("11", "ИТ")
+    leaves = _Leaves()
+    chevron = _LyingAttrChevron(_TreeItem("true"), leaves)
+    dialog = _Dialog(leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+    monkeypatch.setattr(professional_roles_module, "_tree_scroll", lambda *_a: True)
+    monkeypatch.setattr(
+        professional_roles_module,
+        "_role_from_tree_input",
+        lambda _input, category: ProfessionalRole("96", "Программист", category),
+    )
+
+    professional_roles_module._collect_category_roles(MagicMock(), dialog, category)
+
+    assert chevron.clicks == 2  # атрибуту не поверили (раскрыли по факту) +
+    # схлопывание: после честного клика aria=true и строки на месте
+
+
+def test_collect_category_honest_failure_when_leaves_never_appear(monkeypatch):
+
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    category = ProfessionalRoleCategory("11", "ИТ")
+    leaves = _Leaves()
+    chevron = _Chevron(_TreeItem("false"), leaves)
+    dialog = _Dialog(leaves)
+
+    def dead_click(self):  # клик есть, эффекта нет
+        chevron.clicks += 1
+
+    chevron.click = dead_click.__get__(chevron)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+
+    with pytest.raises(RuntimeError, match="не раскрылась.*aria-expanded='false'"):
+        professional_roles_module._collect_category_roles(
+            MagicMock(), dialog, category
+        )
+
+
+def test_open_filters_requires_hydration_before_decision(monkeypatch):
+    """#858/#1004: до гидрации тоггла «Фильтры» решение не принимается."""
+    page = MagicMock()
+    monkeypatch.setattr(
+        professional_roles_module,
+        "wait_for_named_control_hydration",
+        lambda *_a, **_k: False,
+    )
+    with pytest.raises(RuntimeError, match="не гидратировалась"):
+        professional_roles_module._open_filters_if_needed(page)
+    page.locator.assert_not_called()
+
+
+def test_open_filters_proceeds_after_hydration(monkeypatch):
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    trigger.is_visible.return_value = True
+    page = MagicMock()
+    page.locator.return_value = trigger
+    monkeypatch.setattr(
+        professional_roles_module,
+        "wait_for_named_control_hydration",
+        lambda *_a, **_k: True,
+    )
+    professional_roles_module._open_filters_if_needed(page)
+    page.get_by_role.assert_not_called()  # клик по тогглу не понадобился
+
+
+class _GhostChevron(_Chevron):
+    """Клин виртуализатора: aria щёлкает, строки не размонтируются."""
+
+    def __init__(self, tree_item, leaves):
+        super().__init__(tree_item, leaves, ghost=True)
+
+
+class _DeadChevron(_Chevron):
+    """Клик есть, эффекта нет вообще (атрибут не меняется)."""
+
+    def click(self):
+        self.clicks += 1
+
+
+def test_collapse_wedge_carries_collected_roles(monkeypatch):
+    """Живой дрилл 2026-09-06: aria уходит в false, а строки-призраки остаются —
+    честный TreeVirtualizationWedge, несущий уже собранные роли."""
+    from hhru_bot.professional_roles import (
+        ProfessionalRoleCategory,
+        TreeVirtualizationWedge,
+    )
+
+    leaves = _Leaves()
+    leaves._n = 4
+    chevron = _GhostChevron(_TreeItem("true"), leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+
+    with pytest.raises(TreeVirtualizationWedge) as exc_info:
+        professional_roles_module._collapse_category(
+            MagicMock(), _Dialog(leaves), ProfessionalRoleCategory("11", "ИТ"), leaves
+        )
+    assert "leaf-строк осталось в DOM" in str(exc_info.value)
+    assert chevron.clicks == 1
+
+
+def test_collapse_collects_roles_through_wedge(monkeypatch):
+    """_collect_category_roles не теряет роли категории при клине."""
+    from hhru_bot.professional_roles import (
+        ProfessionalRoleCategory,
+        TreeVirtualizationWedge,
+    )
+
+    category = ProfessionalRoleCategory("11", "ИТ")
+    leaves = _Leaves()
+    leaves._n = 4
+    chevron = _GhostChevron(_TreeItem("true"), leaves)
+    dialog = _Dialog(leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+    monkeypatch.setattr(professional_roles_module, "_tree_scroll", lambda *_a: True)
+    monkeypatch.setattr(
+        professional_roles_module,
+        "_role_from_tree_input",
+        lambda _input, category: ProfessionalRole("96", "Программист", category),
+    )
+
+    with pytest.raises(TreeVirtualizationWedge) as exc_info:
+        professional_roles_module._collect_category_roles(MagicMock(), dialog, category)
+    assert [r.role_id for r in exc_info.value.roles] == ["96"]
+
+
+def test_catalog_loop_recovers_from_wedge_by_reopening_dialog(monkeypatch):
+    """Клин → переоткрытие диалога → сбор продолжается, роли сохранены."""
+    from hhru_bot.professional_roles import (
+        ProfessionalRoleCategory,
+        TreeVirtualizationWedge,
+    )
+
+    categories = [
+        ProfessionalRoleCategory("11", "ИТ"),
+        ProfessionalRoleCategory("12", "Менеджмент"),
+    ]
+    monkeypatch.setattr(
+        professional_roles_module,
+        "_collect_categories",
+        lambda *_a: categories,
+    )
+    monkeypatch.setattr(professional_roles_module, "_wait_for_tree", lambda *_a: None)
+    reopens = []
+    search = MagicMock()
+    search.fill = lambda _v: reopens.append("fill")
+
+    def fake_open(_page):
+        reopens.append("open")
+        return object(), search
+
+    monkeypatch.setattr(
+        professional_roles_module, "_open_vacancy_search_catalog_dialog", fake_open
+    )
+    calls = []
+
+    def fake_collect(_page, _dialog, category):
+        calls.append(category.category_id)
+        if category.category_id == "11":
+            raise TreeVirtualizationWedge(
+                "клин", [ProfessionalRole("96", "Программист", "ИТ")]
+            )
+        return [ProfessionalRole("104", "Руководитель", "Менеджмент")]
+
+    monkeypatch.setattr(
+        professional_roles_module, "_collect_category_roles", fake_collect
+    )
+
+    catalog = professional_roles_module.collect_vacancy_search_role_catalog(object())
+
+    assert calls == ["11", "12"]
+    assert len(reopens) == 4  # старт(open+fill) + переоткрытие(open+fill)
+    assert {r.role_id for r in catalog.roles} == {"96", "104"}
+    assert catalog.roles[0].categories == ("ИТ",)
+
+
+def test_collapse_honest_failure_when_attribute_never_flips(monkeypatch):
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    leaves = _Leaves()
+    leaves._n = 4
+    chevron = _DeadChevron(_TreeItem("true"), leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+
+    with pytest.raises(RuntimeError, match="не сворачивается за 3 попытки"):
+        professional_roles_module._collapse_category(
+            MagicMock(), _Dialog(leaves), ProfessionalRoleCategory("11", "ИТ"), leaves
+        )

--- a/tests/test_professional_roles.py
+++ b/tests/test_professional_roles.py
@@ -430,9 +430,7 @@ def test_collect_category_honest_failure_when_leaves_never_appear(monkeypatch):
     monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
 
     with pytest.raises(RuntimeError, match="не раскрылась.*aria-expanded='false'"):
-        professional_roles_module._collect_category_roles(
-            MagicMock(), dialog, category
-        )
+        professional_roles_module._collect_category_roles(MagicMock(), dialog, category)
 
 
 def test_open_filters_requires_hydration_before_decision(monkeypatch):
@@ -548,22 +546,16 @@ def test_catalog_loop_recovers_from_wedge_by_reopening_dialog(monkeypatch):
         reopens.append("open")
         return object(), search
 
-    monkeypatch.setattr(
-        professional_roles_module, "_open_vacancy_search_catalog_dialog", fake_open
-    )
+    monkeypatch.setattr(professional_roles_module, "_open_vacancy_search_catalog_dialog", fake_open)
     calls = []
 
     def fake_collect(_page, _dialog, category):
         calls.append(category.category_id)
         if category.category_id == "11":
-            raise TreeVirtualizationWedge(
-                "клин", [ProfessionalRole("96", "Программист", "ИТ")]
-            )
+            raise TreeVirtualizationWedge("клин", [ProfessionalRole("96", "Программист", "ИТ")])
         return [ProfessionalRole("104", "Руководитель", "Менеджмент")]
 
-    monkeypatch.setattr(
-        professional_roles_module, "_collect_category_roles", fake_collect
-    )
+    monkeypatch.setattr(professional_roles_module, "_collect_category_roles", fake_collect)
 
     catalog = professional_roles_module.collect_vacancy_search_role_catalog(object())
 

--- a/tests/test_professional_roles.py
+++ b/tests/test_professional_roles.py
@@ -468,6 +468,19 @@ class _GhostChevron(_Chevron):
         super().__init__(tree_item, leaves, ghost=True)
 
 
+class _SlowLeaves(_Leaves):
+    """Размонтирование медленнее одного цикла попытки, но в grace-окно
+    укладывается (ревью #1008): счётчик падает в ноль с третьего чтения."""
+
+    def __init__(self):
+        super().__init__()
+        self._reads = 0
+
+    def count(self):
+        self._reads += 1
+        return 4 if self._reads <= 2 else 0
+
+
 class _DeadChevron(_Chevron):
     """Клик есть, эффекта нет вообще (атрибут не меняется)."""
 
@@ -493,6 +506,22 @@ def test_collapse_wedge_carries_collected_roles(monkeypatch):
             MagicMock(), _Dialog(leaves), ProfessionalRoleCategory("11", "ИТ"), leaves
         )
     assert "leaf-строк осталось в DOM" in str(exc_info.value)
+    assert chevron.clicks == 1
+
+
+def test_collapse_tolerates_slow_unmount_within_grace_window(monkeypatch):
+    """Ревью #1008: быстрое, но не мгновенное размонтирование — не клин;
+    grace-окно дожидается факта пустого списка, и wedge не диагностируется."""
+    from hhru_bot.professional_roles import ProfessionalRoleCategory
+
+    leaves = _SlowLeaves()
+    chevron = _Chevron(_TreeItem("true"), leaves)
+    monkeypatch.setattr(professional_roles_module, "_find_category", lambda *_a: chevron)
+
+    professional_roles_module._collapse_category(
+        MagicMock(), _Dialog(leaves), ProfessionalRoleCategory("11", "ИТ"), leaves
+    )
+
     assert chevron.clicks == 1
 
 


### PR DESCRIPTION
Closes #1004. Стэчится на #1007 (общий хелпер гидрации уже там? нет — хелпер добавлен здесь; base ветка аудита выбрана, чтобы PR #1007 не тянуть в этот diff... см. примечание).

**Живые замеры IAB 2026-09-06** (диалог ролей в фильтрах поиска, редактор позиции python-резюме, всё read-only):
1. `aria-expanded` дерева ролей: честно щёлкает в обе стороны сразу после клика.
2. `aria-selected` в magritte-попапе («Формат работы»): честная на открытии, мгновенно в обе стороны в открытом попапе.
3. `aria-selected` строк tree-selector: синхронно с чекбоксом.
4. **Неожиданное**: виртуализатор дерева может НЕ размонтировать leaf-строки после сворачивания — состояние свернуто, строки остаются «призраками», следующие раскрытия их только дополняют (полный проход воспроизводит клин на «Маркетинг, реклама, PR»). Старый код это молча переживал (mis-attribution ролей), новый честный отказ поймал это боевым FAIL дважды.

**Изменения**
- `_collapse_category`: факт состояния — `aria-expanded`; оставшиеся строки = `TreeVirtualizationWedge`, несущий уже собранные роли; цикл каталога логирует, переоткрывает диалог (свежее дерево) и продолжает.
- Раскрытие: клик шеврона + дожидание факта появления leaf-строк; протухший атрибут не пропустит клик.
- `_open_filters_if_needed`: гидрационный гейт тоггла «Фильтры» (новый хелпер `wait_for_named_control_hydration` в browser.py, класс #858) — до гидрации решение не принимается.
- `common._set_many`: после кликов финальная сверка набора — потерянный клик даёт честный отказ, а не молча полувыбранное состояние.

**Тесты**: факт-детекторы раскрытия/схлопывания, клин с сохранением ролей, recovery цикла, гейт гидрации, верификация `_set_many`; фейки прошли контракт-гард keyword-only. Полный офлайн-прогон зелёный, ruff чист.

**Живой дрилл**: `hhru professional-roles --refresh` → `[OK] 27 категорий, 194 профессии` (до фикса — [FAIL] на клине, воспроизведён и починен).

Примечание для ревью: base = ветка #1007 для чистого diff (этот коммит не зависит от #1007, хелпер гидрации добавляется здесь). Если #1007 смёржат первым, GitHub сам сведёт base.