### PR TITLE
fix(negotiations): доездка guard-а расхождения окон из PR 1068 (indeterminate вместо молчаливой усечёнки)

### DIFF
--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -132,6 +132,31 @@ def remindable_topic_refs(html: str) -> list[RemindableTopicRef]:
     return result
 
 
+def _require_windows_overlap(
+    prev_first_topic_id: str | None, page_refs: list, page_num: int
+) -> None:
+    """Fail-closed guard стопа «ноль новых топиков» (ревью PR #1072).
+
+    Ноль новых тем на странице N>0 доказывает конец списка только если это
+    подтверждённый повтор окна: выдача пересекается с прошлой (первый topic_id
+    прошлой страницы встречается в новой). Если его там нет — окна между GET
+    разъехались (список сдвинулся между запросами) и стоп молча отдал бы
+    усечённый список за полный; в этом случае — ``ResponsesIndeterminate``.
+    Пустая страница и пустая прошлая — серверный контракт конца/нулевого
+    списка, не сдвиг: расхождения в них нет.
+    """
+    if not page_refs or prev_first_topic_id is None:
+        return
+    if prev_first_topic_id not in {r.topic_id for r in page_refs}:
+        from .responses import ResponsesIndeterminate
+
+        raise ResponsesIndeterminate(
+            f"окна страниц {page_num - 1} и {page_num} разошлись: первая тема "
+            f"прошлой выдачи ({prev_first_topic_id}) отсутствует в новой — "
+            f"список сдвинулся между GET, хвост мог быть пропущен"
+        )
+
+
 def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
     """Read SSR topic mappings from every available negotiations page.
 
@@ -150,6 +175,7 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
 
     refs: list[TopicRef] = []
     seen: set[str] = set()
+    prev_first_topic_id: str | None = None
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         goto_hh(page, url)
@@ -173,9 +199,19 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         # аккаунтах; дедуп по topic_id страхует и от сервера, игнорирующего
         # ?page (он вернёт те же темы → ноль новых → стоп).
         if page_num > 0 and not new_refs:
+            # Ревью PR #1072 (находка по семантике #1066): «ноль новых» —
+            # честный конец списка только если новая выдача — подтверждённый
+            # повтор окна (пересекается с прошлой). Если прошлая страница
+            # начиналась с темы, которой в новой нет вовсе, окна между GET
+            # разъехались (список сдвинулся: тема ушла вниз или новая встала
+            # выше) — непросмотренный хвост мог остаться за окном, и молчаливый
+            # стоп здесь выдал бы усечённый список за полный. Пустая страница —
+            # серверный контракт конца, а не сдвиг, индетерминатности в ней нет.
+            _require_windows_overlap(prev_first_topic_id, page_refs, page_num)
             break
         seen.update(r.topic_id for r in new_refs)
         refs.extend(new_refs)
+        prev_first_topic_id = page_refs[0].topic_id if page_refs else prev_first_topic_id
     return refs
 
 
@@ -218,6 +254,7 @@ def paginated_topic_and_remindable_refs(
     topics_out: list[TopicRef] = []
     remindable_out: list[RemindableTopicRef] = []
     seen: set[str] = set()
+    prev_first_topic_id: str | None = None
     for page_num in range(max_pages):
         url = NEGOTIATIONS_URL if page_num == 0 else f"{NEGOTIATIONS_URL}?page={page_num}"
         goto_hh(page, url)
@@ -231,9 +268,15 @@ def paginated_topic_and_remindable_refs(
         # (полное обоснование в комментарии там). Дедуп по topic_id не даёт
         # повторной странице задвоить темы в обоих представлениях.
         if page_num > 0 and not new_ids:
+            # Тот же инвариант расхождения окон, что в paginated_topic_refs
+            # (ревью PR #1072): «ноль новых» доказывает конец списка только
+            # пересечением с прошлой выдачей; полное обоснование — в
+            # _require_windows_overlap.
+            _require_windows_overlap(prev_first_topic_id, page_topics, page_num)
             break
         topics_out.extend(r for r in page_topics if r.topic_id in new_ids)
         remindable_out.extend(r for r in remindable_topic_refs(html) if r.topic_id in new_ids)
+        prev_first_topic_id = page_topics[0].topic_id if page_topics else prev_first_topic_id
         seen.update(new_ids)
         topics = parse_initial_state(html)["applicantNegotiations"]["topicList"]
         # An explicitly empty SSR list is a confirmed empty inbox.  Waiting

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -133,7 +133,7 @@ def remindable_topic_refs(html: str) -> list[RemindableTopicRef]:
 
 
 def _require_windows_overlap(
-    prev_first_topic_id: str | None, page_refs: list, page_num: int
+    prev_first_topic_id: str | None, page_refs: list[TopicRef], page_num: int
 ) -> None:
     """Fail-closed guard стопа «ноль новых топиков» (ревью PR #1072).
 

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -4,11 +4,12 @@ import pytest
 
 from hhru_bot.negotiations_probe import (
     chat_url,
+    paginated_topic_and_remindable_refs,
     paginated_topic_refs,
     parse_initial_state,
     topic_refs,
 )
-from hhru_bot.responses import NotAuthenticated
+from hhru_bot.responses import NotAuthenticated, ResponsesIndeterminate
 
 pytestmark = pytest.mark.integration
 
@@ -178,6 +179,101 @@ def test_paginated_topic_refs_survives_server_ignoring_page_param(monkeypatch):
         "https://hh.ru/applicant/negotiations",
         "https://hh.ru/applicant/negotiations?page=1",
     ]
