### PR TITLE
fix(common): write-путь визарда — гидрация полей, ДР DD.MM.YYYY, gender-чип, телефон-маска, плейсхолдеры ридера

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Write-команды (`apply`/`bump`/`run`/...) сначала `--dry-run`, по
 - `--resume` — Slug из конфига или resume_id HH.ru
 - `--first-name` — Имя
 - `--last-name` — Фамилия
-- `--birthday` — Дата в формате, который принимает форма hh.ru
+- `--birthday` — Дата рождения DD.MM.YYYY (полностью; месяц/год — magritte-комбобоксы)
 - `--gender` — Пол
 - `--phone` — Телефон
 - `--area` — Точный leaf города из live-каталога hh.ru

--- a/src/hhru_bot/commands/common.py
+++ b/src/hhru_bot/commands/common.py
@@ -19,7 +19,10 @@ def register(subparsers) -> None:
     parser.add_argument("--resume", required=True, help="Slug из конфига или resume_id HH.ru")
     parser.add_argument("--first-name", dest="first_name", help="Имя")
     parser.add_argument("--last-name", dest="last_name", help="Фамилия")
-    parser.add_argument("--birthday", help="Дата в формате, который принимает форма hh.ru")
+    parser.add_argument(
+        "--birthday",
+        help="Дата рождения DD.MM.YYYY (полностью; месяц/год — magritte-комбобоксы)",
+    )
     parser.add_argument("--gender", choices=("male", "female"), help="Пол")
     parser.add_argument("--phone", help="Телефон")
     parser.add_argument("--area", help="Точный leaf города из live-каталога hh.ru")

