### PR TITLE
fix(letter): наблюдение letter-match «нет данных» больше не пишется в лог

### DIFF
--- a/src/hhru_bot/apply/letter.py
+++ b/src/hhru_bot/apply/letter.py
@@ -143,6 +143,7 @@ def render_cover_letter(
 def _log_letter_match(vacancy: VacancyCard, letter: str) -> None:
     """Log observation-only letter↔vacancy keyword score (#493, stage 1)."""
     from ..scoring import letter_match_score
+    from ..scoring.resume_match import NO_DATA_RATIONALE
 
     try:
         outcome = letter_match_score(vacancy, letter)
@@ -150,6 +151,12 @@ def _log_letter_match(vacancy: VacancyCard, letter: str) -> None:
         logger.warning(
             "letter-match failed for %s '%s': %s", vacancy.vacancy_id, vacancy.title, exc
         )
+        return
+    if outcome.rationale == NO_DATA_RATIONALE:
+        # «Считать было нечего»: карточка без vacancy_text (reply-employers
+        # собирает её из чата, без текста вакансии). Наблюдение без содержания:
+        # по замыслу #493 stage 1 распределение для калибровки порога строится
+        # на карточках, где скоринг реально считал, — пустышки не пишем и в лог.
         return
     logger.info(
         "letter-match %s '%s': %.1f/100 (%s)",

--- a/tests/test_apply_letter.py
+++ b/tests/test_apply_letter.py
@@ -87,6 +87,26 @@ def test_template_provider_logs_letter_match_score(caplog):
     assert "letter-match 1 'Dev': 100.0/100" in caplog.text
 
 
+def test_render_cover_letter_no_vacancy_text_skips_letter_match_log(caplog):
+    """Карточка без vacancy_text (reply-employers собирает её из чата):
+    наблюдение letter-match «нет данных» не несет содержания — тишина, а не
+    строка 0.0/100 по каждому чату (#493 stage 1: распределение строится на
+    карточках, где скоринг реально считал)."""
+    with caplog.at_level("INFO", logger="hhru_bot.apply.letter"):
+        render_cover_letter("Пишу по {vacancy_title}", _card("Dev", "Acme"))
+
+    assert "letter-match" not in caplog.text
+
+
+def test_template_provider_no_vacancy_text_skips_letter_match_log(caplog):
+    provider = TemplateCoverLetterProvider("Пишу по {vacancy_title}")
+
+    with caplog.at_level("INFO", logger="hhru_bot.apply.letter"):
+        provider.render(_card("Dev", "Acme"))
+
+    assert "letter-match" not in caplog.text
+
+
 # --- AI-провайдер через мок LLMClient (#16 контракт: chat()->NormalizedResponse) ---
 
 


### PR DESCRIPTION
## Что было

`reply-employers` рендерит письма по карточке, собранной из чата, — без
`vacancy_text`. Наблюдательный скоринг письма (#493 stage 1) на такой карточке
всегда даёт `0.0/100 (нет данных для сопоставления)` и печатал эту строку по
каждому чату: в живом прогоне 2026-09-09 — 27 строк шума подряд, ни одна не
несёт содержания и не влияет на решение.

## Фикс

`_log_letter_match` (`src/hhru_bot/apply/letter.py`): исход с маркером
`NO_DATA_RATIONALE` не логируется вовсе. Обоснование — из самого замысла
#493 stage 1 (см. `scoring/resume_match.py:66-71`): распределение, по которому
калибруется порог этапа 2, должно строиться на карточках, где скоринг реально
считал; «считать было нечего» — не наблюдение.

Пути не раздаются: apply-путь (карточки из поиска, с текстом) лог не меняет —
покрыто существующим тестом `test_template_provider_logs_letter_match_score`.

## Тесты

- `test_render_cover_letter_no_vacancy_text_skips_letter_match_log`
- `test_template_provider_no_vacancy_text_skips_letter_match_log`

Оба: карточка без `vacancy_text` → в caplog нет ни одной `letter-match`-строки.
Изменён только `tests/test_apply_letter.py`; `tests/test_scoring_letter_match.py`
в диффе отсутствует — он запускался как регресс-прогон без правок
(29/29 вместе), `ruff check` и `ruff format --check` чистые.

