### PR TITLE
fix(list-resumes): визард дозаполнения вместо списка — черновик читается из URL визарда

### DIFF
--- a/src/hhru_bot/commands/list_resumes.py
+++ b/src/hhru_bot/commands/list_resumes.py
@@ -135,11 +135,15 @@ def _live_rows(cards, alias_by_hash: dict[str, str], with_status: bool, throttle
     """
     rows: list[list[str]] = []
     for card in cards:
+        status_cell = _format_status(card.status)
+        if getattr(card, "unfinished_screen", None):
+            # Черновик из визард-ветки: какой экран hh.ru считает незакрытым.
+            status_cell = f"{status_cell}, незавершённый экран {card.unfinished_screen}"
         row = [
             card.resume_id,
             alias_by_hash.get(card.resume_id, "—"),
             card.title or "—",
-            _format_status(card.status),
+            status_cell,
         ]
         if with_status:
             if hasattr(card, "is_searchable"):
@@ -194,7 +198,8 @@ def run(args: argparse.Namespace) -> None:
         has_login_form,
         launch_context,
     )
-    from ..copy_resume import ResumeListIndeterminate, list_resume_cards
+    from ..common import _on_wizard_common
+    from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
 
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -226,8 +231,19 @@ def run(args: argparse.Namespace) -> None:
                 "при наличии hhtoken). Выполните login."
             )
             return
+        # Живой факт 2026-09-07 (marketing, census на my_resumes): на аккаунте
+        # с единственным незавершённым черновиком hh.ru рендерит на my_resumes
+        # ЭКРАН ДОЗАПОЛНЕНИЯ визарда (resume-profile-screen_common) — карточек
+        # [data-qa='resume'] нет вовсе, и list_resume_cards падает по
+        # 30-секундному таймауту. Экран приходит SSR-разметкой (census видел
+        # его сразу после загрузки), поэтому мгновенной проверки достаточно:
+        # опоздавший рендер уйдёт в прежний путь с его честным отказом.
+        wizard_mode = _on_wizard_common(page)
         try:
-            cards = list_resume_cards(page, navigate=False)
+            if wizard_mode:
+                cards = list_wizard_drafts(page)
+            else:
+                cards = list_resume_cards(page, navigate=False)
         except ResumeListIndeterminate as e:
             # Timeout/интерстишл/дрейф селектора — не подтверждённо пустой
             # аккаунт. Не выдаём это за «резюме не найдено» (см. copy_resume.py);
@@ -240,7 +256,9 @@ def run(args: argparse.Namespace) -> None:
         print("[INFO] На hh.ru не найдено ни одного резюме.")
         return
 
-    if not any(c.title for c in cards):
+    if not any(c.title for c in cards) and not wizard_mode:
+        # В визард-ветке title приходит identity-bound readback'ом (не селектором
+        # карточек) — это предупреждение про другой механизм чтения там ложно.
         print(
             "[INFO] Название резюме не удалось прочитать (селектор заголовка "
             "не подтверждён) — колонка «название» может быть неточной."
@@ -262,6 +280,15 @@ def run(args: argparse.Namespace) -> None:
         header += ["можно bump", "последний bump"]
     print()
     print(_ascii_table(header, _live_rows(cards, alias_by_hash, args.status, throttle, history)))
+
+    if wizard_mode:
+        print()
+        print(
+            "[INFO] hh.ru открыл экран дозаполнения визарда вместо списка "
+            "карточек (незавершённый черновик). Черновик выше прочитан из URL "
+            "визарда + страницы резюме. Дозаполнение: common --resume "
+            "<resume_id> ... / wizard-next --resume <resume_id>."
+        )
 
     hidden_published = [
         card

--- a/src/hhru_bot/commands/list_resumes.py
+++ b/src/hhru_bot/commands/list_resumes.py
@@ -200,6 +200,7 @@ def run(args: argparse.Namespace) -> None:
     )
     from ..common import _on_wizard_common
     from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
+    from ..responses import NotAuthenticated
 
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -244,6 +245,14 @@ def run(args: argparse.Namespace) -> None:
                 cards = list_wizard_drafts(page)
             else:
                 cards = list_resume_cards(page, navigate=False)
+        except NotAuthenticated as exc:
+            # В визард-ветке list_wizard_drafts делает identity-bound readback
+            # (open_confirmed_resume -> require_authenticated_page): сессия может
+            # протухнуть посреди команды, и это sibling ResumeListIndeterminate под
+            # PageStateIndeterminate — без явного лова был бы traceback вместо
+            # [FAIL] (конвенция: commands/delete_resume.py).
+            print(f"[FAIL] Сессия недействительна: {exc}")
+            return
         except ResumeListIndeterminate as e:
             # Timeout/интерстишл/дрейф селектора — не подтверждённо пустой
             # аккаунт. Не выдаём это за «резюме не найдено» (см. copy_resume.py);

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -30,6 +30,7 @@ from .browser import (
     goto_hh,
     has_auth_cookie,
     has_login_form,
+    open_confirmed_resume,
 )
 from .config import ResumeConfig
 from .negotiations_probe import parse_initial_state
@@ -38,6 +39,13 @@ from .negotiations_probe import parse_initial_state
 # copy-resume-only variant; the command layer already treats this shared
 # PageStateIndeterminate subtype as an expired-session failure.
 from .responses import NotAuthenticated
+from .resume_ids import (
+    RESUME_ID_FROM_PATH_OR_QUERY_RE,
+    card_resume_id,
+    read_ssr_resume_items,
+    resume_card_locator,
+    resume_item_attrs,
+)
 
 # Имена `_card_hashes` и `_RESUME_HASH_RE` сохранены как тестируемый seam:
 # тесты monkeypatch'ат их в этом модуле, и вызовы copy_resume_on_hh обязаны
@@ -46,15 +54,10 @@ from .resume_ids import (
     RESUME_ID_FROM_PATH_RE as _RESUME_HASH_RE,
 )
 from .resume_ids import (
-    card_resume_id,
-    read_ssr_resume_items,
-    resume_card_locator,
-    resume_item_attrs,
-)
-from .resume_ids import (
     page_card_hashes as _card_hashes,
 )
 from .resume_limits import RESUME_QUOTA_UNREADABLE_REASON, resume_limit_reason
+from .resume_state import parse_resume_state
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -71,6 +74,11 @@ logger = logging.getLogger("hhru_bot.copy_resume")
 # operation at the dedicated, stable list surface (#311).
 RESUMES_LIST_URL = RESUMES_FULL_LIST_URL
 COPY_TIMEOUT_MS = 30_000
+# Визард дозаполнения: hh.ru переписывает URL на /profile/resume/common?resume=<id>
+# (живой факт 2026-09-07). goto_hh уже дождался load, но SPA-редирект на визард
+# может догонять — бюджет на появление resume= в URL до первого решения.
+_WIZARD_URL_SETTLE_POLL_MS = 250
+_WIZARD_URL_SETTLE_ATTEMPTS = 20  # 20 × 250 мс = 5 c
 PROFILE_STALL_SECONDS = 15.0
 PROFILE_ABSOLUTE_TIMEOUT_SECONDS = 300.0
 PROFILE_POLL_MS = 250
@@ -104,6 +112,10 @@ class ResumeCard:
     # searchable flag.  Do not infer visibility from publication status.
     is_searchable: bool | None = None
     ssr_unavailable: bool = False  # True если SSR данные недоступны или некорректны
+    # nextIncompleteScreenId черновика, прочитанный identity-bound readback'ом
+    # (list_wizard_drafts); None у обычных карточек списка — карточки списка
+    # этот экран не показывают.
+    unfinished_screen: str | None = None
 
 
 @dataclass(frozen=True)
@@ -471,6 +483,61 @@ def list_resume_cards(
             )
         )
     return cards
+
+
+def list_wizard_drafts(page: Page) -> list[ResumeCard]:
+    """Резюме аккаунта, когда hh.ru рендерит ВИЗАВД дозаполнения вместо списка.
+
+    Живой факт 2026-09-07 (marketing, census на /applicant/my_resumes): у
+    аккаунта с единственным незавершённым черновиком hh.ru не показывает
+    карточки [data-qa='resume'] вовсе — вместо списка рендерится экран
+    ``common`` визарда, и list_resume_cards честно падает по 30-секундному
+    таймауту. Карточек и SSR ``applicantResumes`` на этой странице нет
+    (живой probe 2026-09-07: InitialState визарда секцию не содержит);
+    источник идентичности — URL: hh.ru переписывает его на
+    ``/profile/resume/common?resume=<id>`` — та же query-форма ``resume=``,
+    которой create-resume доверяет с #778. Данные (title/статус/
+    nextIncompleteScreenId) дочитываются identity-bound readback'ом страницы
+    резюме (тот же путь, что доказывает черновик в create-resume:
+    open_confirmed_resume + parse_resume_state). READ-only: goto + чтение,
+    ничего не кликается. Ветка показывает Тот черновик, который визард
+    дозаполняет, — прочие (гипотетические) черновики не заявляются.
+
+    Fail-closed: resume_id не появился в URL за бюджет (редирект на визард
+    не завершился) — ResumeListIndeterminate (та же таксономия, что у
+    list_resume_cards): неподтверждённое состояние, а не «резюме нет».
+    """
+    resume_hash = ""
+    for _attempt in range(_WIZARD_URL_SETTLE_ATTEMPTS):
+        match = RESUME_ID_FROM_PATH_OR_QUERY_RE.search(page.url)
+        if match:
+            resume_hash = match.group(1)
+            break
+        page.wait_for_timeout(_WIZARD_URL_SETTLE_POLL_MS)
+    if not resume_hash:
+        raise ResumeListIndeterminate(
+            "экран дозаполнения черновика открыт вместо списка карточек, но "
+            f"resume_id не появился в URL за бюджет "
+            f"{_WIZARD_URL_SETTLE_ATTEMPTS * _WIZARD_URL_SETTLE_POLL_MS} мс "
+            f"(URL: {page.url}) — список не подтверждён"
+        )
+
+    # Identity-bound readback: открытая страница визарда не содержит title,
+    # поэтому черновик дочитывается на своей странице (goto + строгие
+    # auth/identity-проверки — как у create-resume).
+    open_confirmed_resume(page, resume_hash)
+    state = parse_resume_state(page.content(), resume_hash)
+    return [
+        ResumeCard(
+            resume_id=resume_hash,
+            title=state.title or "",
+            url=f"{HH_BASE_URL}/resume/{resume_hash}",
+            status=state.status,
+            is_searchable=state.is_searchable,
+            ssr_unavailable=False,
+            unfinished_screen=state.next_incomplete_screen_id,
+        )
+    ]
 
 
 class ResumeIdMapping(dict[str, str]):

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -354,6 +354,104 @@ def test_non_dict_ssr_state_marks_unavailable(monkeypatch, raw_state):
     assert cards[0].ssr_unavailable
 
 
+# --- list_wizard_drafts (экран дозаполнения вместо списка, 2026-09-07) ---------
+
+
+class _WizardPage:
+    """Страница визарда: URL переписан на /profile/resume/common?resume=<id>,
+    SSR applicantResumes отсутствует (живой probe 2026-09-07), карточек нет.
+
+    ``land_on(resume_id, markup)`` подменяет content() — как реальная
+    навигация open_confirmed_resume меняет страницу на страницу резюме."""
+
+    def __init__(self, url: str):
+        self.url = url
+        self._content = ""
+        self.landed: list[str] = []
+        self.settled_polls = 0
+
+    def wait_for_timeout(self, ms):
+        # первый poll «дожидается» SPA-редиректа: URL получает resume=<id>
+        self.settled_polls += 1
+        if "?resume=" not in self.url:
+            self.url = f"{self.url.split('?')[0]}?resume={ID_A}"
+
+    def locator(self, selector):
+        raise AssertionError(f"list_wizard_drafts не читает локаторы: {selector}")
+
+    def content(self):
+        return self._content
+
+    def land_on(self, resume_id: str, markup: str) -> None:
+        self._content = markup
+        self.landed.append(resume_id)
+
+
+_RESUME_MARKUP = json.dumps(
+    {
+        "resumes": [
+            {
+                # nextIncompleteScreenId живёт в identity-записи (_attributes),
+                # title — в теле элемента (живой shape bootstrap, resume_state.py)
+                "_attributes": {
+                    "hash": ID_A,
+                    "status": "not_finished",
+                    "nextIncompleteScreenId": "common",
+                },
+                "title": [{"string": "Тестировщик программного обеспечения"}],
+            }
+        ]
+    },
+    ensure_ascii=False,
+)
+
+
+def test_list_wizard_drafts_reads_title_and_screen_from_readback(monkeypatch):
+    """Черновик из URL-формы ``resume=`` (живой факт 2026-09-07: hh.ru
+    переписывает URL на /profile/resume/common?resume=<id>) + identity-bound
+    readback: title/статус/nextIncompleteScreenId дочитываются со страницы
+    резюме — тот же путь, что доказывает черновик в create-resume."""
+    page = _WizardPage(f"https://hh.ru/profile/resume/common?resume={ID_A}")
+    monkeypatch.setattr(
+        cr, "open_confirmed_resume", lambda p, rid, **_kw: p.land_on(rid, _RESUME_MARKUP)
+    )
+
+    cards = cr.list_wizard_drafts(page)
+
+    assert page.landed == [ID_A]
+    assert page.settled_polls == 0  # id был в URL сразу — poll не понадобился
+    assert len(cards) == 1
+    assert cards[0].resume_id == ID_A
+    assert cards[0].title == "Тестировщик программного обеспечения"
+    assert cards[0].status == "not_finished"
+    assert cards[0].unfinished_screen == "common"
+    assert cards[0].url == f"https://hh.ru/resume/{ID_A}"
+
+
+def test_list_wizard_drafts_waits_for_late_url_settle(monkeypatch):
+    """SPA-редирект на визард догоняет после load: id появляется в URL не сразу —
+    бюджет poll'а снимает гонку (паттерн «commit не значит отрисовано»)."""
+    page = _WizardPage("https://hh.ru/applicant/my_resumes")
+    monkeypatch.setattr(
+        cr, "open_confirmed_resume", lambda p, rid, **_kw: p.land_on(rid, _RESUME_MARKUP)
+    )
+
+    cards = cr.list_wizard_drafts(page)
+
+    assert page.settled_polls == 1
+    assert cards[0].resume_id == ID_A
+
+
+def test_list_wizard_drafts_fails_closed_when_url_never_settles():
+    """Визард открыт, но resume= в URL так и не появился — прежняя таксономия:
+    indeterminate, не «резюме нет» и не пустой список за факт."""
+    page = _WizardPage("https://hh.ru/applicant/my_resumes")
+    page.wait_for_timeout = lambda ms: None  # URL не меняется никогда
+
+    with pytest.raises(cr.ResumeListIndeterminate, match="resume_id не появился в URL"):
+        cr.list_wizard_drafts(page)
+
+
 # --- resolve_numeric_resume_ids (#212) ----------------------------------------
 #
 # Маппинг «хэш резюме → числовой id» из SSR /applicant/resumes: Applicant