--- a/src/hhru_bot/commands/list_resumes.py
+++ b/src/hhru_bot/commands/list_resumes.py
@@ -135,11 +135,15 @@ def _live_rows(cards, alias_by_hash: dict[str, str], with_status: bool, throttle
     """
     rows: list[list[str]] = []
     for card in cards:
+        status_cell = _format_status(card.status)
+        if getattr(card, "unfinished_screen", None):
+            # Черновик из визард-ветки: какой экран hh.ru считает незакрытым.
+            status_cell = f"{status_cell}, незавершённый экран {card.unfinished_screen}"
         row = [
             card.resume_id,
             alias_by_hash.get(card.resume_id, "—"),
             card.title or "—",
-            _format_status(card.status),
+            status_cell,
         ]
         if with_status:
             if hasattr(card, "is_searchable"):
@@ -194,7 +198,8 @@ def run(args: argparse.Namespace) -> None:
         has_login_form,
         launch_context,
     )
-    from ..copy_resume import ResumeListIndeterminate, list_resume_cards
+    from ..common import _on_wizard_common
+    from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
 
     with launch_context(
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
@@ -226,8 +231,19 @@ def run(args: argparse.Namespace) -> None:
                 "при наличии hhtoken). Выполните login."
             )
             return
+        # Живой факт 2026-09-07 (marketing, census на my_resumes): на аккаунте
+        # с единственным незавершённым черновиком hh.ru рендерит на my_resumes
+        # ЭКРАН ДОЗАПОЛНЕНИЯ визарда (resume-profile-screen_common) — карточек
+        # [data-qa='resume'] нет вовсе, и list_resume_cards падает по
+        # 30-секундному таймауту. Экран приходит SSR-разметкой (census видел
+        # его сразу после загрузки), поэтому мгновенной проверки достаточно:
+        # опоздавший рендер уйдёт в прежний путь с его честным отказом.
+        wizard_mode = _on_wizard_common(page)
         try:
-            cards = list_resume_cards(page, navigate=False)
+            if wizard_mode:
+                cards = list_wizard_drafts(page)
+            else:
+                cards = list_resume_cards(page, navigate=False)
         except ResumeListIndeterminate as e:
             # Timeout/интерстишл/дрейф селектора — не подтверждённо пустой
             # аккаунт. Не выдаём это за «резюме не найдено» (см. copy_resume.py);
@@ -240,7 +256,9 @@ def run(args: argparse.Namespace) -> None:
         print("[INFO] На hh.ru не найдено ни одного резюме.")
         return
 
-    if not any(c.title for c in cards):
+    if not any(c.title for c in cards) and not wizard_mode:
+        # В визард-ветке title приходит identity-bound readback'ом (не селектором
+        # карточек) — это предупреждение про другой механизм чтения там ложно.
         print(
             "[INFO] Название резюме не удалось прочитать (селектор заголовка "
             "не подтверждён) — колонка «название» может быть неточной."
@@ -262,6 +280,15 @@ def run(args: argparse.Namespace) -> None:
         header += ["можно bump", "последний bump"]
     print()
     print(_ascii_table(header, _live_rows(cards, alias_by_hash, args.status, throttle, history)))
+
+    if wizard_mode:
+        print()
+        print(
+            "[INFO] hh.ru открыл экран дозаполнения визарда вместо списка "
+            "карточек (незавершённый черновик). Черновик выше прочитан из URL "
+            "визарда + страницы резюме. Дозаполнение: common --resume "
+            "<resume_id> ... / wizard-next --resume <resume_id>."
+        )
 
     hidden_published = [
         card

--- a/src/hhru_bot/commands/list_resumes.py
+++ b/src/hhru_bot/commands/list_resumes.py
@@ -198,6 +198,12 @@ def run(args: argparse.Namespace) -> None:
         has_login_form,
         launch_context,
     )
+
+    # Осознанный private-кросс-импорт: предикат принадлежит common.py (его
+    # write-гейтам), здесь — тот же детектор, чтобы не плодить второй.
+    # Прецедент в кодовой базе: commands/probe.py импортирует
+    # _build_letter_provider из ._common. Если таких импортов станет больше —
+    # вынести в маленький публичный хелпер.
     from ..common import _on_wizard_common
     from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
 

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -99,6 +99,9 @@ REQUIRED_FIELDS = (
 BIRTHDAY_MONTH = "[data-qa='resume-profile-common-birthday-month-selector']"
 BIRTHDAY_YEAR = "[data-qa='resume-profile-common-birthday-year-input']"
 CITIZENSHIP_SELECTOR = "[data-qa='resume-profile-common-citizenship-selector']"
+# Тексты-плейсхолдеры magritte-select-activator'ов, которые НЕ являются
+# выбранным значением (живой экран common визарда, 2026-09-08).
+_SELECT_PLACEHOLDER_TEXTS = {"Месяц", "Год"}
 
 
 @dataclass(frozen=True)
@@ -157,6 +160,22 @@ def _strict(page: Page, selector: str, label: str):
     if loc.count() != 1:
         raise RuntimeError(f"поле {label} не подтверждено однозначно")
     return loc.first
+
+
+# #991/#840: поля common гидратируются СЕКУДЫ после видимости; fill/check/клик
+# в этом окне теряются при React-монтировании — форма остаётся пустой при
+# «успешно» выполненном вводе (живой факт 2026-09-08: surname/day/phone
+# value="" в post-save дампе при заполненных аргументах). Гейт — тот же, что
+# у SAVE (#991), но ДО каждого ввода.
+_FIELD_HYDRATION_TIMEOUT_MS = 10_000
+
+
+def _hydrated_strict(page: Page, selector: str, label: str):
+    """Поле строго + гейт гидрации ДО ввода: ввод в негидратированное поле
+    React молча отбрасывает при монтировании."""
+    if not wait_for_react_hydration(page, selector, timeout_ms=_FIELD_HYDRATION_TIMEOUT_MS):
+        raise RuntimeError(f"поле {label} не гидратировано — ввод был бы потерян")
+    return _strict(page, selector, label)
 
 
 def open_common_form(page: Page, resume: ResumeConfig):
@@ -382,12 +401,20 @@ def _read_common(page: Page) -> CommonValues:
             return None
         return activator.inner_text().strip() or None
 
+    # Плейсхолдеры activator'ов ДР («Месяц»/«Год») — НЕ значения: живой факт
+    # 2026-09-08 — пустая дата читалась как «Месяц Год», merge_prefilled считал
+    # её заполненной и скалил заполнение (валидация hh.ru затем отвергала
+    # пустую дату при «заполненном» отчёте).
+    def activator_state(selector: str, label: str) -> str:
+        text = activator_value(selector, label)
+        return "" if text in _SELECT_PLACEHOLDER_TEXTS else text
+
     birthday = " ".join(
         part
         for part in (
             soft_value(BIRTHDAY, "birthday-day"),
-            activator_value(BIRTHDAY_MONTH, "birthday-month"),
-            activator_value(BIRTHDAY_YEAR, "birthday-year"),
+            activator_state(BIRTHDAY_MONTH, "birthday-month"),
+            activator_state(BIRTHDAY_YEAR, "birthday-year"),
         )
         if part
     )
@@ -497,22 +524,112 @@ def _set_tree(page: Page, trigger_selector: str, values: list[str], label: str) 
     modal.first.wait_for(state="hidden", timeout=_WAIT_MS)
 
 
+def _select_magritte_option(
+    page: Page, container_selector: str, option_qa: str, label: str
+) -> None:
+    """Выбор в magritte-комбобоксе ДР-экрана: activator -> опция по data-qa.
+
+    Identity — data-qa опции: месяц ``magritte-select-option-{01..12}`` (тот же
+    magritte-виджет, что у month-комбобоксов опыта #840), год —
+    ``magritte-select-option-{1900..2012}`` (живой DOM 2026-09-08, визард
+    common черновика). Опция не появилась/неоднозначна — fail-closed отказ,
+    не клик по «похожей».
+    """
+    activator_selector = f"{container_selector} [data-qa='magritte-select-activator']"
+    hydrated = wait_for_react_hydration(
+        page, activator_selector, timeout_ms=_FIELD_HYDRATION_TIMEOUT_MS
+    )
+    if not hydrated:
+        raise RuntimeError(f"комбобокс {label} не гидратирован — клик был бы потерян")
+    activator = page.locator(activator_selector)
+    if activator.count() != 1:
+        raise RuntimeError(f"комбобокс {label} не подтверждён однозначно ({activator.count()})")
+    activator.first.click()
+    option = page.locator(f"[data-qa='{option_qa}']")
+    try:
+        option.first.wait_for(state="visible", timeout=_WAIT_MS)
+    except PlaywrightError as exc:
+        raise RuntimeError(f"опция {label} не появилась ({option_qa}): {exc}") from exc
+    if option.count() != 1:
+        raise RuntimeError(f"опция {label} неоднозначна ({option_qa}): {option.count()}")
+    option.first.click()
+
+
+def _apply_birthday(page: Page, value: str) -> None:
+    """Заполнить ДР: день в input, месяц/год — magritte-комбобоксы.
+
+    Формат ``DD.MM.YYYY`` (полный) или ``DD`` (только день — legacy-вызов без
+    month/year; экран сам держит месяц/год предзаполненными). Валидация до
+    первого клика: мусорная дата не должна открывать комбобоксы.
+    """
+    parts = [part.strip() for part in value.split(".")]
+    day = parts[0]
+    if not day.isdigit():
+        raise RuntimeError(f"день рождения не число: {value!r} (формат DD.MM.YYYY)")
+    _hydrated_strict(page, BIRTHDAY, "birthday-day").fill(day)
+    if len(parts) == 1:
+        return
+    if len(parts) != 3 or not parts[1].isdigit() or not parts[2].isdigit():
+        raise RuntimeError(f"дата рождения не DD.MM.YYYY: {value!r}")
+    month = int(parts[1])
+    year = parts[2]
+    if not 1 <= month <= 12:
+        raise RuntimeError(f"месяц рождения вне 1..12: {value!r}")
+    _select_magritte_option(
+        page, BIRTHDAY_MONTH, f"magritte-select-option-{month:02d}", "birthday-month"
+    )
+    _select_magritte_option(page, BIRTHDAY_YEAR, f"magritte-select-option-{year}", "birthday-year")
+
+
+def _apply_phone(page: Page, value: str) -> None:
+    """Заполнить телефон; маскированный ввод обязан ПРИНЯТЬ значение.
+
+    Маска-инпут может молча сбросить ``fill`` (живой факт 2026-09-08: census
+    после save показал пустой input при заполненном аргументе) — поэтому после
+    заполнения значение проверяется, и при пустом вводе повторяется
+    посимвольным набором. Пустой результат — fail-closed отказ ДО save.
+    """
+    loc = _hydrated_strict(page, PHONE, "phone")
+    loc.fill(value)
+    if not (loc.input_value() or "").strip():
+        loc.fill("")
+        loc.press_sequentially(value, delay=30)
+    if not (loc.input_value() or "").strip():
+        raise RuntimeError(
+            "поле phone не приняло значение (маскированный ввод) — сохранение отменено"
+        )
+
+
+def _apply_gender(page: Page, value: str) -> None:
+    """Пол — radio-чип (Мужской/Женский), НЕ <select>: check(), не select_option.
+
+    select_option на radio-чипе падает «not a <select> element»; чип адресуется
+    своим data-qa строго (0/2 совпадений — отказ).
+    """
+    chip_selector = GENDER if value == "male" else GENDER_FEMALE
+    if not wait_for_react_hydration(page, chip_selector, timeout_ms=_FIELD_HYDRATION_TIMEOUT_MS):
+        raise RuntimeError(f"чип пола {value!r} не гидратирован — клик был бы потерян")
+    chip = page.locator(chip_selector)
+    if chip.count() != 1:
+        raise RuntimeError(f"чип пола {value!r} не подтверждён однозначно ({chip.count()})")
+    chip.first.check()
+
+
 def apply_common(page: Page, values: CommonValues) -> None:
     """Fill explicit values only; all controls must resolve exactly once."""
     selectors = {
         "first_name": (FIRST_NAME, values.first_name),
         "last_name": (LAST_NAME, values.last_name),
-        "birthday": (BIRTHDAY, values.birthday),
-        "gender": (GENDER, values.gender),
-        "phone": (PHONE, values.phone),
     }
     for name, (selector, value) in selectors.items():
         if value is not None:
-            loc = _strict(page, selector, name)
-            if name == "gender":
-                loc.select_option(value)
-            else:
-                loc.fill(value)
+            _hydrated_strict(page, selector, name).fill(value)
+    if values.birthday is not None:
+        _apply_birthday(page, values.birthday)
+    if values.gender is not None:
+        _apply_gender(page, values.gender)
+    if values.phone is not None:
+        _apply_phone(page, values.phone)
     if values.area is not None:
         # #993: на экране common визарда черновика поле города не рендерится
         # вовсе (live 2026-09-05) — прежняя ошибка «не подтверждено

--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -100,7 +100,11 @@ BIRTHDAY_MONTH = "[data-qa='resume-profile-common-birthday-month-selector']"
 BIRTHDAY_YEAR = "[data-qa='resume-profile-common-birthday-year-input']"
 CITIZENSHIP_SELECTOR = "[data-qa='resume-profile-common-citizenship-selector']"
 # Тексты-плейсхолдеры magritte-select-activator'ов, которые НЕ являются
-# выбранным значением (живой экран common визарда, 2026-09-08).
+# выбранным значением (живой экран common визарда, 2026-09-08). Хрупко к
+# смене локали/формулировок hh.ru: новая формулировка молча вернёт баг
+# «плейсхолдер читается как значение» (симптом: merge_prefilled скалит
+# заполнение, валидация hh.ru отвергает пустую дату при «заполненном»
+# --show) — при таком поведении проверять этот набор первым.
 _SELECT_PLACEHOLDER_TEXTS = {"Месяц", "Год"}
 
 
@@ -555,26 +559,49 @@ def _select_magritte_option(
     option.first.click()
 
 
-def _apply_birthday(page: Page, value: str) -> None:
-    """Заполнить ДР: день в input, месяц/год — magritte-комбобоксы.
+# Диапазон годов каталога ДР-комбобокса (живой DOM 2026-09-08:
+# magritte-select-option-{1900..2012}); проверяется ДО любого ввода.
+_BIRTHDAY_YEAR_MIN = 1900
+_BIRTHDAY_YEAR_MAX = 2012
+
+
+def _parse_birthday(value: str) -> tuple[str, int | None, str | None]:
+    """Распарсить и провалидировать ВЕСЬ ``--birthday`` до любого ввода.
 
     Формат ``DD.MM.YYYY`` (полный) или ``DD`` (только день — legacy-вызов без
-    month/year; экран сам держит месяц/год предзаполненными). Валидация до
-    первого клика: мусорная дата не должна открывать комбобоксы.
+    month/year; экран сам держит месяц/год предзаполненными). Отказ здесь
+    полностью безмутирующий: ни fill, ни клик по activator'у ещё не сделаны.
     """
     parts = [part.strip() for part in value.split(".")]
     day = parts[0]
     if not day.isdigit():
         raise RuntimeError(f"день рождения не число: {value!r} (формат DD.MM.YYYY)")
-    _hydrated_strict(page, BIRTHDAY, "birthday-day").fill(day)
     if len(parts) == 1:
-        return
+        return day, None, None
     if len(parts) != 3 or not parts[1].isdigit() or not parts[2].isdigit():
         raise RuntimeError(f"дата рождения не DD.MM.YYYY: {value!r}")
     month = int(parts[1])
     year = parts[2]
     if not 1 <= month <= 12:
         raise RuntimeError(f"месяц рождения вне 1..12: {value!r}")
+    if not _BIRTHDAY_YEAR_MIN <= int(year) <= _BIRTHDAY_YEAR_MAX:
+        raise RuntimeError(
+            f"год рождения вне {_BIRTHDAY_YEAR_MIN}..{_BIRTHDAY_YEAR_MAX} "
+            f"(диапазон комбобокса hh.ru): {value!r}"
+        )
+    return day, month, year
+
+
+def _apply_birthday(page: Page, value: str) -> None:
+    """Заполнить ДР: день в input, месяц/год — magritte-комбобоксы.
+
+    Вся строка валидируется ``_parse_birthday`` до первого ввода — мусорная
+    дата не мутирует экран вовсе (ни fill дня, ни открытие комбобоксов).
+    """
+    day, month, year = _parse_birthday(value)
+    _hydrated_strict(page, BIRTHDAY, "birthday-day").fill(day)
+    if month is None:
+        return
     _select_magritte_option(
         page, BIRTHDAY_MONTH, f"magritte-select-option-{month:02d}", "birthday-month"
     )

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -30,6 +30,7 @@ from .browser import (
     goto_hh,
     has_auth_cookie,
     has_login_form,
+    open_confirmed_resume,
 )
 from .config import ResumeConfig
 from .negotiations_probe import parse_initial_state
@@ -38,6 +39,13 @@ from .negotiations_probe import parse_initial_state
 # copy-resume-only variant; the command layer already treats this shared
 # PageStateIndeterminate subtype as an expired-session failure.
 from .responses import NotAuthenticated
+from .resume_ids import (
+    RESUME_ID_FROM_PATH_OR_QUERY_RE,
+    card_resume_id,
+    read_ssr_resume_items,
+    resume_card_locator,
+    resume_item_attrs,
+)
 
 # Имена `_card_hashes` и `_RESUME_HASH_RE` сохранены как тестируемый seam:
 # тесты monkeypatch'ат их в этом модуле, и вызовы copy_resume_on_hh обязаны
@@ -46,15 +54,10 @@ from .resume_ids import (
     RESUME_ID_FROM_PATH_RE as _RESUME_HASH_RE,
 )
 from .resume_ids import (
-    card_resume_id,
-    read_ssr_resume_items,
-    resume_card_locator,
-    resume_item_attrs,
-)
-from .resume_ids import (
     page_card_hashes as _card_hashes,
 )
 from .resume_limits import RESUME_QUOTA_UNREADABLE_REASON, resume_limit_reason
+from .resume_state import parse_resume_state
 from .selector_groups.resume_list import (
     RESUME_DUPLICATE_INLINE,
     RESUME_DUPLICATE_MENU_ITEM,
@@ -71,6 +74,11 @@ logger = logging.getLogger("hhru_bot.copy_resume")
 # operation at the dedicated, stable list surface (#311).
 RESUMES_LIST_URL = RESUMES_FULL_LIST_URL
 COPY_TIMEOUT_MS = 30_000
+# Визард дозаполнения: hh.ru переписывает URL на /profile/resume/common?resume=<id>
+# (живой факт 2026-09-07). goto_hh уже дождался load, но SPA-редирект на визард
+# может догонять — бюджет на появление resume= в URL до первого решения.
+_WIZARD_URL_SETTLE_POLL_MS = 250
+_WIZARD_URL_SETTLE_ATTEMPTS = 20  # 20 × 250 мс = 5 c
 PROFILE_STALL_SECONDS = 15.0
 PROFILE_ABSOLUTE_TIMEOUT_SECONDS = 300.0
 PROFILE_POLL_MS = 250
@@ -104,6 +112,10 @@ class ResumeCard:
     # searchable flag.  Do not infer visibility from publication status.
     is_searchable: bool | None = None
     ssr_unavailable: bool = False  # True если SSR данные недоступны или некорректны
+    # nextIncompleteScreenId черновика, прочитанный identity-bound readback'ом
+    # (list_wizard_drafts); None у обычных карточек списка — карточки списка
+    # этот экран не показывают.
+    unfinished_screen: str | None = None
 
 
 @dataclass(frozen=True)
@@ -471,6 +483,61 @@ def list_resume_cards(
             )
         )
     return cards
+
+
+def list_wizard_drafts(page: Page) -> list[ResumeCard]:
+    """Резюме аккаунта, когда hh.ru рендерит ВИЗАВД дозаполнения вместо списка.
+
+    Живой факт 2026-09-07 (marketing, census на /applicant/my_resumes): у
+    аккаунта с единственным незавершённым черновиком hh.ru не показывает
+    карточки [data-qa='resume'] вовсе — вместо списка рендерится экран
+    ``common`` визарда, и list_resume_cards честно падает по 30-секундному
+    таймауту. Карточек и SSR ``applicantResumes`` на этой странице нет
+    (живой probe 2026-09-07: InitialState визарда секцию не содержит);
+    источник идентичности — URL: hh.ru переписывает его на
+    ``/profile/resume/common?resume=<id>`` — та же query-форма ``resume=``,
+    которой create-resume доверяет с #778. Данные (title/статус/
+    nextIncompleteScreenId) дочитываются identity-bound readback'ом страницы
+    резюме (тот же путь, что доказывает черновик в create-resume:
+    open_confirmed_resume + parse_resume_state). READ-only: goto + чтение,
+    ничего не кликается. Ветка показывает Тот черновик, который визард
+    дозаполняет, — прочие (гипотетические) черновики не заявляются.
+
+    Fail-closed: resume_id не появился в URL за бюджет (редирект на визард
+    не завершился) — ResumeListIndeterminate (та же таксономия, что у
+    list_resume_cards): неподтверждённое состояние, а не «резюме нет».
+    """
+    resume_hash = ""
+    for _attempt in range(_WIZARD_URL_SETTLE_ATTEMPTS):
+        match = RESUME_ID_FROM_PATH_OR_QUERY_RE.search(page.url)
+        if match:
+            resume_hash = match.group(1)
+            break
+        page.wait_for_timeout(_WIZARD_URL_SETTLE_POLL_MS)
+    if not resume_hash:
+        raise ResumeListIndeterminate(
+            "экран дозаполнения черновика открыт вместо списка карточек, но "
+            f"resume_id не появился в URL за бюджет "
+            f"{_WIZARD_URL_SETTLE_ATTEMPTS * _WIZARD_URL_SETTLE_POLL_MS} мс "
+            f"(URL: {page.url}) — список не подтверждён"
+        )
+
+    # Identity-bound readback: открытая страница визарда не содержит title,
+    # поэтому черновик дочитывается на своей странице (goto + строгие
+    # auth/identity-проверки — как у create-resume).
+    open_confirmed_resume(page, resume_hash)
+    state = parse_resume_state(page.content(), resume_hash)
+    return [
+        ResumeCard(
+            resume_id=resume_hash,
+            title=state.title or "",
+            url=f"{HH_BASE_URL}/resume/{resume_hash}",
+            status=state.status,
+            is_searchable=state.is_searchable,
+            ssr_unavailable=False,
+            unfinished_screen=state.next_incomplete_screen_id,
+        )
+    ]
 
 
 class ResumeIdMapping(dict[str, str]):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -140,6 +140,22 @@ def test_apply_birthday_rejects_garbage_before_clicks(bad):
     assert loc.first.click.call_count == 0
 
 
+@pytest.mark.parametrize("bad_year", ["10.06.1899", "10.06.2013"])
+def test_apply_birthday_rejects_year_out_of_catalog_range_before_any_input(bad_year):
+    """Год вне каталога комбобокса (1900..2012) — отказ ДО fill дня: отказ
+    полностью безмутирующий, экран не тронут вовсе."""
+    page = MagicMock()
+    loc = MagicMock()
+    loc.count.return_value = 1
+    page.locator.side_effect = lambda selector: loc
+
+    with pytest.raises(RuntimeError, match="год рождения вне"):
+        common._apply_birthday(page, bad_year)
+
+    assert loc.first.fill.call_count == 0
+    assert loc.first.click.call_count == 0
+
+
 def test_apply_phone_falls_back_to_sequential_typing(monkeypatch):
     """Маска сбросила fill -> посимвольный набор; если и он не принялся — отказ."""
     monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -52,7 +52,8 @@ def test_missing_required_lists_only_blank_fields():
     assert missing_required(current) == ["last_name", "birthday", "gender", "citizenship"]
 
 
-def test_apply_common_fills_inputs_and_selects_gender():
+def test_apply_common_fills_inputs_checks_gender_and_types_phone(monkeypatch):
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)
     page = MagicMock()
     locators = {}
     for selector in (
@@ -60,10 +61,12 @@ def test_apply_common_fills_inputs_and_selects_gender():
         common.LAST_NAME,
         common.BIRTHDAY,
         common.GENDER,
+        common.GENDER_FEMALE,
         common.PHONE,
     ):
         locators[selector] = MagicMock()
         locators[selector].count.return_value = 1
+    locators[common.PHONE].first.input_value.return_value = "+7 900 111-22-33"
     page.locator.side_effect = lambda selector: locators[selector]
 
     apply_common(
@@ -71,7 +74,6 @@ def test_apply_common_fills_inputs_and_selects_gender():
         CommonValues(
             first_name="Ada",
             last_name="Lovelace",
-            birthday="1815-12-10",
             gender="female",
             phone="+7",
         ),
@@ -79,9 +81,101 @@ def test_apply_common_fills_inputs_and_selects_gender():
 
     locators[common.FIRST_NAME].first.fill.assert_called_once_with("Ada")
     locators[common.LAST_NAME].first.fill.assert_called_once_with("Lovelace")
-    locators[common.BIRTHDAY].first.fill.assert_called_once_with("1815-12-10")
     locators[common.PHONE].first.fill.assert_called_once_with("+7")
-    locators[common.GENDER].first.select_option.assert_called_once_with("female")
+    # #1030-цепочка (2026-09-08): пол — radio-чип, check(), НЕ select_option
+    locators[common.GENDER_FEMALE].first.check.assert_called_once()
+    locators[common.GENDER].first.select_option.assert_not_called()
+
+
+def test_apply_birthday_fills_day_and_magritte_month_year(monkeypatch):
+    """DD.MM.YYYY: день в input, месяц/год — activator-клик + опция по data-qa
+    (месяц с ведущим нулём: magritte-select-option-06)."""
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)
+    page = MagicMock()
+    calls: list[tuple[str, str]] = []
+
+    def locator_for(selector):
+        loc = MagicMock()
+        loc.count.return_value = 1
+        if "[data-qa='magritte-select-activator']" in selector:
+            calls.append(("activator", selector.split(" ")[0]))
+        if selector.startswith("[data-qa='magritte-select-option-"):
+            calls.append(("option", selector))
+        return loc
+
+    page.locator.side_effect = locator_for
+
+    common._apply_birthday(page, "10.06.1995")
+
+    assert ("activator", common.BIRTHDAY_MONTH) in calls
+    assert ("activator", common.BIRTHDAY_YEAR) in calls
+    assert ("option", "[data-qa='magritte-select-option-06']") in calls
+    assert ("option", "[data-qa='magritte-select-option-1995']") in calls
+
+
+def test_apply_birthday_day_only_skips_comboboxes(monkeypatch):
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)
+    page = MagicMock()
+    loc = MagicMock()
+    loc.count.return_value = 1
+    page.locator.side_effect = lambda selector: loc
+
+    common._apply_birthday(page, "10")
+
+    loc.first.fill.assert_called_once_with("10")
+    assert loc.first.click.call_count == 0  # комбобоксы не открывались
+
+
+@pytest.mark.parametrize("bad", ["июнь", "10.13.1995", "10.06.95x", "10..1995"])
+def test_apply_birthday_rejects_garbage_before_clicks(bad):
+    """Мусорная дата — отказ ДО открытия комбобоксов (fail-closed)."""
+    page = MagicMock()
+    loc = MagicMock()
+    loc.count.return_value = 1
+    page.locator.side_effect = lambda selector: loc
+
+    with pytest.raises(RuntimeError, match="рождения"):
+        common._apply_birthday(page, bad)
+
+    assert loc.first.click.call_count == 0
+
+
+def test_apply_phone_falls_back_to_sequential_typing(monkeypatch):
+    """Маска сбросила fill -> посимвольный набор; если и он не принялся — отказ."""
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)
+    page = MagicMock()
+    loc = MagicMock()
+    loc.count.return_value = 1
+    loc.first.input_value.side_effect = ["", "+7 900 111-22-33"]
+    page.locator.side_effect = lambda selector: loc
+
+    common._apply_phone(page, "+7 900 111-22-33")
+
+    loc.first.fill.assert_any_call("+7 900 111-22-33")
+    loc.first.fill.assert_any_call("")
+    loc.first.press_sequentially.assert_called_once()
+
+
+def test_apply_phone_fails_closed_when_mask_rejects_value(monkeypatch):
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: True)
+    page = MagicMock()
+    loc = MagicMock()
+    loc.count.return_value = 1
+    loc.first.input_value.return_value = ""
+    page.locator.side_effect = lambda selector: loc
+
+    with pytest.raises(RuntimeError, match="не приняло значение"):
+        common._apply_phone(page, "+7 900 111-22-33")
+
+
+def test_apply_common_refuses_fill_into_unhydrated_field(monkeypatch):
+    """#858/#991: ввод в негидратированное поле React отбрасывает при монтировании
+    (живой факт 2026-09-08: value=\"\" в post-save дампе) — отказ ДО ввода."""
+    monkeypatch.setattr(common, "wait_for_react_hydration", lambda *_a, **_k: False)
+    page = MagicMock()
+
+    with pytest.raises(RuntimeError, match="не гидратирован"):
+        apply_common(page, CommonValues(first_name="Ada"))
 
 
 @pytest.mark.browser_unit
