### PR TITLE
refactor(edit-experience): детектор _on_wizard_common до list_resume_cards (#1037)

### DIFF
--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -343,6 +343,7 @@ def _run(args: argparse.Namespace, progress) -> bool:
                 list_resume_cards,
                 list_wizard_drafts,
             )
+            from ..responses import NotAuthenticated
 
             # #1037: детектор визарда — ДО чтения карточек (как в list-resumes,
             # #1032): на аккаунте «визард вместо списка» (единственный
@@ -352,17 +353,25 @@ def _run(args: argparse.Namespace, progress) -> bool:
             # SSR-разметкой сразу после goto, поэтому мгновенной проверки
             # достаточно; промах детекта (гонка) уходит в обычный путь.
             goto_hh(page, RESUMES_LIST_URL)
-            if _on_wizard_common(page):
-                # resume-titles для панели привязки нужны те же — читаем
-                # черновик визард-ридером (URL + identity-readback).
-                cards = list_wizard_drafts(page)
-            else:
-                try:
-                    cards = list_resume_cards(page, navigate=False)
-                except ResumeListIndeterminate:
-                    # Страховка #1036: детект промахнулся, карточки не
-                    # появились — прежний исключение-фолбэк на визард-ридер.
+            try:
+                if _on_wizard_common(page):
+                    # resume-titles для панели привязки нужны те же — читаем
+                    # черновик визард-ридером (URL + identity-readback).
                     cards = list_wizard_drafts(page)
+                else:
+                    try:
+                        cards = list_resume_cards(page, navigate=False)
+                    except ResumeListIndeterminate:
+                        # Страховка #1036: детект промахнулся, карточки не
+                        # появились — прежний исключение-фолбэк на
+                        # визард-ридер.
+                        cards = list_wizard_drafts(page)
+            except NotAuthenticated as exc:
+                # identity-bound readback визард-ридера требует живой сессии —
+                # она может протухнуть посреди команды; sibling-обработка
+                # list_resumes (#1032): [FAIL] вместо traceback.
+                print(f"[FAIL] {resume.id} — Сессия недействительна: {exc}")
+                return True
             resume_titles = {card.resume_id: card.title for card in cards}
             # begin_attempt() right before the real mutation, after the page/
             # context are already open (#465 review): counting the attempt

--- a/src/hhru_bot/commands/edit_experience.py
+++ b/src/hhru_bot/commands/edit_experience.py
@@ -335,16 +335,34 @@ def _run(args: argparse.Namespace, progress) -> bool:
             # mode edit of an existing row also lands on the shared panel
             # screen and needs the same reconciliation (see
             # experience.py::edit_experience_on_hh docstring).
-            from ..copy_resume import ResumeListIndeterminate, list_resume_cards, list_wizard_drafts
+            from ..browser import goto_hh
+            from ..common import _on_wizard_common
+            from ..copy_resume import (
+                RESUMES_LIST_URL,
+                ResumeListIndeterminate,
+                list_resume_cards,
+                list_wizard_drafts,
+            )
 
-            try:
-                cards = list_resume_cards(page)
-            except ResumeListIndeterminate:
-                # Аккаунт в состоянии «визард вместо списка» (единственный
-                # незавершённый черновик, #1032): карточек нет вовсе, а
+            # #1037: детектор визарда — ДО чтения карточек (как в list-resumes,
+            # #1032): на аккаунте «визард вместо списка» (единственный
+            # незавершённый черновик) list_resume_cards иначе платит полный
+            # COPY_TIMEOUT_MS (30с) за гарантированный отказ, прежде чем
+            # фолбэк доберётся до list_wizard_drafts. Экран common приходит
+            # SSR-разметкой сразу после goto, поэтому мгновенной проверки
+            # достаточно; промах детекта (гонка) уходит в обычный путь.
+            goto_hh(page, RESUMES_LIST_URL)
+            if _on_wizard_common(page):
                 # resume-titles для панели привязки нужны те же — читаем
                 # черновик визард-ридером (URL + identity-readback).
                 cards = list_wizard_drafts(page)
+            else:
+                try:
+                    cards = list_resume_cards(page, navigate=False)
+                except ResumeListIndeterminate:
+                    # Страховка #1036: детект промахнулся, карточки не
+                    # появились — прежний исключение-фолбэк на визард-ридер.
+                    cards = list_wizard_drafts(page)
             resume_titles = {card.resume_id: card.title for card in cards}
             # begin_attempt() right before the real mutation, after the page/
             # context are already open (#465 review): counting the attempt

