### PR TITLE
chore(scripts): архив разведочных скриптов #857 #956 #1004 и photo-flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ select = ["E", "F", "I", "UP", "B"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["E501"]
+# Архивные разведочные one-off скрипты (см. PR #1019): не сопровождаемый код,
+# длинные inline-JS строки для page.evaluate, импорты после sys.path-настройки.
+"scripts/explore_*" = ["E501", "E402", "B007", "F541", "I001"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/explore_857_additional.py
+++ b/scripts/explore_857_additional.py
@@ -1,0 +1,35 @@
+"""Read-only probe: what education markers render on a fresh draft resume (#857)."""
+
+from playwright.sync_api import sync_playwright
+
+RESUME_URL = "https://hh.ru/resume/c5434470ff1107824d0039ed1f465465324869"
+STATE = "data/accounts/default/storage_state/hh_session.json"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
+
+MARKERS = [
+    "resume-edit-button-additionalEducation-0",
+    "resume-list-card-additionalEducation",
+    "resume-edit-button-education-0",
+    "resume-list-card-education",
+]
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    ctx = browser.new_context(storage_state=STATE, user_agent=UA)
+    page = ctx.new_page()
+    page.goto(RESUME_URL, wait_until="commit", timeout=90000)
+    page.wait_for_timeout(12000)  # let the SPA hydrate
+    print("URL:", page.url)
+    for m in MARKERS:
+        attr = f"[data-qa='{m}']"
+        print(f"{m}: count={page.locator(attr).count()}")
+        for i in range(min(page.locator(attr).count(), 3)):
+            el = page.locator(attr).nth(i)
+            print("   visible:", el.is_visible(), "| text:", el.inner_text()[:120].replace("\n", " | "))
+    # any data-qa containing ducation or dditional
+    qa = page.eval_on_selector_all(
+        "[data-qa]",
+        "els => els.map(e => e.getAttribute('data-qa')).filter(v => /[Ee]ducation|dditional/.test(v))",
+    )
+    print("education-related data-qa:", sorted(set(qa)))
+    browser.close()

--- a/scripts/explore_857_additional.py
+++ b/scripts/explore_857_additional.py
@@ -2,7 +2,7 @@
 
 from playwright.sync_api import sync_playwright
 
-RESUME_URL = "https://hh.ru/resume/c5434470ff1107824d0039ed1f465465324869"
+RESUME_URL = "https://hh.ru/resume/0000111122223333444455556666777788889999"
 STATE = "data/accounts/default/storage_state/hh_session.json"
 UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
 
@@ -25,7 +25,12 @@ with sync_playwright() as p:
         print(f"{m}: count={page.locator(attr).count()}")
         for i in range(min(page.locator(attr).count(), 3)):
             el = page.locator(attr).nth(i)
-            print("   visible:", el.is_visible(), "| text:", el.inner_text()[:120].replace("\n", " | "))
+            print(
+                "   visible:",
+                el.is_visible(),
+                "| text:",
+                el.inner_text()[:120].replace("\n", " | "),
+            )
     # any data-qa containing ducation or dditional
     qa = page.eval_on_selector_all(
         "[data-qa]",

--- a/scripts/explore_collapse_1004.py
+++ b/scripts/explore_collapse_1004.py
@@ -42,13 +42,17 @@ def main() -> None:
                     ok = True
                     break
                 box = chevron.bounding_box()
-                hit = page.evaluate(
-                    """([x, y]) => {
+                hit = (
+                    page.evaluate(
+                        """([x, y]) => {
                         const t = document.elementFromPoint(x, y);
                         return t ? {tag: t.tagName, qa: (t.getAttribute('data-qa')||'').slice(0,60)} : null;
                     }""",
-                    [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2],
-                ) if box else None
+                        [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2],
+                    )
+                    if box
+                    else None
+                )
                 chevron.click()
                 for _ in range(30):
                     if leaves.count() == 0:

--- a/scripts/explore_collapse_1004.py
+++ b/scripts/explore_collapse_1004.py
@@ -1,0 +1,94 @@
+"""Разовый probe #1004: почему клик схлопывания категории не доходит до
+дерева в CLI-браузере (в IAB тот же жест работает). Read-only: диалог
+фильтров поиска, без apply, без сохранения чего-либо."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hhru_bot.browser import launch_context, goto_hh  # noqa: E402
+from hhru_bot import professional_roles as pr  # noqa: E402
+
+
+def main() -> None:
+    with launch_context(Path("data/storage_state/hh_session.json")) as context:
+        page = context.pages[0] if context.pages else context.new_page()
+        goto_hh(page, pr.SEARCH_URL)
+        pr._open_filters_if_needed(page)
+        dialog, _search = pr._open_vacancy_search_catalog_dialog(page)
+        pr._wait_for_tree(page, dialog)
+        categories = pr._collect_categories(page, dialog)
+        print("категорий собрано:", len(categories))
+        leaves = dialog.locator("[role='treeitem'][aria-level='2']")
+        for cat in categories:
+            chevron = pr._find_category(page, dialog, cat.category_id)
+            ti = chevron.locator("xpath=ancestor::*[@role='treeitem'][1]")
+            if ti.get_attribute("aria-expanded") != "true" or leaves.count() == 0:
+                chevron.click()
+                leaves.first.wait_for(state="attached", timeout=5_000)
+            # мини-обход: до конца видимости
+            for _ in range(30):
+                if pr._tree_scroll(dialog, "inspect"):
+                    break
+                pr._tree_scroll(dialog, "advance")
+            # схлопывание с диагностикой
+            ok = False
+            for attempt in range(3):
+                chevron = pr._find_category(page, dialog, cat.category_id)
+                if leaves.count() == 0:
+                    ok = True
+                    break
+                box = chevron.bounding_box()
+                hit = page.evaluate(
+                    """([x, y]) => {
+                        const t = document.elementFromPoint(x, y);
+                        return t ? {tag: t.tagName, qa: (t.getAttribute('data-qa')||'').slice(0,60)} : null;
+                    }""",
+                    [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2],
+                ) if box else None
+                chevron.click()
+                for _ in range(30):
+                    if leaves.count() == 0:
+                        ok = True
+                        break
+                    page.wait_for_timeout(100)
+                if ok:
+                    print(f"  «{cat.label}»: сошлось с попытки {attempt + 1}, hit={hit}")
+                    break
+                aria_now = ti.get_attribute("aria-expanded")
+                print(f"  «{cat.label}»: клик потерян, hit={hit}, aria-expanded={aria_now!r}")
+            if not ok:
+                print(f"  «{cat.label}»: НЕ СХЛОПНУЛАСЬ; id={cat.category_id}")
+                aria_now = ti.get_attribute("aria-expanded")
+                print("  aria-expanded после попыток:", aria_now)
+                # призраки должно вытеснить следующее раскрытие
+                ids_js = (
+                    "() => [...document.querySelectorAll("
+                    "\"[role='treeitem'][aria-level='2'] input\")]"
+                    ".map(i => (i.getAttribute('data-qa')||'').slice(-12))"
+                )
+                ids_before = page.evaluate(ids_js)
+                nxt = categories[categories.index(cat) + 1]
+                nch = pr._find_category(page, dialog, nxt.category_id)
+                nch.click()
+                page.wait_for_timeout(900)
+                ids_after = page.evaluate(ids_js)
+                print("  id строк до раскрытия следующей:", ids_before[:12])
+                print("  id строк после:", ids_after[:14])
+                print("  призраки вытеснены:", set(ids_before).isdisjoint(set(ids_after)))
+                return
+                detail = page.evaluate(
+                    """() => [...document.querySelectorAll("[role='treeitem'][aria-level='2']")].map(r => ({
+                        qa: (r.getAttribute('data-qa') || '').slice(0, 40), h: r.offsetHeight,
+                        top: Math.round(r.getBoundingClientRect().top)}))"""
+                )
+                print("  оставшиеся строки:", detail[:10])
+                return
+        print("ВСЕ КАТЕГОРИИ СОШЛИСЬ")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore_experience_add.py
+++ b/scripts/explore_experience_add.py
@@ -14,7 +14,7 @@ from playwright.sync_api import sync_playwright
 from hhru_bot.browser import goto_hh, require_authenticated_page
 from hhru_bot.config import load_config_or_exit
 
-CONFIG_PATH = "/Users/axisrow/Projects/hhru/data/config.yaml"
+CONFIG_PATH = ROOT / "data" / "config.yaml"
 TARGET_SLUG = "marketing"
 
 
@@ -81,7 +81,9 @@ def main() -> int:
                 for i in range(min(loc.count(), 5)):
                     try:
                         inp = loc.nth(i)
-                        print(f"  [{i}] visible={inp.is_visible()} value={inp.input_value()!r} placeholder={inp.get_attribute('placeholder')!r} name={inp.get_attribute('name')!r}")
+                        print(
+                            f"  [{i}] visible={inp.is_visible()} value={inp.input_value()!r} placeholder={inp.get_attribute('placeholder')!r} name={inp.get_attribute('name')!r}"
+                        )
                     except Exception as exc:
                         print(f"  [{i}] error: {exc}")
 
@@ -108,13 +110,15 @@ def main() -> int:
         for i in range(min(checkboxes.count(), 15)):
             cb = checkboxes.nth(i)
             try:
-                label = cb.evaluate('el => el.closest("label")?.innerText || el.getAttribute("aria-label") || ""')
+                label = cb.evaluate(
+                    'el => el.closest("label")?.innerText || el.getAttribute("aria-label") || ""'
+                )
                 print(f"  cb[{i}] checked={cb.is_checked()} label={label!r}")
             except Exception as exc:
                 print(f"  cb[{i}] error: {exc}")
 
         # Check if target resume is mentioned
-        for keyword in (resume.resume_id, "marketing", "Ведущий performance-маркетолог"):
+        for keyword in (resume.resume_id, "marketing", "маркетолог"):
             loc = page.locator(f':has-text("{keyword}")')
             if loc.count() > 0:
                 print(f"\nkeyword '{keyword}' count: {loc.count()}")
@@ -126,7 +130,9 @@ def main() -> int:
                         pass
 
         # Try to find and click cancel
-        cancel = page.locator('[data-qa="profile-layout-cancel-button"], button:has-text("Отмена"), button:has-text("Назад")')
+        cancel = page.locator(
+            '[data-qa="profile-layout-cancel-button"], button:has-text("Отмена"), button:has-text("Назад")'
+        )
         if cancel.count() > 0:
             print(f"\ncancel button found, clicking...")
             cancel.first.click()

--- a/scripts/explore_experience_add.py
+++ b/scripts/explore_experience_add.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Read-only exploration for #786/#787: inspect form after clicking Добавить."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from playwright.sync_api import sync_playwright
+
+from hhru_bot.browser import goto_hh, require_authenticated_page
+from hhru_bot.config import load_config_or_exit
+
+CONFIG_PATH = "/Users/axisrow/Projects/hhru/data/config.yaml"
+TARGET_SLUG = "marketing"
+
+
+def main() -> int:
+    config = load_config_or_exit(CONFIG_PATH)
+    resume = next((r for r in config.resumes if r.id == TARGET_SLUG), None)
+    if resume is None:
+        print(f"resume {TARGET_SLUG!r} not found")
+        return 1
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False)
+        context = browser.new_context(
+            storage_state=str(ROOT / "data" / "storage_state" / "hh_session.json"),
+            user_agent=config.user_agent,
+        )
+        page = context.new_page()
+
+        print("=== open resume page ===")
+        goto_hh(page, f"https://hh.ru/resume/{resume.resume_id}")
+        require_authenticated_page(page)
+        print(f"URL: {page.url}")
+
+        # Click the "Добавить" link in experience card
+        add_links = page.locator('[data-qa="resume-list-card-experience"] [data-qa="link"]')
+        add_link = None
+        for i in range(add_links.count()):
+            link = add_links.nth(i)
+            if "Добавить" in link.inner_text():
+                add_link = link
+                break
+
+        if add_link is None:
+            print("Добавить link not found")
+            context.close()
+            browser.close()
+            return 1
+
+        print("clicking Добавить...")
+        add_link.click()
+        page.wait_for_timeout(3000)
+        print(f"URL after click: {page.url}")
+
+        # Dump form HTML
+        main_el = page.locator('main, [data-qa="profile-layout-form"], form')
+        if main_el.count() > 0:
+            html = main_el.first.inner_html()
+            print(f"main HTML (first 3000 chars): {html[:3000]!r}")
+
+        # Look for company/position inputs by various selectors
+        for sel in (
+            'input[placeholder*="Компания"], input[placeholder*="компания"]',
+            'input[placeholder*="Должность"], input[placeholder*="должность"]',
+            '[data-qa*="company"] input, [data-qa*="position"] input',
+            '[data-qa*="experience"] input',
+            'input[name*="company"], input[name*="position"]',
+            'input[name*="employer"], input[name*="job"]',
+            '[data-qa="resume-profile-experience-specific-company-input-0"]',
+            '[data-qa="resume-profile-experience-specific-position-input-0"]',
+        ):
+            loc = page.locator(sel)
+            if loc.count() > 0:
+                print(f"\nFOUND input selector: {sel} (count={loc.count()})")
+                for i in range(min(loc.count(), 5)):
+                    try:
+                        inp = loc.nth(i)
+                        print(f"  [{i}] visible={inp.is_visible()} value={inp.input_value()!r} placeholder={inp.get_attribute('placeholder')!r} name={inp.get_attribute('name')!r}")
+                    except Exception as exc:
+                        print(f"  [{i}] error: {exc}")
+
+        # Check for resume binding panel
+        for text in ("Резюме с этим местом работы", "Привязать к резюме", "resumeFrom"):
+            loc = page.locator(f':has-text("{text}")')
+            if loc.count() > 0:
+                print(f"\ntext '{text}' count: {loc.count()}")
+                for i in range(min(loc.count(), 5)):
+                    try:
+                        el = loc.nth(i).evaluate("""el => ({
+                            tag: el.tagName,
+                            data_qa: el.getAttribute('data-qa'),
+                            text: el.innerText?.slice(0, 300),
+                            html: el.innerHTML?.slice(0, 500),
+                        })""")
+                        print(f"  [{i}] {el}")
+                    except Exception as exc:
+                        print(f"  [{i}] error: {exc}")
+
+        # Check checkboxes
+        checkboxes = page.locator('input[type="checkbox"]')
+        print(f"\ncheckbox count: {checkboxes.count()}")
+        for i in range(min(checkboxes.count(), 15)):
+            cb = checkboxes.nth(i)
+            try:
+                label = cb.evaluate('el => el.closest("label")?.innerText || el.getAttribute("aria-label") || ""')
+                print(f"  cb[{i}] checked={cb.is_checked()} label={label!r}")
+            except Exception as exc:
+                print(f"  cb[{i}] error: {exc}")
+
+        # Check if target resume is mentioned
+        for keyword in (resume.resume_id, "marketing", "Ведущий performance-маркетолог"):
+            loc = page.locator(f':has-text("{keyword}")')
+            if loc.count() > 0:
+                print(f"\nkeyword '{keyword}' count: {loc.count()}")
+                for i in range(min(loc.count(), 3)):
+                    try:
+                        text = loc.nth(i).inner_text()
+                        print(f"  [{i}] {text[:200]!r}")
+                    except Exception:
+                        pass
+
+        # Try to find and click cancel
+        cancel = page.locator('[data-qa="profile-layout-cancel-button"], button:has-text("Отмена"), button:has-text("Назад")')
+        if cancel.count() > 0:
+            print(f"\ncancel button found, clicking...")
+            cancel.first.click()
+            page.wait_for_timeout(1000)
+            print(f"URL after cancel: {page.url}")
+
+        context.close()
+        browser.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/explore_fill_956.py
+++ b/scripts/explore_fill_956.py
@@ -4,8 +4,8 @@ read back what the DOM actually holds. No save is pressed."""
 
 from playwright.sync_api import sync_playwright
 
-STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
-RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+STATE = "data/storage_state/hh_session.json"
+RESUME = "0000111122223333444455556666777788889999"
 COMPANY = "[data-qa*='resume-profile-experience-specific-company-input']"
 POSITION = "[data-qa*='resume-profile-experience-specific-position-input']"
 
@@ -28,9 +28,24 @@ with sync_playwright() as p:
         for label in ("С полями сразу",):
             pass
         page.wait_for_timeout(300)
-        print("t=0.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+        print(
+            "t=0.3s company=",
+            repr(comp.first.input_value()),
+            "position=",
+            repr(pos.first.input_value()),
+        )
         page.wait_for_timeout(2000)
-        print("t=2.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+        print(
+            "t=2.3s company=",
+            repr(comp.first.input_value()),
+            "position=",
+            repr(pos.first.input_value()),
+        )
         page.wait_for_timeout(5000)
-        print("t=7.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+        print(
+            "t=7.3s company=",
+            repr(comp.first.input_value()),
+            "position=",
+            repr(pos.first.input_value()),
+        )
     browser.close()

--- a/scripts/explore_fill_956.py
+++ b/scripts/explore_fill_956.py
@@ -1,0 +1,36 @@
+"""Read-only drill (#956): open the shared experience add-form on the Дворник
+draft, fill company/position/months the way experience.py does, wait, then
+read back what the DOM actually holds. No save is pressed."""
+
+from playwright.sync_api import sync_playwright
+
+STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
+RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+COMPANY = "[data-qa*='resume-profile-experience-specific-company-input']"
+POSITION = "[data-qa*='resume-profile-experience-specific-position-input']"
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    ctx = browser.new_context(storage_state=STATE)
+    page = ctx.new_page()
+    page.goto(f"https://hh.ru/resume/{RESUME}", wait_until="domcontentloaded")
+    page.wait_for_timeout(4000)
+    add = page.locator("[data-qa='resume-list-card-experience'] [data-qa='link']")
+    add.click()
+    page.wait_for_timeout(4000)
+    print("url:", page.url)
+    comp = page.locator(COMPANY)
+    pos = page.locator(POSITION)
+    print("company count:", comp.count(), "position count:", pos.count())
+    if comp.count():
+        comp.first.fill("ТСЖ «Зелёный квартал»")
+        pos.first.fill("Дворник")
+        for label in ("С полями сразу",):
+            pass
+        page.wait_for_timeout(300)
+        print("t=0.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+        page.wait_for_timeout(2000)
+        print("t=2.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+        page.wait_for_timeout(5000)
+        print("t=7.3s company=", repr(comp.first.input_value()), "position=", repr(pos.first.input_value()))
+    browser.close()

--- a/scripts/explore_full_add_956.py
+++ b/scripts/explore_full_add_956.py
@@ -4,22 +4,26 @@ each stage."""
 
 from playwright.sync_api import sync_playwright
 
-STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
-RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+STATE = "data/storage_state/hh_session.json"
+RESUME = "0000111122223333444455556666777788889999"
 COMPANY = "[data-qa*='resume-profile-experience-specific-company-input']"
 POSITION = "[data-qa*='resume-profile-experience-specific-position-input']"
+
 
 def state(page, tag):
     comp = page.locator(COMPANY)
     pos = page.locator(POSITION)
     year = page.locator("[data-qa='resume-profile-experience-specific-year-input']")
     months = page.locator("[data-qa='magritte-select-activator']")
-    desc = page.locator("[data-qa*='resume-profile-experience-specific-description-input'], textarea")
+    desc = page.locator(
+        "[data-qa*='resume-profile-experience-specific-description-input'], textarea"
+    )
     print(
         f"[{tag}] company={comp.first.input_value()!r} position={pos.first.input_value()!r} "
         f"year={year.first.input_value() if year.count() else 'N/A'!r} "
         f"months={months.count()} desc={desc.count()}"
     )
+
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)

--- a/scripts/explore_full_add_956.py
+++ b/scripts/explore_full_add_956.py
@@ -1,0 +1,65 @@
+"""Read-only drill #956 stage 2: replicate the full add-row flow (fills,
+panel uncheck clicks, month select) WITHOUT save; dump field state after
+each stage."""
+
+from playwright.sync_api import sync_playwright
+
+STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
+RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+COMPANY = "[data-qa*='resume-profile-experience-specific-company-input']"
+POSITION = "[data-qa*='resume-profile-experience-specific-position-input']"
+
+def state(page, tag):
+    comp = page.locator(COMPANY)
+    pos = page.locator(POSITION)
+    year = page.locator("[data-qa='resume-profile-experience-specific-year-input']")
+    months = page.locator("[data-qa='magritte-select-activator']")
+    desc = page.locator("[data-qa*='resume-profile-experience-specific-description-input'], textarea")
+    print(
+        f"[{tag}] company={comp.first.input_value()!r} position={pos.first.input_value()!r} "
+        f"year={year.first.input_value() if year.count() else 'N/A'!r} "
+        f"months={months.count()} desc={desc.count()}"
+    )
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    ctx = browser.new_context(storage_state=STATE)
+    page = ctx.new_page()
+    page.goto(f"https://hh.ru/resume/{RESUME}", wait_until="domcontentloaded")
+    page.wait_for_timeout(4000)
+    page.locator("[data-qa='resume-list-card-experience'] [data-qa='link']").click()
+    page.wait_for_timeout(4000)
+    state(page, "after open")
+    page.locator(COMPANY).first.fill("ТСЖ «Зелёный квартал»")
+    page.locator(POSITION).first.fill("Дворник")
+    state(page, "after fills t0")
+    page.wait_for_timeout(2500)
+    state(page, "after 2.5s")
+    # open start-month combobox and pick Январь
+    act = page.locator("[data-qa='magritte-select-activator']")
+    print("activators:", act.count())
+    if act.count() >= 1:
+        act.first.click()
+        page.wait_for_timeout(1500)
+        opts = page.locator("[data-qa='magritte-select-option-01']")
+        print("option01 count:", opts.count())
+        if opts.count():
+            opts.first.click()
+            page.wait_for_timeout(1000)
+    state(page, "after month pick")
+    # panel: expand + uncheck one other checkbox
+    boxes = page.locator("input[type='checkbox'][aria-label]")
+    print("panel boxes:", boxes.count())
+    if boxes.count() > 1:
+        boxes.nth(1).click()  # uncheck some other resume
+        page.wait_for_timeout(1500)
+    state(page, "after panel uncheck")
+    act = page.locator("[data-qa='magritte-select-activator']")
+    for i in range(act.count()):
+        print(f"[triggers {i}]", repr(act.nth(i).inner_text()))
+    page.wait_for_timeout(3000)
+    state(page, "after 3s more")
+    act = page.locator("[data-qa='magritte-select-activator']")
+    for i in range(act.count()):
+        print(f"[triggers+3s {i}]", repr(act.nth(i).inner_text()))
+    browser.close()

--- a/scripts/explore_panel_956.py
+++ b/scripts/explore_panel_956.py
@@ -4,8 +4,8 @@ in the DOM. No save is pressed; the form is left via Cancel."""
 
 from playwright.sync_api import sync_playwright
 
-STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
-RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+STATE = "data/storage_state/hh_session.json"
+RESUME = "0000111122223333444455556666777788889999"
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=True)

--- a/scripts/explore_panel_956.py
+++ b/scripts/explore_panel_956.py
@@ -1,0 +1,55 @@
+"""Read-only drill (#956): open the shared experience editor for the Дворник
+draft and dump the resume-binding panel: which titles/checkboxes are really
+in the DOM. No save is pressed; the form is left via Cancel."""
+
+from playwright.sync_api import sync_playwright
+
+STATE = "/Users/axisrow/Projects/hhru/data/storage_state/hh_session.json"
+RESUME = "4c263117ff110c845a0039ed1f525447414c53"
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    ctx = browser.new_context(storage_state=STATE)
+    page = ctx.new_page()
+    page.goto(f"https://hh.ru/resume/{RESUME}", wait_until="domcontentloaded")
+    page.wait_for_timeout(4000)
+    add = page.locator("[data-qa='resume-list-card-experience'] [data-qa='link']")
+    print("add count:", add.count())
+    add.click()
+    page.wait_for_timeout(4000)
+    print("url:", page.url)
+    # find the binding panel
+    panel = page.locator("text=Резюме с этим местом работы")
+    print("panel text count:", panel.count())
+    boxes = page.locator("[role='checkbox']")
+    print("role=checkbox count:", boxes.count())
+    labels = page.locator("input[type='checkbox']")
+    print("input checkbox count:", labels.count())
+    for i in range(labels.count()):
+        el = labels.nth(i)
+        print("box", i, "checked=", el.is_checked(), "aria=", el.get_attribute("aria-label"))
+    expand = page.locator("xpath=//button[contains(., 'Развернуть')]")
+    print("expand count:", expand.count())
+    if expand.count() >= 1:
+        page.wait_for_timeout(2500)
+        expand.first.click()
+        page.wait_for_timeout(3000)
+        labels = page.locator("input[type='checkbox']")
+        print("after expand input checkbox count:", labels.count())
+        for i in range(labels.count()):
+            el = labels.nth(i)
+            print("box", i, "checked=", el.is_checked(), "aria=", el.get_attribute("aria-label"))
+        page.wait_for_timeout(2000)
+        labels = page.locator("input[type='checkbox']")
+        print("after settle count:", labels.count())
+        for i in range(labels.count()):
+            el = labels.nth(i)
+            print("box", i, "checked=", el.is_checked(), "aria=", el.get_attribute("aria-label"))
+    # dump the panel region text
+    html = page.content()
+    idx = html.find("Резюме с этим местом работы")
+    print("---- panel html ----")
+    print(html[idx - 200 : idx + 6000] if idx != -1 else "panel marker not found")
+    with open("/tmp/panel_956.html", "w") as f:
+        f.write(html)
+    browser.close()

--- a/scripts/explore_photo_assign.py
+++ b/scripts/explore_photo_assign.py
@@ -1,0 +1,94 @@
+"""Назначение уже загруженного фото на резюме: клик по edit-button ->
+модалка «Все загруженные фото» -> photo-viewer-action-assign-current.
+
+Один мутирующий клик (assign). Остальное — навигация и чтение DOM.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hhru_bot.browser import (
+    dismiss_cookie_banner,
+    goto_hh,
+    launch_context,
+    require_authenticated_page,
+)
+from hhru_bot.config import load_config_or_exit
+from hhru_bot.logging_setup import LOG_DIR
+from hhru_bot.selector_groups.resume_photo import (
+    RESUME_AVATAR_BLOCK,
+    RESUME_AVATAR_IMAGE,
+)
+
+RESUME_ID = sys.argv[1]
+
+config = load_config_or_exit("data/config.yaml")
+
+
+def wait_react_props(page, selector, timeout_s=15):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        wired = page.evaluate(
+            """(sel) => {
+              const i = document.querySelector(sel);
+              return i ? Object.keys(i).some(k => k.startsWith("__reactProps$")) : false;
+            }""",
+            selector,
+        )
+        if wired:
+            return True
+        page.wait_for_timeout(500)
+    return False
+
+
+with launch_context(config.storage_state_file, headless=True) as context:
+    page = context.new_page()
+    goto_hh(page, f"https://hh.ru/resume/{RESUME_ID}")
+    require_authenticated_page(page)
+    dismiss_cookie_banner(page)
+    avatar = page.locator(RESUME_AVATAR_BLOCK).first
+    avatar.wait_for(state="visible", timeout=15000)
+    print("img до:", page.locator(RESUME_AVATAR_IMAGE).count())
+
+    page.evaluate(
+        """() => {
+          const c = document.querySelector("[class*='ContainerForMicroFrontend-resumePhotoViewer']");
+          if (c) c.scrollIntoView({block: "center"});
+        }"""
+    )
+    print("гидратация:", wait_react_props(page, "input[data-qa='resume-photo-proxy-gallery-input']"))
+    page.wait_for_timeout(1000)
+
+    page.locator("[data-qa='resume-avatar-edit-button']").first.click()
+    print("edit-button кликнут, жду модалку вьювера...")
+
+    assign_btn = page.locator("[data-qa='photo-viewer-action-assign-current']")
+    try:
+        assign_btn.first.wait_for(state="visible", timeout=15000)
+        print("вьювер открыт, assign-current видим")
+    except Exception:
+        out = LOG_DIR / f"photo_assign_nomodal_{time.strftime('%H%M%S')}.html"
+        out.write_text(page.content(), encoding="utf-8")
+        print("МОДАЛКА НЕ ОТКРЫЛАСЬ, дамп:", out.name)
+        sys.exit(1)
+    # дать анимации модалки закончиться (overlay перехватывал клики)
+    page.wait_for_timeout(2500)
+    out = LOG_DIR / f"photo_assign_modal_{time.strftime('%H%M%S')}.html"
+    out.write_text(page.content(), encoding="utf-8")
+    print("дамп модалки:", out.name)
+    assign_btn.first.click(timeout=20000)
+    print("assign-current кликнут")
+
+    for _ in range(20):
+        if page.locator(RESUME_AVATAR_IMAGE).count() > 0:
+            break
+        page.wait_for_timeout(1000)
+    print("img в аватаре после assign:", page.locator(RESUME_AVATAR_IMAGE).count())
+    out = LOG_DIR / f"photo_assign_final_{time.strftime('%H%M%S')}.html"
+    out.write_text(page.content(), encoding="utf-8")
+    print("финальный дамп:", out.name)

--- a/scripts/explore_photo_assign.py
+++ b/scripts/explore_photo_assign.py
@@ -61,7 +61,9 @@ with launch_context(config.storage_state_file, headless=True) as context:
           if (c) c.scrollIntoView({block: "center"});
         }"""
     )
-    print("гидратация:", wait_react_props(page, "input[data-qa='resume-photo-proxy-gallery-input']"))
+    print(
+        "гидратация:", wait_react_props(page, "input[data-qa='resume-photo-proxy-gallery-input']")
+    )
     page.wait_for_timeout(1000)
 
     page.locator("[data-qa='resume-avatar-edit-button']").first.click()

--- a/scripts/explore_photo_block.py
+++ b/scripts/explore_photo_block.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Read-only exploration: photo block on the resume page.
+
+Dumps HTML to data/logs/ and prints structured findings. Read-only: if a
+file chooser opens after clicking the photo control, no file is ever set —
+the chooser is abandoned, which cancels it.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from playwright.sync_api import sync_playwright
+
+from hhru_bot.browser import dismiss_cookie_banner, goto_hh, require_authenticated_page
+from hhru_bot.config import load_config_or_exit
+
+CONFIG_PATH = str(ROOT / "data" / "config.yaml")
+LOG_DIR = ROOT / "data" / "logs"
+
+
+def describe(loc, index: int) -> None:
+    try:
+        info = loc.nth(index).evaluate(
+            """el => ({
+                tag: el.tagName,
+                data_qa: el.getAttribute('data-qa'),
+                id: el.id,
+                cls: (el.className || '').toString().slice(0, 120),
+                text: (el.innerText || '').slice(0, 120),
+                visible: !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length),
+            })"""
+        )
+        print(f"  [{index}] {info}")
+    except Exception as exc:
+        print(f"  [{index}] error: {exc}")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: explore_photo_block.py <resume_id>")
+        return 1
+    resume_id = sys.argv[1]
+    config = load_config_or_exit(CONFIG_PATH)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False)
+        context = browser.new_context(
+            storage_state=str(ROOT / "data" / "storage_state" / "hh_session.json"),
+            user_agent=config.user_agent,
+        )
+        page = context.new_page()
+
+        print("=== open resume page ===")
+        goto_hh(page, f"https://hh.ru/resume/{resume_id}")
+        require_authenticated_page(page)
+        dismiss_cookie_banner(page)
+        print(f"URL: {page.url}")
+
+        full_path = LOG_DIR / f"explore_photo_full_{stamp}.html"
+        full_path.write_text(page.content(), encoding="utf-8")
+        print(f"full page HTML: {full_path}")
+
+        print("\n=== input[type=file] in resting DOM ===")
+        inputs = page.locator("input[type='file']")
+        print(f"count: {inputs.count()}")
+        for i in range(inputs.count()):
+            try:
+                attrs = inputs.nth(i).evaluate(
+                    """el => ({
+                        accept: el.getAttribute('accept'),
+                        hidden: el.hidden,
+                        display: getComputedStyle(el).display,
+                        data_qa: el.getAttribute('data-qa'),
+                        name: el.name,
+                        parent_tag: el.parentElement?.tagName,
+                        parent_data_qa: el.parentElement?.getAttribute('data-qa'),
+                    })"""
+                )
+                print(f"  [{i}] {attrs}")
+            except Exception as exc:
+                print(f"  [{i}] error: {exc}")
+
+        print("\n=== elements mentioning Фото ===")
+        hits = page.locator(
+            "[data-qa*='photo' i], [data-qa*='avatar' i], "
+            "[class*='photo' i], [aria-label*='фото' i]"
+        )
+        print(f"count: {hits.count()}")
+        for i in range(min(hits.count(), 20)):
+            describe(hits, i)
+
+        print("\n=== clickable elements with text Фото ===")
+        clickables = page.locator(
+            "button:has-text('фото'), a:has-text('фото'), "
+            "[role='button']:has-text('фото'), span:has-text('Фото')"
+        )
+        print(f"count: {clickables.count()}")
+        for i in range(min(clickables.count(), 20)):
+            describe(clickables, i)
+
+        # Find the add-photo control: prefer data-qa hit, else text hit.
+        add_button = None
+        for sel in (
+            "[data-qa*='photo' i][role='button'], [data-qa*='photo' i] button, "
+            "button[data-qa*='photo' i]",
+            "button:has-text('Добавить фото'), button:has-text('Загрузить фото'), "
+            "[role='button']:has-text('Добавить фото')",
+        ):
+            loc = page.locator(sel)
+            if loc.count() >= 1:
+                add_button = loc.first
+                print(f"\nadd-photo control via: {sel} (count={loc.count()})")
+                break
+        if add_button is None:
+            print("\nadd-photo control NOT found by any probe selector")
+        else:
+            print("\n=== click add-photo control (chooser intercepted, no file set) ===")
+            try:
+                with page.expect_file_chooser(timeout=5000) as fc_info:
+                    add_button.click()
+                chooser = fc_info.value
+                print("FILE CHOOSER OPENED — native chooser mechanism confirmed")
+                print(f"  is_multiple: {chooser.is_multiple()}")
+                # No set_files() — read-only; abandoning cancels the chooser.
+            except Exception as exc:
+                print(f"no native chooser within 5s: {type(exc).__name__}")
+                page.wait_for_timeout(2000)
+                modal_path = LOG_DIR / f"explore_photo_after_click_{stamp}.html"
+                modal_path.write_text(page.content(), encoding="utf-8")
+                print(f"DOM after click dumped: {modal_path}")
+                print(f"URL after click: {page.url}")
+                modals = page.locator("[role='dialog'], .modal, [data-qa*='modal' i]")
+                print(f"dialog/modal count: {modals.count()}")
+                for i in range(min(modals.count(), 5)):
+                    describe(modals, i)
+
+        context.close()
+        browser.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/explore_photo_click_popup.py
+++ b/scripts/explore_photo_click_popup.py
@@ -1,0 +1,75 @@
+"""Read-only диагностика: что рождает клик по edit-button / аватару —
+попап, chooser, ничего? Дампы DOM до/после, diff по ключевым маркерам.
+Мутаций hh.ru нет: только клики по UI и наблюдение.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hhru_bot.browser import (
+    dismiss_cookie_banner,
+    goto_hh,
+    launch_context,
+    require_authenticated_page,
+)
+from hhru_bot.config import load_config_or_exit
+from hhru_bot.logging_setup import LOG_DIR
+from hhru_bot.selector_groups.resume_photo import RESUME_AVATAR_BLOCK
+
+RESUME_ID = sys.argv[1]
+
+config = load_config_or_exit("data/config.yaml")
+
+
+class _R:
+    resume_url = f"https://hh.ru/resume/{RESUME_ID}"
+
+
+resume = _R()
+
+MARKERS = ["modal-overlay", "role=dialog", "drop-base", "popup", "upload",
+           "crop", "gallery-input", "fileinput", "FileInput", "Portfolio",
+           "portfolio", "Загрузит", "загрузит", "Выберит", "выберит"]
+
+
+def scan(page, label):
+    html = page.content()
+    found = {m: html.count(m) for m in MARKERS if html.count(m)}
+    print(f"[{label}] маркеры: {found}")
+    return html
+
+
+with launch_context(config.storage_state_file, headless=True) as context:
+    page = context.new_page()
+    goto_hh(page, resume.resume_url)
+    require_authenticated_page(page)
+    dismiss_cookie_banner(page)
+    page.locator(RESUME_AVATAR_BLOCK).first.wait_for(state="visible", timeout=15000)
+    time.sleep(5)  # дать гидратации закончиться
+
+    before = scan(page, "до клика")
+
+    btn = page.locator("[data-qa='resume-avatar-edit-button']").first
+    btn.click()
+    time.sleep(3)
+    after_btn = scan(page, "после клика edit-button")
+
+    avatar = page.locator(RESUME_AVATAR_BLOCK).first
+    avatar.click()
+    time.sleep(3)
+    after_avatar = scan(page, "после клика avatar")
+
+    diff_keys = {k for k in set(after_btn) | set(after_avatar) if
+                 after_btn.get(k, 0) != before.get(k, 0)
+                 or after_avatar.get(k, 0) != before.get(k, 0)}
+    print("изменившиеся маркеры:", diff_keys or "нет")
+
+    html = page.content()
+    out = LOG_DIR / f"photo_explore_click_{time.strftime('%Y%m%d_%H%M%S')}.html"
+    out.write_text(html, encoding="utf-8")
+    print(f"дамп: {out}")

--- a/scripts/explore_photo_click_popup.py
+++ b/scripts/explore_photo_click_popup.py
@@ -32,9 +32,23 @@ class _R:
 
 resume = _R()
 
-MARKERS = ["modal-overlay", "role=dialog", "drop-base", "popup", "upload",
-           "crop", "gallery-input", "fileinput", "FileInput", "Portfolio",
-           "portfolio", "Загрузит", "загрузит", "Выберит", "выберит"]
+MARKERS = [
+    "modal-overlay",
+    "role=dialog",
+    "drop-base",
+    "popup",
+    "upload",
+    "crop",
+    "gallery-input",
+    "fileinput",
+    "FileInput",
+    "Portfolio",
+    "portfolio",
+    "Загрузит",
+    "загрузит",
+    "Выберит",
+    "выберит",
+]
 
 
 def scan(page, label):
@@ -64,9 +78,11 @@ with launch_context(config.storage_state_file, headless=True) as context:
     time.sleep(3)
     after_avatar = scan(page, "после клика avatar")
 
-    diff_keys = {k for k in set(after_btn) | set(after_avatar) if
-                 after_btn.get(k, 0) != before.get(k, 0)
-                 or after_avatar.get(k, 0) != before.get(k, 0)}
+    diff_keys = {
+        k
+        for k in set(after_btn) | set(after_avatar)
+        if after_btn.get(k, 0) != before.get(k, 0) or after_avatar.get(k, 0) != before.get(k, 0)
+    }
     print("изменившиеся маркеры:", diff_keys or "нет")
 
     html = page.content()

--- a/scripts/explore_photo_full_flow.py
+++ b/scripts/explore_photo_full_flow.py
@@ -1,0 +1,118 @@
+"""Живой прогон полного потока загрузки фото: гидратация инпута ->
+set_input_files -> crop-редактор (photo-editor-apply) -> модалка назначения
+(photo-viewer-action-assign-current) -> маркер успеха.
+
+Клики — боевые мутирующие действия (это и есть санкционированная загрузка
+фото). Дампы DOM на каждом шаге — в data/logs/.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hhru_bot.browser import (
+    dismiss_cookie_banner,
+    goto_hh,
+    launch_context,
+    require_authenticated_page,
+)
+from hhru_bot.config import load_config_or_exit
+from hhru_bot.logging_setup import LOG_DIR
+from hhru_bot.selector_groups.resume_photo import (
+    RESUME_AVATAR_BLOCK,
+    RESUME_AVATAR_IMAGE,
+    RESUME_PHOTO_FILE_INPUT,
+)
+
+RESUME_ID = sys.argv[1]
+PHOTO = sys.argv[2]
+
+config = load_config_or_exit("data/config.yaml")
+
+
+def dump(page, label):
+    out = LOG_DIR / f"photo_flow_{label}_{time.strftime('%H%M%S')}.html"
+    out.write_text(page.content(), encoding="utf-8")
+    print(f"  дамп: {out.name}")
+
+
+def wait_react_props(page, selector, timeout_s=15):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        wired = page.evaluate(
+            """(sel) => {
+              const i = document.querySelector(sel);
+              return i ? Object.keys(i).some(k => k.startsWith("__reactProps$")) : false;
+            }""",
+            selector,
+        )
+        if wired:
+            return True
+        page.wait_for_timeout(500)
+    return False
+
+
+with launch_context(config.storage_state_file, headless=True) as context:
+    page = context.new_page()
+    goto_hh(page, f"https://hh.ru/resume/{RESUME_ID}")
+    require_authenticated_page(page)
+    dismiss_cookie_banner(page)
+    page.locator(RESUME_AVATAR_BLOCK).first.wait_for(state="visible", timeout=15000)
+    print("1. аватар отрисован, img:", page.locator(RESUME_AVATAR_IMAGE).count())
+
+    # Гидратация микрофроненда: скролл контейнера в вьюпорт + поллинг reactProps
+    page.evaluate(
+        """() => {
+          const c = document.querySelector("[class*='ContainerForMicroFrontend-resumePhotoViewer']");
+          if (c) c.scrollIntoView({block: "center"});
+        }"""
+    )
+    ok = wait_react_props(page, "input[data-qa='resume-photo-proxy-gallery-input']")
+    print("2. гидратация gallery-input:", ok)
+    if not ok:
+        dump(page, "no_hydration")
+        sys.exit(1)
+
+    inputs = page.locator(RESUME_PHOTO_FILE_INPUT)
+    print("   input count:", inputs.count())
+    inputs.first.set_input_files(PHOTO)
+    print("3. файл передан, жду редактор...")
+
+    editor_apply = page.locator("[data-qa='photo-editor-apply']")
+    try:
+        editor_apply.first.wait_for(state="visible", timeout=15000)
+        print("4. crop-редактор открыт, apply видим")
+    except Exception:
+        print("4. РЕДАКТОР НЕ ОТКРЫЛСЯ")
+        dump(page, "no_editor")
+        sys.exit(1)
+    dump(page, "editor")
+
+    editor_apply.first.click()
+    print("5. apply кликнут, жду upload + модалку назначения...")
+
+    assign_btn = page.locator("[data-qa='photo-viewer-action-assign-current']")
+    try:
+        assign_btn.first.wait_for(state="visible", timeout=30000)
+        print("6. модалка назначения открыта, assign-current видим")
+        dump(page, "assign_modal")
+    except Exception:
+        print("6. МОДАЛКА НАЗНАЧЕНИЯ НЕ ОТКРЫЛАСЬ (возможно, upload ещё идёт или авто-assign)")
+        dump(page, "no_assign")
+        # продолжаем проверять аватар — вдруг назначение прошло автоматически
+
+    if assign_btn.count() > 0 and assign_btn.first.is_visible():
+        assign_btn.first.click()
+        print("7. assign-current кликнут")
+
+    # маркер успеха: img в блоке аватара
+    for _ in range(30):
+        if page.locator(RESUME_AVATAR_IMAGE).count() > 0:
+            break
+        page.wait_for_timeout(1000)
+    print("8. img в аватаре:", page.locator(RESUME_AVATAR_IMAGE).count())
+    dump(page, "final")

--- a/scripts/explore_photo_pencil_assign.py
+++ b/scripts/explore_photo_pencil_assign.py
@@ -1,0 +1,112 @@
+"""Диагностика + назначение фото из библиотеки: карандашик -> вьювер ->
+«Установить для этого резюме» (поток владельца, скриншоты 2026-09-03).
+
+Один мутирующий клик (assign). Перед ним — read-only инвентарь overlay'ей
+и геометрии кнопки, чтобы понять, кто перехватывает pointer events
+(боевой прогон команды дважды упал на этом шаге).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from hhru_bot.browser import (
+    dismiss_cookie_banner,
+    goto_hh,
+    launch_context,
+    require_authenticated_page,
+)
+from hhru_bot.config import load_config_or_exit
+from hhru_bot.logging_setup import LOG_DIR
+from hhru_bot.selector_groups.resume_photo import (
+    RESUME_AVATAR_BLOCK,
+    RESUME_AVATAR_EDIT_BUTTON,
+    RESUME_AVATAR_IMAGE,
+    RESUME_PHOTO_VIEWER_ASSIGN_CURRENT,
+)
+
+RESUME_ID = sys.argv[1]
+
+config = load_config_or_exit("data/config.yaml")
+
+with launch_context(config.storage_state_file, headless=False) as context:
+    page = context.new_page()
+    goto_hh(page, f"https://hh.ru/resume/{RESUME_ID}")
+    require_authenticated_page(page)
+    dismiss_cookie_banner(page)
+    avatar = page.locator(RESUME_AVATAR_BLOCK).first
+    avatar.wait_for(state="visible", timeout=30000)
+    print("img до:", page.locator(RESUME_AVATAR_IMAGE).count())
+
+    # Карандашик открывает вьювер только УЖЕ гидратированного микрофроненда
+    page.evaluate(
+        """(sel) => {
+          const c = document.querySelector(sel);
+          if (c) c.scrollIntoView({block: "center"});
+        }""",
+        "[class*='ContainerForMicroFrontend-resumePhotoViewer']",
+    )
+    from hhru_bot.browser import wait_for_react_hydration
+
+    wired = wait_for_react_hydration(
+        page,
+        "input[data-qa='resume-photo-proxy-gallery-input']",
+        timeout_ms=20000,
+    )
+    print("гидратация:", wired)
+    page.wait_for_timeout(1000)
+
+    pencil = page.locator(RESUME_AVATAR_EDIT_BUTTON).first
+    pencil.wait_for(state="visible", timeout=15000)
+    pencil.click()
+    print("карандашик кликнут")
+
+    assign_btn = page.locator(RESUME_PHOTO_VIEWER_ASSIGN_CURRENT).first
+    try:
+        assign_btn.wait_for(state="visible", timeout=15000)
+    except Exception:
+        out = LOG_DIR / f"photo_pencil_nomodal_{time.strftime('%H%M%S')}.html"
+        out.write_text(page.content(), encoding="utf-8")
+        print("assign не появился, дамп:", out.name)
+        raise
+    page.wait_for_timeout(2500)
+
+    # Read-only инвентарь: сколько overlay, их геометрия и что сверху в точке кнопки
+    info = page.evaluate(
+        """(sel) => {
+          const btn = document.querySelector(sel);
+          const r = btn ? btn.getBoundingClientRect() : null;
+          const overlays = [...document.querySelectorAll("[data-qa='modal-overlay']")].map(o => {
+            const b = o.getBoundingClientRect();
+            const st = getComputedStyle(o);
+            return {z: st.zIndex, display: st.display, pointer: st.pointerEvents,
+                    rect: [b.x, b.y, b.width, b.height].map(Math.round)};
+          });
+          let topAtBtn = null;
+          if (r) {
+            const el = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+            topAtBtn = el ? (el.tagName + "|" + (el.getAttribute("data-qa") || "") + "|" + el.className.toString().slice(0, 80)) : null;
+          }
+          return {btnRect: r ? [r.x, r.y, r.width, r.height].map(Math.round) : null,
+                  viewport: [innerWidth, innerHeight], overlays, topAtBtn};
+        }""",
+        RESUME_PHOTO_VIEWER_ASSIGN_CURRENT,
+    )
+    print("геометрия/overlay:", info)
+
+    assign_btn.click(timeout=20000)
+    print("assign кликнут")
+
+    for _ in range(30):
+        if page.locator(RESUME_AVATAR_IMAGE).count() > 0:
+            break
+        page.wait_for_timeout(1000)
+    print("img после assign:", page.locator(RESUME_AVATAR_IMAGE).count())
+    page.wait_for_timeout(5000)
+    out = LOG_DIR / f"photo_pencil_assign_{time.strftime('%H%M%S')}.html"
+    out.write_text(page.content(), encoding="utf-8")
+    print("дамп:", out.name)

--- a/scripts/explore_photo_upload_net.py
+++ b/scripts/explore_photo_upload_net.py
@@ -115,15 +115,21 @@ with launch_context(config.storage_state_file, headless=True) as context:
     if chooser is not None:
         chooser.set_files(PHOTO)
         time.sleep(5)
-        print(f"  после chooser: img={page.locator(RESUME_AVATAR_IMAGE).count()}, "
-              f"события={page.evaluate('() => window.__photoEvents')}")
+        print(
+            f"  после chooser: img={page.locator(RESUME_AVATAR_IMAGE).count()}, "
+            f"события={page.evaluate('() => window.__photoEvents')}"
+        )
     print(f"  новые сетевые: {observed[-10:]}")
     time.sleep(5)
     img_after = page.locator(RESUME_AVATAR_IMAGE).count()
     print(f"img финально: {img_after}")
-    print("файлы в инпуте:", page.evaluate(
-        "() => { const i = document.querySelector(\"input[data-qa='resume-photo-proxy-gallery-input']\");"
-        " return i && i.files ? i.files.length : 'gone'; }"))
+    print(
+        "файлы в инпуте:",
+        page.evaluate(
+            "() => { const i = document.querySelector(\"input[data-qa='resume-photo-proxy-gallery-input']\");"
+            " return i && i.files ? i.files.length : 'gone'; }"
+        ),
+    )
 
     html = page.content()
     out = LOG_DIR / f"photo_explore_net_{time.strftime('%Y%m%d_%H%M%S')}.html"

--- a/scripts/explore_photo_upload_net.py
+++ b/scripts/explore_photo_upload_net.py
@@ -1,0 +1,131 @@
+"""Read-only диагностика загрузки фото: какие сетевые запросы рождает
+set_input_files на resume-photo-proxy-gallery-input.
+
+Не мутирует ничего кроме попытки передачи файла в file-input (тот же боевой
+механизм команды upload-photo). Наблюдает request/response события страницы.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from playwright.sync_api import Error as PlaywrightError
+
+from hhru_bot.browser import (
+    dismiss_cookie_banner,
+    goto_hh,
+    launch_context,
+    require_authenticated_page,
+)
+from hhru_bot.config import load_config_or_exit
+from hhru_bot.logging_setup import LOG_DIR
+from hhru_bot.selector_groups.resume_photo import (
+    RESUME_AVATAR_BLOCK,
+    RESUME_AVATAR_IMAGE,
+    RESUME_PHOTO_FILE_INPUT,
+)
+
+RESUME_ID = sys.argv[1]
+PHOTO = sys.argv[2]
+
+config = load_config_or_exit("data/config.yaml")
+
+
+class _R:
+    resume_url = f"https://hh.ru/resume/{RESUME_ID}"
+
+
+resume = _R()
+
+observed: list[str] = []
+
+with launch_context(config.storage_state_file, headless=True) as context:
+    page = context.new_page()
+
+    def on_request(req):
+        if "hh.ru" in req.url and req.method != "GET":
+            observed.append(f"REQ {req.method} {req.url}")
+        elif any(k in req.url for k in ("upload", "photo", "avatar")):
+            observed.append(f"REQ {req.method} {req.url}")
+
+    def on_response(resp):
+        if any(k in resp.url for k in ("upload", "photo", "avatar")):
+            observed.append(f"RESP {resp.status} {resp.url}")
+
+    page.on("request", on_request)
+    page.on("response", on_response)
+
+    goto_hh(page, resume.resume_url)
+    require_authenticated_page(page)
+    dismiss_cookie_banner(page)
+    avatar = page.locator(RESUME_AVATAR_BLOCK).first
+    avatar.wait_for(state="visible", timeout=15000)
+
+    img_before = page.locator(RESUME_AVATAR_IMAGE).count()
+    print(f"img до передачи: {img_before}")
+
+    inp = page.locator(RESUME_PHOTO_FILE_INPUT).first
+    print(f"file-input count: {page.locator(RESUME_PHOTO_FILE_INPUT).count()}")
+
+    # Подписка на change/input события в DOM — доходит ли событие до инпута.
+    page.evaluate(
+        """() => {
+          window.__photoEvents = [];
+          const inp = document.querySelector("input[data-qa='resume-photo-proxy-gallery-input']");
+          if (!inp) return "no-input";
+          inp.addEventListener('change', () => window.__photoEvents.push(
+            'change files=' + (inp.files ? inp.files.length : 'null') +
+            ' name=' + (inp.files && inp.files[0] ? inp.files[0].name : '-')));
+          inp.addEventListener('input', () => window.__photoEvents.push('input'));
+          return "ok";
+        }"""
+    )
+
+    inp.set_input_files(PHOTO)
+    print("set_input_files выполнен")
+
+    for i in range(20):
+        time.sleep(1)
+        events = page.evaluate("() => window.__photoEvents")
+        if events or observed:
+            break
+    print(f"DOM-события на инпуте: {page.evaluate('() => window.__photoEvents')}")
+
+    # Гипотеза: обработчик активируется кликом по edit-button (или по аватару).
+    # Кликаем и смотрим, меняется ли DOM и появляются ли события/запросы.
+    page.evaluate("() => { window.__photoEvents = []; }")
+    btn = page.locator("[data-qa='resume-avatar-edit-button']").first
+    btn.click()
+    time.sleep(2)
+    print("после клика по edit-button:")
+    print(f"  DOM-события: {page.evaluate('() => window.__photoEvents')}")
+    print(f"  новые сетевые: {observed[-5:]}")
+    chooser = None
+    try:
+        with page.expect_file_chooser(timeout=3000) as fc_info:
+            btn.click()
+        chooser = fc_info.value
+        print("  file chooser ОТКРЫЛСЯ на втором клике")
+    except PlaywrightError:
+        print("  file chooser не открылся на втором клике")
+    if chooser is not None:
+        chooser.set_files(PHOTO)
+        time.sleep(5)
+        print(f"  после chooser: img={page.locator(RESUME_AVATAR_IMAGE).count()}, "
+              f"события={page.evaluate('() => window.__photoEvents')}")
+    print(f"  новые сетевые: {observed[-10:]}")
+    time.sleep(5)
+    img_after = page.locator(RESUME_AVATAR_IMAGE).count()
+    print(f"img финально: {img_after}")
+    print("файлы в инпуте:", page.evaluate(
+        "() => { const i = document.querySelector(\"input[data-qa='resume-photo-proxy-gallery-input']\");"
+        " return i && i.files ? i.files.length : 'gone'; }"))
+
+    html = page.content()
+    out = LOG_DIR / f"photo_explore_net_{time.strftime('%Y%m%d_%H%M%S')}.html"
+    out.write_text(html, encoding="utf-8")
+    print(f"дамп: {out}")


### PR DESCRIPTION
## Что

Архив 12 неотслеживаемых разведочных скриптов из `scripts/` — живые one-off
скрипты исследования DOM/сети, оставшиеся от ишью #857 (photo assign),
#956 (fill/full-add/panel experience) и #1004 (collapse/aria-сверка), плюс
серия photo-flow разведок (assign, block, click-popup, full-flow,
pencil-assign, upload-net).

## Почему PR, а не удаление

Скрипты уже выполнили свою задачу (выводы закреплены в CLAUDE.md/ишью), но
содержат подтверждённые рабочие паттерны доступа к живому DOM
(`resume-photo-proxy-gallery-input`, set_input_files на скрытый file-input,
интерцепты upload-запросов), на которые удобно ссылаться в будущих
photo/experience фичах.

Read-only по отношению к hh.ru-логике: в `src/` и `tests/` изменений нет,
CLI не затронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
