### PR TITLE
fix(common): известное отсутствие полей на common-визарде черновика — без drift-пакета (#1090)

### DIFF
--- a/src/hhru_bot/common.py
+++ b/src/hhru_bot/common.py
@@ -664,7 +664,9 @@ def apply_common(page: Page, values: CommonValues) -> None:
         if page.locator(AREA).count() == 0:
             raise PageStateIndeterminate(
                 "поле «Город» не рендерится на экране common визарда черновика — "
-                "укажите город в резюме вручную или на другом экране"
+                "известное состояние (#1002/#1090), не дрейф: сабмит common проходит "
+                "и без города (обязательные поля hh.ru предзаполняет из профиля), "
+                "город задаётся дальше по визарду или вручную"
             )
         _set_tree(page, AREA, [values.area], "area")
     if values.metro is not None:
@@ -712,19 +714,27 @@ def _condition_field(page: Page, label: str):
     """Resolve a work-condition control by its visible label, honestly.
 
     #993: the draft-wizard common screen does not render these fields at all
-    (live 2026-09-05). A bare «не найдено однозначно (совпадений: 0)» left
-    the combat runs without an actionable reason — on the wizard shape the
-    refusal names the screen instead.
+    (live 2026-09-05, #1002 — census отрисованных контролов: 0; вхождения
+    строки в HTML — литералы JSON-бандлов). A bare «не найдено однозначно
+    (совпадений: 0)» left the combat runs without an actionable reason — on
+    the wizard shape the refusal names the screen instead.
+
+    #1090: известное отсутствие классифицируется ДО labelled_field — тот
+    пишет generic drift-пакет, который здесь был бы шумом про уже понятное
+    состояние. optional_labelled_field возвращает None без drift; неоднозначность
+    (>1) по-прежнему уходит в drift-диагностику.
     """
-    try:
-        return labelled_field(page, label)
-    except PageStateIndeterminate as exc:
-        if _on_wizard_common(page):
+    if _on_wizard_common(page):
+        field = optional_labelled_field(page, label)
+        if field is None:
             raise PageStateIndeterminate(
                 f"поле {label!r} не рендерится на экране common визарда черновика — "
-                "эти условия работы задаются на другом экране или вручную"
-            ) from exc
-        raise
+                "известное состояние (#1002/#1090), не дрейф: сабмит common проходит "
+                "без этого поля (обязательные поля hh.ru предзаполняет из профиля), "
+                "условия работы задаются дальше по визарду или вручную"
+            )
+        return field
+    return labelled_field(page, label)
 
 
 def _wizard_ticket_activator(page: Page):
@@ -759,17 +769,23 @@ def _work_ticket_field(page: Page):
     NO «Наличие трудовой книжки» — writing «Да/Нет» into the work-permit
     select would mutate a DIFFERENT field, so the #993 fallback is removed:
     the wizard shape refuses honestly.
