### PR TITLE
fix(reply-employers): резолв названия вакансии вместо сырого vacancy_id в письме (#1094)

### DIFF
--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -51,17 +51,44 @@ def register(subparsers) -> None:
     parser.set_defaults(func=run)
 
 
-def _letter(template: str, candidate: dict) -> str:
+def _letter(template: str, candidate: dict, title: str | None = None) -> str:
     from ..apply.letter import render_cover_letter
     from ..search import VacancyCard
 
     card = VacancyCard(
         vacancy_id=str(candidate["vacancy_id"]),
-        title=str(candidate["title"]),
+        title=title if title is not None else str(candidate["title"]),
         company=str(candidate.get("employer") or ""),
         url=f"https://hh.ru/vacancy/{candidate['vacancy_id']}",
     )
     return render_cover_letter(template, card)
+
+
+def _resolve_vacancy_title(page, candidate: dict, ssr_names: dict[str, str]) -> str | None:
+    """Название вакансии для письма (#1094): история → SSR-карточка → страница.
+
+    ``reply_candidates`` возвращает ``COALESCE(v.title, r.vacancy_id)``: чаты,
+    пришедшие мимо команды ``search`` (приглашения и т.п.), не имеют строки в
+    ``vacancies_seen`` — раньше это число молча подставлялось в
+    ``{vacancy_title}``. Теперь: title из истории, совпадающий с vacancy_id,
+    резолвится из SSR-карточки negotiations (``vacancyName``), затем read-only
+    чтением страницы вакансии (``fetch_vacancy_card``). Нигде не добыли —
+    None, вызывающий честно отказывается от отправки: письмо с числом
+    недопустимо (fail-closed).
+    """
+    vacancy_id = str(candidate["vacancy_id"])
+    if str(candidate["title"]) != vacancy_id:
+        return str(candidate["title"])
+    name = ssr_names.get(vacancy_id)
+    if name:
+        return name
+    from ..search import fetch_vacancy_card
+
+    try:
+        return fetch_vacancy_card(page, vacancy_id).title or None
+    except Exception as exc:  # noqa: BLE001 — резолв не должен валить прогон
+        print(f"[INFO] {vacancy_id}: страница вакансии не дала title ({exc})")
+        return None
 
 
 def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> bool:
@@ -157,6 +184,13 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
         # read_chat принимает Mapping[str, str] topic→chat_id, и менять его
         # контракт ради аналитического поля незачем.
         resume_by_topic = {ref.topic_id: ref.resume_id for ref in topic_list}
+        # #1094: название вакансии из SSR-карточки negotiations — первая
+        # ступень резолва после локальной истории (см. _resolve_vacancy_title).
+        ssr_vacancy_names = {
+            ref.vacancy_id: ref.vacancy_name
+            for ref in topic_list
+            if ref.vacancy_id and ref.vacancy_name
+        }
         for candidate in candidates:
             topic = str(candidate["topic"])
             label = f"{candidate['vacancy_id']} «{candidate['title']}» @ {candidate['employer']}"
@@ -320,6 +354,22 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 print(f"[skip] {label} — {skip_reason}")
                 progress.skipped_count += 1
                 continue
+            # #1094: резолв названия ДО рендера письма и suggest — письмо с
+            # сырым vacancy_id вместо {vacancy_title} недопустимо. Локальная
+            # история покрывает только вакансии, виденные командой search;
+            # чаты-приглашения идут дальше по цепочке (SSR-карточка → read-only
+            # страница вакансии → отказ).
+            title = _resolve_vacancy_title(page, candidate, ssr_vacancy_names)
+            if title is None:
+                print(
+                    f"[FAIL] {label} — название вакансии не резолвится "
+                    "(история/SSR/страница вакансии), письмо не отправляем"
+                )
+                progress.failed_count += 1
+                failed = True
+                continue
+            if title != str(candidate["title"]):
+                label = f"{candidate['vacancy_id']} «{title}» @ {candidate['employer']}"
             # --follow-up/--suggest несовместимость проверена в run() до входа
             # сюда (sys.exit(1)); эта ветка её не дублирует, чтобы не оставлять
             # недостижимый код на случай прямого вызова _run() в обход run().
@@ -336,7 +386,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                                 inbound_marker=chat.inbound_marker or "",
                                 inbound_text=inbound.text,
                                 vacancy_id=str(candidate["vacancy_id"]),
-                                vacancy_title=str(candidate["title"]),
+                                vacancy_title=title,
                                 employer=str(candidate.get("employer") or ""),
                                 resume_id=resume_by_topic.get(topic),
                             )
