### PR TITLE
fix(negotiations): конец списка тем — ноль новых топиков, а не исчезнувший пейджер

### DIFF
--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -136,17 +136,20 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
     """Read SSR topic mappings from every available negotiations page.
 
     ``topicList`` is paginated with the cards, so reading only page zero makes
-    chats on later pages look unavailable. Navigation is GET-only and uses the
-    same confirmed pager contract as ``fetch_responses``.
+    chats on later pages look unavailable. Navigation is GET-only по
+    серверному контракту ``?page=N``; конец списка доказывается данными
+    (страница без новых топиков), а не UI-пейджером — подробности дрейфа
+    в комментарии внутри цикла.
     """
     if max_pages < 1:
         raise ValueError("max_pages must be >= 1")
 
     # Lazy imports avoid a module cycle while responses.py recovers topics.
     from .browser import goto_hh, require_authenticated_page
-    from .responses import NEGOTIATIONS_URL, _has_next_page
+    from .responses import NEGOTIATIONS_URL
 
     refs: list[TopicRef] = []
+    seen: set[str] = set()
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         goto_hh(page, url)
@@ -158,15 +161,21 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         # пустой inbox, но с другой причиной, которую вызывающий код не
         # должен путать с завершённой пагинацией.
         require_authenticated_page(page)
-        refs.extend(topic_refs(page.content()))
-        try:
-            has_next = _has_next_page(page, page_num)
-        except AttributeError:
-            # Lightweight read-only fakes may expose content() but not the
-            # pagination locators; they represent a single page.
-            has_next = False
-        if not has_next:
+        page_refs = topic_refs(page.content())
+        new_refs = [r for r in page_refs if r.topic_id not in seen]
+        # Живой дрейф 2026-09-09: hh.ru убрал пейджер из UI (карточки за
+        # пределами первой двадцатки подгружаются скроллом), но серверный
+        # GET-контракт ?page=N жив — повторный census подтвердил вторую
+        # страницу с 10 темами при «Все 30». «Пейджер не отрисован» больше
+        # не доказывает «страница одна», поэтому конец списка определяется
+        # данными: страница без НОВЫХ топиков (пустая или повтор первой) —
+        # конец. Стоимость — один лишний GET за обход на одностраничных
+        # аккаунтах; дедуп по topic_id страхует и от сервера, игнорирующего
+        # ?page (он вернёт те же темы → ноль новых → стоп).
+        if page_num > 0 and not new_refs:
             break
+        seen.update(r.topic_id for r in new_refs)
+        refs.extend(new_refs)
     return refs
 
 
@@ -203,19 +212,29 @@ def paginated_topic_and_remindable_refs(
         NEGOTIATIONS_URL,
         RENDER_TIMEOUT_MS,
         ResponsesIndeterminate,
-        _has_next_page,
     )
     from .selector_groups import negotiations as ns
 
     topics_out: list[TopicRef] = []
     remindable_out: list[RemindableTopicRef] = []
+    seen: set[str] = set()
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         goto_hh(page, url)
         require_authenticated_page(page)
         html = page.content()
-        topics_out.extend(topic_refs(html))
-        remindable_out.extend(remindable_topic_refs(html))
+        page_topics = topic_refs(html)
+        new_ids = {r.topic_id for r in page_topics if r.topic_id not in seen}
+        # Тот же дрейф 2026-09-09, что в paginated_topic_refs: пейджер из UI
+        # убран, серверный GET-контракт ?page=N жив — конец списка
+        # определяется нулём новых топиков, а не отсутствием пейджера
+        # (полное обоснование в комментарии там). Дедуп по topic_id не даёт
+        # повторной странице задвоить темы в обоих представлениях.
+        if page_num > 0 and not new_ids:
+            break
+        topics_out.extend(r for r in page_topics if r.topic_id in new_ids)
+        remindable_out.extend(r for r in remindable_topic_refs(html) if r.topic_id in new_ids)
+        seen.update(new_ids)
         topics = parse_initial_state(html)["applicantNegotiations"]["topicList"]
         # An explicitly empty SSR list is a confirmed empty inbox.  Waiting
         # for a card in that case would turn a valid zero-result read into a
@@ -235,8 +254,6 @@ def paginated_topic_and_remindable_refs(
                     f"страницы {page_num} не подтверждена: карточки переписки "
                     f"не появились за {RENDER_TIMEOUT_MS} мс"
                 ) from None
-        if not _has_next_page(page, page_num):
-            break
     return topics_out, remindable_out
 
 

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -101,6 +101,85 @@ def test_paginated_topic_refs_collects_all_pages(monkeypatch):
     ]
 
 