@@ -899,6 +993,52 @@ def test_wizard_read_work_ticket_from_container(monkeypatch):
     result = common._read_common(_WizardShapePage())
     assert result.work_ticket == ""
     assert result.work_permit == "Россия"
+
+
+class _BirthdayWizardPage(_WizardShapePage):
+    """Визард с комбобоксами ДР: month_text/year_text — текст activator'ов
+    (плейсхолдеры «Месяц»/«Год» или выбранные «Июнь»/«1995»)."""
+
+    def __init__(self, month_text, year_text, day=""):
+        super().__init__()
+        self._day = day
+
+        def activator_container(text):
+            m = MagicMock()
+            m.count.return_value = 1
+            act = MagicMock()
+            act.count.return_value = 1
+            act.first.inner_text.return_value = text
+            m.first.locator.return_value = act
+            return m
+
+        self._month = activator_container(month_text)
+        self._year = activator_container(year_text)
+
+    def locator(self, selector):
+        if selector == common.BIRTHDAY_MONTH:
+            return self._month
+        if selector == common.BIRTHDAY_YEAR:
+            return self._year
+        if selector == common.BIRTHDAY:
+            m = MagicMock()
+            m.count.return_value = 1
+            m.first.input_value.return_value = self._day
+            return m
+        return super().locator(selector)
+
+
+def test_birthday_placeholders_are_not_values():
+    """«Месяц»/«Год» — плейсхолдеры activator'ов, НЕ значения: пустая дата
+    не считается заполненной (иначе merge_prefilled скалил заполнение,
+    живой факт 2026-09-08 — валидация hh.ru отвергала пустую дату)."""
+    result = common._read_common(_BirthdayWizardPage("Месяц", "Год"))
+    assert result.birthday == ""
+
+
+def test_birthday_selected_activators_read_as_values():
+    result = common._read_common(_BirthdayWizardPage("Июнь", "1995", day="15"))
+    assert result.birthday == "15 Июнь 1995"
 
 
 def test_wizard_area_refuses_honestly(monkeypatch):

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -354,6 +354,104 @@ def test_non_dict_ssr_state_marks_unavailable(monkeypatch, raw_state):
     assert cards[0].ssr_unavailable
 
 