--- a/tests/test_manual_input_commands.py
+++ b/tests/test_manual_input_commands.py
@@ -286,13 +286,15 @@ def test_edit_experience_manual_entry_appends_to_non_empty_resume(tmp_path, caps
     from hhru_bot.experience import ExperienceEntry, ExperienceResult
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", _fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: False)
     monkeypatch.setattr(
         "hhru_bot.experience.read_experience_on_hh",
         lambda page, resume_id: [
             ExperienceEntry(company="Старая компания", position="Старая должность")
         ],
     )
-    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda page: [])
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda *page, **_kw: [])
     captured = {}
 
     def fake_edit_experience_on_hh(
@@ -335,8 +337,10 @@ def test_edit_experience_manual_entry_creates_first_row_on_empty_resume(
     from hhru_bot.experience import ExperienceResult
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", _fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: False)
     monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda page, resume_id: [])
-    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda page: [])
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda *page, **_kw: [])
     captured = {}
 
     def fake_edit_experience_on_hh(

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -276,6 +276,8 @@ def test_edit_experience_uncertain_outcome_is_not_counted_as_failed(
         yield SimpleNamespace(new_page=lambda: object())
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: False)
     monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
     monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda *_a, **_kw: [])
     monkeypatch.setattr(
@@ -312,7 +314,67 @@ def test_edit_experience_falls_back_to_wizard_drafts_when_list_is_wizard(
     """Аккаунт с единственным незавершённым черновиком: список карточек не
     рендерится (#1032), а resume-titles для панели привязки читаются ДО
     мутации (#782) — раньше это валило команду до клика. Фолбэк на
-    list_wizard_drafts даёт те же titles, мутация доезжает."""
+    list_wizard_drafts даёт те же titles, мутация доезжает. #1037: путь через
+    детектор — list_resume_cards не вызывается вовсе (нет 30с-платы)."""
+    import hhru_bot.commands.edit_experience as command
+    from hhru_bot.experience import ExperienceResult
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: True)
+    monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
+
+    def _fail_if_called(*_a, **_kw):
+        raise AssertionError("list_resume_cards не должен вызываться в визард-ветке")
+
+    monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", _fail_if_called)
+    monkeypatch.setattr(
+        "hhru_bot.copy_resume.list_wizard_drafts",
+        lambda *_a, **_kw: [SimpleNamespace(resume_id="r1", title="Черновик")],
+    )
+
+    captured = {}
+
+    def fake_edit(_page, _resume_id, _plan, *, resume_titles=None, **_kw):
+        captured["titles"] = resume_titles
+        return [ExperienceResult("строка 1: добавлена", success=True)]
+
+    monkeypatch.setattr("hhru_bot.experience.edit_experience_on_hh", fake_edit)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="fill",
+        career=None,
+        existing=None,
+        entry=['{"company": "a", "position": "b", "start_month": "1"}'],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    # run() возвращает «failed»-флаг (cli.py): чистый успех — False
+    assert command.run(args) is False
+    assert captured["titles"] == {"r1": "Черновик"}
+
+
+def test_edit_experience_keeps_exception_fallback_when_wizard_detect_misses(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Страховка #1036 остаётся (#1037): детект промахнулся (гонка рендера),
+    карточки не появились — ResumeListIndeterminate всё ещё уводит в
+    list_wizard_drafts, а не в [FAIL]."""
     import hhru_bot.commands.edit_experience as command
     from hhru_bot.copy_resume import ResumeListIndeterminate
     from hhru_bot.experience import ExperienceResult
@@ -327,6 +389,8 @@ def test_edit_experience_falls_back_to_wizard_drafts_when_list_is_wizard(
         yield SimpleNamespace(new_page=lambda: object())
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: False)
     monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
 
     def _raise_wizard(*_a, **_kw):
@@ -360,7 +424,6 @@ def test_edit_experience_falls_back_to_wizard_drafts_when_list_is_wizard(
         history=str(history_path),
     )
 
-    # run() возвращает «failed»-флаг (cli.py): чистый успех — False
     assert command.run(args) is False
     assert captured["titles"] == {"r1": "Черновик"}
 
@@ -1384,6 +1447,8 @@ def test_edit_experience_hard_failure_wins_over_uncertain_in_same_batch(
         yield SimpleNamespace(new_page=lambda: object())
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: False)
     monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
     monkeypatch.setattr("hhru_bot.copy_resume.list_resume_cards", lambda *_a, **_kw: [])
     monkeypatch.setattr(

--- a/tests/test_resume_edit_command_runs.py
+++ b/tests/test_resume_edit_command_runs.py
@@ -428,6 +428,52 @@ def test_edit_experience_keeps_exception_fallback_when_wizard_detect_misses(
     assert captured["titles"] == {"r1": "Черновик"}
 
 
+def test_edit_experience_expired_session_in_wizard_readback_is_fail_not_traceback(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """identity-bound readback визард-ридера требует живой сессии (#1032):
+    NotAuthenticated из list_wizard_drafts — [FAIL] команды, не traceback
+    (sibling-обработка list_resumes, review-тред PR #1041)."""
+    import hhru_bot.commands.edit_experience as command
+    from hhru_bot.responses import NotAuthenticated
+
+    resume = SimpleNamespace(id="r1", resume_id="r1")
+    config = SimpleNamespace(storage_state_file="session.json", user_agent=None)
+    monkeypatch.setattr("hhru_bot.config.load_config_or_exit", lambda _path: config)
+    monkeypatch.setattr("hhru_bot.commands._common.resolve_resume", lambda *_a, **_kw: resume)
+
+    @contextmanager
+    def fake_launch_context(*_args, **_kwargs):
+        yield SimpleNamespace(new_page=lambda: object())
+
+    monkeypatch.setattr("hhru_bot.browser.launch_context", fake_launch_context)
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hhru_bot.common._on_wizard_common", lambda *_a, **_kw: True)
+    monkeypatch.setattr("hhru_bot.experience.read_experience_on_hh", lambda *_a, **_kw: [])
+
+    def _raise_auth(*_a, **_kw):
+        raise NotAuthenticated("сессия истекла")
+
+    monkeypatch.setattr("hhru_bot.copy_resume.list_wizard_drafts", _raise_auth)
+
+    history_path = tmp_path / "history.db"
+    args = argparse.Namespace(
+        config="config.yaml",
+        headless=True,
+        resume="r1",
+        mode="fill",
+        career=None,
+        existing=None,
+        entry=['{"company": "a", "position": "b", "start_month": "1"}'],
+        dry_run=False,
+        force=True,
+        history=str(history_path),
+    )
+
+    assert command.run(args) is True
+    assert "Сессия недействительна" in capsys.readouterr().out
+
+
 def test_edit_languages_launch_failure_before_attempt_does_not_count_as_attempted(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
## Что сделано

Closes #1037.

В `edit-experience` детектор визард-состояния `_on_wizard_common` теперь вызывается
ДО чтения карточек `list_resume_cards` (тот же приём, что в `list-resumes`, #1032):

- после `goto_hh(RESUMES_LIST_URL)` мгновенная проверка `resume-profile-screen_common`
  (экран приходит SSR-разметкой, так что мгновенной проверки достаточно);
- визард-ветка → `list_wizard_drafts` сразу, без 30-секундной платы `COPY_TIMEOUT_MS`;
- обычный аккаунт → `list_resume_cards(navigate=False)`, путь и задержки прежние;
- исключение-фолбэк #1036 (`ResumeListIndeterminate` → `list_wizard_drafts`) оставлен
  как страховка на гонку (детект промахнулся, карточки не появились).

`import-resume` не трогал: там `_read_resume_titles` при `ResumeListIndeterminate`
намеренно возвращает None (отказ от опыта вместо риска over-binding #782) — перевод
его на визард-ридер менял бы поведение, это отдельное решение. Дифф минимальный,
зона общая с #1039 (list-resumes) — сам `list_resumes.py` не затронут.

## Тесты

- `test_edit_experience_falls_back_to_wizard_drafts_when_list_is_wizard` — переписан
  на путь детектора (+ ассерт, что `list_resume_cards` в визард-ветке не вызывается);
- новый `test_edit_experience_keeps_exception_fallback_when_wizard_detect_misses` —
  страховка #1036;
- обновлены стабы в `test_manual_input_commands.py` (goto_hh/_on_wizard_common, **kw).

`ruff check` + `ruff format --check` — чисто; полный `pytest -q -n 4 --dist worksteal` — зелёный.

## Риски

Детектор — `count() == 1` сразу после goto: ложный негатив (редкий рендер позже) уходит
в прежний путь с его исключением-страховкой; ложный позитив на обычном списке не виден
(экран common там не рендерится). Живой прогон на визард-аккаунте не выполнялся —
поведение подтверждено тестами и живым фактом #1032/#1036.