--- a/tests/test_list_resumes_command.py
+++ b/tests/test_list_resumes_command.py
@@ -229,11 +229,14 @@ def test_registers_list_resumes_subparser():
 
 
 class _FakeCard:
-    def __init__(self, resume_id, title, status=None, ssr_unavailable=False):
+    def __init__(
+        self, resume_id, title, status=None, ssr_unavailable=False, unfinished_screen=None
+    ):
         self.resume_id = resume_id
         self.title = title
         self.status = status
         self.ssr_unavailable = ssr_unavailable
+        self.unfinished_screen = unfinished_screen
 
 
 class _StubThrottle:
@@ -547,6 +550,96 @@ def test_default_live_indeterminate_state_prints_fail_not_empty(capsys, tmp_path
     assert "не найдено" not in out
     # fallback на локальную таблицу не происходит
     assert "backend" not in out
+
+
+# --- визард-ветка (экран дозаполнения вместо списка, 2026-09-07) ---------------
+
+
+def _patch_wizard(monkeypatch, drafts, *, predicate=True):
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeContext())
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url, **kw: None)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: predicate)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", lambda page: list(drafts))
+
+    def _boom(page, navigate=True):
+        raise AssertionError("в визард-ветке list_resume_cards не вызывается")
+
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", _boom)
+
+
+def test_wizard_mode_lists_draft_with_screen_hint(capsys, tmp_path, monkeypatch):
+    """Единственный незавершённый черновик: hh.ru рендерит экран дозаполнения
+    вместо карточек — команда читает черновик через list_wizard_drafts, печатает
+    таблицу с незавершённым экраном и подсказку дозаполнения, не [FAIL]."""
+    config = _live_env(tmp_path, monkeypatch)
+    drafts = [
+        _FakeCard(
+            "88888888",
+            "Тестировщик программного обеспечения",
+            status="not_finished",
+            unfinished_screen="common",
+        )
+    ]
+    _patch_wizard(monkeypatch, drafts)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" not in out
+    assert "88888888" in out
+    assert "Тестировщик программного обеспечения" in out
+    assert "черновик, незавершённый экран common" in out
+    assert "экран дозаполнения" in out
+    assert "wizard-next --resume" in out
+
+
+def test_wizard_mode_indeterminate_still_fails_closed(capsys, tmp_path, monkeypatch):
+    """Визард открыт, но черновики не прочитаны — прежний честный [FAIL],
+    не «резюме не найдено» и не пустая таблица."""
+    from hhru_bot.copy_resume import ResumeListIndeterminate
+
+    config = _live_env(tmp_path, monkeypatch)
+
+    def _raise(page):
+        raise ResumeListIndeterminate(
+            "экран дозаполнения черновика открыт, но resume_id не появился в URL"
+        )
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeContext())
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url, **kw: None)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: True)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _raise)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "resume_id не появился в URL" in out
+    assert "не найдено" not in out
+
+
+def test_no_wizard_keeps_card_list_path(capsys, tmp_path, monkeypatch):
+    """Предикат визарда False — прежний путь list_resume_cards; визард-ридер
+    не дёргается вовсе."""
+    config = _live_env(tmp_path, monkeypatch)
+    fake_cards = [_FakeCard("11111111", "Backend developer", "modified")]
+    _patch_live(monkeypatch, fake_cards)
+
+    def _boom_wizard(page):
+        raise AssertionError("вне визарда list_wizard_drafts не вызывается")
+
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: False)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _boom_wizard)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "11111111" in out
+    assert "экран дозаполнения" not in out
 
 
 def test_default_live_stale_cookie_rejects_login_form(capsys, tmp_path, monkeypatch):