+# --- list_wizard_drafts (экран дозаполнения вместо списка, 2026-09-07) ---------
+
+
+class _WizardPage:
+    """Страница визарда: URL переписан на /profile/resume/common?resume=<id>,
+    SSR applicantResumes отсутствует (живой probe 2026-09-07), карточек нет.
+
+    ``land_on(resume_id, markup)`` подменяет content() — как реальная
+    навигация open_confirmed_resume меняет страницу на страницу резюме."""
+
+    def __init__(self, url: str):
+        self.url = url
+        self._content = ""
+        self.landed: list[str] = []
+        self.settled_polls = 0
+
+    def wait_for_timeout(self, ms):
+        # первый poll «дожидается» SPA-редиректа: URL получает resume=<id>
+        self.settled_polls += 1
+        if "?resume=" not in self.url:
+            self.url = f"{self.url.split('?')[0]}?resume={ID_A}"
+
+    def locator(self, selector):
+        raise AssertionError(f"list_wizard_drafts не читает локаторы: {selector}")
+
+    def content(self):
+        return self._content
+
+    def land_on(self, resume_id: str, markup: str) -> None:
+        self._content = markup
+        self.landed.append(resume_id)
+
+
+_RESUME_MARKUP = json.dumps(
+    {
+        "resumes": [
+            {
+                # nextIncompleteScreenId живёт в identity-записи (_attributes),
+                # title — в теле элемента (живой shape bootstrap, resume_state.py)
+                "_attributes": {
+                    "hash": ID_A,
+                    "status": "not_finished",
+                    "nextIncompleteScreenId": "common",
+                },
+                "title": [{"string": "Тестировщик программного обеспечения"}],
+            }
+        ]
+    },
+    ensure_ascii=False,
+)
+
+
+def test_list_wizard_drafts_reads_title_and_screen_from_readback(monkeypatch):
+    """Черновик из URL-формы ``resume=`` (живой факт 2026-09-07: hh.ru
+    переписывает URL на /profile/resume/common?resume=<id>) + identity-bound
+    readback: title/статус/nextIncompleteScreenId дочитываются со страницы
+    резюме — тот же путь, что доказывает черновик в create-resume."""
+    page = _WizardPage(f"https://hh.ru/profile/resume/common?resume={ID_A}")
+    monkeypatch.setattr(
+        cr, "open_confirmed_resume", lambda p, rid, **_kw: p.land_on(rid, _RESUME_MARKUP)
+    )
+
+    cards = cr.list_wizard_drafts(page)
+
+    assert page.landed == [ID_A]
+    assert page.settled_polls == 0  # id был в URL сразу — poll не понадобился
+    assert len(cards) == 1
+    assert cards[0].resume_id == ID_A
+    assert cards[0].title == "Тестировщик программного обеспечения"
+    assert cards[0].status == "not_finished"
+    assert cards[0].unfinished_screen == "common"
+    assert cards[0].url == f"https://hh.ru/resume/{ID_A}"
+
+
+def test_list_wizard_drafts_waits_for_late_url_settle(monkeypatch):
+    """SPA-редирект на визард догоняет после load: id появляется в URL не сразу —
+    бюджет poll'а снимает гонку (паттерн «commit не значит отрисовано»)."""
+    page = _WizardPage("https://hh.ru/applicant/my_resumes")
+    monkeypatch.setattr(
+        cr, "open_confirmed_resume", lambda p, rid, **_kw: p.land_on(rid, _RESUME_MARKUP)
+    )
+
+    cards = cr.list_wizard_drafts(page)
+
+    assert page.settled_polls == 1
+    assert cards[0].resume_id == ID_A
+
+
+def test_list_wizard_drafts_fails_closed_when_url_never_settles():
+    """Визард открыт, но resume= в URL так и не появился — прежняя таксономия:
+    indeterminate, не «резюме нет» и не пустой список за факт."""
+    page = _WizardPage("https://hh.ru/applicant/my_resumes")
+    page.wait_for_timeout = lambda ms: None  # URL не меняется никогда
+
+    with pytest.raises(cr.ResumeListIndeterminate, match="resume_id не появился в URL"):
+        cr.list_wizard_drafts(page)
+
+
 # --- resolve_numeric_resume_ids (#212) ----------------------------------------
 #
 # Маппинг «хэш резюме → числовой id» из SSR /applicant/resumes: Applicant

