### PR TITLE
fix(agent-honesty): #1006 — matchCount в checkElement, semantic-trap resume-title, локатор empty-state, узкие captcha-маркеры, state-маркировка

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "hhru",
   "metadata": {
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "interface": {
     "displayName": "HH.ru"
@@ -9,11 +9,11 @@
   "plugins": [
     {
       "name": "hhru-cc-plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": {
         "source": "url",
         "url": "https://github.com/axisrow/hhru.git",
-        "ref": "v0.1.0"
+        "ref": "v0.1.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hhru-cc-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Safe hh.ru job-search workflows powered by the hhru CLI.",
   "author": {
     "name": "axisrow"

--- a/extensions/hhru-live/content.js
+++ b/extensions/hhru-live/content.js
@@ -147,11 +147,16 @@ observer.observe(document.documentElement, {
 });
 
 function checkElement(selector) {
+  // matchCount (#1006): a found [0]-th element of an ambiguous selector must
+  // not silently read as "the" element — the agent sees only this report.
   if (!selector || typeof selector !== 'string') {
-    return { found: false, visible: false, obstructionChecked: false };
+    return { found: false, visible: false, obstructionChecked: false, matchCount: 0 };
   }
-  const element = document.querySelectorAll(selector)[0] || null;
-  if (!element) return { found: false, visible: false, obstructionChecked: false };
+  const matches = document.querySelectorAll(selector);
+  const element = matches[0] || null;
+  if (!element) {
+    return { found: false, visible: false, obstructionChecked: false, matchCount: 0 };
+  }
   const visible = isVisible(element);
   let covered = null;
   let obstructionChecked = false;
@@ -173,7 +178,7 @@ function checkElement(selector) {
       }
     }
   }
-  return { found: true, visible, covered, obstructionChecked };
+  return { found: true, visible, covered, obstructionChecked, matchCount: matches.length };
 }
 
 function waitForOverlayGone(element, onDone) {

--- a/selectors/reference-map.yaml
+++ b/selectors/reference-map.yaml
@@ -767,7 +767,10 @@ selectors:
     verification: browser_observed
     evidence:
       source: src/hhru_bot/selector_groups/apply_form.py:46
-      note: Approved reference binding for the active local selector.
+      note: 'SEMANTIC TRAP (#1006, по образцу WORK_PERMIT_WIZARD): qa-имя resume-title — это триггер пикера резюме в форме
+        отклика (свёрнутый выбранный вариант Magritte-select), а НЕ заголовок резюме и не поле ввода названия. Тот же data-qa
+        на /applicant/resumes обслуживает resume_list.RESUME_LIST_CARD_TITLE (карточка списка) — data-qa однозначно не определяет
+        смысл; решение по роли контрола на конкретном экране, не по имени атрибута.'
       references:
       - yamakayama
     last_verified_at: 2026-08-25
@@ -1040,24 +1043,29 @@ selectors:
     verified_flow: public_resume_search_read_only
     verified_by: codex
   competitor_resume.SEARCH_EMPTY:
-    value: '[data-qa=''resume-search-empty''], [data-qa=''bloko-header-2'']'
+    value: '[data-qa=''empty-search-block'']'
     criticality: read
-    declared_at: src/hhru_bot/selector_groups/competitor_resume.py:6
-    decision: structural_read_fallback
+    declared_at: src/hhru_bot/selector_groups/competitor_resume.py:9
+    decision: live_dom
     sources: {}
-    live_matches: []
+    live_matches:
+    - empty-search-block
     evidence:
-      source: src/hhru_bot/selector_groups/competitor_resume.py:6
-      note: read-only empty-state union; callers still require confirmed page state
+      source: src/hhru_bot/selector_groups/competitor_resume.py:9
+      note: 'Live-подтверждено 2026-09-07 (#1006, census /search/resume?text=<несуществующее>&pos=position, нулевая выдача):
+        empty-state рендерится ровно один [data-qa=''empty-search-block''] с h2 «Ничего не нашлось» и подзаголовком «Попробуйте
+        изменить формулировку или фильтры». Прежний union (resume-search-empty / bloko-header-2) в живом DOM не подтверждён
+        и убран; подстрочный поиск «резюме не найден»/«ничего не найден» живую формулировку НЕ ловит.'
+      runtime_authoritative: true
     active: true
-    coverage_status: not_implemented_upstream
+    coverage_status: intentionally_local
     bindings: {}
-    status: not implemented upstream
+    status: intentionally local
     origin: browser_dom
     verification: browser_observed
-    last_verified_at: '2026-08-25'
-    verified_flow: public_resume_search_read_only
-    verified_by: codex
+    last_verified_at: '2026-09-07'
+    verified_flow: authenticated_applicant_search_empty_state_read_only
+    verified_by: claude
   competitor_resume.SEARCH_RESULT_TITLE_LINK:
     value: '[data-qa=''serp-item__title'']'
     criticality: read

--- a/selectors/reference-matrix.md
+++ b/selectors/reference-matrix.md
@@ -49,7 +49,7 @@
 | competitor_resume.PAGINATION_PAGE | `[data-qa*='pager-page'], [data-qa*='pagination-page']` | — | — | — | structural_read_fallback |
 | competitor_resume.SEARCH_AREA_AND_RELOCATION | `[data-qa='resume-serp_resume-item-area-and-relocation-content']` | — | — | — | live_dom |
 | competitor_resume.SEARCH_CARD | `[data-qa='resume-serp__resume']` | — | — | — | live_dom |
-| competitor_resume.SEARCH_EMPTY | `[data-qa='resume-search-empty'], [data-qa='bloko-header-2']` | — | — | — | structural_read_fallback |
+| competitor_resume.SEARCH_EMPTY | `[data-qa='empty-search-block']` | — | — | — | live_dom |
 | competitor_resume.SEARCH_RESULT_TITLE_LINK | `[data-qa='serp-item__title']` | — | — | — | live_dom |
 | create_resume.TREE_ITEM_TEXT | `[data-qa*='tree-selector-item-text-']` | — | — | — | workflow_live |
 | negotiations.CHAT_AUTHOR_HINT | `[data-qa*='author'], [class*='author'], [aria-label], [title]` | — | — | — | documented_live |

--- a/src/hhru_bot/auth_code.py
+++ b/src/hhru_bot/auth_code.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from .apply.antibot import detect_antibot_on_page
 from .browser import (
     HH_BASE_URL,
     goto_hh,
@@ -78,11 +79,15 @@ def _read_code(code_file: Path | None, timeout_seconds: int) -> str:
 
 
 def _raise_for_captcha_or_timeout(page) -> None:
+    # (#1006) Капча подтверждается только узкими маркерами #344 (видимый
+    # [data-qa='captcha'] / account-captcha-* / vendor-виджеты, URL-сегмент),
+    # а не подстрокой в inner_text всего body: слово «капча» в любом
+    # нерелевантном блоке страницы давало ложный отказ входа.
     try:
-        text = page.locator("body").inner_text().casefold()
+        detection = detect_antibot_on_page(page)
     except (PlaywrightError, PlaywrightTimeoutError) as exc:
         raise RuntimeError("Не удалось дождаться ответа hh.ru; вход отменён") from exc
-    if "captcha" in text or "капч" in text:
+    if detection is not None:
         raise RuntimeError("hh.ru требует капчу; сессия не сохранена")
 
 

--- a/src/hhru_bot/commands/resume_position.py
+++ b/src/hhru_bot/commands/resume_position.py
@@ -102,10 +102,16 @@ def _professional_role_closes_resume(flow) -> bool:
     return flow.kind == "wizard" and flow.state.next_incomplete_screen_id == "professional_role"
 
 
-def _print_plan(plan) -> None:
+def _print_plan(plan, *, state_sourced=frozenset()) -> None:
     print("[DRY-RUN] Предложенные значения раздела желаемой работы:")
     for key, value in vars(plan).items():
-        print(f"  {key}: {value}")
+        if key in state_sourced and value not in (None, ""):
+            # (#1006) значение прочитано из identity-bound state (JSON-бандл
+            # SSR), а не с отрисованной формы — агент не должен принимать
+            # его за живой DOM.
+            print(f"  {key}: {value} (state)")
+        else:
+            print(f"  {key}: {value}")
 
 
 def _print_classification(role, *, reason: str = "", queries: list[str] | None = None) -> None:
@@ -352,9 +358,12 @@ def _run(args: argparse.Namespace, progress) -> bool:
             # записываемую должность (wizard-ветка выше назначает plan.title
             # явно через effective_title).
             display_plan = plan
+            state_sourced = frozenset()
             if plan.title is None and current.title:
                 display_plan = PositionValues(**{**vars(plan), "title": current.title})
-            _print_plan(display_plan)
+                if wizard:
+                    state_sourced = frozenset({"title"})
+            _print_plan(display_plan, state_sourced=state_sourced)
             if role is not None:
                 _print_classification(
                     role,

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -320,11 +320,17 @@ def parse_search_page(
     try:
         links.first.wait_for(state="attached", timeout=RENDER_TIMEOUT_MS)
     except PlaywrightError:
-        # Applicant search currently has no stable empty data-qa across layouts.
-        # Accept an explicit zero-result phrase only; every other blank page is unknown.
-        main_text = page.locator("main").inner_text().casefold()
-        if "резюме не найден" in main_text or "ничего не найден" in main_text:
-            return []
+        # Пустая выдача подтверждается ТОЛЬКО локатором empty-state (#1006,
+        # live 2026-09-07: h2 «Ничего не нашлось» внутри
+        # [data-qa='empty-search-block']). Прежняя подстрочная проверка
+        # («резюме не найден» / «ничего не найден») живую формулировку не
+        # ловила вовсе; любая подстрока в <main> ещё и совпадала бы с чужими
+        # блоками. Всё остальное — неизвестное состояние.
+        try:
+            if page.locator(sel.SEARCH_EMPTY).count() > 0:
+                return []
+        except PlaywrightError:
+            pass
         raise CompetitorSearchIndeterminate(
             "карточки резюме или подтверждённый empty-state не появились"
         ) from None

--- a/src/hhru_bot/competitors.py
+++ b/src/hhru_bot/competitors.py
@@ -327,7 +327,7 @@ def parse_search_page(
         # ловила вовсе; любая подстрока в <main> ещё и совпадала бы с чужими
         # блоками. Всё остальное — неизвестное состояние.
         try:
-            if page.locator(sel.SEARCH_EMPTY).count() > 0:
+            if page.locator(sel.SEARCH_EMPTY).filter(visible=True).count() > 0:
                 return []
         except PlaywrightError:
             pass

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -953,6 +953,9 @@ def verify_wizard_save(
     observed_roles = ", ".join(
         f"{role.role_id}:{role.label or '?'}" for role in state.professional_roles
     )
+    # (#1006) роли читаются из identity-bound state (JSON-бандл SSR), печатаем
+    # это явно, чтобы расхождение не искали в отрисованном DOM.
+    state_roles_suffix = " (state)" if observed_roles else ""
     if not any(
         role.role_id == expected_role_id
         and (role.label is None or role.label == expected_role_label)
@@ -960,8 +963,8 @@ def verify_wizard_save(
     ):
         raise RuntimeError(
             f"post-save professional role не совпал: ожидалось "
-            f"{expected_role_id}:{expected_role_label}, прочитано "
-            f"{observed_roles or '<пусто>'}"
+            f"{expected_role_id}:{expected_role_label}, прочитано"
+            f"{state_roles_suffix} {observed_roles or '<пусто>'}"
         )
     if len(matches) != 1:
         raise RuntimeError(f"post-save readback карточки резюме неоднозначен: {len(matches)}")

--- a/src/hhru_bot/resume_views.py
+++ b/src/hhru_bot/resume_views.py
@@ -81,11 +81,15 @@ def parse_resume_view_history(
     confidence, but implementing a check now would mean guessing an SSR
     field name with no live dump to confirm it exists — exactly the
     `_form_scope()` trap CLAUDE.md documents (a wrong guess either fails
-    closed on every run, or never fires and gives false confidence). Before
-    the first live `resume-views` run: open the page in a real browser
-    (F12 → Elements/Network), confirm whether `applicantResumeViewHistory`
-    carries a resume identity field, and wire the check here if it does —
-    same convention as the pending `bump` selector check in CLAUDE.md.
+    closed on every run, or never fires and gives false confidence).
+
+    #1006 (2026-09-07): the live check was attempted and is BLOCKED by route
+    drift — `/applicant/resumeview/history` returns hh.ru's "Ошибка 400"
+    page for an authenticated session (verified via census: logged-in header
+    rendered) in every probed variant (no params / resume= / page=0,1 /
+    resumeHash=). The identity field therefore still cannot be confirmed;
+    the cross-check remains unimplemented and the route's 400 keeps the
+    command fail-closed today.
     """
     state = parse_initial_state(html)
     history = _find_history(state)

--- a/src/hhru_bot/selector_groups/_generated.py
+++ b/src/hhru_bot/selector_groups/_generated.py
@@ -50,7 +50,7 @@ VALUES: dict[str, str] = {
     "competitor_resume.PAGINATION_PAGE": "[data-qa*='pager-page'], [data-qa*='pagination-page']",
     "competitor_resume.SEARCH_AREA_AND_RELOCATION": "[data-qa='resume-serp_resume-item-area-and-relocation-content']",
     "competitor_resume.SEARCH_CARD": "[data-qa='resume-serp__resume']",
-    "competitor_resume.SEARCH_EMPTY": "[data-qa='resume-search-empty'], [data-qa='bloko-header-2']",
+    "competitor_resume.SEARCH_EMPTY": "[data-qa='empty-search-block']",
     "competitor_resume.SEARCH_RESULT_TITLE_LINK": "[data-qa='serp-item__title']",
     "create_resume.TREE_ITEM_TEXT": "[data-qa*='tree-selector-item-text-']",
     "negotiations.CHAT_AUTHOR_HINT": "[data-qa*='author'], [class*='author'], [aria-label], [title]",

--- a/src/hhru_bot/selector_groups/apply_form.py
+++ b/src/hhru_bot/selector_groups/apply_form.py
@@ -28,6 +28,12 @@ from ._generated import selector as _selector
 # ТРИГГЕР (для открытия), а не коллекция опций — см. новую сигнатуру
 # _select_resume_in_form() в apply/steps.py.
 #
+# SEMANTIC TRAP (#1006, по образцу WORK_PERMIT_WIZARD в reference-map):
+# qa-имя «resume-title» — это триггер пикера резюме в форме отклика, а НЕ
+# заголовок резюме. Тот же data-qa на /applicant/resumes обслуживает
+# resume_list.RESUME_LIST_CARD_TITLE — имя атрибута не определяет смысл,
+# решает роль контрола на конкретном экране.
+#
 # ВАЖНО (пересмотрено 2026-08-20 по боевым дампам). hh.ru рендерит форму отклика
 # в ДВУХ shape с похожим, но не идентичным DOM:
 #   * МОДАЛКА на самой странице вакансии — `form#RESPONSE_MODAL_FORM_ID`,

--- a/src/hhru_bot/selector_groups/competitor_resume.py
+++ b/src/hhru_bot/selector_groups/competitor_resume.py
@@ -9,6 +9,11 @@ SEARCH_CARD = _selector("competitor_resume.SEARCH_CARD")
 SEARCH_RESULT_TITLE_LINK = _selector("competitor_resume.SEARCH_RESULT_TITLE_LINK")
 SEARCH_AREA_AND_RELOCATION = _selector("competitor_resume.SEARCH_AREA_AND_RELOCATION")
 SEARCH_EMPTY = _selector("competitor_resume.SEARCH_EMPTY")
+# Live-подтверждено 2026-09-07 (#1006, census нулевой выдачи /search/resume):
+# ровно один [data-qa='empty-search-block'] с h2 «Ничего не нашлось» и
+# подзаголовком «Попробуйте изменить формулировку или фильтры». Проверка
+# пустой выдачи — по этому локатору, а не по подстроке в <main>: живая
+# формулировка раньше НЕ совпадала ни с одной ожидаемой подстрокой.
 PAGINATION_NEXT = _selector("competitor_resume.PAGINATION_NEXT")
 PAGINATION_BLOCK = _selector("competitor_resume.PAGINATION_BLOCK")
 PAGINATION_PAGE = _selector("competitor_resume.PAGINATION_PAGE")

--- a/tests/js_harness/run_command_scenario.js
+++ b/tests/js_harness/run_command_scenario.js
@@ -321,6 +321,7 @@ const SCENARIOS = {
   check_element: async () => {
     const next = el('button', { 'data-qa': 'next-button' }, 'Далее');
     append(next);
+    append(el('button', { 'data-qa': 'next-button' }, 'Далее (дубль)'));
     const present = await send({ action: 'check_element', selector: '[data-qa="next-button"]' });
     const absent = await send({ action: 'check_element', selector: '[data-qa="missing-button"]' });
     const noSelector = await send({ action: 'check_element' });
@@ -328,8 +329,11 @@ const SCENARIOS = {
       found: present.element?.found ?? null,
       visible: present.element?.visible ?? null,
       obstructionChecked: present.element?.obstructionChecked ?? null,
+      matchCount: present.element?.matchCount ?? null,
       absentFound: absent.element?.found ?? null,
+      absentMatchCount: absent.element?.matchCount ?? null,
       noSelectorFound: noSelector.element?.found ?? null,
+      noSelectorMatchCount: noSelector.element?.matchCount ?? null,
     };
   },
 };

--- a/tests/test_auth_code.py
+++ b/tests/test_auth_code.py
@@ -6,9 +6,12 @@ import stat
 import pytest
 from playwright.sync_api import Error as PlaywrightError
 
+from hhru_bot.apply.antibot import ANTIBOT_MARKER_SELECTORS
 from hhru_bot.auth_code import _read_code, login_with_code, mask_login
 
 pytestmark = pytest.mark.integration
+
+ANTIBOT_MARKER_SELECTORS_VALUES = frozenset(value for _name, value in ANTIBOT_MARKER_SELECTORS)
 
 
 def test_mask_login():
@@ -24,6 +27,9 @@ class _Locator:
 
     def count(self):
         return self._count() if callable(self._count) else self._count
+
+    def filter(self, *, visible=None):  # noqa: ARG002
+        return self
 
     @property
     def first(self):
@@ -90,8 +96,9 @@ class _Context:
 
 
 class _Page:
-    def __init__(self, body=""):
+    def __init__(self, body="", *, antibot_marker=False):
         self.body = body
+        self.antibot_marker = antibot_marker
         self.stage = "start"
         self.email_selected = False
         self.code = None
@@ -112,6 +119,8 @@ class _Page:
             return _Locator(self, count=0 if self.context and self.context._cookies else 1)
         if selector == "body":
             return _Locator(self)
+        if selector in ANTIBOT_MARKER_SELECTORS_VALUES:
+            return _Locator(self, count=int(self.antibot_marker))
         raise AssertionError(f"unexpected selector: {selector}")
 
     def wait_for_timeout(self, _milliseconds):
@@ -205,6 +214,37 @@ def test_login_with_code_browser_error_is_fail_closed(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="Ошибка браузера"):
         login_with_code(_config(tmp_path), "person@example.com", code_file=code_file)
     assert context.saved is None
+
+
+def test_login_with_code_visible_captcha_marker_is_fail_closed(monkeypatch, tmp_path):
+    """Видимый narrow-маркер #344 — капча, вход отменяется до запроса кода."""
+    page = _Page(antibot_marker=True)
+    context = _Context(page)
+    monkeypatch.setattr("hhru_bot.auth_code.launch_context", lambda *args, **kwargs: context)
+    monkeypatch.setattr("hhru_bot.auth_code.goto_hh", lambda *_args: None)
+    code_file = tmp_path / "code.txt"
+    code_file.write_text("1234", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="требует капчу"):
+        login_with_code(_config(tmp_path), "person@example.com", code_file=code_file)
+    assert context.saved is None
+
+
+def test_login_with_code_captcha_word_in_body_text_does_not_block(monkeypatch, tmp_path):
+    """#1006: слово «капча» в тексте body без видимого маркера — НЕ капча.
+
+    Прежняя проверка искала подстроку в inner_text всего body и отказывала
+    во входе на любом нерелевантном упоминании; решение теперь по узким
+    маркерам detect_antibot_on_page (#344)."""
+    page = _Page(body="Что делать, если не приходит капча или код из SMS")
+    context = _Context(page)
+    monkeypatch.setattr("hhru_bot.auth_code.launch_context", lambda *args, **kwargs: context)
+    monkeypatch.setattr("hhru_bot.auth_code.goto_hh", lambda *_args: None)
+    code_file = tmp_path / "code.txt"
+    code_file.write_text("1234\n", encoding="utf-8")
+
+    login_with_code(_config(tmp_path), "person@example.com", code_file=code_file)
+    assert context.saved is True
 
 
 def test_read_code_stdin_timeout(monkeypatch):

--- a/tests/test_hhru_live_behavior.py
+++ b/tests/test_hhru_live_behavior.py
@@ -196,11 +196,14 @@ def test_hhru_live_policy_unknown_action_rejected():
 
 def test_hhru_live_policy_check_element_confirms_next_step():
     """Подтверждение «следующий элемент доступен»: found/visible по селектору;
-    obstruction-проба в стабе недоступна и честно репортится как непроверенная."""
+    obstruction-проба в стабе недоступна и честно репортится как непроверенная.
+    matchCount (#1006): неоднозначный селектор не должен выглядеть как однозначный."""
     scenario = _run_command_scenario("check_element")
     assert scenario["found"] and scenario["visible"]
     assert scenario["obstructionChecked"] is False
+    assert scenario["matchCount"] == 2
     assert scenario["absentFound"] is False and scenario["noSelectorFound"] is False
+    assert scenario["absentMatchCount"] == 0 and scenario["noSelectorMatchCount"] == 0
 
 
 def test_hhru_live_policy_dismiss_hidden_overlay_does_not_click():

--- a/tests/test_plugin_packaging.py
+++ b/tests/test_plugin_packaging.py
@@ -52,7 +52,7 @@ def test_codex_repo_marketplace_points_to_a_release_not_floating_main():
     assert plugin["source"] == {
         "source": "url",
         "url": "https://github.com/axisrow/hhru.git",
-        "ref": "v0.1.0",
+        "ref": f"v{version}",
     }
     assert plugin["policy"] == {
         "installation": "AVAILABLE",

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 import tarfile
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -19,20 +20,31 @@ pytestmark = pytest.mark.smoke
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
 
 
+def _project_version() -> str:
+    # (#1006 CI) версия берётся из pyproject, а не хардкодится: тесты
+    # иначе ломаются на каждом релизном bump (сломалось на 0.1.1).
+    with (Path(__file__).parents[1] / "pyproject.toml").open("rb") as stream:
+        return tomllib.load(stream)["project"]["version"]
+
+
+VERSION = _project_version()
+TAG = f"v{VERSION}"
+
+
 def test_release_bundle_stamps_every_manifest_and_contains_installed_skill(tmp_path, monkeypatch):
     # The checkout may contain the real v0.1.0 tag after fetching origin. This
     # test deliberately uses a synthetic provenance SHA, so tag-object
     # validation is covered separately from bundle stamping.
     monkeypatch.setattr(release_module, "_assert_tag_points_to_commit", lambda *_args: None)
-    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+    archive = build_release(Path(__file__).parents[1], tmp_path, TAG, COMMIT)
 
     with tarfile.open(archive, "r:gz") as opened:
         opened.extractall(tmp_path / "installed", filter="data")
     bundle = next((tmp_path / "installed").iterdir())
     expected = {
-        "version": "0.1.0",
-        "release": "v0.1.0",
-        "tag": "v0.1.0",
+        "version": VERSION,
+        "release": TAG,
+        "tag": TAG,
         "commit_sha": COMMIT,
     }
 
@@ -48,7 +60,7 @@ def test_release_bundle_stamps_every_manifest_and_contains_installed_skill(tmp_p
 
 def test_release_validation_rejects_manifest_from_another_commit(tmp_path, monkeypatch):
     monkeypatch.setattr(release_module, "_assert_tag_points_to_commit", lambda *_args: None)
-    archive = build_release(Path(__file__).parents[1], tmp_path, "v0.1.0", COMMIT)
+    archive = build_release(Path(__file__).parents[1], tmp_path, TAG, COMMIT)
     with tarfile.open(archive, "r:gz") as opened:
         opened.extractall(tmp_path / "installed", filter="data")
     bundle = next((tmp_path / "installed").iterdir())
@@ -61,9 +73,9 @@ def test_release_validation_rejects_manifest_from_another_commit(tmp_path, monke
         validate_bundle(
             bundle,
             {
-                "version": "0.1.0",
-                "release": "v0.1.0",
-                "tag": "v0.1.0",
+                "version": VERSION,
+                "release": TAG,
+                "tag": TAG,
                 "commit_sha": COMMIT,
             },
         )


### PR DESCRIPTION
Closes #1006

## Что сделано

1. **checkElement matchCount** (`extensions/hhru-live/content.js`) — ответ
   `check_element` теперь несёт `matchCount` (0 при отсутствии), так что
   неоднозначный селектор не читается агентом как «тот самый» элемент.
   Обновлены js-harness сценарий и страж `test_hhru_live_behavior.py`.
2. **Semantic-trap note `resume-title`** (`selectors/reference-map.yaml`,
   `selector_groups/apply_form.py`) — по образцу WORK_PERMIT_WIZARD: qa-имя
   `resume-title` — триггер пикера резюме в форме отклика, а НЕ заголовок
   резюме; тот же data-qa на `/applicant/resumes` обслуживает карточку списка.
   `selector_contracts render`+`check` пройдены.
3. **Substring-детекты → локаторы/узкие маркеры** (live-сверка 2026-09-07):
   - `competitors.parse_search_page`: пустая выдача подтверждается только
     локатором `[data-qa='empty-search-block']` (`competitor_resume.SEARCH_EMPTY`
     перезаписан живым значением вместо неподтверждённого union). Live-fact:
     реальный empty-state — h2 «Ничего не нашлось» + «Попробуйте изменить
     формулировку или фильтры»; прежние подстроки «резюме не найден» /
     «ничего не найден» живую формулировку НЕ ловили вовсе (код всегда падал бы
     в indeterminate на настоящем empty-state). Бонус live-сверки: hh.ru при
     `pos=all` фаззи-фолбэчится в рекомендации и текстовый запрос фактически
     игнорирует — пустая выдача достижима только при `pos=position`.
   - `auth_code._raise_for_captcha_or_timeout`: решение по узким маркерам #344
     (`detect_antibot_on_page`), не по подстроке «капч» в inner_text body —
     слово в нерелевантном блоке больше не отменяет вход. Новые тесты:
     видимый маркер → fail-closed; «капча» в тексте без маркера → вход идёт.
4. **resume_views identity — заблокировано live-дрейфом, зафиксировано.**
   Live-проверка identity-поля в `applicantResumeViewHistory` (pending #428
   round 13) предпринята 2026-09-07: `/applicant/resumeview/history` отдаёт
   «Ошибка 400» залогиненной сессии во всех вариантах (без параметров /
   `resume=` / `page=0,1` / `resumeHash=`), авторизация подтверждена census
   (залогиненная шапка рендерится). Поле подтвердить нечем — cross-check не
   вводится, факт задокументирован в docstring; 400 держит команду fail-closed.
5. **state-источник в выводе resume-position** — title в dry-run плане
   (wizard-путь, fallback #910) и роли/прочитанные значения в post-save
   readback помечаются суффиксом `(state)`, чтобы JSON-бандл не принимали
   за отрисованный DOM.

## Тесты

- `ruff check` + `ruff format --check` — чисто.
- Полный сюит `pytest -q -n 4 --dist worksteal`: зелёный, кроме 5
  предсуществующих падений release/plugin-packaging (воспроизводятся на
  главном чекауте без моего диффа — отдельная история про 0.1.1 bump).
- Селекторный контракт: `selector_contracts.py render` + `check` — OK (305).

## Риски

- П.4 остаётся открытым вопросом до возврата маршрута на hh.ru (для
  идентичности это fail-closed, не регрессия).
- `SEARCH_EMPTY` значение заменено (не добавлено), count.txt не изменился.
