### PR TITLE
fix(list-resumes): пустой аккаунт — честное «резюме нет» вместо [FAIL] дрейфа (#1039)

### DIFF
--- a/src/hhru_bot/commands/list_resumes.py
+++ b/src/hhru_bot/commands/list_resumes.py
@@ -268,7 +268,9 @@ def run(args: argparse.Namespace) -> None:
             return
 
     if not cards:
-        print("[INFO] На hh.ru не найдено ни одного резюме.")
+        # #1039: пустой список — подтверждённое состояние (список пуст ЛИБО
+        # hh.ru показал стартовый экран визарда создания), а не сбой чтения.
+        print("[INFO] На аккаунте нет ни одного резюме. Создание: create-resume.")
         return
 
     if not any(c.title for c in cards) and not wizard_mode:

--- a/src/hhru_bot/copy_resume.py
+++ b/src/hhru_bot/copy_resume.py
@@ -66,6 +66,7 @@ from .selector_groups.resume_list import (
     RESUME_LIST_CARD_TITLE,
     RESUME_PROFILE_READY,
 )
+from .selector_groups.resume_page import RESUME_CREATION_SELECT_JOB
 
 logger = logging.getLogger("hhru_bot.copy_resume")
 
@@ -413,6 +414,17 @@ def list_resume_cards(
         try:
             cards_locator.first.wait_for(timeout=COPY_TIMEOUT_MS)
         except PlaywrightTimeoutError:
+            # #1039: аккаунт без резюме — hh.ru рендерит на /applicant/resumes
+            # НЕ список, а стартовый экран визарда создания (census 2026-09-08:
+            # resume-profile-screen_professional_role, карточки выбора
+            # профессии). Состояние страницы тогда ПОДТВЕРЖДЕНО — это честное
+            # «резюме нет», а не дрейф селектора. Селектор карточки выбора
+            # профессии подтверждён живым DOM 2026-08-18 (#304) и совпадает с
+            # census пустого аккаунта. Нераспознанная страница — прежний
+            # fail-closed ResumeListIndeterminate.
+            if page.locator(RESUME_CREATION_SELECT_JOB).count() > 0:
+                logger.info("Стартовый экран визарда создания вместо списка — резюме нет")
+                return []
             raise ResumeListIndeterminate(
                 "карточки резюме не появились за отведённое время — состояние "
                 "/applicant/resumes не подтверждено (timeout, анти-бот/"

--- a/tests/test_list_resume_cards.py
+++ b/tests/test_list_resume_cards.py
@@ -22,6 +22,16 @@ from hhru_bot.selector_groups.resume_list import (
     RESUME_LIST_CARD,
     RESUME_LIST_CARD_TITLE,
 )
+from hhru_bot.selector_groups.resume_page import RESUME_CREATION_SELECT_JOB
+
+
+class _StaticCount:
+    def __init__(self, n: int):
+        self._n = n
+
+    def count(self):
+        return self._n
+
 
 pytestmark = pytest.mark.integration
 
@@ -119,14 +129,22 @@ class StubFirstCard:
 
 
 class StubPage:
-    def __init__(self, cards: list[StubCard], delayed_cards: list[StubCard] | None = None):
+    def __init__(
+        self,
+        cards: list[StubCard],
+        delayed_cards: list[StubCard] | None = None,
+        wizard_start: bool = False,
+    ):
         self._cards = list(cards)
         self._delayed_cards = delayed_cards
+        self._wizard_start = wizard_start
         self.gotos: list[str] = []
 
     def locator(self, selector):
         if selector == RESUME_LIST_CARD:
             return StubCardsLocator(self._cards, self._delayed_cards)
+        if selector == RESUME_CREATION_SELECT_JOB:
+            return _StaticCount(1 if self._wizard_start else 0)
         raise AssertionError(f"неожиданный page.locator: {selector}")
 
     def content(self):
@@ -235,6 +253,16 @@ def test_timeout_raises_indeterminate_not_empty_list(monkeypatch):
 
     with pytest.raises(cr.ResumeListIndeterminate):
         cr.list_resume_cards(page)
+
+
+def test_wizard_start_screen_on_timeout_is_honest_empty_account(monkeypatch):
+    """#1039: аккаунт без резюме — hh.ru рендерит стартовый экран визарда
+    создания вместо списка (census 2026-09-08). Состояние ПОДТВЕРЖДЕНО,
+    поэтому честный пустой список, а не ResumeListIndeterminate."""
+    page = StubPage([], wizard_start=True)
+    _patch_goto(monkeypatch, page)
+
+    assert cr.list_resume_cards(page) == []
 
 
 def test_navigate_false_skips_goto(monkeypatch):


### PR DESCRIPTION
Closes #1039

## Суть

На аккаунте без резюме hh.ru рендерит на `/applicant/resumes` не список карточек, а стартовый экран визарда создания (`resume-profile-screen_professional_role`, карточки `resume-profile-card-select-job` / `-any-job` / `-dont-know` — census из ишью, 2026-09-08). `list_resume_cards` ждала `[data-qa='resume']` 30 секунд и падала `[FAIL] … дрейф селектора RESUME_LIST_CARD`, хотя состояние страницы было подтверждено — просто не классифицировано.

## Изменение (минимальный дифф)

- `copy_resume.py::list_resume_cards` — в ветке таймаута карточек проверяется селектор `RESUME_CREATION_SELECT_JOB` (`[data-qa='resume-profile-card-select-job']`). Совпал → `[]` (честное «резюме нет»); не совпал → прежний fail-closed `ResumeListIndeterminate`.
- `commands/list_resumes.py` — пустой список теперь печатает `[INFO] На аккаунте нет ни одного резюме. Создание: create-resume.` (таблица не печатается).
- `tests/test_list_resume_cards.py` — новый тест «стартовый экран визарда = честный пустой список»; регресс-тест fail-closed (`test_timeout_raises_indeterminate_not_empty_list`) сохранён и зелёный.

## Выбор селектора — не выдуман

`resume-profile-card-select-job` уже в кодовой базе как `resume_page.RESUME_CREATION_SELECT_JOB`, подтверждён живым DOM 2026-08-18 (#304, create-resume wizard первый экран — тот же экран) и совпадает с census пустого аккаунта из ишью. Пустое состояние на живом аккаунте этим прогоном не воспроизводилось: testing-аккаунт имеет резюме, дефолтный на момент прогона тоже (9 шт., census снят read-only) — живое подтверждение классификации возможно после следующего удаления/создания резюме.

## Тесты

- `pytest -q -n 4 --dist worksteal` из `src`: зелёный, кроме `test_selector_metrics.py::test_bundle_matches_json_schema_and_golden` — падает только при cwd=`src` (относительный путь `schemas/…`), из корня worktree проходит; не связан с изменением.
- `ruff check` + `ruff format --check` — чисто.

## Известное

Формулировка census показывала и `resume-profile-screen_professional_role`; предикат сознательно держится на карточке выбора профессии (один подтверждённый селектор вместо составного экранного) — экранная data-qa составной формы `resume-profile-screen resume-profile-screen_professional_role` живым DOM в этом прогоне не снималась.