--- a/tests/test_list_resumes_command.py
+++ b/tests/test_list_resumes_command.py
@@ -622,6 +622,30 @@ def test_wizard_mode_indeterminate_still_fails_closed(capsys, tmp_path, monkeypa
     assert "не найдено" not in out
 
 
+def test_wizard_mode_not_authenticated_fails_clean(capsys, tmp_path, monkeypatch):
+    """Сессия протухла посреди identity-bound readback визарда — [FAIL], а не
+    traceback: NotAuthenticated ловится явно (конвенция delete_resume)."""
+    from hhru_bot.responses import NotAuthenticated
+
+    config = _live_env(tmp_path, monkeypatch)
+
+    def _raise(page):
+        raise NotAuthenticated("страница резюме содержит форму входа")
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeContext())
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url, **kw: None)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: True)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _raise)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "[FAIL] Сессия недействительна" in out
+    assert "Traceback" not in out
+
+
 def test_no_wizard_keeps_card_list_path(capsys, tmp_path, monkeypatch):
     """Предикат визарда False — прежний путь list_resume_cards; визард-ридер
     не дёргается вовсе."""


### PR DESCRIPTION
## Что случилоcь

`list-resumes` на аккаунте с единственным незавершённым черновиком падал:

```
[FAIL] карточки резюме не появились за отведённое время — состояние
/applicant/resumes не подтверждено (timeout, анти-бот/интерстишл-страница
или дрейф селектора RESUME_LIST_CARD)
```