+
+    #1090: известное отсутствие классифицируется ДО labelled_field (как в
+    _condition_field) — иначе тот успевает написать generic drift-пакет про
+    уже понятное состояние.
     """
-    try:
-        return labelled_field(page, WORK_TICKET)
-    except PageStateIndeterminate as exc:
-        if _wizard_ticket_activator(page) is not None or _on_wizard_common(page):
+    if _wizard_ticket_activator(page) is not None or _on_wizard_common(page):
+        field = optional_labelled_field(page, WORK_TICKET)
+        if field is None:
             raise PageStateIndeterminate(
                 "поле «Наличие трудовой книжки» не рендерится на экране common "
-                "визарда черновика (контрол work-ticket-selector — это "
-                "«Разрешение на работу», писать в него «Да/Нет» нельзя)"
-            ) from exc
-        raise
+                "визарда черновика — известное состояние (#997/#1090), не дрейф "
+                "(контрол work-ticket-selector — это «Разрешение на работу», "
+                "писать в него «Да/Нет» нельзя; сабмит common проходит без "
+                "этого поля)"
+            )
+        return field
+    return labelled_field(page, WORK_TICKET)
 
 
 def _set_control(page, field, value: str, labels: dict[str, str]) -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1087,6 +1087,52 @@ def test_wizard_condition_chip_refuses_honestly(monkeypatch):
     assert "не рендерится на экране common визарда" in str(raised)
 
 
+def test_wizard_known_absence_is_not_drift(monkeypatch):
+    """#1090: отсутствие «Формат работы» на common-визарде черновика —
+    известное состояние (#1002, census: 0 отрисованных контролов): отказ
+    называет экран и обход, а generic drift-пакет НЕ пишется."""
+    from hhru_bot import drift
+    from hhru_bot.browser import PageStateIndeterminate
+
+    def _no_drift(*_args, **_kwargs):
+        raise AssertionError("известное состояние не должно писать drift-пакет")
+
+    monkeypatch.setattr(drift, "emit_drift_report", _no_drift)
+    page = _WizardShapePage()
+    try:
+        apply_common(page, CommonValues(work_format=["remote"]))
+        raised = None
+    except PageStateIndeterminate as exc:
+        raised = exc
+    assert raised is not None
+    message = str(raised)
+    assert "известное состояние" in message
+    assert "сабмит common проходит" in message
+
+
+def test_wizard_work_ticket_absence_is_not_drift(monkeypatch):
+    """#1090/#997: «Наличие трудовой книжки» на wizard-shape отсутствует —
+    известное состояние, отказ без drift-пакета, с предупреждением про
+    work-ticket-selector («Разрешение на работу»)."""
+    from hhru_bot import drift
+    from hhru_bot.browser import PageStateIndeterminate
+
+    def _no_drift(*_args, **_kwargs):
+        raise AssertionError("известное состояние не должно писать drift-пакет")
+
+    monkeypatch.setattr(drift, "emit_drift_report", _no_drift)
+    page = _WizardShapePage()
+    try:
+        apply_common(page, CommonValues(work_ticket="true"))
+        raised = None
+    except PageStateIndeterminate as exc:
+        raised = exc
+    assert raised is not None
+    message = str(raised)
+    assert "известное состояние" in message
+    assert "Разрешение на работу" in message
+
+
 def test_open_common_published_resume_refuses_honestly(monkeypatch):
     """#995: у опубликованного резюме hh.ru редиректит на /resume/{hash} —
     честный отказ «визанд только у черновиков» + дамп, а не «форма не


### PR DESCRIPTION
## Суть

Ишью #1090: при `common --work-format` / `--city` на common-экране визарда черновика бот выдавал generic drift-пакет (`labelled_field совпадений: 0`), хотя отсутствие этих контролов — подтверждённое известное состояние (#1002: census отрисованных контролов 0; вхождения строк в HTML — литералы JSON-бандлов/i18n; #1009: сабмит common без них проходит, `nextIncompleteScreenId` двигается).

Механика бага: `browser.labelled_field` (#1069) пишет drift-пакет ДО проброса исключения, а переклассификация в «известное состояние» жила в catch-блоке `_condition_field`/`_work_ticket_field` — файл уже был написан.

## Правка (`src/hhru_bot/common.py`)

- `_condition_field` / `_work_ticket_field`: на wizard-shape (`_on_wizard_common` / `_wizard_ticket_activator`) известное отсутствие распознаётся ДО `labelled_field`, через `optional_labelled_field` (0 совпадений → `None` без drift-пакета). Неоднозначность (>1) по-прежнему уходит в drift-диагностику; edit-shape путь не изменился (`labelled_field` как раньше).
- Сообщения теперь называют состояние известным («не дрейф», #1002/#1090) и дают обход: сабмит common проходит без этих полей (обязательные hh.ru предзаполняет из профиля), условия/город задаются дальше по визарду или вручную. У `--work-ticket` сохранено предупреждение #997 про work-ticket-selector («Разрешение на работу»).
- Сообщение для «Город» (поднималось напрямую, без drift) дополнено той же формулировкой.

## Тесты

- `test_wizard_known_absence_is_not_drift`, `test_wizard_work_ticket_absence_is_not_drift`: monkeypatch `drift.emit_drift_report` падает, если вызван — известное состояние не пишет drift-пакет; ассерты на формулировку и обход.

## Проверено

- `pytest tests -q -n 4 --dist worksteal` — зелёный;
- `ruff check` + `ruff format --check` — чисто.

## Риски / follow-up

- Классификация «известное состояние» опирается на `_on_wizard_common` (count `RESUME_COMMON_FORM` == 1) — на edit-shape отсутствие поля по-прежнему честный drift, поведение не сужено.
- Живой прогон не выполнялся (не санкционирован); подтверждение поведения — наexisting живых фактах #1002/#1009 и юнит-тестах.

Closes #1090
