### PR TITLE
refactor(competitors): отделить жизненный цикл collection run от CLI (#1047)

### DIFF
--- a/src/hhru_bot/commands/competitors.py
+++ b/src/hhru_bot/commands/competitors.py
@@ -1,19 +1,50 @@
-"""Collect and report applicant-visible competitor resumes (#578)."""
+"""Collect and report applicant-visible competitor resumes (#578).
+
+CLI-слой (`run_collect`/`run_report`): аргументы, сообщения и коды выхода.
+Жизненный цикл сбора (состояние run, checkpoint/финализация, сигналы, цикл
+страниц) живёт в пакете `competitor_collection` (#1047).
+"""
 
 from __future__ import annotations
 
 import argparse
 import logging
-import math
 import signal
-import threading
 import time
-from collections.abc import Callable
 from dataclasses import replace
+from functools import partial
 
+from ..competitor_collection import (
+    CollectionLifecycle,
+    CollectionParams,
+    CollectionRunState,
+    SignalTermination,
+    collect_pages,
+    collection_status,
+    format_duration,
+    format_elapsed,
+    observed_eta,
+    page_cap_reached,
+    progress,
+    throttle_estimate,
+)
 from ..exit_codes import CommandExitCode
+from ..history import CommandRunBusy, History
 
-logger = logging.getLogger("hhru_bot.competitors")
+# Re-exported for tests and back-compat (#1047): реализации переехали в
+# competitor_collection, имена остались на прежнем месте.
+__all__ = [
+    "_collection_status",
+    "_format_duration",
+    "_format_elapsed",
+    "_observed_eta",
+    "_page_cap_reached",
+    "_progress",
+    "_throttle_estimate",
+    "register",
+    "run_collect",
+    "run_report",
+]
 
 
 def _positive(value: str) -> int:
@@ -37,156 +68,14 @@ def _detail_workers(value: str) -> int:
     return parsed
 
 
-def _page_cap_reached(max_pages: int | None, pages_fetched: int, has_next: bool) -> bool:
-    return has_next and max_pages is not None and pages_fetched >= max_pages
-
-
-def _collection_status(*, details_failed: int, limited: bool) -> str:
-    if limited:
-        return "limited"
-    return "partial" if details_failed else "complete"
-
-
-def _format_duration(seconds: float) -> str:
-    if seconds < 30:
-        return f"{max(0, round(seconds))} с"
-    total_minutes = max(1, round(seconds / 60))
-    hours, minutes = divmod(total_minutes, 60)
-    if hours and minutes:
-        return f"{hours} ч {minutes} мин"
-    if hours:
-        return f"{hours} ч"
-    return f"{minutes} мин"
-
-
-def _format_elapsed(seconds: float) -> str:
-    total_seconds = max(0, round(seconds))
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    parts: list[str] = []
-    if hours:
-        parts.append(f"{hours} ч")
-    if minutes:
-        parts.append(f"{minutes} мин")
-    parts.append(f"{seconds} с")
-    return " ".join(parts)
-
-
-def _observed_eta(state: dict, *, elapsed: float) -> str | None:
-    processed = state["saved"] + state["failed"]
-    expected = state.get("expected_details")
-    if not expected or processed < 3 or processed >= expected or elapsed <= 0:
-        return None
-    seconds = elapsed / processed * (expected - processed)
-    return (
-        f"осталось~{_format_duration(seconds)} "
-        f"(диапазон {_format_duration(seconds * 0.75)}-{_format_duration(seconds * 1.25)})"
-    )
-
-
-def _throttle_estimate(
-    *,
-    details: int,
-    requested_page_size: int,
-    observed_page_size: int,
-    min_delay: float,
-    max_delay: float,
-    workers: int = 1,
-) -> str:
-    active_workers = max(1, min(workers, details))
-    # Every request — the first included — now waits the configured delay
-    # (competitor_workers._worker_main, #663 Codex review), so a worker's
-    # wait count equals its request count, not request count minus one.
-    waits = math.ceil(details / active_workers)
-    return (
-        f"запрошено={requested_page_size}/стр., фактически={observed_page_size}/стр., "
-        f"объём~{details} деталей, workers={active_workers}; только паузы троттлинга "
-        f"{_format_duration(waits * min_delay)}-{_format_duration(waits * max_delay)}; "
-        "ETA уточнится по фактической скорости"
-    )
-
-
-def _progress(
-    message: str,
-    *,
-    quiet: bool,
-    level: int = logging.INFO,
-    always: bool = False,
-) -> None:
-    if always or not quiet:
-        try:
-            print(message, flush=True)
-        except BrokenPipeError:
-            # A detached PTY must not kill collection before the durable
-            # checkpoint/finalizer can run. The file log remains available.
-            pass
-    record = logger.makeRecord(logger.name, level, __file__, 0, message, (), None)
-    for handler in logging.getLogger("hhru_bot").handlers:
-        if isinstance(handler, logging.FileHandler):
-            handler.handle(record)
-
-
-class _SignalTermination(BaseException):
-    def __init__(self, signum: int):
-        self.signum = signum
-
-
-class _Heartbeat:
-    def __init__(
-        self,
-        snapshot: Callable[[], dict],
-        checkpoint: Callable[[], None],
-        *,
-        run_id: str,
-        quiet: bool,
-        started_at: float,
-    ):
-        self.snapshot = snapshot
-        self.checkpoint = checkpoint
-        self.run_id = run_id
-        self.quiet = quiet
-        self.started_at = started_at
-        self.stop = threading.Event()
-        self.thread = threading.Thread(target=self._run, daemon=True)
-        self.failure: Exception | None = None
-
-    def _run(self) -> None:
-        while not self.stop.wait(45):
-            try:
-                self.checkpoint()
-            except Exception as exc:
-                self.failure = exc
-                _progress(
-                    f"[FAIL] run_id={self.run_id} heartbeat не сохранён: "
-                    f"{type(exc).__name__}: {exc}",
-                    quiet=self.quiet,
-                    level=logging.ERROR,
-                    always=True,
-                )
-                return
-            state = self.snapshot()
-            page = state["last_started_page"]
-            page_label = page + 1 if page is not None else "не начата"
-            eta = _observed_eta(state, elapsed=time.monotonic() - self.started_at)
-            eta_suffix = f", {eta}" if eta else ""
-            _progress(
-                f"[HEARTBEAT] run_id={self.run_id} competitors collect жив: "
-                f"страница={page_label}, карточек={state['cards']}, "
-                f"сохранено={state['saved']}, ошибок={state['failed']}{eta_suffix}",
-                quiet=self.quiet,
-            )
-
-    def raise_if_failed(self) -> None:
-        if self.failure is not None:
-            raise self.failure
-
-    def __enter__(self):
-        self.thread.start()
-        return self
-
-    def __exit__(self, *_args):
-        self.stop.set()
-        self.thread.join(timeout=1)
+# Aliases preserved for tests importing the historical underscore names.
+_page_cap_reached = page_cap_reached
+_collection_status = collection_status
+_format_duration = format_duration
+_format_elapsed = format_elapsed
+_observed_eta = observed_eta
+_progress = progress
+_throttle_estimate = throttle_estimate
 
 
 def register(subparsers) -> None:
@@ -290,19 +179,8 @@ def register(subparsers) -> None:
 
 
 def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
-    from ..apply.antibot import AntiBotChallengeDetected, AntiBotDetection
-    from ..browser import goto_hh, launch_context
-    from ..competitor_workers import DetailWorkerConfig, DetailWorkerPool
-    from ..competitors import (
-        CompetitorSearchCard,
-        build_competitor_search_url,
-        coverage_warning,
-        has_next_search_page,
-        inspect_search_coverage,
-        parse_search_page,
-    )
+    from ..competitors import coverage_warning
     from ..config import load_config_or_exit
-    from ..history import CommandRunBusy, History
 
     query = args.text.strip()
     if not query:
@@ -331,84 +209,30 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
     progress_verbosity = 0 if getattr(args, "quiet", False) else args.progress_verbosity
     quiet = progress_verbosity == 0
     requested_page_size = args.items_per_page
+    started_at = time.monotonic()
+    emit = partial(progress, quiet=quiet)
 
     for recovered in started["recovered"]:
-        _progress(
+        emit(
             f"[RECOVERED] run_id={recovered['run_id']} status={recovered['status']}; "
             f"checkpoint: страниц={recovered['pages_fetched']}, "
             f"карточек={recovered['cards_seen']}, сохранено={recovered['details_saved']}; "
             f"причина={recovered['detail']}",
-            quiet=quiet,
             level=logging.WARNING,
         )
     if getattr(args, "resume", False):
         if started["resumed_from_run_id"]:
-            _progress(
+            emit(
                 f"[RESUME] run_id={run_id} from={started['resumed_from_run_id']}; "
-                f"начальная страница={page_num + 1}",
-                quiet=quiet,
+                f"начальная страница={page_num + 1}"
             )
         else:
-            _progress(
+            emit(
                 f"[INFO] run_id={run_id}: подходящий checkpoint не найден, "
-                "начинаем с первой страницы",
-                quiet=quiet,
+                "начинаем с первой страницы"
             )
 
-    state = {
-        "pages": 0,
-        "cards": 0,
-        # Cumulative cards from *completed* pages only, kept in sync with
-        # last_completed_page. cards_seen (state["cards"]) already includes
-        # the in-progress page's cards as soon as they're parsed -- if a
-        # checkpoint fires before that page's details finish, resume_page
-        # still points at that same unfinished page, and a resume must not
-        # double-count its cards into the rank offset (#660, Codex review).
-        "cards_completed": 0,
-        "saved": 0,
-        "failed": 0,
-        "last_started_page": None,
-        "last_completed_page": None,
-        "resume_page": page_num,
-        "observed_page_size": started["resume_observed_page_size"],
-        "expected_details": None,
-    }
-    state_lock = threading.Lock()
-    checkpoint_lock = threading.Lock()
-
-    def snapshot() -> dict:
-        with state_lock:
-            return dict(state)
-
-    def checkpoint() -> None:
-        # Snapshot and SQLite write are one ordered operation. Without this
-        # lock a delayed heartbeat could overwrite a newer completed-page
-        # checkpoint written by the main thread (#654 Codex review).
-        with checkpoint_lock:
-            current = snapshot()
-            history.checkpoint_competitor_collection(
-                run_id,
-                pages_fetched=current["pages"],
-                cards_seen=current["cards"],
-                details_saved=current["saved"],
-                details_failed=current["failed"],
-                last_started_page=current["last_started_page"],
-                last_completed_page=current["last_completed_page"],
-                resume_page=current["resume_page"],
-                observed_page_size=current["observed_page_size"],
-                cards_seen_completed=current["cards_completed"],
-            )
-
-    details_failed = 0
-    new = updated = unchanged = 0
-    limited = False
-    detail_attempts = 0
-    coverage = None
-    target_pages: int | None = None
-    seen_resume_ids: set[str] = set()
-    pages_this_run = 0
-    started_at = time.monotonic()
-    _progress(
+    emit(
         f"[START] run_id={run_id} competitors collect: "
         f"execution_mode={args.execution_mode}, progress_verbosity={progress_verbosity}, "
         f"auth_mode={args.auth_mode}, "
@@ -416,353 +240,87 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
         f"headless={'да' if args.headless else 'нет'}, "
         f"запрошено карточек/страницу={requested_page_size}, "
         f"объём={'до ' + str(args.max_pages) + ' стр.' if args.max_pages else 'до конца выдачи'}, "
-        f"лимит страниц={args.max_pages if args.max_pages is not None else 'без лимита'}",
-        quiet=quiet,
+        f"лимит страниц={args.max_pages if args.max_pages is not None else 'без лимита'}"
     )
 
-    handled_signals = [signal.SIGTERM]
-    if hasattr(signal, "SIGHUP"):
-        handled_signals.append(signal.SIGHUP)
-    previous_handlers = {signum: signal.getsignal(signum) for signum in handled_signals}
+    state = CollectionRunState(
+        resume_page=page_num,
+        observed_page_size=started["resume_observed_page_size"],
+    )
+    lifecycle = CollectionLifecycle(history, run_id)
+    params = CollectionParams(
+        query=query,
+        search_in=args.search_in,
+        auth_mode=args.auth_mode,
+        require_authentication=require_authentication,
+        requested_page_size=requested_page_size,
+        max_pages=args.max_pages,
+        detail_workers=args.detail_workers,
+        headless=args.headless,
+        quiet=quiet,
+        user_agent=config.user_agent,
+        launch_storage_state=config.storage_state_file if require_authentication else None,
+        worker_storage_state=(str(config.storage_state_file) if require_authentication else None),
+        min_delay_seconds=config.throttle.min_delay_seconds,
+        max_delay_seconds=config.throttle.max_delay_seconds,
+        initial_page=page_num,
+        rank_offset_base=rank_offset_base,
+        started_at=started_at,
+    )
+    outcome = collect_pages(params, state, lifecycle, emit=emit)
+    current = outcome.snapshot
+    elapsed_label = format_elapsed(outcome.elapsed_seconds)
 
-    def terminate(signum, _frame):  # noqa: ANN001
-        raise _SignalTermination(signum)
-
-    for signum in handled_signals:
-        signal.signal(signum, terminate)
-
-    caught: BaseException | None = None
-    heartbeat: _Heartbeat | None = None
-    try:
-        with (
-            _Heartbeat(
-                snapshot,
-                checkpoint,
-                run_id=run_id,
-                quiet=quiet,
-                started_at=started_at,
-            ) as heartbeat,
-            launch_context(
-                config.storage_state_file if require_authentication else None,
-                headless=args.headless,
-                user_agent=config.user_agent,
-            ) as context,
-        ):
-            search_page = context.new_page()
-            worker_pool: DetailWorkerPool | None = None
-            try:
-                while True:
-                    with state_lock:
-                        state["last_started_page"] = page_num
-                        state["resume_page"] = page_num
-                    checkpoint()
-                    goto_hh(
-                        search_page,
-                        build_competitor_search_url(
-                            query,
-                            page_num,
-                            items_per_page=requested_page_size,
-                            search_in=args.search_in,
-                        ),
-                    )
-                    cards_before = snapshot()["cards"]
-                    cards = parse_search_page(
-                        search_page,
-                        rank_offset=rank_offset_base + cards_before,
-                        expected_page_size=requested_page_size,
-                        require_authentication=require_authentication,
-                    )
-                    pages_this_run += 1
-                    with state_lock:
-                        state["pages"] += 1
-                        state["cards"] += len(cards)
-                        state["observed_page_size"] = max(
-                            state["observed_page_size"] or 0, len(cards)
-                        )
-                    has_next = has_next_search_page(search_page, page_num)
-                    if coverage is None:
-                        observed_page_size = snapshot()["observed_page_size"]
-                        coverage = inspect_search_coverage(
-                            search_page,
-                            page_num,
-                            observed_page_size=observed_page_size,
-                            requested_page_size=requested_page_size,
-                        )
-                        available_from_here = (
-                            max(1, coverage.available_pages - page_num)
-                            if coverage.available_pages is not None
-                            else None
-                        )
-                        target_pages = args.max_pages
-                        if target_pages is None:
-                            target_pages = available_from_here
-                        elif available_from_here is not None:
-                            target_pages = min(target_pages, available_from_here)
-                        if target_pages is not None and observed_page_size:
-                            expected_details = (
-                                len(cards) + max(0, target_pages - 1) * requested_page_size
-                            )
-                            _progress(
-                                f"[ESTIMATE] run_id={run_id} "
-                                + _throttle_estimate(
-                                    details=expected_details,
-                                    requested_page_size=requested_page_size,
-                                    observed_page_size=observed_page_size,
-                                    min_delay=config.throttle.min_delay_seconds,
-                                    max_delay=config.throttle.max_delay_seconds,
-                                    workers=args.detail_workers,
-                                ),
-                                quiet=quiet,
-                            )
-                    if target_pages is not None:
-                        with state_lock:
-                            state["expected_details"] = (
-                                state["cards"]
-                                + max(0, target_pages - pages_this_run) * requested_page_size
-                            )
-
-                    page_cards = []
-                    for card in cards:
-                        heartbeat.raise_if_failed()
-                        if card.resume_id in seen_resume_ids:
-                            continue
-                        seen_resume_ids.add(card.resume_id)
-                        page_cards.append(card)
-
-                    if page_cards:
-                        # Sizing from just this page (instead of capping at
-                        # args.detail_workers outright) undersizes the pool
-                        # for the rest of the run when an early page is
-                        # mostly duplicates (e.g. --resume) — #663 review.
-                        # grow() is additive/idempotent, so re-evaluating the
-                        # target on every page lets the pool catch up once a
-                        # later page proves there is more work than workers.
-                        target_workers = min(args.detail_workers, state["cards"])
-                        if worker_pool is None:
-                            worker_pool = DetailWorkerPool(
-                                target_workers,
-                                DetailWorkerConfig(
-                                    storage_state_file=(
-                                        str(config.storage_state_file)
-                                        if require_authentication
-                                        else None
-                                    ),
-                                    headless=args.headless,
-                                    user_agent=config.user_agent,
-                                    min_delay_seconds=config.throttle.min_delay_seconds,
-                                    max_delay_seconds=config.throttle.max_delay_seconds,
-                                    require_authentication=require_authentication,
-                                ),
-                            )
-                            worker_pool.start()
-                        elif target_workers > worker_pool.size:
-                            worker_pool.grow(target_workers)
-                        _progress(
-                            f"[WORKERS] run_id={run_id} запущено={worker_pool.size}",
-                            quiet=quiet,
-                        )
-
-                    pending: dict[int, CompetitorSearchCard] = {}
-                    if worker_pool is not None:
-                        for card in page_cards:
-                            task_id = detail_attempts
-                            detail_attempts += 1
-                            pending[task_id] = card
-                            worker_pool.submit(task_id, card)
-
-                    while pending:
-                        heartbeat.raise_if_failed()
-                        assert worker_pool is not None
-                        result = worker_pool.result(timeout=1)
-                        if result is None:
-                            continue
-                        kind = result["kind"]
-                        if kind == "fatal":
-                            raise RuntimeError(
-                                f"detail worker {result['worker_id'] + 1}: "
-                                f"{result['error_type']}: {result['error']}"
-                            )
-                        task_id = result["task_id"]
-                        if task_id not in pending:
-                            continue
-                        card = pending.pop(task_id)
-                        if kind == "antibot":
-                            raise AntiBotChallengeDetected(
-                                AntiBotDetection(
-                                    signal=result["antibot_signal"],
-                                    detail=result["antibot_detail"],
-                                )
-                            )
-                        if kind == "error":
-                            details_failed += 1
-                            with state_lock:
-                                state["failed"] = details_failed
-                            _progress(
-                                f"[WARN] run_id={run_id} резюме rank={card.rank} "
-                                f"не сохранено: {result['error_type']}: {result['error']}",
-                                quiet=quiet,
-                                level=logging.WARNING,
-                            )
-                            continue
-                        outcome = history.upsert_competitor_resume(
-                            result["payload"],
-                            search_query=query,
-                            search_rank=card.rank,
-                            search_in=args.search_in,
-                            auth_mode=args.auth_mode,
-                        )
-                        with state_lock:
-                            state["saved"] += 1
-                        if outcome == "new":
-                            new += 1
-                        elif outcome == "updated":
-                            updated += 1
-                        else:
-                            unchanged += 1
-
-                    with state_lock:
-                        state["last_completed_page"] = page_num
-                        state["cards_completed"] = state["cards"]
-                        state["resume_page"] = page_num + 1 if has_next else None
-                        if not has_next or _page_cap_reached(
-                            args.max_pages, pages_this_run, has_next
-                        ):
-                            state["expected_details"] = state["saved"] + state["failed"]
-                    checkpoint()
-                    current = snapshot()
-                    eta = _observed_eta(current, elapsed=time.monotonic() - started_at)
-                    eta_suffix = f", {eta}" if eta else ""
-                    _progress(
-                        f"[PROGRESS] run_id={run_id} страница={page_num + 1}, "
-                        f"карточек={current['cards']}, "
-                        f"деталей={current['saved'] + current['failed']}, "
-                        f"новых/обновлено={new + updated}, ошибок={current['failed']}"
-                        f"{eta_suffix}",
-                        quiet=quiet,
-                    )
-                    if not has_next:
-                        break
-                    if _page_cap_reached(args.max_pages, pages_this_run, has_next):
-                        limited = True
-                        break
-                    page_num += 1
-            except BaseException as exc:
-                if worker_pool is not None:
-                    worker_pool.close(
-                        terminate=not isinstance(exc, (KeyboardInterrupt, _SignalTermination))
-                    )
-                raise
-            else:
-                if worker_pool is not None:
-                    worker_pool.close()
-    except BaseException as exc:
-        caught = exc
-    finally:
-        for signum, previous in previous_handlers.items():
-            signal.signal(signum, previous)
-
-    current = snapshot()
-    elapsed_label = _format_elapsed(time.monotonic() - started_at)
-    if caught is not None:
-        status = (
-            "partial"
-            if current["pages"]
-            or current["cards"]
-            or current["saved"]
-            or current["failed"]
-            or current["last_started_page"] is not None
-            else "failed"
-        )
-        if isinstance(caught, KeyboardInterrupt):
-            code = CommandExitCode.SIGINT.value
-        elif isinstance(caught, _SignalTermination):
-            code = 128 + caught.signum
-        else:
-            code = 1
-        detail = f"{type(caught).__name__}: {caught}"[:1000]
-        history.finish_competitor_collection(
-            run_id,
-            status=status,
-            pages_fetched=current["pages"],
-            cards_seen=current["cards"],
-            details_saved=current["saved"],
-            details_failed=current["failed"],
-            detail=detail,
-            exit_code=code,
-            resume_page=current["resume_page"],
-            last_started_page=current["last_started_page"],
-            last_completed_page=current["last_completed_page"],
-            observed_page_size=current["observed_page_size"],
-            cards_seen_completed=current["cards_completed"],
-        )
+    if outcome.caught is not None:
+        caught = outcome.caught
+        code = outcome.exit_code
         last_page = (
-            current["last_completed_page"] + 1
-            if current["last_completed_page"] is not None
-            else "нет"
+            current.last_completed_page + 1 if current.last_completed_page is not None else "нет"
         )
-        _progress(
+        emit(
             f"[STOP] run_id={run_id} код завершения={code}; checkpoint: "
-            f"завершённая страница={last_page}, страниц={current['pages']}, "
-            f"карточек={current['cards']}, сохранено={current['saved']}, "
-            f"ошибок={current['failed']}, время={elapsed_label}; причина={detail}",
-            quiet=quiet,
+            f"завершённая страница={last_page}, страниц={current.pages}, "
+            f"карточек={current.cards}, сохранено={current.saved}, "
+            f"ошибок={current.failed}, время={elapsed_label}; причина={outcome.detail}",
             level=logging.ERROR if code == 1 else logging.WARNING,
             always=True,
         )
         if isinstance(caught, KeyboardInterrupt):
             return CommandExitCode.SIGINT
-        if isinstance(caught, _SignalTermination):
+        if isinstance(caught, SignalTermination):
             if caught.signum == signal.SIGTERM:
                 return CommandExitCode.SIGTERM
             return CommandExitCode.SIGHUP
         raise caught
 
-    status = _collection_status(details_failed=details_failed, limited=limited)
-    finish_detail = f"limited_by_max_pages={args.max_pages}" if limited else None
-    exit_code = 1 if details_failed else 0
-    history.finish_competitor_collection(
-        run_id,
-        status=status,
-        pages_fetched=current["pages"],
-        cards_seen=current["cards"],
-        details_saved=current["saved"],
-        details_failed=current["failed"],
-        detail=finish_detail,
-        exit_code=exit_code,
-        resume_page=current["resume_page"] if limited else None,
-        last_started_page=current["last_started_page"],
-        last_completed_page=current["last_completed_page"],
-        observed_page_size=current["observed_page_size"],
-        cards_seen_completed=current["cards_completed"],
-    )
-    total_results = coverage.total_results if coverage else None
-    available_pages = coverage.available_pages if coverage else None
+    total_results = outcome.coverage.total_results if outcome.coverage else None
+    available_pages = outcome.coverage.available_pages if outcome.coverage else None
+    coverage = outcome.coverage
     if coverage is not None:
-        coverage = replace(coverage, observed_page_size=current["observed_page_size"])
+        coverage = replace(coverage, observed_page_size=current.observed_page_size)
     total_label = total_results if total_results is not None else "не подтверждено"
     pages_label = available_pages if available_pages is not None else "не подтверждено"
-    page_size_label = current["observed_page_size"] or "не подтверждено"
-    _progress(
+    page_size_label = current.observed_page_size or "не подтверждено"
+    emit(
         f"Конкуренты: run_id={run_id}, заявлено hh.ru {total_label}, "
         f"доступно страниц {pages_label}, фактически карточек/страницу {page_size_label}, "
-        f"просмотрено страниц {current['pages']}, увидено карточек {current['cards']}, "
-        f"сохранено уникальных {current['saved']}, новых {new}, обновлено {updated}, "
-        f"без изменений {unchanged}, ошибок {current['failed']}, "
-        f"код завершения={exit_code}, время={elapsed_label}",
-        quiet=quiet,
+        f"просмотрено страниц {current.pages}, увидено карточек {current.cards}, "
+        f"сохранено уникальных {current.saved}, новых {outcome.new}, "
+        f"обновлено {outcome.updated}, без изменений {outcome.unchanged}, "
+        f"ошибок {current.failed}, "
+        f"код завершения={outcome.exit_code}, время={elapsed_label}",
         always=True,
     )
     warning = coverage_warning(coverage) if coverage else None
     if warning:
-        _progress(f"[WARN] run_id={run_id} {warning}", quiet=quiet, level=logging.WARNING)
-    if limited:
-        _progress(
+        emit(f"[WARN] run_id={run_id} {warning}", level=logging.WARNING)
+    if outcome.limited:
+        emit(
             f"[WARN] run_id={run_id} выдача ограничена --max-pages={args.max_pages}; "
-            f"следующий checkpoint: страница={current['resume_page'] + 1}",
-            quiet=quiet,
+            f"следующий checkpoint: страница={current.resume_page + 1}",
             level=logging.WARNING,
         )
-    return details_failed > 0
+    return outcome.details_failed > 0
 
 
 def run_report(args: argparse.Namespace) -> None:

--- a/src/hhru_bot/competitor_collection/__init__.py
+++ b/src/hhru_bot/competitor_collection/__init__.py
@@ -1,0 +1,37 @@
+"""Жизненный цикл сборщика конкурентов, отделённый от CLI (#1047)."""
+
+from .lifecycle import (
+    CollectionLifecycle,
+    Heartbeat,
+    SignalTermination,
+    install_termination_handlers,
+    restore_signal_handlers,
+)
+from .progress import format_duration, format_elapsed, observed_eta, progress, throttle_estimate
+from .service import CollectionOutcome, CollectionParams, collect_pages
+from .state import (
+    CollectionRunState,
+    RunSnapshot,
+    collection_status,
+    page_cap_reached,
+)
+
+__all__ = [
+    "CollectionLifecycle",
+    "CollectionOutcome",
+    "CollectionParams",
+    "CollectionRunState",
+    "Heartbeat",
+    "RunSnapshot",
+    "SignalTermination",
+    "collect_pages",
+    "collection_status",
+    "format_duration",
+    "format_elapsed",
+    "install_termination_handlers",
+    "observed_eta",
+    "page_cap_reached",
+    "progress",
+    "restore_signal_handlers",
+    "throttle_estimate",
+]

--- a/src/hhru_bot/competitor_collection/lifecycle.py
+++ b/src/hhru_bot/competitor_collection/lifecycle.py
@@ -1,0 +1,154 @@
+"""Жизненный цикл collection run: checkpoint, финализация, сигналы (#1047).
+
+Адаптер `CollectionLifecycle` — единственное место, где снапшот состояния
+попадает в SQLite (heartbeat/checkpoint и finish). `SignalTermination` и
+`Heartbeat` — собственная механика коллектора; общую инфраструктуру сигналов
+с supervision (#459) здесь сознательно не трогаем — контракты различаются
+и не зафиксированы.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+import time
+from collections.abc import Callable
+
+from ..history import History
+from .progress import observed_eta, progress
+from .state import RunSnapshot
+
+
+class SignalTermination(BaseException):
+    def __init__(self, signum: int):
+        self.signum = signum
+
+
+def install_termination_handlers() -> dict[int, object]:
+    handled_signals = [signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        handled_signals.append(signal.SIGHUP)
+    previous = {signum: signal.getsignal(signum) for signum in handled_signals}
+
+    def terminate(signum, _frame):  # noqa: ANN001
+        raise SignalTermination(signum)
+
+    for signum in handled_signals:
+        signal.signal(signum, terminate)
+    return previous
+
+
+def restore_signal_handlers(previous: dict[int, object]) -> None:
+    for signum, handler in previous.items():
+        signal.signal(signum, handler)  # type: ignore[arg-type]
+
+
+class CollectionLifecycle:
+    """Адаптер history-хранения: checkpoint и финализация одного run."""
+
+    def __init__(self, history: History, run_id: str) -> None:
+        self.run_id = run_id
+        self.history = history
+        # Snapshot and SQLite write are one ordered operation. Without this
+        # lock a delayed heartbeat could overwrite a newer completed-page
+        # checkpoint written by the main thread (#654 Codex review).
+        self._checkpoint_lock = threading.Lock()
+
+    def checkpoint(self, snapshot: RunSnapshot) -> None:
+        with self._checkpoint_lock:
+            self.history.checkpoint_competitor_collection(
+                self.run_id,
+                pages_fetched=snapshot.pages,
+                cards_seen=snapshot.cards,
+                details_saved=snapshot.saved,
+                details_failed=snapshot.failed,
+                last_started_page=snapshot.last_started_page,
+                last_completed_page=snapshot.last_completed_page,
+                resume_page=snapshot.resume_page,
+                observed_page_size=snapshot.observed_page_size,
+                cards_seen_completed=snapshot.cards_completed,
+            )
+
+    def finish(
+        self,
+        snapshot: RunSnapshot,
+        *,
+        status: str,
+        detail: str | None,
+        exit_code: int,
+        resume_page: int | None,
+    ) -> None:
+        self.history.finish_competitor_collection(
+            self.run_id,
+            status=status,
+            pages_fetched=snapshot.pages,
+            cards_seen=snapshot.cards,
+            details_saved=snapshot.saved,
+            details_failed=snapshot.failed,
+            detail=detail,
+            exit_code=exit_code,
+            resume_page=resume_page,
+            last_started_page=snapshot.last_started_page,
+            last_completed_page=snapshot.last_completed_page,
+            observed_page_size=snapshot.observed_page_size,
+            cards_seen_completed=snapshot.cards_completed,
+        )
+
+
+class Heartbeat:
+    def __init__(
+        self,
+        snapshot: Callable[[], RunSnapshot],
+        checkpoint: Callable[[], None],
+        *,
+        run_id: str,
+        quiet: bool,
+        started_at: float,
+    ):
+        self.snapshot = snapshot
+        self.checkpoint = checkpoint
+        self.run_id = run_id
+        self.quiet = quiet
+        self.started_at = started_at
+        self.stop = threading.Event()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.failure: Exception | None = None
+
+    def _run(self) -> None:
+        while not self.stop.wait(45):
+            try:
+                self.checkpoint()
+            except Exception as exc:
+                self.failure = exc
+                progress(
+                    f"[FAIL] run_id={self.run_id} heartbeat не сохранён: "
+                    f"{type(exc).__name__}: {exc}",
+                    quiet=self.quiet,
+                    level=logging.ERROR,
+                    always=True,
+                )
+                return
+            snap = self.snapshot()
+            page = snap.last_started_page
+            page_label = page + 1 if page is not None else "не начата"
+            eta = observed_eta(snap, elapsed=time.monotonic() - self.started_at)
+            eta_suffix = f", {eta}" if eta else ""
+            progress(
+                f"[HEARTBEAT] run_id={self.run_id} competitors collect жив: "
+                f"страница={page_label}, карточек={snap.cards}, "
+                f"сохранено={snap.saved}, ошибок={snap.failed}{eta_suffix}",
+                quiet=self.quiet,
+            )
+
+    def raise_if_failed(self) -> None:
+        if self.failure is not None:
+            raise self.failure
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_args):
+        self.stop.set()
+        self.thread.join(timeout=1)

--- a/src/hhru_bot/competitor_collection/progress.py
+++ b/src/hhru_bot/competitor_collection/progress.py
@@ -1,0 +1,95 @@
+"""Вывод прогресса и человекочитаемые оценки сборщика конкурентов (#1047).
+
+`progress()` — единственный канал сообщений хода сбора: stdout (гасится при
+`quiet` и переживает оборванный PTY) плюс дублирование в файловый лог.
+Чистые форматтеры (`format_*`, `observed_eta`, `throttle_estimate`) отделены
+от побочных эффектов и тестируются напрямую.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from .state import RunSnapshot
+
+logger = logging.getLogger("hhru_bot.competitors")
+
+
+def progress(
+    message: str,
+    *,
+    quiet: bool,
+    level: int = logging.INFO,
+    always: bool = False,
+) -> None:
+    if always or not quiet:
+        try:
+            print(message, flush=True)
+        except BrokenPipeError:
+            # A detached PTY must not kill collection before the durable
+            # checkpoint/finalizer can run. The file log remains available.
+            pass
+    record = logger.makeRecord(logger.name, level, __file__, 0, message, (), None)
+    for handler in logging.getLogger("hhru_bot").handlers:
+        if isinstance(handler, logging.FileHandler):
+            handler.handle(record)
+
+
+def format_duration(seconds: float) -> str:
+    if seconds < 30:
+        return f"{max(0, round(seconds))} с"
+    total_minutes = max(1, round(seconds / 60))
+    hours, minutes = divmod(total_minutes, 60)
+    if hours and minutes:
+        return f"{hours} ч {minutes} мин"
+    if hours:
+        return f"{hours} ч"
+    return f"{minutes} мин"
+
+
+def format_elapsed(seconds: float) -> str:
+    total_seconds = max(0, round(seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    parts: list[str] = []
+    if hours:
+        parts.append(f"{hours} ч")
+    if minutes:
+        parts.append(f"{minutes} мин")
+    parts.append(f"{seconds} с")
+    return " ".join(parts)
+
+
+def observed_eta(snapshot: RunSnapshot, *, elapsed: float) -> str | None:
+    processed = snapshot.saved + snapshot.failed
+    expected = snapshot.expected_details
+    if not expected or processed < 3 or processed >= expected or elapsed <= 0:
+        return None
+    seconds = elapsed / processed * (expected - processed)
+    return (
+        f"осталось~{format_duration(seconds)} "
+        f"(диапазон {format_duration(seconds * 0.75)}-{format_duration(seconds * 1.25)})"
+    )
+
+
+def throttle_estimate(
+    *,
+    details: int,
+    requested_page_size: int,
+    observed_page_size: int,
+    min_delay: float,
+    max_delay: float,
+    workers: int = 1,
+) -> str:
+    active_workers = max(1, min(workers, details))
+    # Every request — the first included — now waits the configured delay
+    # (competitor_workers._worker_main, #663 Codex review), so a worker's
+    # wait count equals its request count, not request count minus one.
+    waits = math.ceil(details / active_workers)
+    return (
+        f"запрошено={requested_page_size}/стр., фактически={observed_page_size}/стр., "
+        f"объём~{details} деталей, workers={active_workers}; только паузы троттлинга "
+        f"{format_duration(waits * min_delay)}-{format_duration(waits * max_delay)}; "
+        "ETA уточнится по фактической скорости"
+    )

--- a/src/hhru_bot/competitor_collection/service.py
+++ b/src/hhru_bot/competitor_collection/service.py
@@ -1,0 +1,394 @@
+"""Сервис сбора: цикл страниц и обработчик одной страницы (#1047).
+
+`collect_pages` — это бывший цикл `run_collect`, очищенный от CLI: он не
+парсит аргументы и не печатает финальный отчёт, а получает параметры и канал
+прогресса и всегда возвращает `CollectionOutcome` — в том числе при
+прерывании сигналом или падении браузера (финализация run в SQLite гарантирована
+внутри, до возврата). `DetailWorkerPool` используется как раньше; поведение
+частичных фейлов, rank offset и scope checkpoint не менялись.
+
+Браузерные и page-парсеры импортируются лениво ВНУТРИ `collect_pages` —
+так же, как это делал `run_collect`: тесты монкипатчат атрибуты модулей
+`hhru_bot.browser`/`hhru_bot.competitors`/`hhru_bot.competitor_workers`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..exit_codes import CommandExitCode
+from .lifecycle import (
+    CollectionLifecycle,
+    Heartbeat,
+    SignalTermination,
+    install_termination_handlers,
+    restore_signal_handlers,
+)
+from .progress import observed_eta, progress, throttle_estimate
+from .state import CollectionRunState, RunSnapshot, collection_status, page_cap_reached
+
+logger = logging.getLogger("hhru_bot.competitors")
+
+# Канал прогресса CLI: print+файл-лог с заранее подшитым quiet.
+Emit = Callable[..., None]
+
+
+@dataclass(frozen=True)
+class CollectionParams:
+    """Всё, что сервису нужно от CLI, кроме history-адаптера и прогресса."""
+
+    query: str
+    search_in: str
+    auth_mode: str
+    require_authentication: bool
+    requested_page_size: int
+    max_pages: int | None
+    detail_workers: int
+    headless: bool
+    quiet: bool
+    user_agent: str | None
+    launch_storage_state: Path | None
+    worker_storage_state: str | None
+    min_delay_seconds: float
+    max_delay_seconds: float
+    initial_page: int
+    rank_offset_base: int
+    started_at: float
+
+
+@dataclass(frozen=True)
+class CollectionOutcome:
+    snapshot: RunSnapshot
+    new: int
+    updated: int
+    unchanged: int
+    details_failed: int
+    limited: bool
+    coverage: object | None
+    status: str
+    exit_code: int
+    detail: str | None
+    caught: BaseException | None
+    elapsed_seconds: float
+
+
+def collect_pages(
+    params: CollectionParams,
+    state: CollectionRunState,
+    lifecycle: CollectionLifecycle,
+    *,
+    emit: Emit = progress,
+) -> CollectionOutcome:
+    from ..browser import goto_hh, launch_context
+    from ..competitor_workers import DetailWorkerConfig, DetailWorkerPool
+    from ..competitors import (
+        build_competitor_search_url,
+        has_next_search_page,
+        inspect_search_coverage,
+        parse_search_page,
+    )
+
+    run_id = lifecycle.run_id
+    quiet = params.quiet
+    new = updated = unchanged = 0
+    limited = False
+    detail_attempts = 0
+    coverage = None
+    target_pages: int | None = None
+    seen_resume_ids: set[str] = set()
+    pages_this_run = 0
+    page_num = params.initial_page
+    rank_offset_base = params.rank_offset_base
+
+    def checkpoint() -> None:
+        lifecycle.checkpoint(state.snapshot())
+
+    previous_handlers = install_termination_handlers()
+
+    caught: BaseException | None = None
+    heartbeat: Heartbeat | None = None
+    try:
+        with (
+            Heartbeat(
+                state.snapshot,
+                checkpoint,
+                run_id=run_id,
+                quiet=quiet,
+                started_at=params.started_at,
+            ) as heartbeat,
+            launch_context(
+                params.launch_storage_state,
+                headless=params.headless,
+                user_agent=params.user_agent,
+            ) as context,
+        ):
+            search_page = context.new_page()
+            worker_pool = None
+            try:
+                while True:
+                    state.begin_page(page_num)
+                    checkpoint()
+                    goto_hh(
+                        search_page,
+                        build_competitor_search_url(
+                            params.query,
+                            page_num,
+                            items_per_page=params.requested_page_size,
+                            search_in=params.search_in,
+                        ),
+                    )
+                    cards_before = state.snapshot().cards
+                    cards = parse_search_page(
+                        search_page,
+                        rank_offset=rank_offset_base + cards_before,
+                        expected_page_size=params.requested_page_size,
+                        require_authentication=params.require_authentication,
+                    )
+                    pages_this_run += 1
+                    state.add_page_results(len(cards))
+                    has_next = has_next_search_page(search_page, page_num)
+                    if coverage is None:
+                        observed_page_size = state.snapshot().observed_page_size
+                        coverage = inspect_search_coverage(
+                            search_page,
+                            page_num,
+                            observed_page_size=observed_page_size,
+                            requested_page_size=params.requested_page_size,
+                        )
+                        available_from_here = (
+                            max(1, coverage.available_pages - page_num)
+                            if coverage.available_pages is not None
+                            else None
+                        )
+                        target_pages = params.max_pages
+                        if target_pages is None:
+                            target_pages = available_from_here
+                        elif available_from_here is not None:
+                            target_pages = min(target_pages, available_from_here)
+                        if target_pages is not None and observed_page_size:
+                            expected_details = (
+                                len(cards) + max(0, target_pages - 1) * params.requested_page_size
+                            )
+                            emit(
+                                f"[ESTIMATE] run_id={run_id} "
+                                + throttle_estimate(
+                                    details=expected_details,
+                                    requested_page_size=params.requested_page_size,
+                                    observed_page_size=observed_page_size,
+                                    min_delay=params.min_delay_seconds,
+                                    max_delay=params.max_delay_seconds,
+                                    workers=params.detail_workers,
+                                ),
+                                quiet=quiet,
+                            )
+                    if target_pages is not None:
+                        state.set_expected_details_from_target(
+                            target_pages, pages_this_run, params.requested_page_size
+                        )
+
+                    page_cards = []
+                    for card in cards:
+                        assert heartbeat is not None
+                        heartbeat.raise_if_failed()
+                        if card.resume_id in seen_resume_ids:
+                            continue
+                        seen_resume_ids.add(card.resume_id)
+                        page_cards.append(card)
+
+                    if page_cards:
+                        # Sizing from just this page (instead of capping at
+                        # detail_workers outright) undersizes the pool
+                        # for the rest of the run when an early page is
+                        # mostly duplicates (e.g. --resume) — #663 review.
+                        # grow() is additive/idempotent, so re-evaluating the
+                        # target on every page lets the pool catch up once a
+                        # later page proves there is more work than workers.
+                        target_workers = min(params.detail_workers, state.snapshot().cards)
+                        if worker_pool is None:
+                            worker_pool = DetailWorkerPool(
+                                target_workers,
+                                DetailWorkerConfig(
+                                    storage_state_file=params.worker_storage_state,
+                                    headless=params.headless,
+                                    user_agent=params.user_agent,
+                                    min_delay_seconds=params.min_delay_seconds,
+                                    max_delay_seconds=params.max_delay_seconds,
+                                    require_authentication=params.require_authentication,
+                                ),
+                            )
+                            worker_pool.start()
+                        elif target_workers > worker_pool.size:
+                            worker_pool.grow(target_workers)
+                        emit(
+                            f"[WORKERS] run_id={run_id} запущено={worker_pool.size}",
+                            quiet=quiet,
+                        )
+
+                    pending: dict[int, object] = {}
+                    if worker_pool is not None:
+                        for card in page_cards:
+                            task_id = detail_attempts
+                            detail_attempts += 1
+                            pending[task_id] = card
+                            worker_pool.submit(task_id, card)
+
+                    while pending:
+                        assert heartbeat is not None
+                        heartbeat.raise_if_failed()
+                        assert worker_pool is not None
+                        result = worker_pool.result(timeout=1)
+                        if result is None:
+                            continue
+                        kind = result["kind"]
+                        if kind == "fatal":
+                            raise RuntimeError(
+                                f"detail worker {result['worker_id'] + 1}: "
+                                f"{result['error_type']}: {result['error']}"
+                            )
+                        task_id = result["task_id"]
+                        if task_id not in pending:
+                            continue
+                        card = pending.pop(task_id)
+                        if kind == "antibot":
+                            from ..apply.antibot import (
+                                AntiBotChallengeDetected,
+                                AntiBotDetection,
+                            )
+
+                            raise AntiBotChallengeDetected(
+                                AntiBotDetection(
+                                    signal=result["antibot_signal"],
+                                    detail=result["antibot_detail"],
+                                )
+                            )
+                        if kind == "error":
+                            state.set_failed(state.snapshot().failed + 1)
+                            emit(
+                                f"[WARN] run_id={run_id} резюме rank={card.rank} "
+                                f"не сохранено: {result['error_type']}: {result['error']}",
+                                quiet=quiet,
+                                level=logging.WARNING,
+                            )
+                            continue
+                        outcome = lifecycle.history.upsert_competitor_resume(
+                            result["payload"],
+                            search_query=params.query,
+                            search_rank=card.rank,
+                            search_in=params.search_in,
+                            auth_mode=params.auth_mode,
+                        )
+                        state.mark_saved()
+                        if outcome == "new":
+                            new += 1
+                        elif outcome == "updated":
+                            updated += 1
+                        else:
+                            unchanged += 1
+
+                    state.complete_page(
+                        page_num,
+                        has_next=has_next,
+                        cap_reached=page_cap_reached(params.max_pages, pages_this_run, has_next),
+                    )
+                    checkpoint()
+                    current = state.snapshot()
+                    eta = observed_eta(current, elapsed=time.monotonic() - params.started_at)
+                    eta_suffix = f", {eta}" if eta else ""
+                    emit(
+                        f"[PROGRESS] run_id={run_id} страница={page_num + 1}, "
+                        f"карточек={current.cards}, "
+                        f"деталей={current.saved + current.failed}, "
+                        f"новых/обновлено={new + updated}, ошибок={current.failed}"
+                        f"{eta_suffix}",
+                        quiet=quiet,
+                    )
+                    if not has_next:
+                        break
+                    if page_cap_reached(params.max_pages, pages_this_run, has_next):
+                        limited = True
+                        break
+                    page_num += 1
+            except BaseException as exc:
+                if worker_pool is not None:
+                    worker_pool.close(
+                        terminate=not isinstance(exc, (KeyboardInterrupt, SignalTermination))
+                    )
+                raise
+            else:
+                if worker_pool is not None:
+                    worker_pool.close()
+    except BaseException as exc:
+        caught = exc
+    finally:
+        restore_signal_handlers(previous_handlers)
+
+    current = state.snapshot()
+    elapsed_seconds = time.monotonic() - params.started_at
+    if caught is not None:
+        status = (
+            "partial"
+            if current.pages
+            or current.cards
+            or current.saved
+            or current.failed
+            or current.last_started_page is not None
+            else "failed"
+        )
+        if isinstance(caught, KeyboardInterrupt):
+            code = CommandExitCode.SIGINT.value
+        elif isinstance(caught, SignalTermination):
+            code = 128 + caught.signum
+        else:
+            code = 1
+        detail = f"{type(caught).__name__}: {caught}"[:1000]
+        lifecycle.finish(
+            current,
+            status=status,
+            detail=detail,
+            exit_code=code,
+            resume_page=current.resume_page,
+        )
+        return CollectionOutcome(
+            snapshot=current,
+            new=new,
+            updated=updated,
+            unchanged=unchanged,
+            details_failed=current.failed,
+            limited=False,
+            coverage=coverage,
+            status=status,
+            exit_code=code,
+            detail=detail,
+            caught=caught,
+            elapsed_seconds=elapsed_seconds,
+        )
+
+    details_failed = current.failed
+    status = collection_status(details_failed=details_failed, limited=limited)
+    finish_detail = f"limited_by_max_pages={params.max_pages}" if limited else None
+    exit_code = 1 if details_failed else 0
+    lifecycle.finish(
+        current,
+        status=status,
+        detail=finish_detail,
+        exit_code=exit_code,
+        resume_page=current.resume_page if limited else None,
+    )
+    return CollectionOutcome(
+        snapshot=current,
+        new=new,
+        updated=updated,
+        unchanged=unchanged,
+        details_failed=details_failed,
+        limited=limited,
+        coverage=coverage,
+        status=status,
+        exit_code=exit_code,
+        detail=finish_detail,
+        caught=None,
+        elapsed_seconds=elapsed_seconds,
+    )

--- a/src/hhru_bot/competitor_collection/service.py
+++ b/src/hhru_bot/competitor_collection/service.py
@@ -183,7 +183,6 @@ def collect_pages(
                                     max_delay=params.max_delay_seconds,
                                     workers=params.detail_workers,
                                 ),
-                                quiet=quiet,
                             )
                     if target_pages is not None:
                         state.set_expected_details_from_target(
@@ -225,7 +224,6 @@ def collect_pages(
                             worker_pool.grow(target_workers)
                         emit(
                             f"[WORKERS] run_id={run_id} запущено={worker_pool.size}",
-                            quiet=quiet,
                         )
 
                     pending: dict[int, object] = {}
@@ -266,11 +264,10 @@ def collect_pages(
                                 )
                             )
                         if kind == "error":
-                            state.set_failed(state.snapshot().failed + 1)
+                            state.mark_failed()
                             emit(
                                 f"[WARN] run_id={run_id} резюме rank={card.rank} "
                                 f"не сохранено: {result['error_type']}: {result['error']}",
-                                quiet=quiet,
                                 level=logging.WARNING,
                             )
                             continue
@@ -304,7 +301,6 @@ def collect_pages(
                         f"деталей={current.saved + current.failed}, "
                         f"новых/обновлено={new + updated}, ошибок={current.failed}"
                         f"{eta_suffix}",
-                        quiet=quiet,
                     )
                     if not has_next:
                         break

--- a/src/hhru_bot/competitor_collection/state.py
+++ b/src/hhru_bot/competitor_collection/state.py
@@ -1,0 +1,111 @@
+"""Типизированное состояние collection run сборщика конкурентов (#1047).
+
+Раньше `run_collect` держал изменяемый dict `state` плюс россыпь локальных
+счётчиков; здесь тот же набор счётчиков собран в один потокобезопасный объект
+с чистым снапшотом. Контракт с checkpoint (#660) не изменился: `cards`
+включает карточки текущей незавершённой страницы, а `cards_completed` — только
+завершённых, синхронно с `last_completed_page`.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RunSnapshot:
+    """Иммутабельный срез счётчиков на момент чтения."""
+
+    pages: int
+    cards: int
+    cards_completed: int
+    saved: int
+    failed: int
+    last_started_page: int | None
+    last_completed_page: int | None
+    resume_page: int | None
+    observed_page_size: int | None
+    expected_details: int | None
+
+
+def page_cap_reached(max_pages: int | None, pages_fetched: int, has_next: bool) -> bool:
+    return has_next and max_pages is not None and pages_fetched >= max_pages
+
+
+def collection_status(*, details_failed: int, limited: bool) -> str:
+    if limited:
+        return "limited"
+    return "partial" if details_failed else "complete"
+
+
+class CollectionRunState:
+    """Потокобезопасные счётчики одного collection run."""
+
+    def __init__(
+        self,
+        *,
+        resume_page: int | None,
+        observed_page_size: int | None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._pages = 0
+        self._cards = 0
+        self._cards_completed = 0
+        self._saved = 0
+        self._failed = 0
+        self._last_started_page: int | None = None
+        self._last_completed_page: int | None = None
+        self._resume_page = resume_page
+        self._observed_page_size = observed_page_size
+        self._expected_details: int | None = None
+
+    def snapshot(self) -> RunSnapshot:
+        with self._lock:
+            return RunSnapshot(
+                pages=self._pages,
+                cards=self._cards,
+                cards_completed=self._cards_completed,
+                saved=self._saved,
+                failed=self._failed,
+                last_started_page=self._last_started_page,
+                last_completed_page=self._last_completed_page,
+                resume_page=self._resume_page,
+                observed_page_size=self._observed_page_size,
+                expected_details=self._expected_details,
+            )
+
+    def begin_page(self, page_num: int) -> None:
+        with self._lock:
+            self._last_started_page = page_num
+            self._resume_page = page_num
+
+    def add_page_results(self, card_count: int) -> None:
+        with self._lock:
+            self._pages += 1
+            self._cards += card_count
+            self._observed_page_size = max(self._observed_page_size or 0, card_count)
+
+    def set_expected_details_from_target(
+        self, target_pages: int, pages_this_run: int, requested_page_size: int
+    ) -> None:
+        with self._lock:
+            self._expected_details = self._cards + max(0, target_pages - pages_this_run) * (
+                requested_page_size
+            )
+
+    def mark_saved(self) -> None:
+        with self._lock:
+            self._saved += 1
+
+    def set_failed(self, count: int) -> None:
+        with self._lock:
+            self._failed = count
+
+    def complete_page(self, page_num: int, *, has_next: bool, cap_reached: bool) -> None:
+        with self._lock:
+            self._last_completed_page = page_num
+            self._cards_completed = self._cards
+            self._resume_page = page_num + 1 if has_next else None
+            if not has_next or cap_reached:
+                self._expected_details = self._saved + self._failed

--- a/src/hhru_bot/competitor_collection/state.py
+++ b/src/hhru_bot/competitor_collection/state.py
@@ -98,9 +98,9 @@ class CollectionRunState:
         with self._lock:
             self._saved += 1
 
-    def set_failed(self, count: int) -> None:
+    def mark_failed(self) -> None:
         with self._lock:
-            self._failed = count
+            self._failed += 1
 
     def complete_page(self, page_num: int, *, has_next: bool, cap_reached: bool) -> None:
         with self._lock:

--- a/tests/test_competitor_collection_state.py
+++ b/tests/test_competitor_collection_state.py
@@ -1,0 +1,93 @@
+"""Юнит-тесты типизированного состояния collection run (#1047)."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from hhru_bot.competitor_collection import CollectionRunState
+
+pytestmark = pytest.mark.unit
+
+
+def test_snapshot_is_immutable_copy_of_counters():
+    state = CollectionRunState(resume_page=0, observed_page_size=None)
+    state.begin_page(0)
+    state.add_page_results(3)
+
+    snap = state.snapshot()
+    state.add_page_results(2)
+    state.mark_saved()
+
+    assert snap.pages == 1
+    assert snap.cards == 3
+    assert snap.saved == 0
+    assert state.snapshot().cards == 5
+    assert state.snapshot().saved == 1
+    with pytest.raises(Exception):  # noqa: B017, PT011 -- frozen dataclass
+        snap.cards = 100  # type: ignore[misc]
+
+
+def test_complete_page_tracks_cards_completed_and_resume_page():
+    state = CollectionRunState(resume_page=None, observed_page_size=None)
+    state.begin_page(2)
+    state.add_page_results(10)
+    state.mark_saved()
+
+    # Страница ещё не завершена: cards_completed отстаёт от cards (#660).
+    assert state.snapshot().cards_completed == 0
+    assert state.snapshot().resume_page == 2
+
+    state.complete_page(2, has_next=True, cap_reached=False)
+    snap = state.snapshot()
+    assert snap.last_completed_page == 2
+    assert snap.cards_completed == 10
+    assert snap.resume_page == 3
+
+    state.complete_page(3, has_next=False, cap_reached=False)
+    assert state.snapshot().resume_page is None
+    assert state.snapshot().expected_details == 1
+
+
+def test_expected_details_follows_target_then_final_counts():
+    state = CollectionRunState(resume_page=0, observed_page_size=None)
+    state.begin_page(0)
+    state.add_page_results(100)
+    state.set_expected_details_from_target(3, pages_this_run=1, requested_page_size=100)
+    assert state.snapshot().expected_details == 300
+
+    state.set_failed(2)
+    state.complete_page(0, has_next=True, cap_reached=True)
+    # Cap: ожидание схлопывается в фактические исходы, resume_page сохранён.
+    snap = state.snapshot()
+    assert snap.expected_details == 2
+    assert snap.resume_page == 1
+
+
+def test_set_failed_overwrites_instead_of_incrementing():
+    state = CollectionRunState(resume_page=None, observed_page_size=None)
+    state.set_failed(1)
+    state.set_failed(1)
+    assert state.snapshot().failed == 1
+
+
+def test_concurrent_updates_are_serialized():
+    state = CollectionRunState(resume_page=None, observed_page_size=None)
+
+    def worker():
+        for _ in range(200):
+            state.begin_page(0)
+            state.add_page_results(1)
+            state.mark_saved()
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    snap = state.snapshot()
+    assert snap.pages == 800
+    assert snap.cards == 800
+    assert snap.saved == 800

--- a/tests/test_competitor_collection_state.py
+++ b/tests/test_competitor_collection_state.py
@@ -57,7 +57,8 @@ def test_expected_details_follows_target_then_final_counts():
     state.set_expected_details_from_target(3, pages_this_run=1, requested_page_size=100)
     assert state.snapshot().expected_details == 300
 
-    state.set_failed(2)
+    state.mark_failed()
+    state.mark_failed()
     state.complete_page(0, has_next=True, cap_reached=True)
     # Cap: ожидание схлопывается в фактические исходы, resume_page сохранён.
     snap = state.snapshot()
@@ -65,11 +66,20 @@ def test_expected_details_follows_target_then_final_counts():
     assert snap.resume_page == 1
 
 
-def test_set_failed_overwrites_instead_of_incrementing():
+def test_mark_failed_increments_atomically():
     state = CollectionRunState(resume_page=None, observed_page_size=None)
-    state.set_failed(1)
-    state.set_failed(1)
-    assert state.snapshot().failed == 1
+
+    def worker():
+        for _ in range(200):
+            state.mark_failed()
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert state.snapshot().failed == 800
 
 
 def test_concurrent_updates_are_serialized():

--- a/tests/test_competitors_command.py
+++ b/tests/test_competitors_command.py
@@ -22,6 +22,7 @@ from hhru_bot.commands.competitors import (
     _throttle_estimate,
     run_collect,
 )
+from hhru_bot.competitor_collection import RunSnapshot
 from hhru_bot.competitors import (
     CompetitorResume,
     CompetitorSearchCard,
@@ -718,7 +719,18 @@ def test_estimate_accounts_for_parallel_workers():
 
 def test_observed_eta_uses_completed_detail_rate():
     eta = _observed_eta(
-        {"saved": 10, "failed": 0, "expected_details": 100},
+        RunSnapshot(
+            pages=1,
+            cards=10,
+            cards_completed=10,
+            saved=10,
+            failed=0,
+            last_started_page=0,
+            last_completed_page=0,
+            resume_page=1,
+            observed_page_size=10,
+            expected_details=100,
+        ),
         elapsed=200,
     )
 
@@ -726,11 +738,22 @@ def test_observed_eta_uses_completed_detail_rate():
 
 
 def test_observed_eta_waits_for_three_details_and_stops_at_completion():
-    state = {"saved": 2, "failed": 0, "expected_details": 100}
-    assert _observed_eta(state, elapsed=40) is None
+    def _snapshot(saved: int, failed: int) -> RunSnapshot:
+        return RunSnapshot(
+            pages=1,
+            cards=saved + failed,
+            cards_completed=saved + failed,
+            saved=saved,
+            failed=failed,
+            last_started_page=0,
+            last_completed_page=0,
+            resume_page=None,
+            observed_page_size=10,
+            expected_details=100,
+        )
 
-    state = {"saved": 99, "failed": 1, "expected_details": 100}
-    assert _observed_eta(state, elapsed=2000) is None
+    assert _observed_eta(_snapshot(2, 0), elapsed=40) is None
+    assert _observed_eta(_snapshot(99, 1), elapsed=2000) is None
 
 
 def _report_args(tmp_path: Path, **overrides) -> Namespace:


### PR DESCRIPTION
## Что сделано

`run_collect` (`commands/competitors.py`, 474 строки) разбит на CLI-адаптер (~230 строк: аргументы, сообщения, коды выхода) и новый пакет `competitor_collection/`:

| Модуль | Ответственность |
|---|---|
| `state.py` | Типизированное `CollectionRunState` + иммутабельный `RunSnapshot` вместо изменяемого dict `state` и россыпи локальных счётчиков; контракт #660 (`cards` vs `cards_completed`) сохранён |
| `progress.py` | Канал прогресса (`print` + файл-лог, переживает BrokenPipe) и чистые форматтеры ETA/estimate |
| `lifecycle.py` | Адаптер `CollectionLifecycle` — единственная точка записи checkpoint/finish в SQLite (lock против гонки heartbeat, #654); `SignalTermination`, установка/восстановление handlers, `Heartbeat` |
| `service.py` | `collect_pages` — цикл страниц и обработчик одной страницы; всегда возвращает `CollectionOutcome` (финализация run гарантирована внутри, в т.ч. при сигналах, KeyboardInterrupt и падении браузера) |

`DetailWorkerPool` сохранён без изменений. Общая инфраструктура сигналов с supervision (#459) не затронута — контракты не зафиксированы, как и постановлено в ишью.

## Железные инварианты (не менялись)

- прерывание посреди страницы и частично неудачные details не теряют результаты (частичный checkpoint + `partial`-финализация);
- `max-pages`/`--resume` не искажают `rank_offset` и `cards_completed`;
- auth/query/search_in в scope checkpoint;
- сигналы (SIGTERM/SIGHUP → 128+N, SIGINT → спец-код), exit codes, восстановление handlers — как раньше;
- схема БД и CLI-контракт (аргументы, формат сообщений) без изменений.
-underscore-имена `_progress`/`_observed_eta`/`_throttle_estimate`/`_page_cap_reached`/`_collection_status` сохранены в `commands/competitors.py` как re-export — тесты и внешние импорты не сломаны.

## Тесты

- `tests/test_competitors_command.py`, `tests/test_competitors.py`, `tests/test_history_competitors.py` — зелёные (тесты `_observed_eta` переведены с dict на `RunSnapshot` — единственное сознательное изменение).
- Новый `tests/test_competitor_collection_state.py` (unit): иммутабельность снапшота, `cards_completed`/`resume_page` (#660), схлопывание `expected_details` при cap, сериализация под 4 потоками.
- Полный сюит: `pytest -q tests -n 4 --dist worksteal` — зелёный; `ruff check` + `ruff format --check` — чисто.

## Риски / follow-up

- Live-прогоны конкурентов не требовались (по ишью) и не выполнялись; поведение подтверждено offline-тестами, включая subprocess-тест стриминга stdout.
- Сборка coverage-объекта в `CollectionOutcome` типизирована как `object | None` (ленивый импорт `competitors` — под монкипатч тестов); можно уточнить типом после фиксации контрактов.

Closes #1047