--- a/tests/test_list_resumes_command.py
+++ b/tests/test_list_resumes_command.py
@@ -229,11 +229,14 @@ def test_registers_list_resumes_subparser():
 
 
 class _FakeCard:
-    def __init__(self, resume_id, title, status=None, ssr_unavailable=False):
+    def __init__(
+        self, resume_id, title, status=None, ssr_unavailable=False, unfinished_screen=None
+    ):
         self.resume_id = resume_id
         self.title = title
         self.status = status
         self.ssr_unavailable = ssr_unavailable
+        self.unfinished_screen = unfinished_screen
 
 
 class _StubThrottle:
@@ -547,6 +550,96 @@ def test_default_live_indeterminate_state_prints_fail_not_empty(capsys, tmp_path
     assert "не найдено" not in out
     # fallback на локальную таблицу не происходит
     assert "backend" not in out
+
+
+# --- визард-ветка (экран дозаполнения вместо списка, 2026-09-07) ---------------
+
+
+def _patch_wizard(monkeypatch, drafts, *, predicate=True):
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeContext())
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url, **kw: None)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: predicate)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", lambda page: list(drafts))
+
+    def _boom(page, navigate=True):
+        raise AssertionError("в визард-ветке list_resume_cards не вызывается")
+
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", _boom)
+
+
+def test_wizard_mode_lists_draft_with_screen_hint(capsys, tmp_path, monkeypatch):
+    """Единственный незавершённый черновик: hh.ru рендерит экран дозаполнения
+    вместо карточек — команда читает черновик через list_wizard_drafts, печатает
+    таблицу с незавершённым экраном и подсказку дозаполнения, не [FAIL]."""
+    config = _live_env(tmp_path, monkeypatch)
+    drafts = [
+        _FakeCard(
+            "88888888",
+            "Тестировщик программного обеспечения",
+            status="not_finished",
+            unfinished_screen="common",
+        )
+    ]
+    _patch_wizard(monkeypatch, drafts)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" not in out
+    assert "88888888" in out
+    assert "Тестировщик программного обеспечения" in out
+    assert "черновик, незавершённый экран common" in out
+    assert "экран дозаполнения" in out
+    assert "wizard-next --resume" in out
+
+
+def test_wizard_mode_indeterminate_still_fails_closed(capsys, tmp_path, monkeypatch):
+    """Визард открыт, но черновики не прочитаны — прежний честный [FAIL],
+    не «резюме не найдено» и не пустая таблица."""
+    from hhru_bot.copy_resume import ResumeListIndeterminate
+
+    config = _live_env(tmp_path, monkeypatch)
+
+    def _raise(page):
+        raise ResumeListIndeterminate(
+            "экран дозаполнения черновика открыт, но resume_id не появился в URL"
+        )
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **kw: _FakeContext())
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda page: True)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url, **kw: None)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda page: False)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: True)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _raise)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "resume_id не появился в URL" in out
+    assert "не найдено" not in out
+
+
+def test_no_wizard_keeps_card_list_path(capsys, tmp_path, monkeypatch):
+    """Предикат визарда False — прежний путь list_resume_cards; визард-ридер
+    не дёргается вовсе."""
+    config = _live_env(tmp_path, monkeypatch)
+    fake_cards = [_FakeCard("11111111", "Backend developer", "modified")]
+    _patch_live(monkeypatch, fake_cards)
+
+    def _boom_wizard(page):
+        raise AssertionError("вне визарда list_wizard_drafts не вызывается")
+
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda page: False)
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _boom_wizard)
+
+    list_resumes_cmd.run(_args(config, tmp_path / "h.db"))
+
+    out = capsys.readouterr().out
+    assert "11111111" in out
+    assert "экран дозаполнения" not in out
 
 
 def test_default_live_stale_cookie_rejects_login_form(capsys, tmp_path, monkeypatch):


