### PR TITLE
fix(negotiations): пейджер-остатки — clear guard и apply/verify по нулю новых топиков

### DIFF
--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -256,14 +256,14 @@ def _scan_negotiations(
     confirmed_incomplete = False
     attribution_incomparable = False
     reads: list[PageRead] = []
-    # Ноль новых vacancy_id — stop-условие этого скана, поэтому набор обязан
-    # быть ЛОКАЛЬНЫМ для попытки: внешний seen_vacancy_ids накапливается
-    # между NEGOTIATIONS_VERIFY_ATTEMPTS (аудит not_found «прочитано: ...»),
-    # и с ним неизменная страница 0 повторной попытки дала бы ноль «новых»
-    # ещё ДО захода на ?page=1 — опоздавший отклик на хвосте получил бы
-    # ложный not_found (ревью PR #1068). Каждая попытка проходит страницы
-    # заново; накопленный аудит мерджится в конце.
-    attempt_seen: set[str] = set()
+    # Ноль новых записей — stop-условие этого скана, поэтому набор ключей
+    # обязан быть ЛОКАЛЬНЫМ для попытки (внешний seen_vacancy_ids — аудит
+    # «прочитано: ...», копится между всеми NEGOTIATIONS_VERIFY_ATTEMPTS).
+    # Ключ — идентификатор ТЕМЫ (SSR) или карточки (DOM-fallback), не
+    # vacancy_id: у одной вакансии может быть несколько тем (разные резюме),
+    # и вторая тема V на странице 1 не «новая вакансия» — diff по vacancy_id
+    # остановил бы скан до её чтения (ревью PR #1068, вторая находка).
+    attempt_keys: set[str] = set()
     for page_num in range(NEGOTIATIONS_VERIFY_MAX_PAGES):
         if page_num > 0:
             try:
@@ -281,11 +281,11 @@ def _scan_negotiations(
                 break
             else:
                 raise_for_antibot(page)
-        ids_before = set(attempt_seen)
-        found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
-            page, wanted, resume_id, account_resume_ids, attempt_seen
+        found_detail, page_clean, page_problem, page_attribution_incomparable, page_keys = (
+            _scan_single_page(page, wanted, resume_id, account_resume_ids, seen_vacancy_ids)
         )
-        new_ids = attempt_seen - ids_before
+        new_keys = page_keys - attempt_keys
+        attempt_keys |= page_keys
         attribution_incomparable = attribution_incomparable or page_attribution_incomparable
         if page_attribution_incomparable:
             reads.append(
@@ -312,11 +312,9 @@ def _scan_negotiations(
         # hh.ru удалил пейджер из UI, и «пейджер не отрисован» больше не
         # доказывает «страница одна» — иначе отклик на хвосте списка получал
         # ложный not_found с clean=True (нарушение fail-closed серой зоны
-        # #207). Страница без НОВЫХ vacancy_id (пустая или повтор предыдущей
-        # — сервер, игнорирующий ?page, возвращает те же карточки) — конец.
-        # Для поиска вакансии diff по vacancy_id достаточен: если целевая
-        # вакансия была на этой странице, её id был бы новым.
-        if not new_ids:
+        # #207). Страница без НОВЫХ записей (пустая или повтор предыдущей —
+        # сервер, игнорирующий ?page, возвращает те же темы) — конец.
+        if not new_keys:
             break
         if page_num == NEGOTIATIONS_VERIFY_MAX_PAGES - 1:
             # Достигли потолка скана, а последняя страница принесла новые
@@ -329,7 +327,6 @@ def _scan_negotiations(
             break
     # Keep the legacy tuple for the browser reader, but let the typed decision
     # table own the final absence/uncertainty policy (#213).
-    seen_vacancy_ids.update(attempt_seen)
     composed = compose(reads, wanted)
     if composed == "not_found":
         clean = True
@@ -344,15 +341,21 @@ def _scan_single_page(
     resume_id: str | None,
     account_resume_ids: set[str] | None,
     seen_vacancy_ids: set[str],
-) -> tuple[str | None, bool, str | None, bool]:
+) -> tuple[str | None, bool, str | None, bool, set[str]]:
+    """Пятый элемент — ключи прочитанной страницы (идентичность для
+    pagerless-стопа «ноль новых», см. _scan_negotiations): SSR — ключ темы
+    (id/chatId), DOM-fallback — ключ вакансии карточки (DOM не различает
+    несколько тем одной вакансии — его потолок и так fail-closed по
+    атрибуции)."""
     try:
         html = page.content()
     except PlaywrightError as exc:
-        return None, False, f"page.content() упал ({exc})", False
+        return None, False, f"page.content() упал ({exc})", False, set()
     topics = _ssr_topic_list(html)
     if topics is not None:
         # SSR — серверная истина; DOM читает те же данные, fallback не нужен.
         seen_vacancy_ids.update(str(t.get("vacancyId")) for t in topics if t.get("vacancyId"))
+        page_keys = {f"t{t.get('id', t.get('chatId'))}" for t in topics}
         attribution_problem: str | None = None
         for topic in topics:
             if str(topic.get("vacancyId", "")) != wanted:
@@ -388,15 +391,17 @@ def _scan_single_page(
                     f"быть создана предыдущим откликом"
                 )
                 continue
-            return _describe_topic(topic), True, None, False
+            return _describe_topic(topic), True, None, False, page_keys
         return (
             None,
             attribution_problem is None,
             attribution_problem,
             attribution_problem is not None,
+            page_keys,
         )
     dom_ids, cards_seen = _read_dom_vacancy_ids(page)
     seen_vacancy_ids.update(dom_ids)
+    dom_keys = {f"v{v}" for v in dom_ids}
     if wanted in dom_ids:
         if resume_id is not None:
             # DOM-карточка не несёт resumeId — не можем атрибутировать отклик
@@ -405,11 +410,17 @@ def _scan_single_page(
             # attribution_incomparable=True: находка вакансии без атрибуции
             # обязана перевесить чистое чтение ДРУГОЙ попытки (иначе ложный
             # not_found — тот же false negative, что #212 устраняет).
-            return None, False, "DOM-карточка без атрибуции резюме — исход неопределён", True
-        return "DOM-карточка списка (SSR-состояние недоступно)", True, None, False
+            return (
+                None,
+                False,
+                "DOM-карточка без атрибуции резюме — исход неопределён",
+                True,
+                dom_keys,
+            )
+        return "DOM-карточка списка (SSR-состояние недоступно)", True, None, False, dom_keys
     if cards_seen:
-        return None, True, None, False
-    return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)", False
+        return None, True, None, False, dom_keys
+    return None, False, "список не отрендерился (нет ни SSR-состояния, ни карточек)", False, set()
 
 
 def _resume_attribution(

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -256,6 +256,14 @@ def _scan_negotiations(
     confirmed_incomplete = False
     attribution_incomparable = False
     reads: list[PageRead] = []
+    # Ноль новых vacancy_id — stop-условие этого скана, поэтому набор обязан
+    # быть ЛОКАЛЬНЫМ для попытки: внешний seen_vacancy_ids накапливается
+    # между NEGOTIATIONS_VERIFY_ATTEMPTS (аудит not_found «прочитано: ...»),
+    # и с ним неизменная страница 0 повторной попытки дала бы ноль «новых»
+    # ещё ДО захода на ?page=1 — опоздавший отклик на хвосте получил бы
+    # ложный not_found (ревью PR #1068). Каждая попытка проходит страницы
+    # заново; накопленный аудит мерджится в конце.
+    attempt_seen: set[str] = set()
     for page_num in range(NEGOTIATIONS_VERIFY_MAX_PAGES):
         if page_num > 0:
             try:
@@ -273,11 +281,11 @@ def _scan_negotiations(
                 break
             else:
                 raise_for_antibot(page)
-        ids_before = set(seen_vacancy_ids)
+        ids_before = set(attempt_seen)
         found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
-            page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
+            page, wanted, resume_id, account_resume_ids, attempt_seen
         )
-        new_ids = seen_vacancy_ids - ids_before
+        new_ids = attempt_seen - ids_before
         attribution_incomparable = attribution_incomparable or page_attribution_incomparable
         if page_attribution_incomparable:
             reads.append(
@@ -321,6 +329,7 @@ def _scan_negotiations(
             break
     # Keep the legacy tuple for the browser reader, but let the typed decision
     # table own the final absence/uncertainty policy (#213).
+    seen_vacancy_ids.update(attempt_seen)
     composed = compose(reads, wanted)
     if composed == "not_found":
         clean = True

--- a/src/hhru_bot/apply/verify.py
+++ b/src/hhru_bot/apply/verify.py
@@ -49,13 +49,7 @@ from playwright.sync_api import Page
 
 from ..browser import goto_hh, has_auth_cookie, has_login_form
 from ..negotiations_probe import parse_initial_state
-from ..responses import (
-    NEGOTIATIONS_URL,
-    RENDER_TIMEOUT_MS,
-    ResponsesIndeterminate,
-    _has_next_page,
-    parse_response_card,
-)
+from ..responses import NEGOTIATIONS_URL, RENDER_TIMEOUT_MS, parse_response_card
 from ..selector_groups import negotiations as ns
 from .antibot import raise_for_antibot
 from .steps import _dump_navigation_diagnostics
@@ -76,15 +70,15 @@ logger = logging.getLogger("hhru_bot.apply.verify")
 #: отваливающиеся под DDoS-Guard загрузки списка (goto_hh внутри тоже ретраит).
 NEGOTIATIONS_VERIFY_ATTEMPTS = 2
 NEGOTIATIONS_VERIFY_POLL_INTERVAL_MS = 10_000
-#: Сканируем страницу 0 и, если пагинатор подтверждает продолжение, страницу 1:
+#: Сканируем страницу 0 и, если она принесла новые карточки, страницу 1:
 #: список отсортирован по свежести, только что отправленный отклик был бы на
-#: странице 0 — глубокий скан не нужен. Достижение потолка при подтверждённой
-#: пагинации — indeterminate, а не not_found (см. _scan_negotiations).
+#: странице 0 — глубокий скан не нужен. Конец списка доказывается нулём новых
+#: vacancy_id (дрейф 2026-09-09: пейджер из UI удалён, PR #1066/#1067), а не
+#: пейджером; достижение потолка при непустом продолжении — indeterminate, а
+#: не not_found (см. _scan_negotiations).
 #: Инвариант «свежий отклик на странице 0» проверен живой пробой 2026-08-16
 #: (#210): все 14 тем аккаунта строго по creationTime по убыванию, свежайшая —
-#: на странице 0. Решение по напряжению 1 #210: документировать инвариант,
-#: НЕ переводя неподтверждённый пагинатор на fail-closed (0 случаев
-#: ResponsesIndeterminate в логах на ту дату — эвристика не стреляет).
+#: на странице 0.
 NEGOTIATIONS_VERIFY_MAX_PAGES = 2
 #: Окно стабилизации DOM-списка в fallback-пути: карточки могут догружаться
 #: (отложенный/виртуализированный рендер), и чтение count до стабилизации
@@ -270,17 +264,20 @@ def _scan_negotiations(
                 # Inspect a page rendered before the navigation timeout before
                 # treating it as an ordinary incomplete scan.
                 raise_for_antibot(page)
-                # Пагинация была подтверждена на странице 0 (мы сюда дошли) —
-                # страница 1 не дочитана: целевая вакансия могла быть на ней.
+                # На страницу 1 нас привели НОВЫЕ топики страницы 0 — список
+                # продолжается, и страница 1 не дочитана: целевая вакансия
+                # могла быть на ней.
                 problem = f"goto страницы {page_num} списка не прошёл ({exc})"
                 confirmed_incomplete = True
                 reads.append(PageRead(PageSource.SSR, (), Partial(problem)))
                 break
             else:
                 raise_for_antibot(page)
+        ids_before = set(seen_vacancy_ids)
         found_detail, page_clean, page_problem, page_attribution_incomparable = _scan_single_page(
             page, wanted, resume_id, account_resume_ids, seen_vacancy_ids
         )
+        new_ids = seen_vacancy_ids - ids_before
         attribution_incomparable = attribution_incomparable or page_attribution_incomparable
         if page_attribution_incomparable:
             reads.append(
@@ -303,13 +300,22 @@ def _scan_negotiations(
         if found_detail is not None:
             return found_detail, True, None, False, False
         clean = clean or page_clean
-        if not _has_next_page_confirmed(page, page_num):
+        # Конец списка доказывается данными (дрейф 2026-09-09, PR #1066/#1067):
+        # hh.ru удалил пейджер из UI, и «пейджер не отрисован» больше не
+        # доказывает «страница одна» — иначе отклик на хвосте списка получал
+        # ложный not_found с clean=True (нарушение fail-closed серой зоны
+        # #207). Страница без НОВЫХ vacancy_id (пустая или повтор предыдущей
+        # — сервер, игнорирующий ?page, возвращает те же карточки) — конец.
+        # Для поиска вакансии diff по vacancy_id достаточен: если целевая
+        # вакансия была на этой странице, её id был бы новым.
+        if not new_ids:
             break
         if page_num == NEGOTIATIONS_VERIFY_MAX_PAGES - 1:
-            # Достигли потолка скана, но пагинатор подтверждает продолжение —
-            # целевая вакансия могла быть на непросканированной странице 2+.
+            # Достигли потолка скана, а последняя страница принесла новые
+            # карточки — продолжение списка не опровергнуто, целевая вакансия
+            # могла быть на непросканированной странице 2+.
             # Fail-closed: indeterminate, а не ложный not_found (#207).
-            problem = "достигнут потолок скана при подтверждённой пагинации"
+            problem = "достигнут потолок скана при непустом продолжении списка"
             confirmed_incomplete = True
             reads.append(PageRead(PageSource.SSR, (), Partial(problem)))
             break
@@ -532,18 +538,4 @@ def _dom_list_stable(page: Page, initial_ids: set[str]) -> bool:
         fresh = _read_dom_ids(page)
         return fresh is not None and fresh == initial_ids
     except PlaywrightError:
-        return False
-
-
-def _has_next_page_confirmed(page: Page, page_num: int) -> bool:
-    try:
-        return _has_next_page(page, page_num)
-    except ResponsesIndeterminate:
-        # Неподтверждённый пагинатор — не причина indeterminate-вердикта:
-        # свежий отклик был бы на странице 0. Инвариант сортировки по
-        # свежести проверен живой пробой 2026-08-16 (#210): 14/14 тем строго
-        # по creationTime по убыванию; 0 случаев ResponsesIndeterminate в
-        # логах на ту дату — оставляем as-is (документированное решение по
-        # напряжению 1 #210, не fail-closed).
-        logger.warning("[VERIFY] пагинация не подтверждена — сканирую только прочитанное")
         return False

--- a/src/hhru_bot/commands/clear_negotiations.py
+++ b/src/hhru_bot/commands/clear_negotiations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import NoReturn
 from urllib.parse import quote
 
 from playwright.sync_api import Error as PlaywrightError
@@ -16,7 +17,7 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from ..browser import HH_BASE_URL, goto_hh
 from ..negotiations_probe import topic_refs
-from ..responses import _has_next_page, fetch_responses
+from ..responses import ResponsesIndeterminate, fetch_responses
 from ..selector_groups.negotiations import (
     NEGOTIATION_ITEM,
     NEGOTIATION_WITHDRAW,
@@ -54,7 +55,7 @@ def register(subparsers) -> None:
     p.set_defaults(func=run)
 
 
-def _fail(message: str) -> None:
+def _fail(message: str) -> NoReturn:
     print(f"[FAIL] {message}", file=sys.stderr)
     raise SystemExit(1)
 
@@ -324,7 +325,22 @@ def _run_account_wide(args, config, history, throttle, progress: ApplyProgress) 
         config.storage_state_file, headless=args.headless, user_agent=config.user_agent
     ) as context:
         page = context.new_page()
-        cards = fetch_responses(page, max_pages=args.max_pages)
+        # Полнота списка для необратимого отзыва подтверждается нулём новых
+        # топиков (pagerless-режим fetch_responses), а не UI-пейджером:
+        # hh.ru удалил пейджер из /applicant/negotiations (дрейф 2026-09-09,
+        # PR #1066), и прежний guard на _has_next_page молча перестал
+        # срабатывать — clear отозвал бы первые 20 тем и отчитался успехом
+        # при невидимом остатке. ResponsesIndeterminate = список не дочитан
+        # до конца (потолок --max-pages при непустом продолжении, нечитаемый
+        # SSR) — отказ до любого клика, инвариант PR #196 сохранён (#1067).
+        try:
+            cards = fetch_responses(page, max_pages=args.max_pages, pagerless=True)
+        except ResponsesIndeterminate as exc:
+            _fail(
+                f"Список откликов не дочитан до конца: {exc}. Увеличьте "
+                "--max-pages — иначе часть откликов не будет отозвана. "
+                "Ничего не отозвано."
+            )
 
         # An empty first-page result from fetch_responses() is NOT a confirmed
         # empty inbox (Codex review round 2, PR #196): responses.py's own
@@ -343,19 +359,11 @@ def _run_account_wide(args, config, history, throttle, progress: ApplyProgress) 
                 file=sys.stderr,
             )
 
-        # Fail-closed on truncated pagination (Codex review, PR #196): fetch_responses
-        # silently stops after --max-pages pages even if hh.ru has more. Withdrawing
-        # only the truncated prefix and reporting success on a destructive,
-        # irreversible operation would leave an unwithdrawn remainder invisible to
-        # the operator. _has_next_page() is the same confirmed-pagination check
-        # fetch_responses itself uses internally; re-run it against the last loaded
-        # page (page is left there by fetch_responses) before withdrawing anything.
-        if cards and _has_next_page(page, args.max_pages - 1):
-            _fail(
-                f"Достигнут лимит --max-pages={args.max_pages}, но на hh.ru есть ещё "
-                "страницы откликов. Увеличьте --max-pages — иначе часть откликов "
-                "не будет отозвана. Ничего не отозвано."
-            )
+        # Fail-closed на усечённой пагинации (Codex review, PR #196; обновлено
+        # под безпейджерный hh.ru в #1067): полнота списка теперь доказывается
+        # внутри pagerless-обхода fetch_responses (ноль новых топиков = конец),
+        # и его ResponsesIndeterminate обработан выше — отдельная перепроверка
+        # пейджером невозможна: пейджер из UI удалён.
 
         # Cards without a resolved topic (no chat, or ambiguous SSR match — see
         # ResponseItem.topic_ambiguous) are legitimately skipped from withdrawal,

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -314,6 +314,7 @@ def fetch_responses(
     *,
     strict_empty: bool = False,
     strict_scrape: bool = False,
+    pagerless: bool = False,
 ) -> list[ResponseItem]:
     """Собирает ответы работодателей с /applicant/negotiations.
 
@@ -322,6 +323,13 @@ def fetch_responses(
     подтверждённой последней странице. Неподтверждённая пагинация поднимает
     :class:`ResponsesIndeterminate`, а не выдаёт неопределённость за последнюю
     страницу.
+
+    ``pagerless=True`` (для clear-negotiations, #1067): конец списка
+    определяется нулём НОВЫХ SSR-топиков на странице, а не UI-пейджером —
+    hh.ru убрал пейджер из /applicant/negotiations (дрейф 2026-09-09, PR
+    #1066), и «пейджер не отрисован» больше не доказывает «страница одна».
+    Достижение ``max_pages`` при непустой последней странице поднимает
+    :class:`ResponsesIndeterminate`: полнота списка не подтверждена.
 
     Read-only по hh.ru: только goto + чтение, никаких кликов действий.
 
@@ -345,6 +353,7 @@ def fetch_responses(
     успешного парсинга) остаётся легитимным и не блокирует чекпоинт.
     """
     results: list[ResponseItem] = []
+    seen_topic_ids: set[str] = set()
 
     if max_pages <= 0:
         raise ValueError("max_pages must be positive")
@@ -425,6 +434,7 @@ def fetch_responses(
         # overcounts and a `-count:` slice would reach into the previous
         # page's already-resolved results and risk assigning them this
         # page's SSR topics.
+        page_topic_ids: set[str] = set()
         try:
             from .negotiations_probe import chat_url, parse_initial_state, topic_refs
 
@@ -433,6 +443,7 @@ def fetch_responses(
             html = page.content()
             try:
                 refs = topic_refs(html)
+                page_topic_ids = {ref.topic_id for ref in refs}
             except AttributeError as exc:
                 # #742 round 2 (Codex review): topic_refs() runs before the
                 # raw_topics shape validation below and assumes
@@ -570,6 +581,14 @@ def fetch_responses(
         except ResponsesIndeterminate:
             raise
         except (TypeError, ValueError, KeyError, json.JSONDecodeError, PlaywrightError):
+            if pagerless:
+                # Ноль новых топиков — единственное доказательство конца списка
+                # в pagerless-режиме; без прочитанного SSR topicList его нечем
+                # подтвердить — fail-closed, а не «дочитано».
+                raise ResponsesIndeterminate(
+                    f"страница {page_num}: SSR topicList не прочитан — полнота "
+                    "списка без пейджера не подтверждается (#1067)"
+                ) from None
             if strict_empty or strict_scrape:
                 # #742: отсутствующий/битый HH-Lux-InitialState — тот же
                 # неопределённый page-state, что и не появившиеся карточки
@@ -582,6 +601,29 @@ def fetch_responses(
                 ) from None
             logger.warning("SSR topic mapping unavailable; keeping parsed chat URLs")
 
+        if pagerless:
+            # Дрейф 2026-09-09 (PR #1066): пейджер из UI удалён, серверный
+            # GET-контракт ?page=N жив — конец списка доказывается данными:
+            # страница без НОВЫХ топиков (пустая или повтор предыдущей) —
+            # конец. Дедуп по topic_id страхует и от сервера, игнорирующего
+            # ?page (он вернёт те же темы -> ноль новых -> стоп).
+            if page_num > 0 and not (page_topic_ids - seen_topic_ids):
+                logger.info(
+                    "Страница %d без новых топиков — достигнут конец списка откликов",
+                    page_num,
+                )
+                break
+            if page_num == max_pages - 1 and page_topic_ids:
+                # Последняя страница бюджета непуста, а пейджера, который
+                # доказал бы «дальше пусто», больше не существует — полнота
+                # списка не подтверждена. Для необратимого clear-negotiations
+                # это отказ до любого клика (инвариант PR #196, #1067).
+                raise ResponsesIndeterminate(
+                    f"обход достиг --max-pages={max_pages} при непустой странице "
+                    f"{page_num} — продолжение списка не опровергнуто"
+                )
+            seen_topic_ids |= page_topic_ids
+            continue
         has_next = _has_next_page(page, page_num)
         if not has_next:
             logger.info("Достигнута последняя страница откликов (%d)", page_num)

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -354,17 +354,43 @@ def test_found_on_second_page():
     assert f"{NEGOTIATIONS_URL}?page=1" in page.goto_calls
 
 
+def test_found_on_lazy_tail_without_pager():
+    # Дрейф 2026-09-09 (#1067): пейджер из UI удалён, но тема целевой
+    # вакансии может лежать за пределами первой страницы (lazy-хвост).
+    # Раньше «пейджер не отрисован» завершал скан после страницы 0 →
+    # ложный not_found с clean=True — нарушение fail-closed серой зоны #207.
+    # Теперь продолжение доказывают НОВЫЕ vacancy_id страницы 0.
+    page0 = _ssr_html([_topic(7, "999999")])  # без пейджера
+    page1 = _ssr_html([_topic(9, _V2)])
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: page0, f"{NEGOTIATIONS_URL}?page=1": page1})
+    result = verify_response_in_negotiations(page, _V2)
+    assert result.found
+    assert f"{NEGOTIATIONS_URL}?page=1" in page.goto_calls
+
+
 # --- not_found: подтверждённое отсутствие ------------------------------------
 
 
 def test_not_found_on_clean_ssr_read():
+    # Одностраничный аккаунт после дрейфа 2026-09-09 (пейджер удалён, PR
+    # #1066/#1067): конец списка подтверждается пустой следующей страницей —
+    # серверный ?page=1 за пределами списка отдаёт пустой topicList.
     page = FakeNegotiationsPage(
-        {NEGOTIATIONS_URL: _ssr_html([_topic(7, "999999"), _topic(8, "888888")])}
+        {
+            NEGOTIATIONS_URL: _ssr_html([_topic(7, "999999"), _topic(8, "888888")]),
+            f"{NEGOTIATIONS_URL}?page=1": _ssr_html([]),
+        }
     )
     result = verify_response_in_negotiations(page, _V2)
     assert result.status == "not_found"
     # Polling: обе попытки с интервалом (отклик мог появиться с задержкой).
-    assert page.goto_calls == [NEGOTIATIONS_URL, NEGOTIATIONS_URL]
+    # Попытка 2 не ходит на ?page=1 повторно: seen_vacancy_ids накапливается
+    # между попытками, и страница 0 без новых вакансий уже доказывает конец.
+    assert page.goto_calls == [
+        NEGOTIATIONS_URL,
+        f"{NEGOTIATIONS_URL}?page=1",
+        NEGOTIATIONS_URL,
+    ]
     assert page.wait_for_timeout_calls == [10_000]
 
 
@@ -669,7 +695,11 @@ class _IncomparableSecondAttemptPage(FakeNegotiationsPage):
     ровно тот false-negative, что #212 призван устранить)."""
 
     def __init__(self, page0_clean: str, page0_incomparable: str):
-        super().__init__({NEGOTIATIONS_URL: page0_clean})
+        # ?page=1 — подтверждённо пустой хвост одностраничного аккаунта
+        # (серверный контракт конца списка после дрейфа 2026-09-09, PR #1066).
+        super().__init__(
+            {NEGOTIATIONS_URL: page0_clean, f"{NEGOTIATIONS_URL}?page=1": _ssr_html([])}
+        )
         self._clean = page0_clean
         self._incomparable = page0_incomparable
         self._page0_gotos = 0

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -122,6 +122,11 @@ class FakeNegotiationsPage:
         goto_error: Exception | None = None,
     ):
         self._pages = {} if pages is None else dict(pages)
+        # Живой контракт конца списка (дрейф 2026-09-09, PR #1066/#1067):
+        # одностраничный аккаунт на ?page=1 получает подтверждённо пустой
+        # topicList — «нулевых новых» достаточно для конца скана. Фикстуры
+        # с ЯВНЫМ ?page=1 (многостраничные сценарии) дефолт не затирает.
+        self._pages.setdefault(f"{NEGOTIATIONS_URL}?page=1", _ssr_html([]))
         self._authed = authed
         self._goto_error = goto_error
         self._html = ""
@@ -384,14 +389,45 @@ def test_not_found_on_clean_ssr_read():
     result = verify_response_in_negotiations(page, _V2)
     assert result.status == "not_found"
     # Polling: обе попытки с интервалом (отклик мог появиться с задержкой).
-    # Попытка 2 не ходит на ?page=1 повторно: seen_vacancy_ids накапливается
-    # между попытками, и страница 0 без новых вакансий уже доказывает конец.
+    # Каждая попытка проходит страницы заново (ноль новых vacancy_id —
+    # stop-условие внутри ОДНОЙ попытки, набор локален): между поллами
+    # хвост мог измениться, поэтому ?page=1 читается и в повторе.
     assert page.goto_calls == [
         NEGOTIATIONS_URL,
         f"{NEGOTIATIONS_URL}?page=1",
         NEGOTIATIONS_URL,
+        f"{NEGOTIATIONS_URL}?page=1",
     ]
     assert page.wait_for_timeout_calls == [10_000]
+
+
+class _DelayedTailPage(FakeNegotiationsPage):
+    """Попытка 1: страница 0 без цели, страница 1 пуста. Попытка 2: страница 0
+    НЕИЗМЕННА, а опоздавший отклик появился на странице 1 (между поллами)."""
+
+    def __init__(self, page0: str, page1_delayed: str):
+        super().__init__({NEGOTIATIONS_URL: page0, f"{NEGOTIATIONS_URL}?page=1": _ssr_html([])})
+        self._page1_delayed = page1_delayed
+        self._page1_gotos = 0
+
+    def goto(self, url: str, *, wait_until: str = "") -> None:  # noqa: ARG002
+        if url == f"{NEGOTIATIONS_URL}?page=1":
+            self._page1_gotos += 1
+            self.goto_calls.append(url)
+            self._html = self._page1_delayed if self._page1_gotos > 1 else self._pages[url]
+            return
+        super().goto(url, wait_until=wait_until)
+
+
+def test_found_on_delayed_tail_of_second_attempt():
+    # Ревью PR #1068: seen_vacancy_ids не должен накапливаться между
+    # попытками — иначе неизменная страница 0 повторного полла дала бы ноль
+    # «новых» ещё до захода на ?page=1, и опоздавший отклик на хвосте
+    # получил бы ложный not_found. Каждая попытка ходит по страницам заново.
+    page = _DelayedTailPage(_ssr_html([_topic(7, "999999")]), _ssr_html([_topic(9, _V2)]))
+    result = verify_response_in_negotiations(page, _V2)
+    assert result.found
+    assert page.goto_calls.count(f"{NEGOTIATIONS_URL}?page=1") == 2
 
 
 def test_not_found_on_server_rendered_empty_list():

--- a/tests/test_apply_verify.py
+++ b/tests/test_apply_verify.py
@@ -430,6 +430,20 @@ def test_found_on_delayed_tail_of_second_attempt():
     assert page.goto_calls.count(f"{NEGOTIATIONS_URL}?page=1") == 2
 
 
+def test_found_second_topic_of_same_vacancy_on_next_page():
+    # Ревью PR #1068 (вторая находка): у одной вакансии может быть несколько
+    # тем (разные резюме). Прогресс-признак пейджинга — идентификатор ТЕМЫ,
+    # не vacancy_id: тема V с чужим резюме на странице 0 не делает вторую
+    # тему той же V на странице 1 «не новой» — diff по vacancy_id
+    # останавливал бы скан до чтения страницы 1 и возвращал not_found.
+    page0 = _ssr_html([_topic(7, _V2, "R1")])  # V, чужое резюме — скан идёт дальше
+    page1 = _ssr_html([_topic(8, _V2, "R2")])  # V, наше резюме — found
+    page = FakeNegotiationsPage({NEGOTIATIONS_URL: page0, f"{NEGOTIATIONS_URL}?page=1": page1})
+    result = verify_response_in_negotiations(page, _V2, resume_id="R2", account_resume_ids={"R2"})
+    assert result.found
+    assert f"{NEGOTIATIONS_URL}?page=1" in page.goto_calls
+
+
 def test_not_found_on_server_rendered_empty_list():
     # topicList=[] — сервер честно отрисовал пустой список: это чистое чтение,
     # а не «не отрендерилось».

--- a/tests/test_clear_negotiations_command.py
+++ b/tests/test_clear_negotiations_command.py
@@ -347,15 +347,15 @@ def test_run_topic_returns_true_on_failed_withdraw(tmp_path, monkeypatch):
 
 
 def test_account_wide_rejects_when_max_pages_truncated(tmp_path, monkeypatch):
-    """Codex review (PR #196): hitting --max-pages must not look like completeness.
+    """PR #196 -> #1067: hitting --max-pages must not look like completeness.
 
-    fetch_responses() silently stops after --max-pages pages even if more
-    negotiations exist on hh.ru. Withdrawing only what was found and
-    reporting success on a destructive, irreversible operation would leave a
-    silent remainder. clear_negotiations must re-check _has_next_page() and
-    fail closed instead.
+    Пейджер из UI /applicant/negotiations удалён hh.ru (дрейф 2026-09-09),
+    прежний guard на _has_next_page молча перестал срабатывать. Полнота
+    списка для необратимого отзыва теперь подтверждается pagerless-обходом
+    fetch_responses: ResponsesIndeterminate (потолок --max-pages при
+    непустом продолжении) обязан превращаться в отказ ДО любого клика, а не в
+    молчаливый успех с невзысканным остатком.
     """
-    from hhru_bot.responses import ResponseItem
 
     class Page:
         pass
@@ -370,7 +370,15 @@ def test_account_wide_rejects_when_max_pages_truncated(tmp_path, monkeypatch):
         def __exit__(self, *exc):
             return False
 
-    cards = [ResponseItem(vacancy_id="1", status="read", topic="tp1")]
+    from hhru_bot.responses import ResponsesIndeterminate
+
+    def _indeterminate_truncation(page, max_pages, *, pagerless=False):
+        assert pagerless is True  # полнота списка подтверждается без пейджера
+        raise ResponsesIndeterminate(
+            f"обход достиг --max-pages={max_pages} при непустой странице 1 — "
+            "продолжение списка не опровергнуто"
+        )
+
     history = History(tmp_path / "history.db")
     monkeypatch.setattr(command, "confirm_write", lambda *args, **kwargs: True)
     monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *args, **kwargs: Context())
@@ -382,8 +390,7 @@ def test_account_wide_rejects_when_max_pages_truncated(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("hhru_bot.history.History", lambda *args, **kwargs: history)
     monkeypatch.setattr("hhru_bot.throttle.Throttle", lambda *args, **kwargs: None)
-    monkeypatch.setattr(command, "fetch_responses", lambda page, max_pages: cards)
-    monkeypatch.setattr(command, "_has_next_page", lambda page, page_num: True)
+    monkeypatch.setattr(command, "fetch_responses", _indeterminate_truncation)
 
     with pytest.raises(SystemExit) as exc:
         command.run(_args(account_wide=True, force=True, max_pages=5))
@@ -427,7 +434,7 @@ def test_account_wide_empty_discovery_warns_but_does_not_hard_fail(tmp_path, mon
     )
     monkeypatch.setattr("hhru_bot.history.History", lambda *args, **kwargs: history)
     monkeypatch.setattr("hhru_bot.throttle.Throttle", lambda *args, **kwargs: None)
-    monkeypatch.setattr(command, "fetch_responses", lambda page, max_pages: [])
+    monkeypatch.setattr(command, "fetch_responses", lambda page, max_pages, *, pagerless=False: [])
 
     failed = command.run(_args(account_wide=True, force=True))
     assert failed is False  # no false refusal for a legitimately empty account
@@ -485,8 +492,9 @@ def test_account_wide_skipped_cards_flip_exit_status(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("hhru_bot.history.History", lambda *args, **kwargs: history)
     monkeypatch.setattr("hhru_bot.throttle.Throttle", lambda *args, **kwargs: Throttle())
-    monkeypatch.setattr(command, "fetch_responses", lambda page, max_pages: cards)
-    monkeypatch.setattr(command, "_has_next_page", lambda page, page_num: False)
+    monkeypatch.setattr(
+        command, "fetch_responses", lambda page, max_pages, *, pagerless=False: cards
+    )
 
     failed = command.run(_args(account_wide=True, force=True))
     assert failed is True  # a skipped card is an incomplete account-wide run
@@ -542,8 +550,9 @@ def test_account_wide_skips_cards_without_topic(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("hhru_bot.history.History", lambda *args, **kwargs: history)
     monkeypatch.setattr("hhru_bot.throttle.Throttle", lambda *args, **kwargs: Throttle())
-    monkeypatch.setattr(command, "fetch_responses", lambda page, max_pages: cards)
-    monkeypatch.setattr(command, "_has_next_page", lambda page, page_num: False)
+    monkeypatch.setattr(
+        command, "fetch_responses", lambda page, max_pages, *, pagerless=False: cards
+    )
 
     import contextlib
     import io

--- a/tests/test_responses_pagination.py
+++ b/tests/test_responses_pagination.py
@@ -184,3 +184,141 @@ def test_fetch_responses_timeout_on_confirmed_later_page_is_indeterminate(monkey
 def test_fetch_responses_rejects_nonpositive_page_limit():
     with pytest.raises(ValueError, match="positive"):
         responses.fetch_responses(object(), max_pages=0)
+
+
+# --- pagerless (#1067): конец списка без пейджера — по нулю новых топиков ---
+
+
+class _PagerlessPage:
+    """Фейк Page для pagerless-обхода: URL -> (карточки, SSR html)."""
+
+    BASE = "https://hh.ru/applicant/negotiations"
+
+    def __init__(self, pages: dict[str, tuple[list, str]]):
+        self._pages = pages
+        self._cards: list = []
+        self._html = ""
+        self.visited: list[str] = []
+
+    def goto(self, url: str, *, wait_until: str = ""):  # noqa: ARG002
+        self.visited.append(url)
+        self._cards, self._html = self._pages[url]
+
+    @property
+    def context(self):
+        class _Ctx:
+            def cookies(self):
+                return [{"name": "hhtoken", "value": "x"}]
+
+        return _Ctx()
+
+    def locator(self, selector: str):
+        if selector == LOGIN_FORM:
+            return _Locator([])
+        assert selector == ns.NEGOTIATION_ITEM
+        return _PagerlessCardsLocator(self._cards)
+
+    def content(self) -> str:
+        return self._html
+
+
+class _PagerlessCardsLocator:
+    """Карточки уже «отрендерены» фейком; wait_for ничего не ждёт."""
+
+    def __init__(self, cards: list):
+        self.cards = cards
+
+    def count(self):
+        return len(self.cards)
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state: str, timeout: int):  # noqa: ARG002
+        return None
+
+    def nth(self, index: int):
+        return self.cards[index]
+
+
+def _ssr(topics: list[tuple[int, int, str]]) -> str:
+    entries = ",".join(f'{{"id":{t},"chatId":{c},"vacancyId":"{v}"}}' for t, c, v in topics)
+    return (
+        '<template id="HH-Lux-InitialState">'
+        f'{{"applicantNegotiations":{{"topicList":[{entries}]}}}}'
+        "</template>"
+    )
+
+
+def _run_pagerless(monkeypatch, page):
+    monkeypatch.setattr(responses, "goto_hh", lambda p, url: p.goto(url))
+    monkeypatch.setattr(responses, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(
+        responses,
+        "parse_response_card",
+        lambda card: responses.ResponseItem(vacancy_id=card, status=responses.ResponseStatus.READ),
+    )
+    return page
+
+
+def test_pagerless_reads_lazy_tail_beyond_missing_pager(monkeypatch):
+    """Дрейф 2026-09-09 (#1067): пейджера нет, но хвост за первой двадцаткой жив.
+
+    Страница 1 приносит НОВЫЕ топики — обход обязан их собрать: раньше
+    «пейджер не отрисован» читался как «страница одна» и clear-negotiations
+    видел только первые 20 тем.
+    """
+    url0, url1 = _PagerlessPage.BASE, f"{_PagerlessPage.BASE}?page=1"
+    page = _PagerlessPage(
+        {
+            url0: (["1", "2"], _ssr([(1, 11, "1"), (2, 22, "2")])),
+            url1: (["3", "4"], _ssr([(3, 33, "3"), (4, 44, "4")])),
+            f"{_PagerlessPage.BASE}?page=2": ([], _ssr([])),
+        }
+    )
+    _run_pagerless(monkeypatch, page)
+
+    items = responses.fetch_responses(page, max_pages=3, pagerless=True)
+
+    assert sorted(i.vacancy_id for i in items) == ["1", "2", "3", "4"]
+    assert page.visited == [url0, url1, f"{_PagerlessPage.BASE}?page=2"]
+
+
+def test_pagerless_stops_when_server_ignores_page_param(monkeypatch):
+    """Сервер, игнорирующий ?page, возвращает те же темы: ноль новых -> стоп
+    без дублей (карточки не задваиваются)."""
+    url0 = _PagerlessPage.BASE
+    same = (["1"], _ssr([(1, 11, "1")]))
+    page = _PagerlessPage({url0: same, f"{url0}?page=1": same, f"{url0}?page=2": same})
+    _run_pagerless(monkeypatch, page)
+
+    items = responses.fetch_responses(page, max_pages=3, pagerless=True)
+
+    # Карточки повторной страницы попадают в results (дедуп делает upsert в
+    # истории по UNIQUE) — но обход обязан остановиться, не дойдя до page=2.
+    assert [i.vacancy_id for i in items] == ["1", "1"]
+    assert page.visited == [url0, f"{url0}?page=1"]
+
+
+def test_pagerless_cap_with_nonempty_page_is_indeterminate(monkeypatch):
+    """Потолок --max-pages при непустой последней странице: полнота списка не
+    подтверждена — ResponsesIndeterminate (clear-negotiations превращает его
+    в отказ ДО отзыва, инвариант PR #196)."""
+    url0 = _PagerlessPage.BASE
+    page = _PagerlessPage({url0: (["1"], _ssr([(1, 11, "1")]))})
+    _run_pagerless(monkeypatch, page)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="--max-pages"):
+        responses.fetch_responses(page, max_pages=1, pagerless=True)
+
+
+def test_pagerless_unreadable_ssr_is_indeterminate(monkeypatch):
+    """Ноль новых — единственное доказательство конца; нечитаемый SSR не должен
+    превращаться в «дочитано» (fail-closed)."""
+    url0 = _PagerlessPage.BASE
+    page = _PagerlessPage({url0: (["1"], "<html>no ssr</html>")})
+    _run_pagerless(monkeypatch, page)
+
+    with pytest.raises(responses.ResponsesIndeterminate, match="SSR topicList"):
+        responses.fetch_responses(page, max_pages=2, pagerless=True)


### PR DESCRIPTION
Closes #1067

Фоллоу-ап PR #1066 по ревью issuecomment-5589211653 (находка 1): после
дрейфа 2026-09-09 (hh.ru убрал пейджер из UI `/applicant/negotiations`,
хвост подгружается lazy-скроллом; серверный GET-контракт `?page=N` жив)
на ветке остались два потребителя negotiations-пагинации со старой
пейджер-семантикой, для которых дрейф менял поведение молча.

## Что

- **`commands/clear_negotiations.py` — guard необратимой операции
  (инвариант PR #196).** Прежний guard на `_has_next_page` молчал:
  пейджер не отрисовывается никогда → False всегда → clear на аккаунте
  >20 тем отозвал бы первые 20 и отчитался успехом при невидимом
  невзысканном остатке. Теперь полнота списка подтверждается
  pagerless-обходом `fetch_responses`; `ResponsesIndeterminate` (потолок
  `--max-pages` при непустом продолжении, нечитаемый SSR) превращается в
  `[FAIL]` ДО любого клика отзыва.
- **`responses.py` — `fetch_responses(pagerless=True)`.** Конец списка
  по нулю НОВЫХ SSR-топиков (та же семантика, что у обходчиков PR #1066);
  потолок `max_pages` при непустой последней странице →
  `ResponsesIndeterminate`. Дефолт выключен: strict-семантика
  `responses --sync` (identity-импорт ledger) не тронута — заявленный
  остаток отдельного прохода.
- **`apply/verify.py` — серая зона #207.** `_has_next_page_confirmed`
  удалён: «пейджер не отрисован» завершал скан после страницы 0 → отклик
  на lazy-хвосте получал **ложный not_found с clean=True** вместо честного
  вердикта. Конец скана — страница без НОВЫХ vacancy_id (diff
  `seen_vacancy_ids`, для поиска вакансии этого достаточно: целевая
  вакансия на странице дала бы новый id); потолок
  `NEGOTIATIONS_VERIFY_MAX_PAGES=2` при непустом продолжении —
  indeterminate (fail-closed #207). Бюджет 2 страниц не менялся —
  инвариант «свежий отклик на странице 0» (#210) жив.

## Тесты

- `test_apply_verify.py`: found на lazy-хвосте БЕЗ пейджера (главный
  регресс-кейс ложного not_found); not_found на одностраничном аккаунте
  подтверждается пустой следующей страницей (серверный контракт конца).
- `test_responses_pagination.py`: lazy-хвост за первой страницей
  собирается; сервер, игнорирующий `?page`, — стоп по нулю новых без
  захода на page=2; потолок при непустой странице → Indeterminate;
  нечитаемый SSR → Indeterminate (fail-closed).
- `test_clear_negotiations_command.py`: `ResponsesIndeterminate` от
  pagerless-обхода → SystemExit, ноль строк в `actions` (ничего не
  отозвано до проверки полноты); существующие моки переведены на
  pagerless-сигнатуру.

## Живые прогоны

Не выполнялись: `clear-negotiations` необратим — по правилам проекта
боевой clear не гоняется вовсе, проверка только тестами. Живой read-only
прогон не добавляет ничего сверх уже зафиксированного в #1066 факта
дрейфа.

Сюит `-n 4 --dist worksteal` зелёный, `ruff check` + `ruff format
--check` зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