+def _state_html(topic_ids):
+    state = {
+        "applicantNegotiations": {
+            "topicList": [
+                {"id": tid, "chatId": tid + 100, "vacancyId": tid + 200} for tid in topic_ids
+            ]
+        }
+    }
+    return '<template id="HH-Lux-InitialState">' + json.dumps(state) + "</template>"
+
+
+def test_paginated_topic_refs_walks_pagerless_lazy_tail(monkeypatch):
+    """Дрейф 2026-09-09: hh.ru убрал пейджер из UI (хвост списка — lazy-скролл),
+    серверный ?page=N жив. Отсутствие пейджера больше не «страница одна»:
+    обход продолжает GET-ить следующую страницу, пока та приносит НОВЫЕ
+    топики; страница-повтор/пустышка — конец. Живой факт: «Все 30» при 20
+    карточках SSR, ?page=1 отдал оставшиеся 10, ?page=2 — повтор."""
+
+    pages = {
+        0: [1, 2, 3],
+        1: [4, 5],
+        2: [4, 5],  # сервер за последней страницей повторяет хвост
+    }
+
+    class Page:
+        def __init__(self):
+            self.page_num = 0
+
+        def content(self):
+            return _state_html(pages[self.page_num])
+
+    page = Page()
+    urls = []
+
+    def goto(_page, url):
+        urls.append(url)
+        page.page_num = len(urls) - 1
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    refs = paginated_topic_refs(page, max_pages=5)
+
+    assert [ref.topic_id for ref in refs] == ["1", "2", "3", "4", "5"]
+    assert urls[-1] == "https://hh.ru/applicant/negotiations?page=2"
+
+
+def test_paginated_topic_refs_survives_server_ignoring_page_param(monkeypatch):
+    """Сервер, игнорирующий ?page (отдаёт первую страницу на любой номер), —
+    ноль новых топиков на page=1 → стоп, без дублей и без вечного цикла."""
+
+    class Page:
+        def __init__(self):
+            self.page_num = 0
+
+        def content(self):
+            return _state_html([1, 2])
+
+    page = Page()
+    urls = []
+
+    def goto(_page, url):
+        urls.append(url)
+        page.page_num = len(urls) - 1
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    refs = paginated_topic_refs(page, max_pages=5)
+
+    assert [ref.topic_id for ref in refs] == ["1", "2"]
+    assert urls == [
+        "https://hh.ru/applicant/negotiations",
+        "https://hh.ru/applicant/negotiations?page=1",
+    ]
+
+
 # --- Codex review (#201): expired session must not surface as a raw ValueError
 
 


### PR DESCRIPTION
## Что

Живой дрейф 2026-09-09 (аккаунт testing): hh.ru убрал пейджер из UI
`/applicant/negotiations` — карточки за пределами первой двадцатки
подгружаются lazy-скроллом (`magritte-loader`), при этом таб «Все»
честно показывает 30. Серверный GET-контракт `?page=N` жив: census по
`?page=1` отдал оставшиеся 10 тем.

Следствие до фикса: `_has_next_page` читал «пейджер не отрисован» как
«страница одна» — все обходчики списка (`probe --negotiations`,
`robot-reply`, `reply-employers`, remindable-walk) видели только первые
20 тем по свежести. Чат рекрутера <рекрутер-1> (topic 5558191986, последняя активность
2026-09-08) выпал из выборки, и `robot-reply` отказывал «не найден в
живом negotiations-списке».

## Фикс

- Конец списка доказывается данными: страница без НОВЫХ топиков
  (пустая или повтор первой) завершает обход. Дедуп по `topic_id` —
  повторная страница не задваивает темы ни в маппинге, ни в remindable.
- `_has_next_page` из обходчиков убран: позитивная семантика («пейджер
  есть — следующая страница существует») поглощена нулём новых;
  отрицательную («пейджера нет — страница одна») hh.ru опроверг живьём.
  Сам helper остаётся для `fetch_responses`.
- Цена: один лишний GET за обход на одностраничных аккаунтах; сервер,
  игнорирующий `?page`, вернёт те же темы → ноль новых → стоп (тест есть).

## Живая верификация (аккаунт testing, read-only + санкционированный ответ)

- `probe --negotiations --max-pages 3`: 30 тем (было 20), topic
  5558191986 разрешается в chat 5610561242.
- `robot-reply --topic 5558191986 --text ... --force`: `[OK] текст
  доставлен, последнее сообщение наше` (success=1) — ответ, весь
  вчерашний день блокированный пропавшим топиком, доставлен.

## Известный остаток

`fetch_responses` (`responses --sync`) держит собственный цикл на
`_has_next_page` и в этом диффе не тронут — его strict-семантика
(identity-импорт ledger, `ResponsesIndeterminate` на исчерпание
max_pages) заслуживает отдельного прохода.

Сюит `-n 4 --dist worksteal` зелёный, ruff зелёный.