### PR DESCRIPTION
Продолжение #1032: та же живая сессия «резюме на свежем аккаунте» упёрлась в
write-путь экрана common визарда. Все правки подтверждены боевыми прогонами
(дампы в data/logs/common_save_failure_20260908_*.html/.census.txt).

## Живые факты 2026-09-08 (экран common визарда, единственный черновик)

1. **Ввод до гидрации поля теряется.** Post-save дампы: value="" у
   surname/day/phone при выполненных филлах. Гейт #991 (wait_for_react_hydration)
   стоял только на кнопке SAVE — поля оставались без гейта, а гидратируются
   секунды (#840).
2. **ДР не записывался вовсе.** Месяц/год — magritte-комбобоксы; apply_common
   заполнял только day-input. Опции: `magritte-select-option-{01..12}` (месяц),
   `magritte-select-option-{1900..2012}` (год — снято живым DOM в этом PR).
3. **Плейсхолдеры читались как значения.** Ридер ДР собирал текст activator'ов
   «Месяц»/«Год» → birthday выглядел заполненным → merge_prefilled скалил
   заполнение → валидация hh.ru отвергала пустую дату при «заполненном» --show.
4. **Пол — radio-чип**, select_option на нём структурно невозможен.
5. **Телефон — маскированный ввод**, молча сбрасывающий значения.

## Изменения (`src/hhru_bot/common.py`, `commands/common.py`)

- `_hydrated_strict`: строгий резолв + гейт гидрации ДО каждого ввода (fill,
  check, клик activator'а) — тот же паттерн, что у SAVE (#991), расширенный
  на поля (#858/#840).
- `_apply_birthday`: `--birthday DD.MM.YYYY` — день в input, месяц/год через
  `_select_magritte_option` (activator → опция по data-qa, fail-closed при
  0/2 опциях); валидация даты до первого клика; `DD` — legacy день-только.
- Ридер ДР: `_SELECT_PLACEHOLDER_TEXTS` («Месяц», «Год») — плейсхолдер не
  значение.
- `_apply_gender`: check() чипа по data-qa (male/female).
- `_apply_phone`: fill → контроль input_value → press_sequentially-фолбэк →
  fail-closed до save.
- `--birthday` help обновлён под DD.MM.YYYY.

## Проверки

- Полный pytest зелёный, ruff check/format чистые; новые unit-тесты:
  hydration-отказ до ввода, ДР (parse/выборы/day-only/мусор), phone
  (фолбэк/fail-closed), плейсхолдеры ≠ значения.
- **Живой acceptance**: боевой прогон под вторым аккаунтом — все значения
  легли в форму (post-save дамп: day=15, месяц «Июнь», год 1995, phone
  value заполнен). Экран дальше не проходит по внешней причине: hh.ru
  требует SMS-подтверждение непривязанного телефона — код существует только
  на устройстве владельца аккаунта; в CLI это честный uncertain + дамп.

Мерж — за владельцем.
