### PR TITLE
fix(negotiations-chat): автор сообщения по CSS-модульным маркерам (дрейф message_my, #1044)

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Write-команды (`apply`/`bump`/`run`/...) сначала `--dry-run`, по
 
 - `--url` — Полный URL страницы hh.ru
 - `--json` — Машиночитаемый JSON-вывод
+- `--wait-ms WAIT_MS` — Подождать N мс после загрузки перед снимком (гидратация React, #858)
 
 ### `clear-negotiations`
 

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -674,6 +674,18 @@ _CENSUS_JS = r"""() => {
       role: el.getAttribute('role') || '',
       label: (el.getAttribute('aria-label') || '').slice(0, 80),
       text: (el.innerText || el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 80),
+      classes: (typeof el.className === 'string' ? el.className : '').trim().slice(0, 120),
+      ancestors: (() => {
+        // #1044: селекторы бывают не на самом контроле, а на предках (автор
+        // сообщения чата) — вертикаль классов предков до 6 уровней вверх.
+        const chain = [];
+        for (let node = el.parentElement, hop = 0; node && hop < 6;
+             node = node.parentElement, hop += 1) {
+          const cls = (typeof node.className === 'string' ? node.className : '').trim();
+          if (cls) chain.push(cls.split(/\s+/).slice(0, 6).join(' ').slice(0, 120));
+        }
+        return chain.join(' | ').slice(0, 400);
+      })(),
       visible,
     });
   }
@@ -751,6 +763,7 @@ _SUBTREE_CENSUS_JS = r"""(root) => {
       role: el.getAttribute('role') || '',
       label: (el.getAttribute('aria-label') || '').slice(0, 80),
       text: (el.innerText || el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 80),
+      classes: (typeof el.className === 'string' ? el.className : '').trim().slice(0, 120),
       visible,
     });
   }

