### PR TITLE
fix(apply): приём предвыбранного резюме по SSR — вакансии с обязательным письмом больше не падают

### DIFF
--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -398,7 +398,8 @@ def _preselected_resume_confirmed_by_ssr(page: Page, resume_id: str) -> bool:
 
     try:
         state = parse_initial_state(page.content())
-    except (ValueError, json.JSONDecodeError):
+    # JSONDecodeError — подкласс ValueError, одного ValueError достаточно.
+    except ValueError:
         return False
     statuses = state.get("applicantVacancyResponseStatuses")
     if not isinstance(statuses, dict) or len(statuses) != 1:

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -386,7 +386,13 @@ def _preselected_resume_confirmed_by_ssr(page: Page, resume_id: str) -> bool:
     ``responseImpossible`` не true — это не «доверие дефолту» (#33), а чтение
     фактического выбора из состояния страницы (паттерн verify_wizard_save).
     Ровно одна запись в statuses: страница формы описывает одну вакансию;
-    иное — дрейф, не подтверждение.
+    иное — дрейф, не подтверждение. Ровно ОДНО резюме в ``resumes`` с нашим
+    hash: ``resumes`` — реестр доступности аккаунта для вакансии (рядом в SSR
+    живут usedResumeIds/unusedResumeIds/hiddenResumeIds, т.е. записей может
+    быть несколько), а какое из них предвыбрано формой состояние не сообщает.
+    Принять «наш hash есть среди многих» — submit с резюме, выбранным hh.ru,
+    а не нашим (#33); multi-resume-запись — дрейф относительно наблюдавшегося
+    single-resume shape, не подтверждение.
     """
     from ..negotiations_probe import parse_initial_state
 
@@ -401,13 +407,13 @@ def _preselected_resume_confirmed_by_ssr(page: Page, resume_id: str) -> bool:
     if not isinstance(entry, dict) or entry.get("responseImpossible") is True:
         return False
     resumes = entry.get("resumes")
-    if not isinstance(resumes, dict) or not resumes:
+    if not isinstance(resumes, dict) or len(resumes) != 1:
         return False
-    return any(
-        isinstance(item, dict)
-        and item.get("hash") == resume_id
-        and item.get("isIncomplete") is not True
-        for item in resumes.values()
+    only = next(iter(resumes.values()))
+    return (
+        isinstance(only, dict)
+        and only.get("hash") == resume_id
+        and only.get("isIncomplete") is not True
     )
 
 

--- a/src/hhru_bot/apply/steps.py
+++ b/src/hhru_bot/apply/steps.py
@@ -371,6 +371,46 @@ def fill_cover_letter(page: Page, letter: str) -> str | None:
     return None
 
 
+def _preselected_resume_confirmed_by_ssr(page: Page, resume_id: str) -> bool:
+    """SSR-подтверждение ПРЕДВЫБРАННОГО резюме без дропдауна (2026-09-09).
+
+    Живой факт (дамп probe_137014905_form.html + скриншот живой формы): на
+    вакансиях с ОБЯЗАТЕЛЬНЫМ сопроводительным письмом hh.ru предвыбирает
+    единственное резюме аккаунта и НЕ монтирует дропдаун — клик по
+    APPLY_RESUME_SELECT панель не открывает, прежний путь выбора падал
+    «резюме не найдено среди опций», не доходя до письма (которое apply
+    заполняет всегда). Источник истины — SSR HH-Lux-InitialState (тот же
+    носитель, что у negotiations):
+    ``applicantVacancyResponseStatuses[<vacancy>].resumes[<id>].hash``.
+    Подтверждение identity-bound: hash совпал, запись не incomplete и
+    ``responseImpossible`` не true — это не «доверие дефолту» (#33), а чтение
+    фактического выбора из состояния страницы (паттерн verify_wizard_save).
+    Ровно одна запись в statuses: страница формы описывает одну вакансию;
+    иное — дрейф, не подтверждение.
+    """
+    from ..negotiations_probe import parse_initial_state
+
+    try:
+        state = parse_initial_state(page.content())
+    except (ValueError, json.JSONDecodeError):
+        return False
+    statuses = state.get("applicantVacancyResponseStatuses")
+    if not isinstance(statuses, dict) or len(statuses) != 1:
+        return False
+    entry = next(iter(statuses.values()))
+    if not isinstance(entry, dict) or entry.get("responseImpossible") is True:
+        return False
+    resumes = entry.get("resumes")
+    if not isinstance(resumes, dict) or not resumes:
+        return False
+    return any(
+        isinstance(item, dict)
+        and item.get("hash") == resume_id
+        and item.get("isIncomplete") is not True
+        for item in resumes.values()
+    )
+
+
 def ensure_resume_selected(page: Page, resume_id: str) -> str | None:
     """Подтверждает выбор резюме в форме отклика. None — подтверждено, иначе причина отказа.
 
@@ -428,23 +468,31 @@ def ensure_resume_selected(page: Page, resume_id: str) -> str | None:
             "отправка отменена (нестабильная страница)"
         )
     if not _select_resume_in_form(page, resume_id):
-        # Гейт «компаний-клиентов HeadHunter» (живой дамп
-        # probe_137014905_form.html, 2026-09-09): форма отрисовывается, но
-        # вместо дропдауна опций резюме рендерит СВЁРНУТОЕ предупреждение
-        # (max-height:0) — клик по триггеру панель не монтирует. Безликое
-        # «не удалось выбрать» прятало реальную причину за разбором дампа.
-        # Признак — наличие узла (тот же селектор, что у #350-детекта
-        # расширённого предупреждения), НЕ его видимость/текст: текст hh.ru
-        # держит легаси-имя режима «Видно компаниям-клиентам HeadHunter»,
-        # которого нет среди пяти актуальных radio видимости и в enum схемы
-        # accessType — парсить его нельзя.
-        from ..selector_groups import vacancy_page
-
+        # Два различимых исхода, оба ДО submit (на hh.ru следа нет):
+        # (а) резюме ПРЕДВЫБРАНО формой без дропдауна (shape с обязательным
+        #     письмом, 2026-09-09) — identity подтверждается SSR, выбор не
+        #     требуется, продолжаем к письму;
+        # (б) выбора нет и SSR нашего резюме не подтверждает — fail-closed
+        #     отказ прежней семантики (#33), с уточнением причины, если в DOM
+        #     есть свёрнутое hidden-resume-warning (узел есть — признак
+        #     наличия узла, НЕ его текста: текст hh.ru держит легаси-имя
+        #     режима «Видно компаниям-клиентам HeadHunter», которого нет
+        #     среди пяти актуальных radio видимости; живая проверка
+        #     2026-09-09 показала, что отклик на таких формах возможен при
+        #     заполненном письме, поэтому тексту предупреждения доверять
+        #     нельзя — см. PR #1082/#1084).
+        if _preselected_resume_confirmed_by_ssr(page, resume_id):
+            logger.info(
+                "Резюме '%s' предвыбрано формой (SSR identity подтверждён), "
+                "дропдаун не монтируется — выбор не требуется",
+                resume_id,
+            )
+            return None
         if page.locator(vacancy_page.VACANCY_HIDDEN_RESUME_WARNING).count():
             return (
-                "вакансия компании-клиента HeadHunter: видимость резюме не "
-                f"позволяет отклик, резюме '{resume_id}' недоступно для выбора "
-                "(hidden-resume-warning)"
+                f"резюме '{resume_id}' не выбрано в форме отклика: дропдаун не "
+                "открылся, SSR предвыбор не подтверждает, в DOM свёрнутое "
+                "предупреждение hidden-resume-warning"
             )
         return f"не удалось однозначно выбрать резюме '{resume_id}' в форме отклика"
     return None

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -668,21 +668,31 @@ def test_fill_form_missing_submit_returns_reason_no_click():
     assert "кнопка отправки отклика не найдена" in result
 
 
-def _ssr_form_state_html(resume_hash: str | None) -> str:
+def _ssr_form_state_html(resume_hash: str | None, *, multi_resume: bool = False) -> str:
     """SSR HH-Lux-InitialState формы отклика с предвыбранным резюме.
 
     Живой shape (дамп probe_137014905_form.html, 2026-09-09):
     applicantVacancyResponseStatuses[<vacancy>].resumes[<id>].hash +
     responseImpossible. resume_hash=None — состояние без нашего резюме.
+    multi_resume=True — наш hash среди ДВУХ резюме (реестр доступности
+    multi-resume аккаунта, не предвыбор). Числовые ключи резюме — очевидно
+    подставные: реальные id аккаунта в фикстурах запрещены (hex-страж
+    числовой id не ловит).
     """
+    resumes: dict
+    if multi_resume:
+        resumes = {
+            "111111111": {"hash": resume_hash, "isIncomplete": False},
+            "222222222": {"hash": "e" * 38, "isIncomplete": False},
+        }
+    elif resume_hash:
+        resumes = {"111111111": {"hash": resume_hash, "isIncomplete": False}}
+    else:
+        resumes = {"111111111": {"hash": "f" * 38, "isIncomplete": False}}
     entry: dict = {
         "hiddenResumeIds": [],
         "responseImpossible": False,
-        "resumes": (
-            {"286449044": {"hash": resume_hash, "isIncomplete": False}}
-            if resume_hash
-            else {"286449044": {"hash": "f" * 38, "isIncomplete": False}}
-        ),
+        "resumes": resumes,
     }
     state = {"applicantVacancyResponseStatuses": {"136173988": entry}}
     return (
@@ -718,6 +728,25 @@ def test_fill_form_rejects_preselection_of_foreign_resume():
     page = FakeStepsPage()
     page.content_html = _ssr_form_state_html("OTHER")
     page.set_visible(apply_form.APPLY_RESUME_SELECT, True)
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "не удалось однозначно выбрать резюме 'RID'" in result
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_rejects_multi_resume_ssr_registry():
+    """``resumes`` в SSR — реестр доступности, не предвыбор: на multi-resume
+    аккаунте наш hash среди ДВУХ записей не доказывает, что форма предвыбрала
+    именно наше (рядом в SSR живут usedResumeIds/unusedResumeIds). Принять
+    такой реестр — submit с резюме, выбранным hh.ru (#33); ровно одна запись
+    с нашим hash — единственный принимаемый shape."""
+    page = FakeStepsPage()
+    page.content_html = _ssr_form_state_html("RID", multi_resume=True)
+    page.set_visible(apply_form.APPLY_RESUME_SELECT, True)  # опций нет: option_resume_ids=[]
     page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
 

--- a/tests/test_apply_steps.py
+++ b/tests/test_apply_steps.py
@@ -9,6 +9,7 @@ submit даёт отказ при отсутствии.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -252,6 +253,10 @@ class FakeStepsPage:
 
     def __init__(self) -> None:
         self.states: dict[str, _SelectorState] = {}
+        # SSR-состояние страницы (HH-Lux-InitialState) для
+        # _preselected_resume_confirmed_by_ssr; по умолчанию состояния нет —
+        # parse_initial_state честно откажет, как страница без шаблона.
+        self.content_html = "<html>diagnostic</html>"
         self.navigation_entered = 0
         self.last_navigation_timeout: int | None = None
         self.last_navigation_wait_until: str | None = None
@@ -271,7 +276,7 @@ class FakeStepsPage:
 
     def content(self) -> str:
         self.content_calls += 1
-        return "<html>diagnostic</html>"
+        return self.content_html
 
     def wait_for_function(self, _expression, *, arg=None, timeout=None, polling=None):
         self.wait_for_function_calls.append(("function", arg, timeout))
@@ -663,20 +668,78 @@ def test_fill_form_missing_submit_returns_reason_no_click():
     assert "кнопка отправки отклика не найдена" in result
 
 
-def test_fill_form_hidden_resume_warning_names_the_gate():
-    """Гейт «компаний-клиентов HeadHunter» (живой дамп
-    probe_137014905_form.html, 2026-09-09): форма отрисована (триггер
-    резюме, письмо, submit на месте), но опций резюме нет — вместо дропдауна
-    свёрнутое hidden-resume-warning. Причина отказа обязана называть гейт,
-    а не прятать его за безликим «не удалось однозначно выбрать резюме»."""
+def _ssr_form_state_html(resume_hash: str | None) -> str:
+    """SSR HH-Lux-InitialState формы отклика с предвыбранным резюме.
+
+    Живой shape (дамп probe_137014905_form.html, 2026-09-09):
+    applicantVacancyResponseStatuses[<vacancy>].resumes[<id>].hash +
+    responseImpossible. resume_hash=None — состояние без нашего резюме.
+    """
+    entry: dict = {
+        "hiddenResumeIds": [],
+        "responseImpossible": False,
+        "resumes": (
+            {"286449044": {"hash": resume_hash, "isIncomplete": False}}
+            if resume_hash
+            else {"286449044": {"hash": "f" * 38, "isIncomplete": False}}
+        ),
+    }
+    state = {"applicantVacancyResponseStatuses": {"136173988": entry}}
+    return (
+        '<template style="display:none" id="HH-Lux-InitialState">'
+        + json.dumps(state)
+        + "</template>"
+    )
+
+
+def test_fill_form_accepts_ssr_confirmed_preselected_resume():
+    """Shape с ОБЯЗАТЕЛЬНЫМ письмом (живой факт 2026-09-09: скриншот живой
+    формы + дамп probe_137014905): hh.ru предвыбирает единственное резюме
+    аккаунта БЕЗ дропдауна — клик по триггеру панель не монтирует. Когда SSR
+    формы подтверждает наш hash, выбор не требуется: путь продолжается к
+    письму и submit (письмо обязательно — без него submit disabled)."""
+    page = FakeStepsPage()
+    page.content_html = _ssr_form_state_html("RID")
+    page.set_visible(apply_form.APPLY_RESUME_SELECT, True)  # опций нет: option_resume_ids=[]
+    page.set_visible(vacancy_page.VACANCY_HIDDEN_RESUME_WARNING, True)
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is None
+    assert page._state(apply_form.APPLY_COVER_LETTER_TEXTAREA).fills == ["письмо"]
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 1
+
+
+def test_fill_form_rejects_preselection_of_foreign_resume():
+    """SSR подтверждает ЧУЖОЕ резюме (hh.ru предвыбрал не наше) — приём
+    предвыбора не срабатывает, fail-closed отказ #33."""
+    page = FakeStepsPage()
+    page.content_html = _ssr_form_state_html("OTHER")
+    page.set_visible(apply_form.APPLY_RESUME_SELECT, True)
+    page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
+    page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
+
+    result = steps.fill_response_form(page, "RID", "письмо")
+
+    assert result is not None
+    assert "не удалось однозначно выбрать резюме 'RID'" in result
+    assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
+
+
+def test_fill_form_hidden_resume_warning_names_the_dom_fact():
+    """Дропдаун не открылся, SSR предвыбор НЕ подтверждает, в DOM свёрнутое
+    hidden-resume-warning — различимый отказ, описывающий DOM-факт без
+    вины «видимости»: текст предупреждения — легаси hh.ru (режима «Видно
+    компаниям-клиентам HeadHunter» нет среди пяти актуальных radio), живая
+    проверка 2026-09-09 показала, что отклик возможен при заполненном
+    письме — доверять тексту нельзя, только наличию узла."""
     page = FakeStepsPage()
     page.set_visible(apply_form.APPLY_RESUME_SELECT, True)  # опций нет: option_resume_ids=[]
     # Фейк различает только present/absent: visible-флаг здесь изображает
-    # ПРИСУТСТВИЕ узла, а прод-сигнал гейта — наличие СВЁРНУТОГО (max-height:0)
+    # ПРИСУТСТВИЕ узла, а прод-сигнал — наличие СВЁРНУТОГО (max-height:0)
     # предупреждения (детект по count() в ensure_resume_selected, не по видимости).
-    # Если фейк получит computed-style-семантику (как у
-    # _hidden_resume_warning_is_expanded), свёрнутый shape должен моделироваться
-    # здесь первым — этот тест место, где она проявится.
     page.set_visible(vacancy_page.VACANCY_HIDDEN_RESUME_WARNING, True)
     page.set_visible(apply_form.APPLY_COVER_LETTER_TEXTAREA, True)
     page.set_visible(apply_form.APPLY_SUBMIT_BUTTON, True)
@@ -684,8 +747,8 @@ def test_fill_form_hidden_resume_warning_names_the_gate():
     result = steps.fill_response_form(page, "RID", "письмо")
 
     assert result is not None
-    assert "компании-клиента HeadHunter" in result
     assert "hidden-resume-warning" in result
+    assert "не выбрано в форме отклика" in result
     # Отказ ДО submit: отклик не отправлялся.
     assert page._state(apply_form.APPLY_SUBMIT_BUTTON).clicks == 0
 


### PR DESCRIPTION
## Что

Продолжение #1081/#1082: скриншот живой формы от пользователя опроверг
гипотезу «гейта видимости» и вскрыл реальную причину тройного FAIL.

## Живые факты (скриншот залогиненной формы 137014905, 2026-09-09)

- форма показывает «Сопроводительное письмо обязательное для этой
  вакансии»; резюме «Тестировщик программного обеспечения» ПРЕДВЫБРАНО
  (без дропдауна); submit disabled ровно пока письмо пусто — **отклик
  возможен при заполненном письме**;
- свёрнутое `hidden-resume-warning` в DOM — инертный легаси-узел, не
  блокер; вердикт #1082 «видимость не позволяет отклик» — неверная
  причинность (переформулирован);
- SSR HH-Lux-InitialState формы несёт источник истины:
  `applicantVacancyResponseStatuses[<vacancy>].resumes[<id>].hash`
  (наш `7decaf00…`), `responseImpossible: false`, `hiddenResumeIds: []`.

## Механика FAIL (137014905, 136861255, 132283257)

hh.ru предвыбирает единственное резюме аккаунта и НЕ монтирует
дропдаун — клик по `APPLY_RESUME_SELECT` панель не открывает,
`_select_resume_in_form` падал «резюме не найдено среди опций», не
доходя до письма. Apply всегда заполняет письмо из конфига — вопрос
«почему скилл не использует функцию писем» имел ответ «умирал шагом
раньше».

## Фикс

- `_preselected_resume_confirmed_by_ssr`: при неудачном выборе резюме —
  identity-bound чтение SSR (hash совпал, запись не incomplete,
  `responseImpossible` не true, ровно одна запись statuses). Не «доверие
  дефолту» (#33), а чтение фактического выбора из состояния страницы
  (паттерн verify_wizard_save); чужой hash или дрейф схемы — прежний
  fail-closed отказ.
- Причина hidden-resume-warning переформулирована в DOM-факт без вины
  «видимости».

## Верификация

- `apply --dry-run --limit 5`: обе раньше падавшие вакансии (137014905
  КонсультантПлюс, 136861255 Деко Системс) проходят путь до submit;
  в actions ничего не записано (чистый dry-run).
- Сюит `-n 4 --dist worksteal` зелёный, ruff зелёный.

- [x] Боевой прогон (до 2 откликов на эти вакансии) — выполнен 2026-09-09
  по санкции пользователя (факты — в комментарии от 2026-09-09).

Closes #1081