+
+
+def _pages_page(pages):
+    class Page:
+        def __init__(self):
+            self.page_num = 0
+
+        def content(self):
+            return _state_html(pages[self.page_num])
+
+    page = Page()
+    urls = []
+
+    def goto(_page, url):
+        urls.append(url)
+        page.page_num = len(urls) - 1
+
+    return page, goto, urls
+
+
+def test_paginated_topic_refs_empty_next_page_confirms_end(monkeypatch):
+    """Пустая следующая страница — серверный контракт конца, не сдвиг окон:
+    стоп по нулю новых без indeterminate."""
+
+    page, goto, urls = _pages_page({0: [1, 2], 1: []})
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    refs = paginated_topic_refs(page, max_pages=3)
+
+    assert [ref.topic_id for ref in refs] == ["1", "2"]
+    assert urls[-1] == "https://hh.ru/applicant/negotiations?page=1"
+
+
+def test_paginated_topic_refs_shifted_window_raises_indeterminate(monkeypatch):
+    """Ревью PR #1072: список сдвинулся между GET — окно page=1 целиком из уже
+    виденных тем, но НЕ пересекается с началом прошлой выдачи (первой темы
+    прошлой страницы в новой нет). Стоп по нулю новых молча отдал бы усечённый
+    список за полный; вместо этого — ResponsesIndeterminate (fail-closed)."""
+
+    # page 0: темы 1-5; между GET сверху встали новые темы → окно page=1
+    # сползло назад на 3-5 (все уже seen), хвост 6+ остался за окном.
+    page, goto, _urls = _pages_page({0: [1, 2, 3, 4, 5], 1: [3, 4, 5]})
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    with pytest.raises(ResponsesIndeterminate, match="разошлись"):
+        paginated_topic_refs(page, max_pages=3)
+
+
+def test_combined_walk_shifted_window_raises_indeterminate(monkeypatch):
+    """Тот же инвариант для комбинированного обхода (#710): сдвиг окна между
+    страницами → ResponsesIndeterminate, а не молчаливая усечёнка тем/флагов
+    напоминаний."""
+
+    def remindable_state_html(topic_ids):
+        state = {
+            "applicantNegotiations": {
+                "topicList": [
+                    {
+                        "id": tid,
+                        "chatId": tid + 100,
+                        "vacancyId": tid + 200,
+                        "responseReminderState": {"allowed": False},
+                    }
+                    for tid in topic_ids
+                ]
+            }
+        }
+        return '<template id="HH-Lux-InitialState">' + json.dumps(state) + "</template>"
+
+    pages = {0: [1, 2, 3, 4, 5], 1: [3, 4, 5]}
+
+    class Page:
+        def __init__(self):
+            self.page_num = 0
+
+        def content(self):
+            return remindable_state_html(pages[self.page_num])
+
+    page = Page()
+
+    def goto(_page, url):
+        page.page_num = 0 if url.endswith("negotiations") else int(url.rsplit("=", 1)[1])
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", goto)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    with pytest.raises(ResponsesIndeterminate, match="разошлись"):
+        paginated_topic_and_remindable_refs(page, max_pages=3)
 
 
 # --- Codex review (#201): expired session must not surface as a raw ValueError


### PR DESCRIPTION
Доставка guard-а от сдвига окон между GET из PR #1068.

## Контекст

Находка code-review PR #1072 по `negotiations_probe.py:233` (семантика конца
списка из #1066/#1067): стоп обходчика по нулю новых топиков молча резал
хвост ленты при сдвиге списка между GET — тема ушла вниз или новая встала
выше, окно `?page=N` целиком из уже виденных тем, но не пересекается с
прошлой выдачей; дедуп по `topic_id` не спасает, «ноль новых» выдавал
усеченный список за полный.

Коммит с фиксом ушел в ветку `fix/negotiations-pagerless-guards` уже ПОСЛЕ
мерджа PR #1068 и в `main` не попал (verify: compare diverged, ahead 1) —
этот PR доезжает его на актуальный `origin/main` (cherry-pick `51a69309`,
код идентичен). Ишью #1067 уже закрыто тем мерджем, Closes-ключа нет —
сошлиться: #1067, #1068.

## Что

- `negotiations_probe.py`: в обоих обходчиках (`paginated_topic_refs`,
  `paginated_topic_and_remindable_refs`) ноль новых топиков доказывает конец
  списка только пересечением окон — первый `topic_id` прошлой выдачи обязан
  встретиться в новой; при расхождении — `ResponsesIndeterminate`
  (fail-closed). Пустая следующая страница — серверный контракт конца, не
  сдвиг. Общая проверка — `_require_windows_overlap`.
- Тесты: сдвиг окна → `ResponsesIndeterminate` для обоих обходчиков;
  пустая следующая страница — подтвержденный конец без indeterminate.

## Проверки

- Полный сюит `pytest -q -n 4 --dist worksteal` — зеленый.
- `ruff check` + `ruff format --check` — зеленые.
- Живые прогоны hh.ru не выполнялись (правка — чистая логика стопа,
  поведение подтверждается фикстурами сдвига).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