--- a/src/hhru_bot/browser.py
+++ b/src/hhru_bot/browser.py
@@ -790,7 +790,10 @@ def census_table(rows: list[dict]) -> str:
     импортов: report импортирует browser)."""
     from .report import _ascii_table
 
-    header = ["data-qa", "tag", "role", "label", "text", "visible"]
+    # #1044: classes в текстовой таблице — классы контрола видны «глазам
+    # агента» без --json. ancestors остаются только машинным каналом (--json):
+    # вертикаль классов до 400 символов не помещается в ASCII-таблицу.
+    header = ["data-qa", "tag", "role", "label", "text", "classes", "visible"]
     rows_out = [
         [
             str(r.get("qa", "")),
@@ -798,6 +801,7 @@ def census_table(rows: list[dict]) -> str:
             str(r.get("role", "")),
             str(r.get("label", "")),
             str(r.get("text", "")),
+            str(r.get("classes", "")),
             "да" if r.get("visible") else "нет",
         ]
         for r in rows

--- a/src/hhru_bot/commands/census.py
+++ b/src/hhru_bot/commands/census.py
@@ -27,6 +27,12 @@ def register(subparsers: Any) -> None:
     )
     parser.add_argument("--url", required=True, help="Полный URL страницы hh.ru")
     parser.add_argument("--json", action="store_true", help="Машиночитаемый JSON-вывод")
+    parser.add_argument(
+        "--wait-ms",
+        type=int,
+        default=0,
+        help="Подождать N мс после загрузки перед снимком (гидратация React, #858)",
+    )
     parser.set_defaults(func=run)
 
 
@@ -39,6 +45,8 @@ def run(args: argparse.Namespace) -> bool:
     ) as context:
         page = context.new_page()
         goto_hh(page, args.url)
+        if getattr(args, "wait_ms", 0):
+            page.wait_for_timeout(args.wait_ms)
         rows = rendered_controls_census(page)
 
     visible_only = [r for r in rows if r.get("visible")]

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -1177,12 +1177,16 @@ def run_negotiations(args: argparse.Namespace) -> bool:
                 )
             print(_ascii_table(["message", "id", "author_marker", "text"], message_rows))
             print(
-                "Корень сообщений чата — census отрисованных контролов "
+                "Корни сообщений чата — census отрисованных контролов "
                 "(сырой HTML в stdout запрещён, #998):"
             )
             message_roots = page.locator(negotiations.CHAT_MESSAGE_ROOT)
-            if message_roots.count():
-                chat_census = subtree_controls_census(message_roots.first)
+            # #1044-цепочка: census по ВСЕМ корням, не только первому —
+            # кнопки быстрых ответов робота («Да»/«Нет») живут в subtree
+            # конкретного сообщения (вопроса), первый корень — наш отклик.
+            for root_index in range(message_roots.count()):
+                print(f"--- сообщение {root_index + 1} ---")
+                chat_census = subtree_controls_census(message_roots.nth(root_index))
                 print(census_table(chat_census["rows"]))
                 if chat_census["truncated"]:
                     print("[WARN] census корня сообщений обрезан по лимиту 120 строк")

--- a/src/hhru_bot/commands/probe.py
+++ b/src/hhru_bot/commands/probe.py
@@ -1091,6 +1091,8 @@ def run_negotiations(args: argparse.Namespace) -> bool:
     """Dump negotiations/chat DOM using only GET navigation and reads."""
     from ..browser import launch_context
     from ..config import load_config_or_exit
+    from ..negotiations_chat import CHAT_AUTHOR_JS as chat_author_js
+    from ..negotiations_chat import author_markers as chat_author_markers
     from ..negotiations_probe import chat_url, paginated_topic_refs
     from ..report import _ascii_table
     from ..responses import NotAuthenticated, ResponsesIndeterminate
@@ -1162,19 +1164,14 @@ def run_negotiations(args: argparse.Namespace) -> bool:
             message_rows = []
             for i in range(messages.count()):
                 loc = messages.nth(i)
-                parent_class = loc.evaluate(
-                    "(el, marker) => { for (let n = el; n; n = n.parentElement) "
-                    "if (String(n.className).split(/\\s+/).includes(marker)) "
-                    "return n.className; return ''; }",
-                    negotiations.CHAT_MESSAGE_MY_MARKER,
-                )
+                author, _label = loc.evaluate(chat_author_js, chat_author_markers())
                 message_rows.append(
                     [
                         str(i + 1),
                         loc.get_attribute("data-qa") or "-",
-                        "own"
-                        if negotiations.CHAT_MESSAGE_MY_MARKER in parent_class.split()
-                        else "other",
+                        # own/employer/system — тот же резолвер, что у
+                        # needs_reply (#1044): префиксы CSS-модульных маркеров.
+                        {"me": "own", "employer": "employer"}.get(author, "system"),
                         loc.inner_text().replace("\n", " ")[:160],
                     ]
                 )

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -20,6 +20,8 @@ from playwright.sync_api import Page
 from .browser import goto_hh
 from .negotiations_probe import chat_url
 from .selector_groups.negotiations import (
+    CHAT_MESSAGE_BOT_MARKER,
+    CHAT_MESSAGE_INCOMING_MARKER,
     CHAT_MESSAGE_INPUT,
     CHAT_MESSAGE_MY_MARKER,
     CHAT_MESSAGE_OTHER_MARKER,
@@ -28,6 +30,64 @@ from .selector_groups.negotiations import (
 )
 
 logger = logging.getLogger("hhru_bot.negotiations_chat")
+
+# #1044: единый браузерный резолвер автора сообщения. Маркеры — префиксы имён
+# классов (CSS-модули добавляют ``--hash``): совпадение это точное имя ИЛИ
+# ``marker + '--<hash>'``. Возвращает сериализуемое [author, label]:
+# author — 'me'|'employer'|null, label — подпись автора с размеченного узла.
+CHAT_AUTHOR_JS = """(el, markers) => {
+  for (let node = el; node; node = node.parentElement) {
+    const classes = String(node.className).split(/\\s+/);
+    const hit = (list) => list.some(
+      (prefix) => classes.includes(prefix)
+        || classes.some((c) => c.startsWith(prefix + '--')));
+    const author = hit(markers.my) ? 'me' : hit(markers.other) ? 'employer' : null;
+    if (author) {
+      const labelNode = node.querySelector(
+        '[data-qa*="author"], [class*="author"], [aria-label], [title]');
+      return [author, labelNode && (labelNode.getAttribute('aria-label')
+        || labelNode.getAttribute('title') || labelNode.textContent || '').trim()];
+    }
+  }
+  return [null, null];
+}"""
+
+
+def author_markers() -> dict[str, list[str]]:
+    """Prefix lists for CHAT_AUTHOR_JS (kept in Python for tests)."""
+    return {
+        "my": [CHAT_MESSAGE_MY_MARKER],
+        "other": [
+            CHAT_MESSAGE_OTHER_MARKER,
+            CHAT_MESSAGE_INCOMING_MARKER,
+            CHAT_MESSAGE_BOT_MARKER,
+        ],
+    }
+
+
+def matches_marker(cls: str, marker: str) -> bool:
+    """CSS-модульное совпадение имени класса с маркером (#1044).
+
+    Живой DOM 2026-09-08: вёрстка чата ушла на CSS-модули, имена классов
+    получили хэш-суффикс (``message_my--PpRVpLiDQMcfwKlp``), поэтому точное
+    сравнение перестало срабатывать. Совпадение — точное имя (старая
+    разметка фикстур) или ``marker + '--<hash>'``; граница ``--`` не даёт
+    «message_mine--…» совпасть с маркером ``message_my``.
+    """
+    return cls == marker or cls.startswith(f"{marker}--")
+
+
+def author_from_ancestors(class_chain: Sequence[str]) -> str | None:
+    """Python-зеркало CHAT_AUTHOR_JS для тестов: цепь классов предков
+    сообщения (снизу вверх) → 'me' | 'employer' | None."""
+    markers = author_markers()
+    for classes in class_chain:
+        names = classes.split()
+        if any(matches_marker(c, m) for c in names for m in markers["my"]):
+            return "me"
+        if any(matches_marker(c, m) for c in names for m in markers["other"]):
+            return "employer"
+    return None
 
 
 class NoReplyForm(RuntimeError):
@@ -176,20 +236,7 @@ def read_last_message(page: Page, chat_id: str) -> ChatMessage | None:
     for index in range(messages.count()):
         item = messages.nth(index)
         item_marker = _message_id(item.get_attribute("data-qa"))
-        item_author, item_label = item.evaluate(
-            """(el, markers) => { for (let node = el; node; node = node.parentElement) {
-                const classes = String(node.className).split(/\\s+/);
-                const author = classes.includes(markers.own) ? 'me'
-                    : classes.includes(markers.other) ? 'employer' : null;
-                if (author) {
-                    const labelNode = node.querySelector(
-                        '[data-qa*="author"], [class*="author"], [aria-label], [title]');
-                    return [author, labelNode && (labelNode.getAttribute('aria-label')
-                        || labelNode.getAttribute('title') || labelNode.textContent || '').trim()];
-                }
-            } return [null, null]; }""",
-            {"own": CHAT_MESSAGE_MY_MARKER, "other": CHAT_MESSAGE_OTHER_MARKER},
-        )
+        item_author, item_label = item.evaluate(CHAT_AUTHOR_JS, author_markers())
         all_messages.append(
             ChatMessage(item_author, item_marker, item.inner_text().strip(), item_label)
         )
@@ -289,16 +336,8 @@ def read_employer_messages(page: Page, chat_id: str) -> list[str]:
     texts: list[str] = []
     for index in range(messages.count() - 1, -1, -1):
         message = messages.nth(index)
-        is_own = message.evaluate(
-            """(el, marker) => {
-                for (let node = el; node; node = node.parentElement) {
-                    if (String(node.className).split(/\\s+/).includes(marker)) return true;
-                }
-                return false;
-            }""",
-            CHAT_MESSAGE_MY_MARKER,
-        )
-        if not is_own:
+        author, _label = message.evaluate(CHAT_AUTHOR_JS, author_markers())
+        if author != "me":
             text = message.inner_text().strip()
             if text:
                 texts.append(text)
@@ -376,16 +415,8 @@ def wait_reply_confirmation(page: Page, timeout_ms: int = 10_000, *, min_count: 
         count = count_visible_messages(page)
         if count >= min_count:
             message = messages.nth(count - 1)
-            author = message.evaluate(
-                """(el, marker) => {
-                    for (let node = el; node; node = node.parentElement) {
-                        if (String(node.className).split(/\\s+/).includes(marker)) return true;
-                    }
-                    return false;
-                }""",
-                CHAT_MESSAGE_MY_MARKER,
-            )
-            if author:
+            author, _label = message.evaluate(CHAT_AUTHOR_JS, author_markers())
+            if author == "me":
                 logger.debug("Отправка в чате подтверждена: последнее сообщение наше")
                 return True
         if time.monotonic() >= deadline:

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -66,16 +66,26 @@ LEGACY_NEGOTIATION_CHAT_LINK = _selector("negotiations.LEGACY_NEGOTIATION_CHAT_L
 
 # Chat route (chatik.hh.ru/chat/<chatId>), confirmed by probe --negotiations
 # --topic (#107). The text node is message-specific; its ancestor carries
-# message_my/message_other, so callers can distinguish our own messages from
+# the author marker, so callers can distinguish our own messages from
 # employer messages without clicking or posting anything. The applicant-action
-# system message (e.g. "отклик отправлен") is excluded — it carries no
-# message_my/message_other marker, so without this exclusion it would be
-# treated as an employer message by any :not(message_my) check.
+# system message (e.g. "пользователь присоединился к чату") is excluded — it
+# carries no author marker, so without this exclusion it would be treated as
+# an employer message by any :not(own) check.
+#
+# #1044 (живой census 2026-09-08): вёрстка чата переехала на CSS-модули —
+# маркеры теперь имена с хэш-суффиксом (message_my--PpRVpLiDQMcfwKlp,
+# chat-bubble_incoming--CgAKL4FOU0shOYzo, chat-bubble_bot--ATOUBrnmcY8nZkrY),
+# поэтому маркер — ПРЕФИКС имени класса, а не точное имя: совпадение считается
+# как `c === marker || c.startsWith(marker + '--')`. Прежнее точное
+# message_other на живом DOM не встречается (сообщения работодателя отличает
+# входящий/бот-бабл), но префикс оставлен для старой разметки фикстур.
 CHAT_MESSAGE_TEXT = _selector("negotiations.CHAT_MESSAGE_TEXT")
 CHAT_MESSAGE_ROOT = _selector("negotiations.CHAT_MESSAGE_ROOT")
 CHAT_AUTHOR_HINT = _selector("negotiations.CHAT_AUTHOR_HINT")
 CHAT_MESSAGE_MY_MARKER = "message_my"
 CHAT_MESSAGE_OTHER_MARKER = "message_other"
+CHAT_MESSAGE_INCOMING_MARKER = "chat-bubble_incoming"
+CHAT_MESSAGE_BOT_MARKER = "chat-bubble_bot"
 
 # Composer controls on chatik.hh.ru.  Keep these here with the read selectors so
 # a markup change cannot leave the write path with a private, stale selector.

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -305,7 +305,8 @@ def test_min_count_default_preserves_plain_reply_behaviour():
 
 
 # --- #1044: дрейф DOM-маркеров автора на CSS-модули -------------------------
-# Живой census 2026-09-08 (census --classes/--ancestors, чаты аккаунта):
+# Живой census 2026-09-08 (колонки classes/ancestors из `census --json`,
+# чаты аккаунта):
 # собственное сообщение:
 #   chat-bubble--TFjICp8IMFIhojGy chat-bubble_with-right-tail--J0NYWVDENy0KLcgZ
 #   chat-bubble_outgoing--C1wSnUG6DlswSx6I | chat-bubble-container--xlH6p5aV4o4u_38b

--- a/tests/test_negotiations_chat.py
+++ b/tests/test_negotiations_chat.py
@@ -5,10 +5,12 @@ import pytest
 from playwright.sync_api import Page
 
 from hhru_bot.negotiations_chat import (
-    CHAT_MESSAGE_MY_MARKER,
+    CHAT_AUTHOR_JS,
     ChatMessage,
+    author_from_ancestors,
     extract_external_test_link,
     is_robot_questionnaire,
+    matches_marker,
     needs_follow_up,
     needs_reply,
     read_chat,
@@ -203,9 +205,12 @@ class _FakeMessage:
     def __init__(self, is_own: bool):
         self._is_own = is_own
 
-    def evaluate(self, _script, marker):
-        assert marker == CHAT_MESSAGE_MY_MARKER
-        return self._is_own
+    def evaluate(self, script, markers):
+        # #1044: резолвер один и тот же (CHAT_AUTHOR_JS + author_markers) —
+        # двойник воспроизводит его вердикт по is_own, не исполняя JS.
+        assert script == CHAT_AUTHOR_JS
+        assert set(markers) == {"my", "other"}
+        return ["me" if self._is_own else "employer", ""]
 
 
 class _FakeMessages:
@@ -297,3 +302,63 @@ def test_min_count_default_preserves_plain_reply_behaviour():
     """min_count=1 (default) is exactly the pre-existing contract."""
     page = _FakeChatPage(authors=[True])
     assert wait_reply_confirmation(cast(Page, page)) is True
+
+
+# --- #1044: дрейф DOM-маркеров автора на CSS-модули -------------------------
+# Живой census 2026-09-08 (census --classes/--ancestors, чаты аккаунта):
+# собственное сообщение:
+#   chat-bubble--TFjICp8IMFIhojGy chat-bubble_with-right-tail--J0NYWVDENy0KLcgZ
+#   chat-bubble_outgoing--C1wSnUG6DlswSx6I | chat-bubble-container--xlH6p5aV4o4u_38b
+#   | message--WgE5qGIVMRAXYnLL message_my--PpRVpLiDQMcfwKlp | ...
+# работодатель-человек: chat-bubble_incoming--CgAKL4FOU0shOYzo
+# работодатель-бот:     chat-bubble_bot--ATOUBrnmcY8nZkrY
+# системное (participant-action): ни одного маркера.
+
+
+def test_marker_matches_css_module_hash_suffix():
+    assert matches_marker("message_my--PpRVpLiDQMcfwKlp", "message_my")
+    assert matches_marker("message_my", "message_my")  # старая разметка
+    assert not matches_marker("message_mine--xxx", "message_my")  # граница --
+    assert not matches_marker("chat-bubble_outgoing--C1wSnUG6DlswSx6I", "message_my")
+
+
+def test_own_message_recognized_through_outgoing_bubble_chain():
+    chain = [
+        "chat-bubble-content--qOhTaYyg5ygPNstt",
+        "chat-bubble--TFjICp8IMFIhojGy chat-bubble_with-right-tail--J0NYWVDENy0KLcgZ "
+        "chat-bubble_outgoing--C1wSnUG6DlswSx6I",
+        "chat-bubble-container--xlH6p5aV4o4u_38b",
+        "message--WgE5qGIVMRAXYnLL message_my--PpRVpLiDQMcfwKlp",
+    ]
+    assert author_from_ancestors(chain) == "me"
+
+
+def test_incoming_human_message_is_employer():
+    chain = [
+        "chat-bubble-content--qOhTaYyg5ygPNstt",
+        "chat-bubble--TFjICp8IMFIhojGy chat-bubble_with-left-tail--__mmuGUjNcDqugJS "
+        "chat-bubble_incoming--CgAKL4FOU0shOYzo",
+    ]
+    assert author_from_ancestors(chain) == "employer"
+
+
+def test_bot_message_is_employer():
+    chain = [
+        "chat-bubble-content--qOhTaYyg5ygPNstt",
+        "chat-bubble--TFjICp8IMFIhojGy chat-bubble_with-left-tail--__mmuGUjNcDqugJS "
+        "chat-bubble_bot--ATOUBrnmcY8nZkrY",
+    ]
+    assert author_from_ancestors(chain) == "employer"
+
+
+def test_system_participant_message_has_no_author():
+    chain = [
+        "content--qbFEo4QXKAQupjDJ",
+        "magritte-scroll-container___QzFOQ_1-0-33 scroll-wrapper--BANmTN9Sz6EwRGzp",
+    ]
+    assert author_from_ancestors(chain) is None
+
+
+def test_legacy_exact_markers_still_classify():
+    assert author_from_ancestors(["message_my"]) == "me"
+    assert author_from_ancestors(["message_other"]) == "employer"


### PR DESCRIPTION
Чинит #1044: `reply-employers` на всех чатах давал `author_unknown` и не мог
ответить работодателю.

## Корень

Вёрстка чата hh.ru переехала на CSS-модули: маркер автора стал именем класса
с хэш-суффиксом (`message_my--PpRVpLiDQMcfwKlp`), а код искал точное имя
`message_my`. Совпадение не срабатывало ни на одном сообщении — fail-closed
классифицировал всё как `author_unknown`, 0 отправок (живой кейс 2026-09-08:
10/10 чатов).

Живые факты сняты расширенным census'ом (новые колонки `classes`/`ancestors`
в JSON-режиме — «глаза» для селекторов, живущих на предках, а не на контроле):

- своё сообщение: `message_my--HASH` на предке (бабл `chat-bubble_outgoing--…`);
- работодатель-человек: `chat-bubble_incoming--CgAKL4FOU0shOYzo`;
- работодатель-бот: `chat-bubble_bot--ATOUBrnmcY8nZkrY`;
- системное «присоединился к чату»: маркеров нет — корректно нейтрально.

## Изменения

- `negotiations_chat.py`: единый `CHAT_AUTHOR_JS`-резолвер (совпадение
  `c === marker || c.startsWith(marker + '--')`) вместо трёх разошедшихся
  инлайнов — потребители `read_last_message`/`read_employer_messages`/
  `wait_reply_confirmation`; Python-зеркало `author_from_ancestors` для тестов.
- `selector_groups/negotiations.py`: маркеры как префиксы + новые
  `chat-bubble_incoming`/`chat-bubble_bot`; `message_other` оставлен для
  старой разметки фикстур.
- `commands/probe.py`: колонка `author_marker` = own/employer/system тем же
  резолвером.
- `browser.py`: census-колонки `classes`/`ancestors`.

## Проверки

- Тесты на живые наблюдённые цепочки классов (своё/incoming/bot/system),
  границу `--` (`message_mine--…` НЕ совпадает с `message_my`) и legacy-имена.
- Полный сюит `-n 4 --dist worksteal` зелёный; ruff check/format зелёные.
- **Живая верификация**: `reply-employers --dry-run` на аккаунте с 10
  переписками — авторы распознаются (`last_message_from_employer` /
  `last_message_from_us` / `robot-questionnaire`), план корректен, 0
  отправок (dry-run).

Мердж — за владельцем.

Closes #1044