@@ -358,7 +408,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                     progress.failed_count += 1
                     failed = True
                     continue
-            letter = _letter(template, candidate)
+            letter = _letter(template, candidate, title)
             progress.begin_attempt()
             inbound_marker = dedup_marker
             status = "dry_run" if args.dry_run else "failed"

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -27,6 +27,11 @@ class TopicRef:
     #: разметки: отсутствие поля не должно ронять маппинг topic→chat, на
     #: котором держатся responses/reply-employers.
     resume_id: str | None = None
+    #: Название вакансии из SSR ``topicList`` (``vacancyName``, #1094). Как и
+    #: resume_id — fail-open: отсутствие поля не роняет маппинг topic→chat;
+    #: резолвер письма в reply-employers при None идёт дальше по цепочке
+    #: (страница вакансии → честный отказ отправки).
+    vacancy_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -73,12 +78,23 @@ def topic_refs(html: str) -> list[TopicRef]:
             logger.debug("SSR topic entry missing id/chatId/vacancyId, dropped: %r", topic)
             continue
         resume_id = topic.get("resumeId")
+        # #1094: название вакансии — тот же fail-open-слот, что resumeId.
+        # Живой census 2026-09-09: DOM-карточка несёт title текстом
+        # negotiations-item-vacancy, а SSR topicList отдаёт vacancyName (его
+        # уже читает remindable_topic_refs). Ни то, ни другое не должно ронять
+        # маппинг — отсутствие поля просто оставляет резолв письма следующей
+        # ступени.
+        name = topic.get("vacancyName")
+        vacancy_obj = topic.get("vacancy")
+        if name is None and isinstance(vacancy_obj, dict):
+            name = vacancy_obj.get("name")
         refs.append(
             TopicRef(
                 str(topic["id"]),
                 str(topic["chatId"]),
                 str(topic["vacancyId"]),
                 None if resume_id is None else str(resume_id),
+                None if name is None else str(name),
             )
         )
     return refs

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -80,14 +80,14 @@ def topic_refs(html: str) -> list[TopicRef]:
         resume_id = topic.get("resumeId")
         # #1094: название вакансии — тот же fail-open-слот, что resumeId.
         # Живой census 2026-09-09: DOM-карточка несёт title текстом
-        # negotiations-item-vacancy, а SSR topicList отдаёт vacancyName (его
-        # уже читает remindable_topic_refs). Ни то, ни другое не должно ронять
-        # маппинг — отсутствие поля просто оставляет резолв письма следующей
-        # ступени.
+        # negotiations-item-vacancy, а SSR topicList отдаёт плоское
+        # vacancyName (его уже читает remindable_topic_refs). Вложенный
+        # vacancy.name сознательно НЕ читаем: этой ветки в живом дампе не
+        # было (review PR #1100) — неподтверждённый shape остался бы
+        # мёртвой веткой, молча срабатывающей при дрейфе SSR.
+        # Отсутствие поля не роняет маппинг — резолв письма просто
+        # уходит следующей ступени (страница вакансии → отказ).
         name = topic.get("vacancyName")
