### PR TITLE
fix(edit-experience): фолбэк на визард-ридер, когда список карточек не рендерится (#1032-цепочка)

### DIFF
--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -335,9 +335,17 @@ def _run(args: argparse.Namespace, progress) -> bool:
             # mode edit of an existing row also lands on the shared panel
             # screen and needs the same reconciliation (see
             # experience.py::edit_experience_on_hh docstring).
-            from ..copy_resume import list_resume_cards
+            from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
 
-            resume_titles = {card.resume_id: card.title for card in list_resume_cards(page)}
+            try:
+                cards = list_resume_cards(page)
+            except ResumeListIndeterminate:
+                # Аккаунт в состоянии «визард вместо списка» (единственный
+                # незавершённый черновик, #1032): карточек нет вовсе, а
+                # resume-titles для панели привязки нужны те же — читаем
+                # черновик визард-ридером (URL + identity-readback).
+                cards = list_wizard_drafts(page)
+            resume_titles = {card.resume_id: card.title for card in cards}
             # begin_attempt() right before the real mutation, after the page/
             # context are already open (#465 review): counting the attempt
             # before launch_context succeeded would misreport a browser-launch

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -306,6 +306,65 @@ def test_edit_experience_uncertain_outcome_is_not_counted_as_failed(
     assert row["failed"] == row["success"] == row["skipped"] == 0
 
 
+def test_edit_experience_falls_back_to_wizard_drafts_when_list_is_wizard(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Аккаунт с единственным незавершённым черновиком: список карточек не
+    рендерится (#1032), а resume-titles для панели привязки читаются ДО
+    мутации (#782) — раньше это валило команду до клика. Фолбэк на
+    list_wizard_drafts даёт те же titles, мутация доезжает."""
+    import hhru_bot.commands.edit_experience as command
+    from hhru_bot.copy_resume import ResumeListIndeterminate
+    from hhru_bot.experience import ExperienceResult
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
+
+    def _raise_wizard(*_a, **_kw):
+        raise ResumeListIndeterminate("карточки резюме не появились")
+
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", _raise_wizard)
+    monkeypatch.setattr(
+        "hhru_bot.copy_resume.list_wizard_drafts",
+        lambda *_a, **_kw: [SimpleNamespace(resume_id="r1", title="Черновик")],
+    )
+
+    captured = {}
+
+    def fake_edit(_page, _resume_id, _plan, *, resume_titles=None, **_kw):
+        captured["titles"] = resume_titles
+        return [ExperienceResult("строка 1: добавлена", success=True)]
+
+    monkeypatch.setattr("hhru_bot.experience.edit_experience_on_hh", fake_edit)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="fill",
+        career=None,
+        existing=None,
+        entry=['{"company": "a", "position": "b", "start_month": "1"}'],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    # run() возвращает «failed»-флаг (cli.py): чистый успех — False
+    assert command.run(args) is False
+    assert captured["titles"] == {"r1": "Черновик"}
+
+
 def test_edit_languages_launch_failure_before_attempt_does_not_count_as_attempted(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
Продолжение цепочки #1032: третий потребитель `list_resume_cards`, ломающийся
на состоянии «визард вместо списка».

## Что случилось

Аккаунт с единственным незаверённым черновиком (hh.ru рендерит экран
дозаполнения вместо списка карточек, #1032). `edit-experience --entry` читает
resume-titles для панели привязки резюме к месту работы ДО мутации (#782)
через `list_resume_cards` — получал `ResumeListIndeterminate` и падал ДО
клика: добавить первую запись опыта такому аккаунту было невозможно (attempted=0).

## Изменение

`src/hhru_bot/commands/edit_experience.py`: `ResumeListIndeterminate` →
фолбэк на `list_wizard_drafts` (механизм #1032: resume_id из URL визарда +
identity-bound readback) — те же titles, мутация доезжает. Контракт
коллектора не меняется.

## Проверки

- Новый тест: список падает → визард-ридер вызван, `resume_titles` доезжает
  до `edit_experience_on_hh`, мутация выполняется; весь файл зелёный.
- **Живой acceptance** (боевой код ветки): запись опыта сохранена и привязана
  (`attempted=1 success=1`), финальный экран experience после этого
  автопубликовал резюме — подтверждено readback'ом `list-resumes`: статус
  «опубликовано».

## Флейк-примечание (не из этого PR)

`tests/test_resume_position_catalog_fixture.py` (browser_unit, реальный
Chromium) нестабилен под `-n 4` при изменении числа тестов: в двух прогонах
упали два РАЗНЫХ теста файла, соло и файлом — зелёные, чистый main — зелёный,
сюит без этого файла с правками ветки — зелёный. Похоже на ресурсную гонку
реального браузера под xdist; отдельно чинить.

Мерж — за владельцем.
