### PR TITLE
fix(resume-position): multi-select-панели коммитятся «Выбрать»; факт-верификация триггера

### DIFF
--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -1041,13 +1041,28 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
             # истекает по таймауту (живой провал 2026-09-09).
             target_qa = option.get_attribute("data-qa") or ""
             checked = panel.locator(SELECT_OPTION_CHECKED)
-            other_qas = [
+            checked_qas = [
                 checked.nth(i).get_attribute("data-qa") or "" for i in range(checked.count())
             ]
-            option.click()
-            for qa in other_qas:
-                if qa and qa != target_qa:
-                    panel.locator(f"label[role='option'][data-qa='{qa}']").click()
+            # Клик по чекбокс-опции — toggle, а не select: уже отмеченную
+            # цель не трогаем, иначе «Выбрать» закоммитит пустой выбор на
+            # идемпотентном повторе (current=None или readback разошёлся с
+            # состоянием чекбоксов — review PR #1065).
+            if target_qa not in checked_qas:
+                option.click()
+            for qa in checked_qas:
+                if qa == target_qa:
+                    continue
+                if not qa:
+                    # Молчаливый пропуск оставил бы полю несколько значений
+                    # (#526), а substring-проверка триггера «Удалённо +1»
+                    # пропустила бы — маркированный отказ с дампом вместо
+                    # тихого нарушения (живой дамп data-qa у опций даёт, но
+                    # дрейф селектора ловится именно здесь).
+                    raise RuntimeError(
+                        "отмеченная опция без data-qa — нечем снять (одно значение на поле, #526)"
+                    )
+                panel.locator(f"label[role='option'][data-qa='{qa}']").click()
             apply_button.click()
         else:
             option.click()

--- a/src/hhru_bot/resume_position.py
+++ b/src/hhru_bot/resume_position.py
@@ -157,6 +157,12 @@ CURRENCY_LABELS = {"RUR": "Рубли", "EUR": "Евро", "USD": "Доллар�
 EMPLOYMENT = "[data-qa='resume-edit-employment-forms']"
 WORK_FORMAT = "[data-qa='resume-edit-work-formats']"
 TRAVEL = "[data-qa='resume-edit-travel-time']"
+# Multi-select-панель (формат работы/занятость): футер с «Выбрать» — выбор
+# коммитится кнопкой, а не закрытием панели (живой дамп 2026-09-09,
+# workformat_panel.html). Отмеченная опция — чекбокс :checked внутри
+# label[role=option] (живое DOM-состояние, не SSR-атрибут).
+SELECT_APPLY = "[data-qa='magritte-select-apply']"
+SELECT_OPTION_CHECKED = "label[role='option']:has(input:checked)"
 BUSINESS_TRIPS = "[data-qa='resume-edit-business-trip-readiness']"
 CANCEL = "[data-qa='resume-partial-edit-cancel']"
 SAVE = "[data-qa='resume-partial-edit-save']"
@@ -998,6 +1004,7 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
     if loc.count() != 1:
         raise RuntimeError(f"селектор формы не подтверждён: {selector}")
     el = loc.first
+    logger.info("_set_control: %s → %s («%s»)", selector, value, labels[value])
     tag = el.evaluate("e=>e.tagName")
     if tag in ("INPUT", "TEXTAREA"):
         el.fill(value)
@@ -1012,19 +1019,57 @@ def _set_control(page: Page, selector: str, value: str, labels: dict[str, str]) 
         panel.wait_for(state="hidden", timeout=_CONTROL_WAIT_TIMEOUT_MS)
         el.click()
         panel.wait_for(state="visible", timeout=_CONTROL_WAIT_TIMEOUT_MS)
+        # Живой дамп панели work-format 2026-09-09: ДВА вида panel-контролов.
+        # (а) Однозначный select (время в пути): клик по опции = выбор,
+        #     панель закрывается outside-кликом (#823).
+        # (б) Multi-select с чекбоксами и футером «Выбрать»
+        #     (data-qa='magritte-select-apply', формат работы/занятость):
+        #     клик по опции ТОЛЬКО отмечает чекбокс, выбор коммитится
+        #     кнопкой; outside-клик вместо неё ОТМЕНЯЕТ выбор — форма
+        #     сохраняла прежнее значение, а команда рапортовала [OK]
+        #     (живой провал 2026-09-08: remote-формат не встал).
         option = panel.get_by_role("option", name=labels[value], exact=True)
         if option.count() != 1:
             raise RuntimeError(f"вариант формы не найден: {labels[value]}")
-        option.click()
-        # Re-clicking the trigger (the earlier approach) does not close this
-        # panel — confirmed live (#823): the panel re-opens/stays open even
-        # after a genuine value change, not just a no-op selection. This
-        # dropdown closes on an outside click instead, same as clicking away
-        # from any Magritte popup; (0, 0) is always outside the panel, which
-        # is positioned near the field, not the viewport corner. Escape is
-        # deliberately avoided because it can close the whole editor form.
-        page.mouse.click(0, 0)
+        apply_button = panel.locator(SELECT_APPLY)
+        if apply_button.count() == 1:
+            # Multi-select: снять прочие отмеченные опции — семантика одного
+            # значения (#526: несколько значений --work-format/--employment
+            # не подтверждены), «Выбрать» фиксирует выбор. Снапшот data-qa
+            # снимается ДО кликов: перерисовка после переключения чекбокса
+            # меняет доступное имя строки, и повторный резолв по имени
+            # истекает по таймауту (живой провал 2026-09-09).
+            target_qa = option.get_attribute("data-qa") or ""
+            checked = panel.locator(SELECT_OPTION_CHECKED)
+            other_qas = [
+                checked.nth(i).get_attribute("data-qa") or "" for i in range(checked.count())
+            ]
+            option.click()
+            for qa in other_qas:
+                if qa and qa != target_qa:
+                    panel.locator(f"label[role='option'][data-qa='{qa}']").click()
+            apply_button.click()
+        else:
+            option.click()
+            # Re-clicking the trigger (the earlier approach) does not close
+            # this panel — confirmed live (#823): the panel re-opens/stays
+            # open even after a genuine value change, not just a no-op
+            # selection. This dropdown closes on an outside click instead,
+            # same as clicking away from any Magritte popup; (0, 0) is always
+            # outside the panel, which is positioned near the field, not the
+            # viewport corner. Escape is deliberately avoided because it can
+            # close the whole editor form.
+            page.mouse.click(0, 0)
         panel.wait_for(state="hidden", timeout=_CONTROL_WAIT_TIMEOUT_MS)
+        # Решение по факту, не по исключению: тихий no-op (мёртвый клик,
+        # неоткрытая панель) здесь становится маркированным отказом, а не
+        # успехом с неизменившимся значением.
+        trigger_text = el.inner_text()
+        if labels[value] not in trigger_text:
+            raise RuntimeError(
+                f"выбор не применился: триггер показывает «{trigger_text.strip()}» "
+                f"после выбора «{labels[value]}»"
+            )
     except (PlaywrightError, RuntimeError) as exc:
         _dump_control_failure(page, selector, exc)
         raise

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -923,6 +923,297 @@ def test_set_control_closes_dropdown_via_outside_click_for_each_value():
     assert control.clicks == 2
 
 
+def test_set_control_commits_multiselect_via_apply_button():
+    """Multi-select-панель (формат работы/занятость): клик по опции ТОЛЬКО
+    отмечает чекбокс, выбор коммитируется кнопкой «Выбрать»
+    (magritte-select-apply); outside-клик вместо неё ОТМЕНЯЕТ выбор (живой
+    дамп 2026-09-09, workformat_panel.html). Снимаются прочие отмеченные —
+    семантика одного значения на поле (#526); снапшот data-qa отмеченных
+    берётся ДО кликов: перерисовка после переключения чекбокса меняет
+    доступное имя строки, повторный резолв по имени истекает таймаутом."""
+
+    class _Row:
+        def __init__(self, panel, qa):
+            self.panel = panel
+            self.qa = qa
+
+        def count(self):
+            return 1
+
+        def get_attribute(self, name):  # noqa: ARG002
+            return self.qa
+
+        def click(self):
+            self.panel.row_clicks.append(self.qa)
+            row = self.panel.rows[self.qa]
+            row["checked"] = not row["checked"]
+
+    class _RowList:
+        def __init__(self, panel, qas):
+            self.panel = panel
+            self.qas = qas
+
+        def count(self):
+            return len(self.qas)
+
+        def nth(self, i):
+            return _Row(self.panel, self.qas[i])
+
+        def click(self):
+            _Row(self.panel, self.qas[0]).click()
+
+    class _ApplyButton:
+        def __init__(self, panel):
+            self.panel = panel
+
+        def count(self):
+            return 1
+
+        def click(self):
+            self.panel.apply_clicks += 1
+            self.panel.open = False
+
+    class FakePanel:
+        def __init__(self):
+            # Дамп workformat_panel.html: «Офис» уже отмечен, ставим «Удалённо».
+            self.rows = {
+                "resume-work-format-office": {"label": "Офис", "checked": True},
+                "resume-work-format-remote": {"label": "Удалённо", "checked": False},
+                "resume-work-format-hybrid": {"label": "Гибрид", "checked": False},
+            }
+            self.open = False
+            self.row_clicks = []
+            self.apply_clicks = 0
+
+        def wait_for(self, *, state, timeout=None):
+            assert self.open is (state == "visible")
+
+        def get_by_role(self, role, *, name, exact):
+            assert (role, exact) == ("option", True)
+            qa = next(q for q, r in self.rows.items() if r["label"] == name)
+            return _Row(self, qa)
+
+        def locator(self, selector):
+            if selector == resume_position.SELECT_APPLY:
+                return _ApplyButton(self)
+            if selector == resume_position.SELECT_OPTION_CHECKED:
+                checked = [q for q, r in self.rows.items() if r["checked"]]
+                return _RowList(self, checked)
+            if selector.startswith("label[role='option'][data-qa='"):
+                qa = selector.split("data-qa='", 1)[1].rstrip("']")
+                return _RowList(self, [qa])
+            raise AssertionError(f"неожиданный селектор панели: {selector}")
+
+    class FakeControl:
+        def __init__(self, panel):
+            self.panel = panel
+            self.clicks = 0
+            self.first = self
+
+        def count(self):
+            return 1
+
+        def evaluate(self, _script):
+            return "BUTTON"
+
+        def click(self):
+            self.clicks += 1
+            self.panel.open = True
+
+        def inner_text(self):
+            # Триггер показывает закоммиченные «Выбрать» значения.
+            labels = [r["label"] for r in self.panel.rows.values() if r["checked"]]
+            return ", ".join(labels)
+
+    panel = FakePanel()
+    control = FakeControl(panel)
+    page = MagicMock()
+    page.locator.side_effect = lambda selector: (
+        panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
+    )
+
+    resume_position._set_control(
+        page, resume_position.WORK_FORMAT, "remote", resume_position.WORK_LABELS
+    )
+
+    # Целевая опция отмечена, прежняя («Офис») снята — one value per field.
+    assert panel.row_clicks == [
+        "resume-work-format-remote",
+        "resume-work-format-office",
+    ]
+    assert panel.rows["resume-work-format-remote"]["checked"] is True
+    assert panel.rows["resume-work-format-office"]["checked"] is False
+    # Выбор закоммичен кнопкой, outside-клик не выполнялся — он отменил бы его.
+    assert panel.apply_clicks == 1
+    page.mouse.click.assert_not_called()
+    assert control.clicks == 1
+
+
+def test_set_control_skips_click_for_already_checked_target():
+    """Клик по чекбокс-опции — toggle: уже отмеченную цель не кликаем, иначе
+    «Выбрать» закоммитит пустой выбор на идемпотентном повторе (current=None
+    или readback разошёлся с чекбоксами — review PR #1065)."""
+
+    class _Row:
+        def __init__(self, panel, qa):
+            self.panel = panel
+            self.qa = qa
+
+        def count(self):
+            return 1
+
+        def get_attribute(self, name):  # noqa: ARG002
+            return self.qa
+
+        def click(self):
+            self.panel.row_clicks.append(self.qa)
+
+    class _RowList:
+        def __init__(self, panel, qas):
+            self.panel = panel
+            self.qas = qas
+
+        def count(self):
+            return len(self.qas)
+
+        def nth(self, i):
+            return _Row(self.panel, self.qas[i])
+
+    class _ApplyButton:
+        def __init__(self, panel):
+            self.panel = panel
+
+        def count(self):
+            return 1
+
+        def click(self):
+            self.panel.apply_clicks += 1
+            self.panel.open = False
+
+    class FakePanel:
+        def __init__(self):
+            self.rows = {
+                "resume-work-format-remote": {"label": "Удалённо", "checked": True},
+            }
+            self.open = False
+            self.row_clicks = []
+            self.apply_clicks = 0
+
+        def wait_for(self, *, state, timeout=None):
+            assert self.open is (state == "visible")
+
+        def get_by_role(self, role, *, name, exact):
+            assert (role, exact) == ("option", True)
+            qa = next(q for q, r in self.rows.items() if r["label"] == name)
+            return _Row(self, qa)
+
+        def locator(self, selector):
+            if selector == resume_position.SELECT_APPLY:
+                return _ApplyButton(self)
+            if selector == resume_position.SELECT_OPTION_CHECKED:
+                checked = [q for q, r in self.rows.items() if r["checked"]]
+                return _RowList(self, checked)
+            if selector.startswith("label[role='option'][data-qa='"):
+                qa = selector.split("data-qa='", 1)[1].rstrip("']")
+                return _RowList(self, [qa])
+            raise AssertionError(f"неожиданный селектор панели: {selector}")
+
+    class FakeControl:
+        def __init__(self, panel):
+            self.panel = panel
+            self.clicks = 0
+            self.first = self
+
+        def count(self):
+            return 1
+
+        def evaluate(self, _script):
+            return "BUTTON"
+
+        def click(self):
+            self.clicks += 1
+            self.panel.open = True
+
+        def inner_text(self):
+            labels = [r["label"] for r in self.panel.rows.values() if r["checked"]]
+            return ", ".join(labels)
+
+    panel = FakePanel()
+    control = FakeControl(panel)
+    page = MagicMock()
+    page.locator.side_effect = lambda selector: (
+        panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
+    )
+
+    resume_position._set_control(
+        page, resume_position.WORK_FORMAT, "remote", resume_position.WORK_LABELS
+    )
+
+    # Цель уже отмечена — ни один чекбокс не переключался, выбор только
+    # закоммичен «Выбрать» и подтверждён триггером.
+    assert panel.row_clicks == []
+    assert panel.apply_clicks == 1
+    assert panel.rows["resume-work-format-remote"]["checked"] is True
+
+
+def test_set_control_fails_when_checked_option_lacks_data_qa(monkeypatch):
+    """Отмеченная опция без data-qa не снимается никогда: молчаливый пропуск
+    оставил бы полю несколько значений (#526), а substring-проверка триггера
+    «Удалённо +1» это пропустила бы — маркированный отказ вместо тихого
+    нарушения (review PR #1065)."""
+    monkeypatch.setattr(resume_position, "_dump_control_failure", MagicMock())
+
+    class _Row:
+        def __init__(self, qa):
+            self.qa = qa
+
+        def count(self):
+            return 1
+
+        def get_attribute(self, name):  # noqa: ARG002
+            return self.qa
+
+    class _RowList:
+        def __init__(self, qas):
+            self.qas = qas
+
+        def count(self):
+            return len(self.qas)
+
+        def nth(self, i):
+            return _Row(self.qas[i])
+
+    class _ApplyButton:
+        def count(self):
+            return 1
+
+    panel = MagicMock()
+    panel.wait_for.return_value = None
+    # «Офис» отмечен, но без data-qa; цель «Удалённо» с data-qa.
+    panel.locator.side_effect = lambda selector: (
+        _ApplyButton()
+        if selector == resume_position.SELECT_APPLY
+        else _RowList([None, "resume-work-format-remote"])
+        if selector == resume_position.SELECT_OPTION_CHECKED
+        else MagicMock()
+    )
+    option = _Row("resume-work-format-remote")
+    panel.get_by_role.return_value = option
+    control = MagicMock()
+    control.count.return_value = 1
+    control.first = control
+    control.evaluate.return_value = "BUTTON"
+    page = MagicMock()
+    page.locator.side_effect = lambda selector: (
+        panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
+    )
+
+    with pytest.raises(RuntimeError, match="без data-qa"):
+        resume_position._set_control(
+            page, resume_position.WORK_FORMAT, "remote", resume_position.WORK_LABELS
+        )
+
+
 def test_set_control_passes_explicit_timeout_to_panel_waits():
     """#561 review: an unlabeled 30s default hang read as CLI silence."""
     panel = MagicMock()

--- a/tests/test_resume_position.py
+++ b/tests/test_resume_position.py
@@ -864,6 +864,14 @@ def test_set_control_closes_dropdown_via_outside_click_for_each_value():
             assert (role, exact) == ("option", True)
             return FakeOption(self, name)
 
+        def locator(self, selector):  # noqa: ARG002
+            # Однозначный select: футера «Выбрать» нет (count 0).
+            class _Absent:
+                def count(self):
+                    return 0
+
+            return _Absent()
+
     class FakeControl:
         def __init__(self, panel):
             self.panel = panel
@@ -880,11 +888,25 @@ def test_set_control_closes_dropdown_via_outside_click_for_each_value():
             self.clicks += 1
             self.panel.open = True
 
+        def inner_text(self):
+            # Триггер показывает последнее выбранное значение — топливо
+            # факт-верификации _set_control (решение по состоянию, не по
+            # отсутствию исключения).
+            return self.panel.selected[-1] if self.panel.selected else ""
+
+    class FakeAbsent:
+        def count(self):
+            return 0
+
     panel = FakePanel()
     control = FakeControl(panel)
     page = MagicMock()
     page.locator.side_effect = lambda selector: (
-        panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
+        panel
+        if selector == resume_position.RESUME_POSITION_DROPDOWN
+        else FakeAbsent()
+        if selector == resume_position.SELECT_APPLY
+        else control
     )
     # An outside click closes this dropdown (#823 live probe) — re-clicking
     # the trigger does not, even for a genuine value change.
@@ -912,9 +934,15 @@ def test_set_control_passes_explicit_timeout_to_panel_waits():
     control.count.return_value = 1
     control.first = control
     control.evaluate.return_value = "BUTTON"
+    # Факт-верификация: триггер показывает выбранное значение.
+    control.inner_text.return_value = "Удалённо"
     page = MagicMock()
     page.locator.side_effect = lambda selector: (
-        panel if selector == resume_position.RESUME_POSITION_DROPDOWN else control
+        panel
+        if selector == resume_position.RESUME_POSITION_DROPDOWN
+        else MagicMock(count=MagicMock(return_value=0))
+        if selector == resume_position.SELECT_APPLY
+        else control
     )
 
     resume_position._set_control(

--- a/tests/test_resume_position_catalog_fixture.py
+++ b/tests/test_resume_position_catalog_fixture.py
@@ -93,7 +93,11 @@ def test_resume_catalog_reuses_one_leaf_id_across_categories():
 def test_resume_catalog_rejects_non_leaf_or_missing_specialization(
     monkeypatch, value, expected_error
 ):
-    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    # 500мс вместо прежних 50мс: на загруженном shared-раннере под xdist
+    # дерево не успевает отрисоваться за 50мс → SpecializationTreeIndeterminate
+    # (flaky CI 2026-09-08, PR #1065); бюджет сюита остаётся с большим запасом
+    # (CI wall 83s против 240s).
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 500)
     playwright, browser, page = _page()
     try:
         page.locator(resume_position.SPECIALIZATION_ADD).click()
@@ -112,7 +116,11 @@ def test_set_specializations_missing_leaf_refusal_lists_visible_candidates(monke
     непуст…» — новая семантика #954: непустой фильтр не «лист отсутствует»,
     фоллбэк «Другое» на нём не срабатывает; перечисление кандидатов сохранено
     (#836, контракт сообщения — #964)."""
-    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    # 500мс вместо прежних 50мс: на загруженном shared-раннере под xdist
+    # дерево не успевает отрисоваться за 50мс → SpecializationTreeIndeterminate
+    # (flaky CI 2026-09-08, PR #1065); бюджет сюита остаётся с большим запасом
+    # (CI wall 83s против 240s).
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 500)
     playwright, browser, page = _page()
     try:
         page.locator(resume_position.SPECIALIZATION_ADD).click()
@@ -130,7 +138,11 @@ def test_set_specializations_missing_leaf_refusal_lists_visible_candidates(monke
 
 @pytest.mark.browser_unit
 def test_validate_specializations_confirms_exact_leaf_without_submit(monkeypatch):
-    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    # 500мс вместо прежних 50мс: на загруженном shared-раннере под xdist
+    # дерево не успевает отрисоваться за 50мс → SpecializationTreeIndeterminate
+    # (flaky CI 2026-09-08, PR #1065); бюджет сюита остаётся с большим запасом
+    # (CI wall 83s против 240s).
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 500)
     playwright, browser, page = _page()
     try:
         refusals = resume_position.validate_specializations_against_tree(
@@ -147,7 +159,11 @@ def test_validate_specializations_confirms_exact_leaf_without_submit(monkeypatch
 
 @pytest.mark.browser_unit
 def test_validate_specializations_refusal_lists_filtered_candidates(monkeypatch):
-    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    # 500мс вместо прежних 50мс: на загруженном shared-раннере под xdist
+    # дерево не успевает отрисоваться за 50мс → SpecializationTreeIndeterminate
+    # (flaky CI 2026-09-08, PR #1065); бюджет сюита остаётся с большим запасом
+    # (CI wall 83s против 240s).
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 500)
     playwright, browser, page = _page()
     try:
         checks = resume_position.validate_specializations_against_tree(
@@ -172,7 +188,11 @@ def test_validate_specializations_empty_filter_is_fallback_eligible(monkeypatch)
     """#954: позитивный empty-state (контейнер прикреплён и пуст) —
     единственный случай, в котором боевой --fallback-other подставит
     «Другое»; dry-run помечает такой чек fallback-eligible."""
-    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 50)
+    # 500мс вместо прежних 50мс: на загруженном shared-раннере под xdist
+    # дерево не успевает отрисоваться за 50мс → SpecializationTreeIndeterminate
+    # (flaky CI 2026-09-08, PR #1065); бюджет сюита остаётся с большим запасом
+    # (CI wall 83s против 240s).
+    monkeypatch.setattr(resume_position, "_CONTROL_WAIT_TIMEOUT_MS", 500)
     playwright, browser, page = _page()
     try:
         checks = resume_position.validate_specializations_against_tree(page, ["qqqzzz-нет"])


### PR DESCRIPTION
## Что

`resume-position --work-format remote` печатал `[OK]`, а формат резюме не
менялся — три боевых прогона подряд (2026-09-08/09) оставляли «На месте
работодателя». Root cause по живому дампу открытой панели: в редакторе
позиции ДВА вида panel-контролов, а `_set_control` жил только по однозначной
схеме.

## Живые факты (дамп workformat_panel.html)

- **Однозначный select** (время в пути): клик по опции = выбор, панель
  закрывается outside-кликом (#823).
- **Multi-select с чекбоксами и футером «Выбрать»** (формат работы,
  занятость): клик по опции только отмечает чекбокс; выбор коммитируется
  кнопкой `data-qa='magritte-select-apply'`. Outside-клик вместо неё
  **отменяет** выбор → форма сохраняла прежнее значение, editor-путь
  команды рапортовал `[OK]` по факту закрытия формы (полевой верификации в
  нём нет — в отличие от wizard-пути).

## Фикс

- `_set_control` различает виды: при наличии «Выбрать» — снапшот `data-qa`
  отмеченных опций ДО кликов (перерисовка после переключения чекбокса меняет
  доступное имя строки — повторный резолв по имени истекает таймаутом),
  клик целевой, снятие прочих отмеченных (одно значение на поле, #526),
  клик «Выбрать».
- **Факт-верификация**: после закрытия панели триггер обязан показать новое
  значение, иначе маркированный отказ с дампом — тихий no-op больше не
  может выглядеть успехом.

## Боевая верификация (аккаунт testing)

`--work-format remote` → `[OK]` → census страницы резюме:
**«Формат работы: Удалённо»** (до фикса — «На месте работодателя» под тем
же `[OK]`). Editor-путь команды по-прежнему завершается закрытием формы,
но мёртвый выбор теперь ловится на месте.

Сюит `-n 4 --dist worksteal` зелёный, ruff зелёный.