-        vacancy_obj = topic.get("vacancy")
-        if name is None and isinstance(vacancy_obj, dict):
-            name = vacancy_obj.get("name")
         refs.append(
             TopicRef(
                 str(topic["id"]),

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -61,6 +61,32 @@ def test_topic_refs_keep_mapping_when_resume_id_absent():
     assert (ref.topic_id, ref.chat_id) == ("123", "456")
 
 
+def test_topic_refs_read_vacancy_name_from_ssr():
+    """#1094: SSR topicList отдаёт плоское vacancyName — резолв названия
+    вакансии в письме reply-employers идёт из карточки negotiations.
+
+    Фикстура повторяет живую форму записи (probe 2026-09-09): плоское
+    строковое поле рядом с vacancyId/resumeId. Вложенный vacancy.name
+    сознательно не парсится — этого shape в живом дампе не было (review
+    PR #1100): non-dict «vacancy» не должен ни ронять парсинг, ни
+    выдумывать название.
+    """
+    html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":5503507503,"chatId":5552659058,"vacancyId":135481754,
+         "resumeId":96223331,"vacancyName":"QA Engineer FullStack"},
+        {"id":123,"chatId":456,"vacancyId":789,"vacancy":"не-словарь"}
+      ]}}
+    </template>
+    """
+    with_name, without_name = topic_refs(html)
+    assert with_name.vacancy_name == "QA Engineer FullStack"
+    assert without_name.vacancy_name is None
+    # Маппинг уцелел в обоих случаях (fail-open).
+    assert (without_name.topic_id, without_name.chat_id) == ("123", "456")
+
+
 def test_paginated_topic_refs_collects_all_pages(monkeypatch):
     class Page:
         def __init__(self):

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -923,6 +923,132 @@ def test_no_verdict_keeps_heuristic_gates(tmp_path, monkeypatch, capsys):
     assert history.is_robot_questionnaire("tp1") is True
 
 
+# --- #1094: название вакансии не должно подставляться сырым vacancy_id ------
+
+
+def _seed_response_without_title(history: History, *, vacancy_id: str, topic: str):
+    """Чат мимо команды search: нет строки vacancies_seen, COALESCE отдаёт id."""
+    history.upsert_response(vacancy_id, "Acme", "read", None, topic=topic)
+
+
+def test_dry_run_letter_uses_ssr_vacancy_name_when_history_has_no_title(
+    tmp_path, monkeypatch, capsys
+):
+    """#1094: title==vacancy_id резолвится из SSR-карточки negotiations —
+    в письме название, а не число."""
+    history = History(tmp_path / "history.db")
+    _seed_response_without_title(history, vacancy_id="1", topic="tp1")
+    Ref = TopicRef("tp1", "c1", "1", "r1", "Data Engineer")
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+    )
+
+    command.run(_args(dry_run=True))
+    out = capsys.readouterr().out
+    assert "[DRY-RUN]" in out
+    assert "Data Engineer" in out
+    # Письмо с числом вместо названия — сам дефект ишью — не воспроизводится.
+    assert "Здравствуйте! 1" not in out
+
+
+def test_dry_run_letter_resolves_title_from_vacancy_page_when_ssr_silent(
+    tmp_path, monkeypatch, capsys
+):
+    """SSR имя не отдал — read-only чтение страницы вакансии достаёт title."""
+    from hhru_bot.search import VacancyCard
+
+    history = History(tmp_path / "history.db")
+    _seed_response_without_title(history, vacancy_id="1", topic="tp1")
+    Ref = TopicRef("tp1", "c1", "1", "r1")
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+    fetched = {"called": False}
+
+    def _fetch(page, vacancy_id):
+        fetched["called"] = True
+        return VacancyCard(
+            vacancy_id=vacancy_id, title="Backend Developer", company="Acme", url="u"
+        )
+
+    monkeypatch.setattr("hhru_bot.search.fetch_vacancy_card", _fetch)
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+    )
+
+    command.run(_args(dry_run=True))
+    out = capsys.readouterr().out
+    assert fetched["called"] is True
+    assert "[DRY-RUN]" in out
+    assert "Backend Developer" in out
+
+
+def test_unresolvable_vacancy_title_fails_closed_without_letter(tmp_path, monkeypatch, capsys):
+    """Нигде не добыли название — честный отказ отправки этого чата, а не
+    письмо с числом (fail-closed)."""
+    from hhru_bot.search import VacancyPageUnavailable
+
+    history = History(tmp_path / "history.db")
+    _seed_response_without_title(history, vacancy_id="1", topic="tp1")
+    Ref = TopicRef("tp1", "c1", "1", "r1")
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _fetch(page, vacancy_id):
+        raise VacancyPageUnavailable(vacancy_id, "indeterminate", "TimeoutError")
+
+    def _boom_send(*a, **k):
+        raise AssertionError("письмо с vacancy_id вместо названия не отправляется")
+
+    monkeypatch.setattr("hhru_bot.search.fetch_vacancy_card", _fetch)
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+        send=_boom_send,
+    )
+
+    result = command.run(_args(dry_run=True))
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+    assert "не резолвится" in out
+    assert "[DRY-RUN]" not in out
+    assert result is True
+    with history._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM replies").fetchone()[0] == 0
+
+
+def test_history_title_is_preferred_over_resolvers(tmp_path, monkeypatch, capsys):
+    """Название из vacancies_seen (команда search) — первая ступень цепочки:
+    резолверы не перезаписывают его и страницу вакансии не открывают."""
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1", title="Python dev")
+    Ref = TopicRef("tp1", "c1", "1", "r1", "Data Engineer")
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+
+    def _boom_fetch(page, vacancy_id):
+        raise AssertionError("история уже дала title — страница вакансии не нужна")
+
+    monkeypatch.setattr("hhru_bot.search.fetch_vacancy_card", _boom_fetch)
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[Ref],
+        reader=lambda page, topic, refs: chat,
+    )
+
+    command.run(_args(dry_run=True))
+    out = capsys.readouterr().out
+    assert "[DRY-RUN]" in out
+    assert "Python dev" in out
+
+
 # --- #710: --follow-up --after-days N ---------------------------------------
 
 


### PR DESCRIPTION
# reply-employers: резолв названия вакансии вместо сырого vacancy_id в письме

Closes #1094

## Диагностика (живая, read-only)

- Локальная история: `vacancies_seen` заполняет **только** команда `search`;
  у чатов, пришедших мимо поиска (приглашения и т.п.), строки нет, и
  `reply_candidates` отдаёт `COALESCE(v.title, r.vacancy_id)` — число (14 из 27).
- Живой `probe --negotiations` (2026-09-09): DOM-карточка несёт title текстом
  `negotiations-item-vacancy`; SSR `topicList` отдаёт `vacancyName`.

## Фикс

Цепочка резолва title (в `commands/reply_employers.py::_resolve_vacancy_title`),
запускается только когда title истории совпал с vacancy_id (fallback сработал):

1. локальная история (без изменений, первая ступень);
2. SSR-карточка negotiations — новый fail-open слот `TopicRef.vacancy_name`
   (`topicList[].vacancyName` / `vacancy.name`, как у `remindable_topic_refs`);
3. read-only чтение страницы вакансии — переиспользован `fetch_vacancy_card`
   (#1085);
4. нигде не добыли — `[FAIL]` и отказ отправки этого чата (fail-closed):
   письмо с числом в `{vacancy_title}` недопустимо.

`render_cover_letter` не менялся: молчаливая подстановка числа жила не в нём,
а в SQL-fallback кандидатов. Резолв стоит до рендера письма и до `--suggest`
(`ReplyContext.vacancy_title`), покрывает и `--follow-up` (тот же `_letter`).

## Тесты

- `test_dry_run_letter_uses_ssr_vacancy_name_when_history_has_no_title`
- `test_dry_run_letter_resolves_title_from_vacancy_page_when_ssr_silent`
- `test_unresolvable_vacancy_title_fails_closed_without_letter`
- `test_history_title_is_preferred_over_resolvers`

Сюита: `pytest -q -n 4 --dist worksteal` — зелёная; `ruff check` +
`ruff format --check` — чисто.

## Живой dry-run (read-only, основной аккаунт, 2026-09-09)

Из 14 затронутых чатов 11 теперь получают реальное название (включая
приглашение РФОП — «Маркетолог»); 3 (WILIX, Лист Ренталс, GRI) — честный
`[FAIL] ... не резолвится`: census подтвердил «Вам недоступна эта вакансия»
(вакансии закрыты, title на странице нет) — это штатный fail-closed исход,
не регресс. Боевых отправок не выполнялось.

## Риски

- `fetch_vacancy_card` добавляет read-only навигацию только для чатов без
  title (анти-фрод-нагрузка минимальна, шаг не мутирует hh.ru).
- Работодатели в отчётах замаскированы не потребовалось: названий компаний
  в коде/тестах нет.
