### PR TITLE
feat: общая рыночная база data/market.db для конкурентов и вакансий (#1106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,17 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           # Предустановленный на ubuntu-раннере apt-репозиторий dl.google.com
-          # (google-chrome-stable) регулярно рассинхронизирует Release/Packages
-          # хэши, и `apt-get update` внутри `--with-deps` падает с
-          # "Hash Sum mismatch" (наблюдено трижды подряд 2026-09-09, run
-          # 34383787081). Chromium ставится из CDN Playwright, а не из этого
-          # репозитория — отключаем его до обновления индексов.
-          sudo rm -f /etc/apt/sources.list.d/dl_google_com_linux_chrome*.list
-          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          # (google-chrome-stable) рассинхронизировал Release/Packages хэши,
+          # и `apt-get update` внутри `--with-deps` падает с "Hash Sum
+          # mismatch" (5 раз подряд 2026-09-09, runs 34383787081/34384467919/
+          # 34384558117 — фиксированные имена файлов на образе не совпали,
+          # источник живёт не в *google-chrome*.list). Chromium ставится из
+          # CDN Playwright, а не из этого репозитория — вырезаем его ПО
+          # СОДЕРЖИМОМУ из всех apt-источников до обновления индексов.
+          # find вместо grep| xargs: grep без совпадений выходит с 1 и валит
+          # шаг на -eo pipefail; find стабильно возвращает 0.
+          sudo sed -i '/dl.google.com/d' /etc/apt/sources.list
+          sudo find /etc/apt/sources.list.d -maxdepth 1 -type f -exec grep -l 'dl.google.com' {} + | sudo xargs -r rm -f || true
           python -m playwright install --with-deps chromium
 
       - name: Install Chromium (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,16 @@ jobs:
           pip install jsonschema ruff pytest pytest-xdist
       - name: Install Chromium (Linux)
         if: runner.os == 'Linux'
-        run: python -m playwright install --with-deps chromium
+        run: |
+          # Предустановленный на ubuntu-раннере apt-репозиторий dl.google.com
+          # (google-chrome-stable) регулярно рассинхронизирует Release/Packages
+          # хэши, и `apt-get update` внутри `--with-deps` падает с
+          # "Hash Sum mismatch" (наблюдено трижды подряд 2026-09-09, run
+          # 34383787081). Chromium ставится из CDN Playwright, а не из этого
+          # репозитория — отключаем его до обновления индексов.
+          sudo rm -f /etc/apt/sources.list.d/dl_google_com_linux_chrome*.list
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          python -m playwright install --with-deps chromium
 
       - name: Install Chromium (Windows)
         if: runner.os == 'Windows'

--- a/src/hhru_bot/cli.py
+++ b/src/hhru_bot/cli.py
@@ -325,6 +325,14 @@ def _write_lock_path(args: argparse.Namespace) -> Path:
         from .professional_roles import DEFAULT_CACHE_PATH
 
         return DEFAULT_CACHE_PATH.expanduser().resolve().parent / ".professional_roles.lock"
+    if args.command == "competitors" and getattr(args, "competitors_command", None) == "collect":
+        # #1106: collect мутирует ОБЩУЮ data/market.db, а не per-account
+        # history — lock обязан быть глобальным вне аккаунт-директорий (тот же
+        # прецедент, что professional_roles выше), иначе два аккаунта Collect'или
+        # бы параллельно в одну базу.
+        from .market_store import DEFAULT_MARKET_PATH
+
+        return DEFAULT_MARKET_PATH.expanduser().resolve().parent / ".market.lock"
     writes_config = args.command == "config" or getattr(args, "write_config", False)
     # copy-resume's post-click list diff is an account-wide reconciliation.
     # Serialize by the config/session identity even when callers intentionally

--- a/src/hhru_bot/commands/competitors.py
+++ b/src/hhru_bot/commands/competitors.py
@@ -29,7 +29,8 @@ from ..competitor_collection import (
     throttle_estimate,
 )
 from ..exit_codes import CommandExitCode
-from ..history import CommandRunBusy, History
+from ..history import CommandRunBusy
+from ..market_store import MarketStore
 
 # Re-exported for tests and back-compat (#1047): реализации переехали в
 # competitor_collection, имена остались на прежнем месте.
@@ -189,7 +190,10 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
         raise ValueError("--auth-mode authenticated требует --detail-workers 1")
 
     config = load_config_or_exit(args.config)
-    history = History(args.history)
+    # Рынок общий на все аккаунты (#1106): collect всегда пишет в data/market.db,
+    # а не в per-account args.history. --account определяет только конфиг/сессию
+    # (authenticated-сбор идёт под сессией этого аккаунта).
+    history = MarketStore()
     require_authentication = args.auth_mode == "authenticated"
     try:
         started = history.begin_competitor_collection(
@@ -325,7 +329,6 @@ def run_collect(args: argparse.Namespace) -> bool | CommandExitCode:
 
 def run_report(args: argparse.Namespace) -> None:
     from ..competitors import report_competitors
-    from ..history import History
 
     query = args.text.strip() if args.text else None
     if args.text is not None and not query:
@@ -336,7 +339,8 @@ def run_report(args: argparse.Namespace) -> None:
         # Область поиска — свойство одной выборки, а не всей базы: без --text
         # фильтровать нечего, и молча игнорировать флаг нельзя.
         raise ValueError("--search-in/--auth-mode требуют --text")
-    history = History(args.history)
+    # Рынок общий (#1106): report читает data/market.db независимо от --account.
+    history = MarketStore()
     rows = history.list_competitor_resumes(query, search_in=search_in, auth_mode=auth_mode)
     limited = history.count_limited_competitor_runs(query, search_in=search_in, auth_mode=auth_mode)
     print(report_competitors(rows, top=args.top, limited_runs=limited))

--- a/src/hhru_bot/commands/market.py
+++ b/src/hhru_bot/commands/market.py
@@ -31,10 +31,12 @@ def register(subparsers) -> None:
 
 
 def run(args: argparse.Namespace) -> None:
-    from ..history import History
+    from ..market_store import MarketStore
     from ..report_market import market_summary
 
-    history = History(args.history)
+    # Рынок общий на все аккаунты (#1106): vacancies_seen живёт в data/market.db
+    # и читается всегда, независимо от --account/args.history.
+    history = MarketStore()
     rows = history.market_salary_by_query(include_estimates=args.estimates)
     print(market_summary(rows))
     ages = history.vacancy_age_distribution()

--- a/src/hhru_bot/commands/search.py
+++ b/src/hhru_bot/commands/search.py
@@ -356,7 +356,9 @@ def _format_card_line(card: VacancyCard) -> str:
     return f"{card.title} — {card.company} ({card.url}){suffix}"
 
 
-def _record_seen(cards: list[VacancyCard], search_query: str, history: History) -> None:
+def _record_seen(
+    cards: list[VacancyCard], search_query: str, history: History, market=None
+) -> None:
     """Записывает собранные карточки в vacancies_seen (#66, рынок).
 
     Побочный эффект сбора — НЕ влияет на поиск/скоринг/вывод. Пишет ВСЕ
@@ -364,6 +366,12 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
     картину сферы, а не только тех, на кого решился откликнуться. Зарплата из
     SalaryInfo (#34); None → «з/п не указана» (тоже пишется для доли рынка без
     зарплаты). Сбой записи НЕ должен валить поиск — рынок лишь удобство.
+
+    #1106: запись ДВОЙНАЯ — в per-account history (vacancies_seen там читают
+    joins личной аналитики: funnel/replies/adaptive) и в общую data/market.db
+    (откуда читает команда market). ``market`` — уже открытый MarketStore или
+    None, если общую базу открыть не удалось: personal-путь важнее, отказ
+    market-записи не должен валить и его.
 
     employer_tier (#93): classify_employer(company, employer_info) на каждую
     карточку — уровень известности (top_tech/big_corp/mid/unknown). Нужен для
@@ -433,6 +441,35 @@ def _record_seen(cards: list[VacancyCard], search_query: str, history: History) 
                 if card.metro_stations is not None
                 else None,
             )
+            if market is not None:
+                # #1106: та же карточка — в общую рыночную базу. Отдельный
+                # try не нужен: сбой любой из двух записей ниже ловит общий
+                # except, а upsert идемпотентен — повторный search допишет.
+                market.upsert_vacancy_seen(
+                    vacancy_id=card.vacancy_id,
+                    search_query=search_query,
+                    title=title,
+                    company=company,
+                    salary_from=salary.salary_from if salary else None,
+                    salary_to=salary.salary_to if salary else None,
+                    salary_currency=salary.currency if salary else None,
+                    employer_tier=tier,
+                    vacancy_text=card.vacancy_text or None,
+                    published_at=card.published_at.isoformat() if card.published_at else None,
+                    address=card.address or None,
+                    is_remote=card.is_remote,
+                    experience=card.experience or None,
+                    snippet_requirement=card.snippet_requirement or None,
+                    snippet_responsibility=card.snippet_responsibility or None,
+                    side_job=card.side_job,
+                    no_resume=card.no_resume,
+                    activity=card.activity or None,
+                    hh_rating=card.hh_rating or None,
+                    hrbrand_winner=card.hrbrand_winner,
+                    metro_stations=json.dumps(card.metro_stations, ensure_ascii=False)
+                    if card.metro_stations is not None
+                    else None,
+                )
         except Exception as e:  # noqa: BLE001 — рынок не должен валить поиск
             logger.warning("Не записать вакансию %s в рынок: %s", card.vacancy_id, e)
 
@@ -449,6 +486,16 @@ def run(args: argparse.Namespace) -> bool:
 
     config = load_config_or_exit(args.config)
     history = History(args.history)
+    # #1106: общая рыночная база для двойной записи vacancies_seen. Открытие
+    # вне try не делаем: невозможность открыть market.db не должна мешать
+    # поиску (personal-история пишется независимо).
+    try:
+        from ..market_store import MarketStore
+
+        market = MarketStore()
+    except Exception as e:  # noqa: BLE001 — рынок не должен валить поиск
+        logger.warning("Не открыть общую рыночную базу market.db: %s", e)
+        market = None
     saved_mode_failed = _run_saved_search_modes(args, config)
     if saved_mode_failed is not None:
         # Режимы --save/--list-saved завершают команду: обычный поиск
@@ -505,7 +552,7 @@ def run(args: argparse.Namespace) -> bool:
                 continue
             # #66: запись собранных карточек в рынок (побочный эффект сбора) —
             # между search_vacancies и filter_candidates, не трогая отбор/скоринг.
-            _record_seen(cards, resume.search.text, history)
+            _record_seen(cards, resume.search.text, history, market=market)
             # pre-LLM фильтр работодателя (#85): пороги из опц. scoring.prefilter.
             scoring = getattr(resume, "scoring", None)
             prefilter = getattr(scoring, "prefilter", None)

--- a/src/hhru_bot/history_schema.py
+++ b/src/hhru_bot/history_schema.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 
+from .market_schema import MARKET_TABLES_DDL
+
 logger = logging.getLogger("hhru_bot.history")
 
 # Схема SQLite — одна константа, CREATE TABLE IF NOT EXISTS для всех таблиц.
@@ -21,7 +23,7 @@ logger = logging.getLogger("hhru_bot.history")
 # сильных изменениях схемы базу пересоздают заново (данных мало). _init_schema()
 # применяет SCHEMA идемпотентно при каждом открытии — IF NOT EXISTS гарантирует,
 # что повторный запуск на существующей базе не падает и не трогает данные.
-SCHEMA = """\
+_SCHEMA_HEAD = """\
 CREATE TABLE IF NOT EXISTS reply_drafts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     topic TEXT NOT NULL, inbound_marker TEXT NOT NULL,
@@ -220,147 +222,14 @@ CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+"""
 
--- vacancies_seen — собранные карточки вакансий (#66, Этап 1: рынок).
--- search СОБИРАЕТ VacancyCard с зарплатой/датой (#34), но НЕ писал их в БД —
--- рынок-анализ (сравнение сфер по медианной ЗП) был не из чего строить. Эта
--- таблица — побочный эффект сбора: одна строка на (vacancy_id, search_query),
--- upsert по свежему scrape обновляет поля и двигает last_seen_at, first_seen_at
--- остаётся первым появлением. Зарплата из SalaryInfo (#34): salary_from/salary_to
--- оба NULL = «з/п не указана» (для доли рынка без зарплаты). Поля НЕ нормализуют
--- валюту в одну — разные сферы могут быть в USD/EUR/RUB, медиана считается в
--- рамках одного search_query (он обычно одной валюты).
--- employer_tier (#93) — уровень известности работодателя (KnownCompanyTier из
--- scoring.classify_employer: top_tech/big_corp/mid/unknown). Записывается при
--- сборе в commands/search._record_seen. Нужен для estimate_salary — эвристической
--- оценки ЗП вакансий без указанной: медиана salary_to по (search_query, tier).
--- Коэффициенты tier'ов считаются ИЗ ДАННЫХ (медианы по tier внутри сферы), а не
--- априорными константами — проверяет гипотезу «известные платят меньше».
+# Рыночные таблицы (vacancies_seen + competitor_*, #1106) живут отдельной константой
+# MARKET_TABLES_DDL в market_schema.py — их создаёт и общая рыночная база
+# data/market.db (MarketStore), а здесь они остаются частью per-account history.db
+# (легаси-данные, доктрина «ничего не удалять»: новые таблицы history.db не читает).
 
-CREATE TABLE IF NOT EXISTS vacancies_seen (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    vacancy_id TEXT NOT NULL,
-    title TEXT,
-    company TEXT,
-    salary_from INTEGER,
-    salary_to INTEGER,
-    salary_currency TEXT,
-    search_query TEXT NOT NULL,
-    first_seen_at TEXT NOT NULL,
-    last_seen_at TEXT NOT NULL,
-    employer_tier TEXT,
-    vacancy_text TEXT,
-    published_at TEXT,
-    -- Доп. признаки карточки для статистики/ML (#517, приоритет-1 из #516):
-    -- город/адрес, метка удалённой работы, категория опыта, структурные
-    -- сниппеты "Требования"/"Обязанности". Все опциональны — NULL/0, если
-    -- hh.ru не отдал блок в разметке карточки (тот же паттерн, что
-    -- employer_tier/vacancy_text/published_at).
-    address TEXT,
-    is_remote INTEGER,
-    experience TEXT,
-    snippet_requirement TEXT,
-    snippet_responsibility TEXT,
-    -- Приоритет-2 из #516: опциональные бейджи "Подработка" и
-    -- "Можно без резюме". NULL означает отсутствие наблюдения.
-    side_job INTEGER,
-    no_resume INTEGER,
-    -- Приоритет-3 из #551: редкие признаки карточки. metro_stations — JSON
-    -- массив строк, так как на карточке может быть несколько станций.
-    activity TEXT,
-    hh_rating TEXT,
-    hrbrand_winner INTEGER,
-    metro_stations TEXT,
-    UNIQUE (vacancy_id, search_query)
-);
-
--- competitor_resumes — текущие профессиональные снимки чужих резюме (#578).
-CREATE TABLE IF NOT EXISTS competitor_resumes (
-    resume_id TEXT PRIMARY KEY,
-    resume_url TEXT NOT NULL,
-    desired_role TEXT NOT NULL,
-    area TEXT,
-    relocation TEXT,
-    business_trips TEXT,
-    metro_station TEXT,
-    salary_from INTEGER,
-    salary_to INTEGER,
-    salary_currency TEXT,
-    experience_months INTEGER,
-    specializations TEXT NOT NULL DEFAULT '[]',
-    employment_types TEXT NOT NULL DEFAULT '[]',
-    work_formats TEXT NOT NULL DEFAULT '[]',
-    languages TEXT NOT NULL DEFAULT '[]',
-    education TEXT NOT NULL DEFAULT '[]',
-    experience_summary TEXT,
-    achievements TEXT,
-    content_hash TEXT NOT NULL,
-    first_seen_at TEXT NOT NULL,
-    last_seen_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS competitor_resume_skills (
-    resume_id TEXT NOT NULL,
-    skill TEXT NOT NULL,
-    proficiency TEXT,
-    first_seen_at TEXT NOT NULL,
-    last_seen_at TEXT NOT NULL,
-    PRIMARY KEY (resume_id, skill)
-);
-
--- Членство резюме в выдаче ключуется полной идентичностью выборки, а не
--- одним текстом запроса (#669). `search_in` и `auth_mode` меняют не точность
--- одной и той же популяции, а то, КАКАЯ популяция собрана: «AI» в режиме
--- full_text даёт ~5000 резюме с ~81% графических дизайнеров (`.ai` — формат
--- Adobe Illustrator в навыках), а position — 619 профильных. Без них в ключе
--- отчёт по одному `--text` молча склеивал бы обе выборки, а общий
--- `search_rank` перезаписывался бы более поздним прогоном.
-CREATE TABLE IF NOT EXISTS competitor_resume_queries (
-    resume_id TEXT NOT NULL,
-    search_query TEXT NOT NULL,
-    search_in TEXT NOT NULL DEFAULT 'full_text',
-    -- 'unknown' (LEGACY_UNKNOWN_SCOPE), а не 'anonymous': режим сессии был
-    -- выбираемым до #669 и в членстве не записывался, поэтому у легаси-строк
-    -- он неизвестен, а не анонимен. NOT NULL — потому что NULL в составном
-    -- PRIMARY KEY не конфликтует сам с собой и ломал бы дедупликацию.
-    auth_mode TEXT NOT NULL DEFAULT 'unknown',
-    search_rank INTEGER NOT NULL,
-    first_seen_at TEXT NOT NULL,
-    last_seen_at TEXT NOT NULL,
-    PRIMARY KEY (resume_id, search_query, search_in, auth_mode)
-);
-CREATE INDEX IF NOT EXISTS idx_competitor_queries_query
-    ON competitor_resume_queries(search_query, search_in, auth_mode, search_rank);
-
-CREATE TABLE IF NOT EXISTS competitor_collection_runs (
-    run_id TEXT PRIMARY KEY,
-    search_query TEXT NOT NULL,
-    auth_mode TEXT,
-    search_in TEXT,
-    max_pages INTEGER NOT NULL,
-    requested_page_size INTEGER NOT NULL DEFAULT 100,
-    status TEXT NOT NULL,
-    pages_fetched INTEGER NOT NULL DEFAULT 0,
-    cards_seen INTEGER NOT NULL DEFAULT 0,
-    details_saved INTEGER NOT NULL DEFAULT 0,
-    details_failed INTEGER NOT NULL DEFAULT 0,
-    started_at TEXT NOT NULL,
-    finished_at TEXT,
-    detail TEXT,
-    owner_pid INTEGER,
-    heartbeat_at TEXT,
-    last_started_page INTEGER,
-    last_completed_page INTEGER,
-    resume_page INTEGER,
-    resumed_from_run_id TEXT,
-    observed_page_size INTEGER,
-    exit_code INTEGER,
-    cards_seen_completed INTEGER
-);
-CREATE INDEX IF NOT EXISTS idx_competitor_runs_query
-    ON competitor_collection_runs(search_query, started_at);
-
+_SCHEMA_TAIL = """\
 -- skipped — журнал отсева вакансий (#87, append-only).
 -- filter_candidates логирует ``[skip] причина``, но НЕ писал её в БД → повторный
 -- search пересматривал те же вакансии заново (трата LLM/времени, когда работают
@@ -614,6 +483,11 @@ CREATE INDEX IF NOT EXISTS idx_test_assignments_detected_at
 CREATE UNIQUE INDEX IF NOT EXISTS idx_test_assignments_dedup
     ON test_assignments(topic, message_text);
 """
+
+# Личные таблицы + рыночные: per-account history.db по-прежнему создаёт ВСЕ
+# таблицы (легаси-данные в старых базах и joins аналитики на vacancies_seen
+# остаются валидными), новая запись competitor-таблиц идёт в data/market.db.
+SCHEMA = _SCHEMA_HEAD + MARKET_TABLES_DDL + _SCHEMA_TAIL
 
 #: Провенанс режима сессии у строк членства, записанных до #669: он там не
 #: хранился, а `--auth-mode authenticated` уже существовал, поэтому подставить

--- a/src/hhru_bot/market_schema.py
+++ b/src/hhru_bot/market_schema.py
@@ -1,0 +1,178 @@
+"""Схема общей рыночной базы data/market.db (#1106).
+
+Рынок один на все аккаунты: резюме и история откликов — личные (per-account
+``data/accounts/<name>/history.db``, доктрина #706), а собранные данные о
+рынке (конкуренты #578 + вакансии #66) — общие. DDL рыночных таблиц живёт
+здесь единственной константой ``MARKET_TABLES_DDL``: её компонует в свою
+SCHEMA и ``history_schema`` (легаси-таблицы в существующих history.db не
+удаляются — доктрина «ничего не удалять»), а ``market_schema.SCHEMA`` — это
+те же таблицы плюс служебная ``market_meta`` с маркером одноразовой миграции.
+Системы миграций нет намеренно (тот же принцип, что и у history_schema):
+новые таблицы дописываются в константу, новые колонки — идемпотентными
+``_ensure_column`` у владельца стоража.
+"""
+
+from __future__ import annotations
+
+# DDL рыночных таблиц — дословно тот же текст, что раньше жил внутри
+# history_schema.SCHEMA: per-account history.db продолжает создавать эти
+# таблицы (существующие базы и joins аналитики остаются валидными), но новый
+# код конкурент-команд читает/пишет их только в data/market.db.
+MARKET_TABLES_DDL = """\
+-- vacancies_seen — собранные карточки вакансий (#66, Этап 1: рынок).
+-- search СОБИРАЕТ VacancyCard с зарплатой/датой (#34), но НЕ писал их в БД —
+-- рынок-анализ (сравнение сфер по медианной ЗП) был не из чего строить. Эта
+-- таблица — побочный эффект сбора: одна строка на (vacancy_id, search_query),
+-- upsert по свежему scrape обновляет поля и двигает last_seen_at, first_seen_at
+-- остаётся первым появлением. Зарплата из SalaryInfo (#34): salary_from/salary_to
+-- оба NULL = «з/п не указана» (для доли рынка без зарплаты). Поля НЕ нормализуют
+-- валюту в одну — разные сферы могут быть в USD/EUR/RUB, медиана считается в
+-- рамках одного search_query (он обычно одной валюты).
+-- employer_tier (#93) — уровень известности работодателя (KnownCompanyTier из
+-- scoring.classify_employer: top_tech/big_corp/mid/unknown). Записывается при
+-- сборе в commands/search._record_seen. Нужен для estimate_salary — эвристической
+-- оценки ЗП вакансий без указанной: медиана salary_to по (search_query, tier).
+-- Коэффициенты tier'ов считаются ИЗ ДАННЫХ (медианы по tier внутри сферы), а не
+-- априорными константами — проверяет гипотезу «известные платят меньше».
+
+CREATE TABLE IF NOT EXISTS vacancies_seen (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vacancy_id TEXT NOT NULL,
+    title TEXT,
+    company TEXT,
+    salary_from INTEGER,
+    salary_to INTEGER,
+    salary_currency TEXT,
+    search_query TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    employer_tier TEXT,
+    vacancy_text TEXT,
+    published_at TEXT,
+    -- Доп. признаки карточки для статистики/ML (#517, приоритет-1 из #516):
+    -- город/адрес, метка удалённой работы, категория опыта, структурные
+    -- сниппеты "Требования"/"Обязанности". Все опциональны — NULL/0, если
+    -- hh.ru не отдал блок в разметке карточки (тот же паттерн, что
+    -- employer_tier/vacancy_text/published_at).
+    address TEXT,
+    is_remote INTEGER,
+    experience TEXT,
+    snippet_requirement TEXT,
+    snippet_responsibility TEXT,
+    -- Приоритет-2 из #516: опциональные бейджи "Подработка" и
+    -- "Можно без резюме". NULL означает отсутствие наблюдения.
+    side_job INTEGER,
+    no_resume INTEGER,
+    -- Приоритет-3 из #551: редкие признаки карточки. metro_stations — JSON
+    -- массив строк, так как на карточке может быть несколько станций.
+    activity TEXT,
+    hh_rating TEXT,
+    hrbrand_winner INTEGER,
+    metro_stations TEXT,
+    UNIQUE (vacancy_id, search_query)
+);
+
+-- competitor_resumes — текущие профессиональные снимки чужих резюме (#578).
+CREATE TABLE IF NOT EXISTS competitor_resumes (
+    resume_id TEXT PRIMARY KEY,
+    resume_url TEXT NOT NULL,
+    desired_role TEXT NOT NULL,
+    area TEXT,
+    relocation TEXT,
+    business_trips TEXT,
+    metro_station TEXT,
+    salary_from INTEGER,
+    salary_to INTEGER,
+    salary_currency TEXT,
+    experience_months INTEGER,
+    specializations TEXT NOT NULL DEFAULT '[]',
+    employment_types TEXT NOT NULL DEFAULT '[]',
+    work_formats TEXT NOT NULL DEFAULT '[]',
+    languages TEXT NOT NULL DEFAULT '[]',
+    education TEXT NOT NULL DEFAULT '[]',
+    experience_summary TEXT,
+    achievements TEXT,
+    content_hash TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS competitor_resume_skills (
+    resume_id TEXT NOT NULL,
+    skill TEXT NOT NULL,
+    proficiency TEXT,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    PRIMARY KEY (resume_id, skill)
+);
+
+-- Членство резюме в выдаче ключуется полной идентичностью выборки, а не
+-- одним текстом запроса (#669). `search_in` и `auth_mode` меняют не точность
+-- одной и той же популяции, а то, КАКАЯ популяция собрана: «AI» в режиме
+-- full_text даёт ~5000 резюме с ~81% графических дизайнеров (`.ai` — формат
+-- Adobe Illustrator в навыках), а position — 619 профильных. Без них в ключе
+-- отчёт по одному `--text` молча склеивал бы обе выборки, а общий
+-- search_rank перезаписывался бы более поздним прогоном.
+CREATE TABLE IF NOT EXISTS competitor_resume_queries (
+    resume_id TEXT NOT NULL,
+    search_query TEXT NOT NULL,
+    search_in TEXT NOT NULL DEFAULT 'full_text',
+    -- 'unknown' (LEGACY_UNKNOWN_SCOPE), а не 'anonymous': режим сессии был
+    -- выбираемым до #669 и в членстве не записывался, поэтому у легаси-строк
+    -- он неизвестен, а не анонимен. NOT NULL — потому что NULL в составном
+    -- PRIMARY KEY не конфликтует сам с собой и ломал бы дедупликацию.
+    auth_mode TEXT NOT NULL DEFAULT 'unknown',
+    search_rank INTEGER NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    PRIMARY KEY (resume_id, search_query, search_in, auth_mode)
+);
+CREATE INDEX IF NOT EXISTS idx_competitor_queries_query
+    ON competitor_resume_queries(search_query, search_in, auth_mode, search_rank);
+
+CREATE TABLE IF NOT EXISTS competitor_collection_runs (
+    run_id TEXT PRIMARY KEY,
+    search_query TEXT NOT NULL,
+    auth_mode TEXT,
+    search_in TEXT,
+    max_pages INTEGER NOT NULL,
+    requested_page_size INTEGER NOT NULL DEFAULT 100,
+    status TEXT NOT NULL,
+    pages_fetched INTEGER NOT NULL DEFAULT 0,
+    cards_seen INTEGER NOT NULL DEFAULT 0,
+    details_saved INTEGER NOT NULL DEFAULT 0,
+    details_failed INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    detail TEXT,
+    owner_pid INTEGER,
+    heartbeat_at TEXT,
+    last_started_page INTEGER,
+    last_completed_page INTEGER,
+    resume_page INTEGER,
+    resumed_from_run_id TEXT,
+    observed_page_size INTEGER,
+    exit_code INTEGER,
+    cards_seen_completed INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_competitor_runs_query
+    ON competitor_collection_runs(search_query, started_at);
+"""
+
+# market_meta — служебная таблица market.db: ключ-значение для маркеров
+# одноразовой миграции из per-account history.db (#1106).
+SCHEMA = (
+    MARKET_TABLES_DDL
+    + """\
+CREATE TABLE IF NOT EXISTS market_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+)
+
+# Маркер выполненной миграции данных из history.db в market.db: его наличие
+# делает повторное открытие no-op (копирование идемпотентно, но гонять его на
+# каждом открытии незачем).
+MIGRATION_MARKER_KEY = "migrated_from_history"

--- a/src/hhru_bot/market_store.py
+++ b/src/hhru_bot/market_store.py
@@ -88,6 +88,13 @@ class MarketStore(AnalyticsMixin, VacanciesMixin, CompetitorsMixin):
         PK/UNIQUE-ключам), но после успешного прохода маркер в market_meta
         снимает работу с последующих открытий. Колонки берутся пересечением
         PRAGMA table_info — легаси-источник может не иметь поздних колонок.
+
+        При конфликте ключа между источниками побеждает ПЕРВЫЙ в порядке
+        ``_history_sources`` (корневой history.db, потом аккаунты по алфавиту),
+        а не самый свежий срез по last_seen_at/updated_at — осознанный выбор
+        для одноразовой миграции: реальная свежесть приезжает первым же
+        collect/search после неё, а гоняться за timestamp'ами между источниками
+        ради строк, которые вот-вот перезапишет штатный upsert, незачем.
         """
         done = conn.execute(
             "SELECT value FROM market_meta WHERE key = ?", (MIGRATION_MARKER_KEY,)

--- a/src/hhru_bot/market_store.py
+++ b/src/hhru_bot/market_store.py
@@ -1,0 +1,139 @@
+"""MarketStore — общая рыночная база data/market.db (#1106).
+
+Рынок один на все аккаунты: конкурент-снимки (#578) и собранные вакансии
+(#66) — факты о рынке hh.ru, а не личная история, поэтому они живут в
+отдельной cwd-относительной базе ``data/market.db`` (дефолт — по образцу
+``cli.DEFAULT_HISTORY_PATH``), которую ``competitors collect/report`` и
+``market`` открывают ВСЕГДА, независимо от ``--account``/``default_account``.
+Личное (actions, лимиты, дедуп, анкеты) остаётся в per-account history.db —
+доктрина #706 не меняется.
+
+Тонкий стораж: повторно использует миксины ``History`` (Competitors/Vacancies/
+Analytics) как есть — им нужен только ``_connect``/``db_path``. Отдельные
+рыночные методы не дублируются. При первом открытии выполняется одноразовая
+миграция КОПИРОВАНИЕМ из корневой data/history.db и всех
+data/accounts/*/history.db (маркер в market_meta); старые таблицы в history.db
+не трогаются и не удаляются — правило проекта «ничего не удалять» абсолютное.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+from .history_analytics import AnalyticsMixin
+from .history_competitors import CompetitorsMixin
+from .history_vacancies import VacanciesMixin
+from .market_schema import MIGRATION_MARKER_KEY, SCHEMA
+
+logger = logging.getLogger("hhru_bot.market")
+
+# Дефолт — ОТНОСИТЕЛЬНЫЙ (relative-to-cwd), тот же принцип, что у
+# cli.DEFAULT_HISTORY_PATH: после `pip install` пакет уезжает в site-packages,
+# привязка к расположению кода ломала бы поиск data/. Читается в рантайме
+# (не в сигнатуре по умолчанию), чтобы тесты могли подменить константу.
+DEFAULT_MARKET_PATH = Path("data") / "market.db"
+
+# Таблицы, переезжающие из per-account history.db при первой миграции.
+_MIGRATION_TABLES = (
+    "competitor_resumes",
+    "competitor_resume_skills",
+    "competitor_resume_queries",
+    "competitor_collection_runs",
+    "vacancies_seen",
+)
+
+
+class MarketStore(AnalyticsMixin, VacanciesMixin, CompetitorsMixin):
+    """Хранилище общей рыночной базы; методы — унаследованные миксины History."""
+
+    def __init__(self, db_path: str | Path | None = None):
+        self.db_path = Path(db_path) if db_path is not None else DEFAULT_MARKET_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(SCHEMA)
+            self._migrate_from_history(conn)
+
+    @contextmanager
+    def _connect(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _history_sources(self) -> list[Path]:
+        """Источники миграции: корневой history.db и все аккаунтовые, рядом с market.db.
+
+        Пути считаем от родителя market.db, а не от cwd: тесты открывают базу
+        во временном каталоге, и искать данные надо рядом с ней, а не в cwd.
+        """
+        parent = self.db_path.parent
+        sources = [parent / "history.db"]
+        accounts_dir = parent / "accounts"
+        if accounts_dir.is_dir():
+            sources.extend(sorted(p for p in accounts_dir.glob("*/history.db") if p.is_file()))
+        return [s for s in sources if s.is_file() and s.resolve() != self.db_path.resolve()]
+
+    def _migrate_from_history(self, conn: sqlite3.Connection) -> None:
+        """Одноразовое копирование рыночных таблиц из history.db (#1106).
+
+        КОПИРОВАНИЕМ, не переносом: источники не мутируются вовсе (правило
+        «ничего не удалять»). Идемпотентно (INSERT OR IGNORE по тем же
+        PK/UNIQUE-ключам), но после успешного прохода маркер в market_meta
+        снимает работу с последующих открытий. Колонки берутся пересечением
+        PRAGMA table_info — легаси-источник может не иметь поздних колонок.
+        """
+        done = conn.execute(
+            "SELECT value FROM market_meta WHERE key = ?", (MIGRATION_MARKER_KEY,)
+        ).fetchone()
+        if done is not None:
+            return
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            for source_path in self._history_sources():
+                self._copy_market_tables(conn, source_path)
+            conn.execute(
+                "INSERT OR REPLACE INTO market_meta (key, value) VALUES (?, ?)",
+                (MIGRATION_MARKER_KEY, datetime.now().isoformat(timespec="seconds")),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            conn.execute("ROLLBACK")
+            raise
+
+    def _copy_market_tables(self, conn: sqlite3.Connection, source_path: Path) -> None:
+        source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
+        source.row_factory = sqlite3.Row
+        try:
+            for table in _MIGRATION_TABLES:
+                src_cols = {
+                    row["name"] for row in source.execute(f"PRAGMA table_info({table})").fetchall()
+                }
+                if not src_cols:
+                    continue  # в этом history.db таблицы нет — нечего копировать
+                dst_cols = {
+                    row["name"] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+                }
+                common = [c for c in dst_cols if c in src_cols]
+                if not common:
+                    continue
+                columns = ", ".join(common)
+                rows = source.execute(f"SELECT {columns} FROM {table}").fetchall()
+                if not rows:
+                    continue
+                conn.executemany(
+                    f"INSERT OR IGNORE INTO {table} ({columns}) VALUES "
+                    f"({', '.join('?' for _ in common)})",
+                    [tuple(row) for row in rows],
+                )
+                logger.info(
+                    "market.db: мигрировано %d строк %s из %s", len(rows), table, source_path
+                )
+        finally:
+            source.close()

--- a/tests/test_competitors_command.py
+++ b/tests/test_competitors_command.py
@@ -29,7 +29,15 @@ from hhru_bot.competitors import (
     CompetitorSearchCoverage,
 )
 from hhru_bot.exit_codes import CommandExitCode
-from hhru_bot.history import History
+from hhru_bot.market_store import MarketStore
+
+
+@pytest.fixture(autouse=True)
+def _market_db(tmp_path, monkeypatch):
+    """#1106: конкурент-команды открывают общую data/market.db, а не
+    per-account history — все тесты файла работают в изолированном market.db."""
+    monkeypatch.setattr("hhru_bot.market_store.DEFAULT_MARKET_PATH", tmp_path / "market.db")
+
 
 pytestmark = pytest.mark.integration
 
@@ -140,7 +148,7 @@ def _patch_runtime(monkeypatch) -> None:
 def test_competing_collect_returns_fail_without_traceback(tmp_path, monkeypatch, capsys):
     """A live collection lease is reported as a normal command failure."""
     _patch_runtime(monkeypatch)
-    history = History(tmp_path / "history.db")
+    history = MarketStore(tmp_path / "market.db")
     history.start_competitor_collection("AI", 1)
 
     result = run_collect(_args(tmp_path))
@@ -174,7 +182,7 @@ def test_signal_finalizes_partial_checkpoint(tmp_path, monkeypatch, signum, expe
     result = run_collect(_args(tmp_path))
 
     assert result is expected
-    row = History(tmp_path / "history.db").competitor_collection_runs()[0]
+    row = MarketStore(tmp_path / "market.db").competitor_collection_runs()[0]
     assert row["status"] == "partial"
     assert row["exit_code"] == expected.value
     assert row["last_started_page"] == 0
@@ -192,7 +200,7 @@ def test_browser_crash_finalizes_run_before_propagating(tmp_path, monkeypatch):
     with pytest.raises(PlaywrightError, match="browser closed"):
         run_collect(_args(tmp_path))
 
-    row = History(tmp_path / "history.db").competitor_collection_runs()[0]
+    row = MarketStore(tmp_path / "market.db").competitor_collection_runs()[0]
     assert row["status"] == "partial"
     assert row["exit_code"] == 1
     assert row["resume_page"] == 0
@@ -276,7 +284,7 @@ def test_auth_mode_controls_context_and_page_guards(
 
 
 def test_resume_starts_after_last_completed_page(tmp_path, monkeypatch):
-    history = History(tmp_path / "history.db")
+    history = MarketStore(tmp_path / "market.db")
     previous = history.start_competitor_collection("AI", 2)
     history.finish_competitor_collection(
         previous,
@@ -414,7 +422,7 @@ def test_variable_page_sizes_update_volume(tmp_path, monkeypatch, capsys):
             desired_role=card.desired_role,
         ),
     )
-    monkeypatch.setattr(History, "upsert_competitor_resume", lambda *_a, **_k: "new")
+    monkeypatch.setattr(MarketStore, "upsert_competitor_resume", lambda *_a, **_k: "new")
     args = _args(tmp_path)
     args.max_pages = 2
 
@@ -423,7 +431,7 @@ def test_variable_page_sizes_update_volume(tmp_path, monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "объём~120 деталей" in output
     assert "страница=2, карточек=120, деталей=120" in output
-    row = History(tmp_path / "history.db").competitor_collection_runs()[0]
+    row = MarketStore(tmp_path / "market.db").competitor_collection_runs()[0]
     assert row["status"] == "complete"
     assert row["cards_seen"] == 120
     assert row["details_saved"] == 120
@@ -444,12 +452,17 @@ from types import SimpleNamespace
 
 from hhru_bot.commands.competitors import run_collect
 from hhru_bot.competitors import CompetitorResume, CompetitorSearchCard, CompetitorSearchCoverage
-from hhru_bot.history import History
+from hhru_bot.market_store import MarketStore
 import hhru_bot.browser
 import hhru_bot.competitor_workers
 import hhru_bot.competitors
 import hhru_bot.config
+import hhru_bot.market_store
 import hhru_bot.throttle
+
+from pathlib import Path
+
+hhru_bot.market_store.DEFAULT_MARKET_PATH = Path({market_path!r})
 
 handshake_read_fd = {handshake_read_fd}
 
@@ -538,7 +551,7 @@ hhru_bot.competitors.has_next_search_page = lambda *_a, **_k: next(_next_pages)
 hhru_bot.competitors.inspect_search_coverage = (
     lambda *_a, **_k: CompetitorSearchCoverage(4, 2, False, 2)
 )
-History.upsert_competitor_resume = lambda _self, *_a, **_k: "new"
+MarketStore.upsert_competitor_resume = lambda _self, *_a, **_k: "new"
 
 _fetch_calls = 0
 
@@ -616,6 +629,7 @@ def test_stdout_streams_progress_line_by_line_before_process_completes(tmp_path)
         src_root=src_root,
         config_path=config_path,
         history_path=history_path,
+        market_path=str(tmp_path / "market.db"),
         handshake_read_fd=handshake_read_fd,
     )
     script_path = tmp_path / "stdout_streaming_child.py"
@@ -769,9 +783,9 @@ def _report_args(tmp_path: Path, **overrides) -> Namespace:
 
 
 def _seed_two_scopes(db: Path) -> None:
-    from hhru_bot.history import History
+    from hhru_bot.market_store import MarketStore
 
-    history = History(db)
+    history = MarketStore(db)
     for resume_id, role, scope in (
         ("designer", "Графический дизайнер", "full_text"),
         ("engineer", "AI Engineer", "position"),
@@ -806,7 +820,7 @@ def test_report_scope_flag_excludes_other_search_in(tmp_path, capsys):
     в него попадали дизайнеры из прежнего full_text-прогона."""
     from hhru_bot.commands.competitors import run_report
 
-    db = tmp_path / "history.db"
+    db = tmp_path / "market.db"
     _seed_two_scopes(db)
 
     run_report(_report_args(tmp_path, search_in="position"))

--- a/tests/test_market_store.py
+++ b/tests/test_market_store.py
@@ -118,6 +118,35 @@ def test_migration_copies_all_rows_once_and_never_deletes_sources(tmp_path, monk
     assert (resumes, seen) == (2, 1)
 
 
+def test_record_seen_dual_writes_to_market_db(tmp_path, monkeypatch):
+    """Двойная запись search (#1106): _record_seen с реальным MarketStore
+    кладёт карточку и в per-account history, и в общую market.db — иначе
+    регрессия «забыл передать market=» пройдёт сюиту незамеченной."""
+    from hhru_bot.commands.search import _record_seen
+    from hhru_bot.search import SalaryInfo, VacancyCard
+
+    monkeypatch.setattr(
+        "hhru_bot.market_store.DEFAULT_MARKET_PATH", tmp_path / "data" / "market.db"
+    )
+    history = History(tmp_path / "data" / "accounts" / "alpha" / "history.db")
+    card = VacancyCard(
+        vacancy_id="00007",
+        title="Backend",
+        company="Acme",
+        url="https://hh.ru/vacancy/00007",
+        salary=SalaryInfo(300000, 400000, "RUB", "raw"),
+    )
+
+    _record_seen([card], "python backend", history, market=MarketStore())
+
+    market_rows = MarketStore(tmp_path / "data" / "market.db").list_vacancies_seen()
+    assert [r["vacancy_id"] for r in market_rows] == ["00007"]
+    assert market_rows[0]["salary_from"] == 300000
+    assert market_rows[0]["search_query"] == "python backend"
+    # Личная история тоже записана (её читают joins аналитики).
+    assert [r["vacancy_id"] for r in history.list_vacancies_seen()] == ["00007"]
+
+
 def test_default_market_path_is_cwd_relative():
     """Дефолт — data/market.db относительно cwd, по образцу history (#1106)."""
     assert str(DEFAULT_MARKET_PATH) == str(Path("data") / "market.db")

--- a/tests/test_market_store.py
+++ b/tests/test_market_store.py
@@ -1,0 +1,123 @@
+"""Интеграционные тесты общей рыночной базы data/market.db (#1106).
+
+Рынок один на все аккаунты: конкурент-снимки и собранные вакансии живут в
+общей базе, которую команды открывают независимо от ``--account``; личная
+история (actions/лимиты/дедуп) остаётся в per-account history.db (доктрина
+#706 — отдельный файл test_multi_account_isolation.py, без правок).
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hhru_bot.history import History
+from hhru_bot.market_store import DEFAULT_MARKET_PATH, MarketStore
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_resume(store, resume_id: str, *, query: str = "Тестировщик") -> None:
+    store.upsert_competitor_resume(
+        {
+            "resume_id": resume_id,
+            "resume_url": f"https://hh.ru/resume/{resume_id}",
+            "desired_role": "Инженер по тестированию",
+            "salary_from": 100_000,
+            "salary_to": 150_000,
+            "salary_currency": "RUB",
+            "experience_months": 24,
+            "specializations": ["Тестировщик"],
+            "employment_types": ["полная занятость"],
+            "work_formats": ["удалённо"],
+            "languages": ["Русский — Родной"],
+            "education": ["Высшее образование"],
+            "experience_summary": None,
+            "achievements": None,
+            "skills": [{"name": "pytest", "proficiency": None}],
+            "content_hash": f"hash:{resume_id}",
+        },
+        search_query=query,
+        search_rank=1,
+        search_in="position",
+    )
+
+
+def test_collect_under_account_a_visible_to_report_under_account_b(tmp_path, monkeypatch, capsys):
+    """Главный критерий #1106: collect под аккаунтом A виден report под B.
+
+    Два полных аккаунта (разные history.db), общая market.db: run_report с
+    args аккаунта B (его config/history) обязан увидеть резюме, записанные
+    «collect'ом» аккаунта A, — потому что конкурент-команды открывают
+    data/market.db, а не args.history.
+    """
+    market_path = tmp_path / "data" / "market.db"
+    monkeypatch.setattr("hhru_bot.market_store.DEFAULT_MARKET_PATH", market_path)
+
+    alpha_history = History(tmp_path / "data" / "accounts" / "alpha" / "history.db")
+    beta_history = History(tmp_path / "data" / "accounts" / "beta" / "history.db")
+    alpha_history.start_competitor_collection("Тестировщик", 1)
+
+    # «collect под аккаунтом A»: команда пишет в общую базу, не в args.history.
+    MarketStore().upsert_vacancy_seen(
+        vacancy_id="00001", search_query="Тестировщик", salary_from=100_000
+    )
+    _seed_resume(MarketStore(), "00002")
+
+    # «report под аккаунтом B»: свежая команда с args аккаунта B.
+    from hhru_bot.commands.competitors import run_report
+
+    run_report(
+        Namespace(
+            text="Тестировщик",
+            search_in=None,
+            auth_mode=None,
+            top=5,
+            config=str(tmp_path / "data" / "accounts" / "beta" / "config.yaml"),
+            history=str(beta_history.db_path),
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Инженер по тестированию" in out
+
+    # Личная история B рынок не получила: конкурент-таблицы beta history пусты.
+    with beta_history._connect() as conn:
+        n = conn.execute("SELECT COUNT(*) AS n FROM competitor_resumes").fetchone()["n"]
+    assert n == 0
+
+
+def test_migration_copies_all_rows_once_and_never_deletes_sources(tmp_path, monkeypatch):
+    """Миграция при первом открытии: все N строк едут, источник не трогается,
+    маркер не даёт копировать повторно (дублей нет)."""
+    data_dir = tmp_path / "data"
+    market_path = data_dir / "market.db"
+    monkeypatch.setattr("hhru_bot.market_store.DEFAULT_MARKET_PATH", market_path)
+
+    # Корневая личная база основного аккаунта + один именованный аккаунт.
+    root = History(data_dir / "history.db")
+    _seed_resume(root, "00003")
+    _seed_resume(root, "00004", query="Python")
+    root.upsert_vacancy_seen(vacancy_id="00005", search_query="Тестировщик", salary_from=200_000)
+    account = History(data_dir / "accounts" / "testing" / "history.db")
+    _seed_resume(account, "00006")
+
+    market = MarketStore(market_path)
+    assert len(market.list_competitor_resumes(None)) == 3
+    assert len(market.list_vacancies_seen()) == 1
+
+    # Повторное открытие — no-op: маркер в market_meta, дублей нет.
+    market_again = MarketStore(market_path)
+    assert len(market_again.list_competitor_resumes(None)) == 3
+
+    # Источники не мутированы (копирование, не перенос): строки на месте.
+    with root._connect() as conn:
+        resumes = conn.execute("SELECT COUNT(*) AS n FROM competitor_resumes").fetchone()["n"]
+        seen = conn.execute("SELECT COUNT(*) AS n FROM vacancies_seen").fetchone()["n"]
+    assert (resumes, seen) == (2, 1)
+
+
+def test_default_market_path_is_cwd_relative():
+    """Дефолт — data/market.db относительно cwd, по образцу history (#1106)."""
+    assert str(DEFAULT_MARKET_PATH) == str(Path("data") / "market.db")

--- a/tests/test_search_command_output.py
+++ b/tests/test_search_command_output.py
@@ -556,7 +556,7 @@ def test_indeterminate_search_skips_resume_without_recording_partial_results(tmp
             partial_results=partial,
         )
 
-    def record_seen(cards, _query, _history):
+    def record_seen(cards, _query, _history, **_kwargs):
         record_seen_calls.append(cards)
 
     monkeypatch.setattr("hhru_bot.browser.launch_context", lambda *a, **k: _Context())
@@ -613,7 +613,7 @@ def _run_search_with_rank(monkeypatch, tmp_path, resumes, ranked):
         "hhru_bot.search.search_vacancies",
         lambda _page, _filters, max_pages: [card for card, _score, _b in ranked],
     )
-    monkeypatch.setattr(search_command_module(), "_record_seen", lambda cards, _q, _h: None)
+    monkeypatch.setattr(search_command_module(), "_record_seen", lambda cards, _q, _h, **_k: None)
     monkeypatch.setattr(
         "hhru_bot.search.filter_candidates", lambda cards, *a, **k: (list(cards), [])
     )


### PR DESCRIPTION
Closes #1106

## Суть

Рынок один на все аккаунты: конкурент-таблицы (#578) и `vacancies_seen`
(#66) живут в общей `data/market.db`, личная история — по-прежнему в
per-account `history.db` (доктрина #706 не меняется,
`tests/test_multi_account_isolation.py` — без правок, зелёный).

- **`market_schema.py`** — DDL рыночных таблиц вынесен в единственную
  константу `MARKET_TABLES_DDL` + служебная `market_meta`; `history_schema`
  компонует свою `SCHEMA` из той же константы — легаси-таблицы в
  существующих history.db остаются и валидны.
- **`market_store.py`** — тонкий `MarketStore` (переиспользует миксины
  `History` без изменений), `DEFAULT_MARKET_PATH` cwd-относительный по
  образцу `DEFAULT_HISTORY_PATH`. При первом открытии — одноразовая
  миграция КОПИРОВАНИЕМ из корневой `data/history.db` и всех
  `data/accounts/*/history.db` (read-only, источники не мутируются),
  маркер переноса в `market_meta`. Старые таблицы не удаляются — правило
  «ничего не удалять» абсолютное.
- **CLI**: `competitors collect/report` и `market` открывают market.db
  всегда, независимо от `--account`/`default_account` (`--account`
  определяет только конфиг/сессию сбора). Write-lock `competitors collect`
  — глобальный `data/.market.lock` вне аккаунт-директорий (прецедент
  `professional_roles`).
- **search** пишет `vacancies_seen` дважды: в per-account history (его
  читают joins личной аналитики: funnel/replies/adaptive) и в общую
  market.db (откуда читает `market`).

## Тесты

- `tests/test_market_store.py` (новые): collect под аккаунтом A виден
  report'у под аккаунтом B; миграция переносит все N строк, не мутирует
  источники и не дублирует при повторном открытии.
- `test_competitors_command.py` адаптирован под market.db (autouse-фикстура
  изолирует DEFAULT_MARKET_PATH в tmp_path).
- `test_search_command_output.py`: патчи `_record_seen` приняли новый
  kwarg.

Прогоны: `pytest -q -n 4 --dist worksteal` — зелёный; `ruff check`,
`ruff format --check`, `gen_cli_docs.py --check` — чисто (CLI-поверхность
не менялась).

## Живая приёмка (read-only)

`competitors report --text Тестировщик --account testing` → **«Резюме в
выборке: 4996»** — те же 4996, что корневая база. Миграция скопировала:
17285 resumes + 188107 skills + 18106 queries + 74 runs + 1416 seen из
корневой, 1426/26428/1529/9/31500 из accounts/default, 421 seen из
accounts/testing.

## Риски

- Миграция гоняется один раз при первом открытии market.db; повторные
  открытия — no-op (маркер). Отказ посреди копирования откатывается
  транзакцией целиком.
- `vacancies_seen` теперь пишется дважды за search (best-effort: сбой
  market-записи не валит personal-запись и сам поиск).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
