### PR TITLE
fix(skills): калиброванный wait_for чипа + остановка ввода до save как failed (#1092)

### DIFF
--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -59,12 +59,25 @@ def _display_level_label(level: str) -> str | None:
 # #801: the skill chip input is an autocomplete combobox. A blind fill+commit
 # for the next skill can race the browser's handling of the previous one and
 # concatenate two skill names into a single chip instead of creating two
-# separate chips. CHIP_COMMIT_TIMEOUT_MS bounds how long each iteration waits
-# for a positive signal (an exact-text chip appeared AND the input cleared)
-# before moving on; CHIP_COMMIT_POLL_MS is the poll interval, matching the
-# poll-loop pattern already used for a similar input-clear wait in
-# resume_position.py. #826: "commit" here is a click on the autocomplete
-# option, not Enter — see RESUME_SKILLS_SUGGEST_USER_INPUT below.
+# separate chips. The positive signal is a chip whose text exactly equals this
+# skill's name AND the input cleared back to empty. #826: "commit" here is a
+# click on the autocomplete option, not Enter — see
+# RESUME_SKILLS_SUGGEST_USER_INPUT below.
+#
+# #1092: the chip appearing is a React screen render, not an instant DOM
+# effect of the click — on a freshly-copied draft resume the first chip
+# regularly took longer than the old flat 5s poll budget, which aborted input
+# on the very first skill. Following the CLAUDE.md pattern "commit не значит
+# отрисовано", the chip is now awaited with an explicit
+# wait_for(state="visible") at a screen-calibrated budget (same scale as
+# SKILLS_LEVELS_STEP_TIMEOUT_MS above, and confirmed by a live census of the
+# draft's keySkills editor: its DOM is identical to the published resume's
+# form — chips-trigger-input/chips-trigger-chip-*/resume-partial-edit-* — so
+# the draft-vs-published shape hypothesis from the issue is NOT confirmed and
+# the failure is a hydration/timing race, not a selector mismatch).
+CHIP_RENDER_TIMEOUT_MS = 15_000
+# The input clearing after the chip lands is a local combobox state change
+# (no server round-trip observed); a short bounded poll is enough for it.
 CHIP_COMMIT_TIMEOUT_MS = 5_000
 CHIP_COMMIT_POLL_MS = 100
 
@@ -421,6 +434,7 @@ def edit_skills_on_hh(
             False, existing, skills, reason="поле ввода навыка не найдено однозначно"
         )
     chips = page.locator(resume_page.RESUME_SKILLS_CHIP)
+    stalled_reason: str | None = None
     for skill in additions:
         input_.fill(skill.name)
         # #826: pressing Enter never commits a chip in this combobox — confirmed
@@ -443,37 +457,71 @@ def edit_skills_on_hh(
             .first
         )
         try:
-            suggestion.wait_for(state="visible", timeout=CHIP_COMMIT_TIMEOUT_MS)
+            suggestion.wait_for(state="visible", timeout=CHIP_RENDER_TIMEOUT_MS)
             suggestion.click()
         except PlaywrightError:
             # No positive signal that the click landed — do not retry blindly.
-            # The poll below still runs and, finding no chip, breaks and lets
-            # the existing post-save Counter check fail-closed on the result
-            # (same principle as the timeout branch below).
+            # The chip wait below then times out, stops further input and
+            # cancels the form before save (fail-closed, zero mutation).
             pass
-        # #801: wait for a positive commit signal before the next iteration's
-        # fill() — a blind fill+click pair for consecutive skills can race the
-        # combobox's autocomplete handling and concatenate two names into one
-        # chip (e.g. "FastAPI" + "LangChain" -> "FastAPILangChain"). Checking
-        # only that the chip count grew would not catch this: a merged chip
-        # still increments the count by one. The positive signal is a chip
-        # whose text exactly equals this skill's name AND the input cleared
-        # back to empty — a timeout does not roll back (the click may already
-        # have reached hh.ru), so it stops issuing further input and lets the
-        # existing post-save Counter check fail-closed on the resulting
-        # mismatch (same principle as "commit не значит отрисовано" elsewhere
-        # in this codebase).
+        # #801/#1092: wait for a positive commit signal before the next
+        # iteration's fill() — a blind fill+click pair for consecutive skills
+        # can race the combobox's autocomplete handling and concatenate two
+        # names into one chip (e.g. "FastAPI" + "LangChain" ->
+        # "FastAPILangChain"). Checking only that the chip count grew would
+        # not catch this: a merged chip still increments the count by one.
+        # The positive signal is a chip whose text exactly equals this
+        # skill's name AND the input cleared back to empty. The chip is a
+        # React render that can lag the click (CLAUDE.md: "commit не значит
+        # отрисовано"), so it gets an explicit wait_for(visible) at the
+        # calibrated screen budget instead of the old flat 5s poll.
         expected_chip = chips.filter(has_text=re.compile(rf"^{re.escape(skill.name)}$"))
-        deadline = time.monotonic() + CHIP_COMMIT_TIMEOUT_MS / 1000
-        while time.monotonic() < deadline and (expected_chip.count() == 0 or input_.input_value()):
-            page.wait_for_timeout(CHIP_COMMIT_POLL_MS)
-        if expected_chip.count() == 0 or input_.input_value():
-            logger.warning(
-                "чип навыка %r не подтверждён за %dмс, дальнейший ввод остановлен",
-                skill.name,
-                CHIP_COMMIT_TIMEOUT_MS,
+        try:
+            expected_chip.first.wait_for(state="visible", timeout=CHIP_RENDER_TIMEOUT_MS)
+        except PlaywrightError:
+            stalled_reason = (
+                f"ввод навыков остановлен: чип {skill.name!r} не подтверждён за "
+                f"{CHIP_RENDER_TIMEOUT_MS}мс"
             )
+            logger.warning("%s, дальнейший ввод остановлен", stalled_reason)
             break
+        # The input clearing is a local combobox state change — a short
+        # bounded poll suffices (#801: a blind fill for the next skill can
+        # otherwise race the previous chip's handling and merge two names).
+        deadline = time.monotonic() + CHIP_COMMIT_TIMEOUT_MS / 1000
+        while time.monotonic() < deadline and input_.input_value():
+            page.wait_for_timeout(CHIP_COMMIT_POLL_MS)
+        if input_.input_value():
+            stalled_reason = (
+                f"ввод навыков остановлен: поле ввода не очистилось после чипа "
+                f"{skill.name!r} за {CHIP_COMMIT_TIMEOUT_MS}мс"
+            )
+            logger.warning("%s", stalled_reason)
+            break
+    if stalled_reason is not None:
+        # #1092: input stopped BEFORE the save click, so nothing reached
+        # hh.ru — the partially typed chips exist only in the editor's local
+        # state. Close the form with the cancel button (the same interaction
+        # dry-run already performs, no mutation on hh.ru) and report a plain
+        # failed result with acted=False, NOT uncertain: save was never
+        # clicked, so there is no mutation to be uncertain about, and an
+        # uncertain row here would only raise a has_unresolved_uncertain
+        # retry barrier for edit_skills.
+        try:
+            page.locator(resume_page.RESUME_PARTIAL_EDIT_CANCEL).click()
+        except PlaywrightError as exc:
+            return SkillsResult(
+                False,
+                existing,
+                skills,
+                reason=f"{stalled_reason}; отмена формы без сохранения не подтверждена: {exc}",
+            )
+        return SkillsResult(
+            False,
+            existing,
+            skills,
+            reason=f"{stalled_reason}; форма закрыта без сохранения (мутации не было)",
+        )
     save = page.locator(resume_page.RESUME_PARTIAL_EDIT_SAVE)
     if save.count() != 1:
         return SkillsResult(

--- a/src/hhru_bot/skills.py
+++ b/src/hhru_bot/skills.py
@@ -508,7 +508,15 @@ def edit_skills_on_hh(
         # uncertain row here would only raise a has_unresolved_uncertain
         # retry barrier for edit_skills.
         try:
-            page.locator(resume_page.RESUME_PARTIAL_EDIT_CANCEL).click()
+            cancel = page.locator(resume_page.RESUME_PARTIAL_EDIT_CANCEL)
+            cancel.click()
+            # Review #1098: a bare cancel click is not proof the editor closed
+            # (hydration can silently swallow it, CLAUDE.md: "commit не значит
+            # отрисовано"). Without this wait the reason below would claim the
+            # form is closed while it may still be on screen. A timeout here
+            # changes nothing about the verdict — cancel does not mutate — but
+            # keeps the wording honest.
+            editor.wait_for(state="hidden", timeout=EDITOR_MOUNT_TIMEOUT_MS)
         except PlaywrightError as exc:
             return SkillsResult(
                 False,

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, call
 
 import pytest
+from playwright.sync_api import Error as PlaywrightError
 
 import hhru_bot.skills as skills_module
 from hhru_bot.browser import RESUME_ERROR_BANNER
@@ -368,8 +369,10 @@ def test_edit_skills_waits_for_each_chip_before_next_addition(monkeypatch) -> No
 
 
 def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
-    """#801: if a chip never confirms, further additions must not be typed —
-    the resulting mismatch is left for the post-save Counter check to catch."""
+    """#801/#1092: if a chip never confirms, further additions must not be
+    typed, the form is cancelled BEFORE save (zero mutation on hh.ru) and the
+    result is a plain failed, not uncertain — save was never clicked, so there
+    is no has_unresolved_uncertain retry barrier for a rerun."""
     resume = bare_resume("resume-id")
     page = MagicMock()
     page.url = "https://hh.ru/resume/resume-id"
@@ -380,9 +383,12 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
     input_.input_value.return_value = ""
     save = MagicMock()
     save.count.return_value = 1
+    cancel = MagicMock()
     chip_locator = MagicMock()
     # The expected chip never appears — simulates a merged/rejected chip.
-    chip_locator.filter.return_value.count.return_value = 0
+    chip_locator.filter.return_value.first.wait_for.side_effect = PlaywrightError(
+        "chip render timeout"
+    )
     trigger = MagicMock()
     trigger.count.return_value = 1
     page.locator.side_effect = lambda selector: {
@@ -391,6 +397,7 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
         skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
         skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
         skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
         skills_module.resume_page.RESUME_SKILLS_CHIP: chip_locator,
         skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
     }[selector]
@@ -404,6 +411,60 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
         "read_display_skills",
         MagicMock(return_value=(Skill("FastAPILangChain", "Средний уровень"),)),
     )
+
+    result = edit_skills_on_hh(
+        page,
+        resume,
+        (Skill("FastAPI", "intermediate"), Skill("LangChain", "intermediate")),
+        dry_run=False,
+        mode="append",
+    )
+
+    assert result.success is False
+    # #1092: input stopped before the save click — nothing reached hh.ru, so
+    # this is a plain failed (acted=False), never an uncertain.
+    assert result.acted is False
+    assert "форма закрыта без сохранения" in result.reason
+    cancel.click.assert_called_once()
+    save.click.assert_not_called()
+    # Only the first skill was typed; the timeout stopped the loop before the
+    # second fill could race the still-unsettled first one.
+    assert input_.fill.call_args_list == [call("FastAPI")]
+
+
+def test_edit_skills_stops_input_when_input_never_clears(monkeypatch) -> None:
+    """#1092: a chip that landed but left the input non-empty (a commit signal
+    that never finished) also stops input pre-save: cancel, no save click,
+    plain failed — not uncertain."""
+    resume = bare_resume("resume-id")
+    page = MagicMock()
+    page.url = "https://hh.ru/resume/resume-id"
+    editor = MagicMock()
+    editor.wait_for.return_value = None
+    input_ = MagicMock()
+    input_.count.return_value = 1
+    # The chip lands, but the combobox never clears the typed text.
+    input_.input_value.return_value = "FastAPI"
+    save = MagicMock()
+    save.count.return_value = 1
+    cancel = MagicMock()
+    trigger = MagicMock()
+    trigger.count.return_value = 1
+    page.locator.side_effect = lambda selector: {
+        RESUME_ERROR_BANNER: _EMPTY_BANNER,
+        skills_module.resume_page.RESUME_SKILLS_EDIT_BUTTON: trigger,
+        skills_module.resume_page.RESUME_SKILLS_CHIP_INPUT: input_,
+        skills_module.resume_page.RESUME_SKILLS_SUGGEST_USER_INPUT: _mock_suggest_locator(),
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_SAVE: save,
+        skills_module.resume_page.RESUME_PARTIAL_EDIT_CANCEL: cancel,
+        skills_module.resume_page.RESUME_SKILLS_CHIP: _mock_chip_locator(),
+        skills_module.resume_page.RESUME_SKILLS_DISPLAY_TAG: _mock_display_tag_locator(),
+    }[selector]
+    monkeypatch.setattr(skills_module, "goto_hh", lambda *_args: None)
+    monkeypatch.setattr(skills_module, "has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr(skills_module, "has_login_form", lambda _page: False)
+    monkeypatch.setattr(skills_module, "open_hydrated_resume_editor", lambda *_a, **_kw: editor)
+    monkeypatch.setattr(skills_module, "read_skills", MagicMock(return_value=()))
     monkeypatch.setattr(skills_module.time, "monotonic", MagicMock(side_effect=range(10_000)))
     monkeypatch.setattr(page, "wait_for_timeout", MagicMock())
 
@@ -416,9 +477,11 @@ def test_edit_skills_stops_input_after_chip_commit_timeout(monkeypatch) -> None:
     )
 
     assert result.success is False
-    assert result.acted is True
-    # Only the first skill was typed; the timeout stopped the loop before the
-    # second fill+Enter could race the still-unsettled first one.
+    assert result.acted is False
+    assert "поле ввода не очистилось" in result.reason
+    assert "форма закрыта без сохранения" in result.reason
+    cancel.click.assert_called_once()
+    save.click.assert_not_called()
     assert input_.fill.call_args_list == [call("FastAPI")]
 
 


### PR DESCRIPTION
## Что случилось (#1092)

`edit-skills --mode fresh` на черновике (копия после `copy-resume`): первый чип
навыка не подтверждался за жёсткие 5000мс, ввод обрывался, а дальше код всё равно
нажимал save → `[FAIL] (uncertain)` и retry-барьер `has_unresolved_uncertain`
при фактически нулевой (или неконтролируемой) мутации.

## Разведка (живой census, read-only)

Снял census формы навыков черновика (`/resume/edit/<id>/keySkills`, аккаунт
ruthaihelp, черновик-копия `qa`) и census той же формы опубликованного резюме
(`sysadmin`):

- DOM формы черновика **идентичен** опубликованному: `chips-trigger-input`,
  `chips-trigger-chip-*`, `resume-editor-skills-recommended-*`,
  `resume-partial-edit-{save,cancel}`. Shape-гипотеза ишью («у черновика иная
  форма») **не подтвердилась** — причина тайминговая (гидратация React), не
  селекторы.
- Попутный факт: карточка черновика сейчас содержит сохранённые навыки с
  уровнями («Продвинутый уровень: Функциональное тестирование…», «Средний
  уровень: …») — прогоны 2026-09-09 реально мутировали черновик, т.е. readback
  «наблюдалось 0» в бою был следствием остановки ввода + всё же нажатого save,
  а не отсутствия мутации.

## Фикс (`src/hhru_bot/skills.py`)

1. **Бюджет подтверждения чипа** — по паттерну «commit не значит отрисовано»:
   чип ждётся явным `wait_for(state="visible")` с калиброванным бюджетом
   `CHIP_RENDER_TIMEOUT_MS = 15_000` (масштаб `SKILLS_LEVELS_STEP_TIMEOUT_MS`),
   вместо плоского 5с-поллинга. Очистка input после чипа — локальный state
   комбобокса, остаётся коротким bounded-poll (`CHIP_COMMIT_TIMEOUT_MS = 5_000`).
2. **Остановка ввода ДО save**: при неподтверждении чипа/неочищенном input форма
   закрывается cancel-кнопкой (то же взаимодействие, что dry-run; мутации на
   hh.ru нет — частично набранные чипы живут только в локальном state
   редактора) и возвращается plain **failed** (`acted=False`), не uncertain.
   Нет retry-барьера `has_unresolved_uncertain` для `edit_skills`.
   Все пост-save ветки (save-клик, skillsLevels, Counter-mismatch, уровни)
   сохраняют прежний uncertain-контракт с `acted=True`.

## Тесты

- переписан `test_edit_skills_stops_input_after_chip_commit_timeout` под новый
  контракт: cancel-клик, save НЕ нажат, `acted is False`, reason «форма закрыта
  без сохранения»;
- добавлен `test_edit_skills_stops_input_when_input_never_clears` — вторая ветка
  остановки (чип есть, input не очистился);
- сюита целиком: `pytest -q -n 4 --dist worksteal` — 0 failed/0 error; ruff
  check + format --check чистые.

## Риски / follow-up

- Живой боевой прогон на черновике не выполнялся (не санкционирован). Новый
  код до ветки остановки ввода идентичен прежнему по механике dry-run.
- `CHIP_RENDER_TIMEOUT_MS = 15_000` — калибровка по аналогии с соседними
  экранами визарда; при живом прогоне может быть уточнена.

Closes #1092

## Артефакты разведки (census, read-only, 2026-09-09, аккаунт ruthaihelp)

Пути — `data/logs/` основного репо (в .gitignore, data-артефакты):

- `data/logs/skills_editor_draft_qa_20260909.census.txt` — census формы навыков
  черновика-копии `qa` (`/resume/edit/d67e…34775/keySkills`, wait-ms 3000):
  видимые `chips-trigger-chip-*` (9 чипов), `chips-trigger-input`,
  `resume-editor-skills-recommended-*`, `resume-partial-edit-{save,cancel}`.
- `data/logs/skills_editor_published_sysadmin_20260909.census.txt` — census той
  же формы опубликованного резюме `sysadmin`
  (`/resume/edit/68074…3137/keySkills`): тот же набор контролов
  (`chips-trigger-input`, `resume-partial-edit-*`) — DOM идентичен, shape-гипотеза
  ишью не подтверждается.
- `data/logs/skills_card_draft_qa_20260909.census.txt` — census карточки
  черновика (`/resume/d67e…34775`): видимые `skill-level-title-3`
  («Продвинутый уровень»), `skill-level-title-2` («Средний уровень»),
  `skill-tag-3007` («Функциональное тестирование») — факт, что прогоны
  2026-09-09 реально сохранили навыки с уровнями; боевой readback «наблюдалось
  0» был ложным (ввод остановлен + всё же нажат save), а не «нулевой мутацией».