Без `resume_id` недоступны `common --resume` / `wizard-next --resume` —
дозаполнение черновика блокировалось целиком.

## Живая диагностика 2026-09-07 (второй аккаунт, сессия валидна)

- census на РЕАЛЬНОМ URL команды (`/applicant/my_resumes`): hh.ru рендерит
  экран `common` визарда дозаполнения (`resume-profile-screen_common`,
  `resume-profile-next-screen`), карточек `[data-qa='resume']` нет вовсе.
- SSR-probe той же страницы: `HH-Lux-InitialState` присутствует, но секции
  `applicantResumes` в нём НЕТ — SSR-путь списка здесь не работает.
- URL страницы переписывается на `/profile/resume/common?resume=<id>` —
  та же query-форма `resume=`, которой create-resume доверяет с #778.
- Под основным аккаунтом (есть опубликованные резюме) список рендерится
  как обычно — состояние специфично для «только незавершённый черновик».

## Изменения

- `copy_resume.list_wizard_drafts(page)`: identity черновика — из URL
  (бюджет poll 250мс x 20 на SPA-редирект), данные — identity-bound
  readback `open_confirmed_resume` + `parse_resume_state` (title / статус /
  nextIncompleteScreenId; тот же путь, что доказывает черновик в
  create-resume). Fail-closed: `resume_id` не появился в URL —
  `ResumeListIndeterminate` с URL в диагностике.
- `commands/list_resumes.py`: предикат `common._on_wizard_common` после
  goto и ДО `list_resume_cards` — контракт коллектора и его потребители
  (import-resume / edit-experience / verify_wizard_save) не меняются.
  Статус-колонка дополняется «незавершённый экран X», после таблицы —
  INFO-подсказка дозаполнения. Вне визарда путь и задержки прежние.
- `ResumeCard.unfinished_screen` — additive, `None` у обычных карточек.

## Проверки

- `pytest` полный — зелёный; `ruff check` + `ruff format --check` — чисто.
- Живой acceptance (боевой код ветки, read-only команда):
  `list-resumes` печатает таблицу с черновиком: resume_id, титул, статус
  «черновик, незавершённый экран common» + INFO-подсказка (реальный
  resume_id здесь сознательно не приводится, правило проекта). Было [FAIL].
- Основной аккаунт не затронут; `--local` и обычный live-путь без визарда
  покрыты тестами (в т.ч. «визард-ридер не дёргается вне визарда»).

Мерж — за владельцем.

Closes #1034
