### PR TITLE
fix(reply-employers): гейт «не отвечать отказавшим» — три слоя защиты (#1104)

### DIFF
--- a/src/hhru_bot/commands/reply_employers.py
+++ b/src/hhru_bot/commands/reply_employers.py
@@ -96,6 +96,7 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
     from ..negotiations_chat import (
         NoReplyForm,
         count_visible_messages,
+        is_dialogue_closed,
         is_robot_questionnaire,
         needs_follow_up,
         needs_reply,
@@ -144,6 +145,12 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
         # в responses.py ловит их так же): истёкшая сессия или не
         # подтверждённая пагинация не должны крашить команду с traceback.
         remindable_topics: set[str] | None = None
+        # Слой 2 гейта «не отвечать отказавшим» (#1104): vacancy_id карточек с
+        # бейджем «Отказ», собранные из того же html страниц ?page=N. В
+        # follow-up-режиме не собирается (там очередь уже исключает discard, а
+        # hh.ru-разрешение напоминалки проверяет remindable-гейт), set остаётся
+        # пустым и гейт ниже — no-op.
+        discard_vacancy_ids: set[str] = set()
         try:
             if follow_up:
                 # #710: локальная история говорит «работодатель молчит N дней»,
@@ -163,7 +170,9 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                 # negotiations (аналогично --max-pages в других командах),
                 # иначе чат, ушедший за пределы первой страницы, тихо
                 # выглядит как empty_chat.
-                topic_list = paginated_topic_refs(page, max_pages=max_pages)
+                topic_list = paginated_topic_refs(
+                    page, max_pages=max_pages, discard_vacancy_ids=discard_vacancy_ids
+                )
         except (NotAuthenticated, ResponsesIndeterminate, ValueError) as exc:
             # ValueError (#710, cycle-review round 2): remindable_topic_refs()
             # -- в отличие от topic_refs(), который молча дропает битые
@@ -195,6 +204,14 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
             topic = str(candidate["topic"])
             label = f"{candidate['vacancy_id']} «{candidate['title']}» @ {candidate['employer']}"
             live_resume_id = resume_by_topic.get(topic)
+            if str(candidate["vacancy_id"]) in discard_vacancy_ids:
+                # Слой 2 гейта «не отвечать отказавшим» (#1104): свежий бейдж
+                # «Отказ» из того же SSR-прохода. Стоит ДО read_chat —
+                # заведомо закрытый чат не стоит ни одного браузерного
+                # чтения (тот же принцип, что у remindable-гейта ниже).
+                print(f"[skip] {label} — работодатель отказал (бейдж переговоров)")
+                progress.skipped_count += 1
+                continue
             if remindable_topics is not None and topic not in remindable_topics:
                 # cycle-review (PR #761): этот гейт стоит ДО read_chat/decide
                 # намеренно (дешёвый ранний выход без лишнего браузерного
@@ -278,6 +295,18 @@ def _run(args: argparse.Namespace, config, history, progress: ApplyProgress) -> 
                     failed = True
                 continue
             assert chat is not None
+            if is_dialogue_closed(page):
+                # Слой 3 гейта «не отвечать отказавшим» (#1104): маркер
+                # закрытого диалога отрисован — hh.ru скрыл композер, поля
+                # ответа здесь не будет никогда. Правда страницы чата, не
+                # устаревающая вместе с локальной историей (слой 1) и бейджем
+                # списка (слой 2). Клика не было, следа на hh.ru нет — чистый
+                # skip до begin_action/journal; дрейф селектора маркера
+                # молча отключает только классификацию, композер-проверка
+                # send_reply_current остаётся fail-closed.
+                print(f"[skip] {label} — работодатель закрыл диалог (отказ), поля ответа нет")
+                progress.skipped_count += 1
+                continue
             # #710: для follow-up нет нового входящего сообщения, дедуплицируем
             # по marker'у самого затишья (status_changed_at кандидата), а не по
             # chat.inbound_marker (это marker НАШЕГО последнего сообщения и не

--- a/src/hhru_bot/history_replies.py
+++ b/src/hhru_bot/history_replies.py
@@ -348,6 +348,15 @@ class RepliesMixin:
     def reply_candidates(self, limit: int | None = None) -> list[dict]:
         """Return account-wide chat candidates using only local history.
 
+        Чаты с бейджем «Отказ» (``responses.status == 'discard'``) исключаются
+        здесь же (#1104): после отказа hh.ru закрывает переписку — композер
+        ответа не отрисуется никогда, а попытка письма отказавшему
+        недопустима. Тот же принцип, что в :meth:`follow_up_candidates`
+        («invitation/discard сюда не попадают»); свежесть статуса здесь не
+        критична — отказ, случившийся после последнего responses-обхода,
+        перехватывают гейт бейджей при планировании и
+        :func:`negotiations_chat.is_dialogue_closed` перед отправкой.
+
         The live message marker is intentionally not available here.  It is
         read only after a candidate chat is opened, where ``has_replied`` can
         perform the final duplicate check.
@@ -358,6 +367,7 @@ class RepliesMixin:
               FROM responses AS r
               LEFT JOIN vacancies_seen AS v ON v.vacancy_id = r.vacancy_id
              WHERE r.topic IS NOT NULL
+               AND r.status != 'discard'
              GROUP BY r.vacancy_id, r.topic
              ORDER BY MAX(r.last_seen_at) DESC, r.id DESC
         """

--- a/src/hhru_bot/negotiations_chat.py
+++ b/src/hhru_bot/negotiations_chat.py
@@ -29,6 +29,7 @@ from .selector_groups.negotiations import (
     CHAT_MESSAGE_SEND,
     CHAT_MESSAGE_TEXT,
     CHAT_MESSAGE_TIME,
+    DIALOGUE_CLOSED_NOTICE,
     QUICK_REPLY_BUTTON,
     QUICK_REPLY_BUTTONS_WRAPPER,
 )
@@ -106,6 +107,25 @@ class NoReplyForm(RuntimeError):
     после начала клика (см. ``send_reply_current``) — на hh.ru в этом случае
     следа нет, повторная попытка безопасна как ``status='failed'``.
     """
+
+
+def is_dialogue_closed(page) -> bool:
+    """Отрисован ли маркер закрытого диалога на открытом чате (#1104).
+
+    Слой 3 гейта «не отвечать отказавшим»: после отказа работодателя hh.ru
+    скрывает композер и рендерит предупреждение «Переписка будет доступна
+    после приглашения работодателя» (``DIALOGUE_CLOSED_NOTICE``). Правда
+    страницы чата, которая не устаревает — в отличие от статуса в локальной
+    истории (слой 1) и бейджа списка при планировании (слой 2).
+
+    Read-only (count по уже открытой странице чата), вызывается ДО
+    ``send_reply_current``: положительный ответ означает, что поле ответа
+    не появится никогда — писать в чат нечего, попытка недопустима.
+    Предупреждение без data-qa, поэтому здесь селектор-префикс CSS-модуля;
+    дрейф селектора здесь не ломает отправку (композер-проверка
+    ``send_reply_current`` остаётся fail-closed), только классификацию.
+    """
+    return page.locator(DIALOGUE_CLOSED_NOTICE).count() > 0
 
 
 # A URL is deliberately restricted to HTTP(S).  This avoids treating email

--- a/src/hhru_bot/negotiations_probe.py
+++ b/src/hhru_bot/negotiations_probe.py
@@ -173,7 +173,9 @@ def _require_windows_overlap(
         )
 
 
-def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
+def paginated_topic_refs(
+    page, max_pages: int = 5, discard_vacancy_ids: set[str] | None = None
+) -> list[TopicRef]:
     """Read SSR topic mappings from every available negotiations page.
 
     ``topicList`` is paginated with the cards, so reading only page zero makes
@@ -181,6 +183,12 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
     серверному контракту ``?page=N``; конец списка доказывается данными
     (страница без новых топиков), а не UI-пейджером — подробности дрейфа
     в комментарии внутри цикла.
+
+    ``discard_vacancy_ids`` (#1104) — опциональный out-параметр: если передан,
+    из того же ``page.content()`` каждой страницы собираются vacancy_id
+    карточек с бейджем «Отказ» (:func:`responses.discard_vacancy_ids_from_html`)
+    — слой 2 гейта «не отвечать отказавшим» без единого дополнительного
+    перехода. None — поведение прежнее (пробники, robot_reply).
     """
     if max_pages < 1:
         raise ValueError("max_pages must be >= 1")
@@ -203,7 +211,15 @@ def paginated_topic_refs(page, max_pages: int = 5) -> list[TopicRef]:
         # пустой inbox, но с другой причиной, которую вызывающий код не
         # должен путать с завершённой пагинацией.
         require_authenticated_page(page)
-        page_refs = topic_refs(page.content())
+        html = page.content()
+        page_refs = topic_refs(html)
+        if discard_vacancy_ids is not None:
+            # Слой 2 #1104: бейджи «Отказ» читаются из того же html, что и SSR
+            # topicList — см. docstring. Ленивый импорт: responses.py сам
+            # импортирует этот модуль (внутри _confirmed_no_new_topics).
+            from .responses import discard_vacancy_ids_from_html
+
+            discard_vacancy_ids.update(discard_vacancy_ids_from_html(html))
         new_refs = [r for r in page_refs if r.topic_id not in seen]
         # Живой дрейф 2026-09-09: hh.ru убрал пейджер из UI (карточки за
         # пределами первой двадцатки подгружаются скроллом), но серверный

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -21,6 +21,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from html import unescape
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
@@ -38,6 +39,16 @@ from .selector_groups import negotiations as ns
 logger = logging.getLogger("hhru_bot.responses")
 
 NEGOTIATIONS_URL = f"{HH_BASE_URL}/applicant/negotiations"
+
+# Карточка переписки в SSR/отрисованном html списка: границы среза задает
+# ТОЧНОЕ data-qa контейнера (якорь с закрывающей кавычкой — иначе матчился бы
+# и negotiations-item-vacancy). Внутри среза: бейдж статуса (префикс
+# negotiations-tag) и ссылка /vacancy/<id> — census #1104 подтвердил порядок
+# и границы на живом html (бейдж и ссылка внутри одного среза, 20 карточек).
+_NEGOTIATION_CARD_RE = re.compile(r'data-qa=["\']negotiations-item["\']')
+_CARD_VACANCY_HREF_RE = re.compile(r'href=["\'][^"\']*?/vacancy/(\d+)')
+_CARD_BADGE_RE = re.compile(r'data-qa=["\']negotiations-tag[^"\']*["\'][^>]*>(.*?)</span>', re.DOTALL)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 # Ждём появления карточек на JS-рендеренной странице. Достаточно для типичного
 # рендера hh.ru; если за это время карточек нет — считаем страницу пустой/селектор
@@ -306,6 +317,66 @@ def parse_response_card(item) -> ResponseItem | None:
         date=date,
         raw_status=raw_status,
     )
+
+
+def discard_vacancy_ids_from_html(html: str) -> set[str]:
+    """Vacancy ids, чья карточка переговоров несёт бейдж «Отказ» (``discard``).
+
+    Слой 2 гейта «не отвечать отказавшим» (#1104): после отказа hh.ru
+    закрывает переписку — композер ответа не отрисуется никогда, а попытка
+    письма отказавшему недопустима. Карточки серверно отрисованы в том же
+    html страницы ``?page=N``, который paginated-обход negotiations_probe и
+    так читает ради SSR ``topicList``, поэтому сбор отказов не стоит ни
+    одного дополнительного перехода.
+
+    Ключ — vacancy_id из ссылки карточки: кандидаты reply-employers keyed
+    by vacancy_id, чат-привязки в карточке нет (census #1104 — chatik-ссылок
+    и select-чекбоксов в карточке нет). Одна вакансия с несколькими
+    переписками при отказе в одной блокируется целиком — консервативно и
+    допустимо: писать в чат отказавшей вакансии всё равно нечего.
+
+    Бейдж читается ТЕКСТОМ через :func:`normalize_status` — тот же источник
+    правды, что и у fetch_responses; data-qa-суффикс
+    ``negotiations-item-discard`` на живом DOM сегодня совпадает с текстом,
+    но контракт держим на тексте (data-qa-имя ≠ подпись на экране).
+
+    Fail-open: дрейф разметки даёт пустой/частичный set и
+    ``logger.warning``, никогда не исключение — парсер не должен ломать
+    walk; страховка пропущенного отказа — слой 3
+    (:func:`negotiations_chat.is_dialogue_closed` перед отправкой).
+    """
+    matches = list(_NEGOTIATION_CARD_RE.finditer(html))
+    if not matches:
+        # Тихо выходим на страницах, где карточек и не должно быть: пустой
+        # хвост пагинации (одна/несколько тем, SSR topicList пуст) всё равно
+        # рендерит блок «Вам подойдут эти вакансии» с /vacancy/-ссылками —
+        # потому отсутствие КАРТОЧЕК само по себе не дрейф. Warning только
+        # когда SSR утверждает непустой список, а ни одной карточки не
+        # отрисовано (дрейф разметки; #1104, ложный Positive на пустом хвосте
+        # первого прогона 2026-09-10).
+        if "applicantNegotiations" in html and '"topicList":[{' in html:
+            logger.warning(
+                "negotiations: SSR topicList непуст, но карточки переписок "
+                "не распознаны в html — гейт бейджей отказов деградировал "
+                "(дрейф разметки?)"
+            )
+        return set()
+
+    discards: set[str] = set()
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(html)
+        card = html[match.end() : end]
+        vacancy_match = _CARD_VACANCY_HREF_RE.search(card)
+        if not vacancy_match:
+            continue
+        badge_match = _CARD_BADGE_RE.search(card)
+        if not badge_match:
+            continue
+        badge_text = _HTML_TAG_RE.sub(" ", badge_match.group(1))
+        badge_text = unescape(re.sub(r"\s+", " ", badge_text)).strip()
+        if normalize_status(badge_text) == ResponseStatus.DISCARD:
+            discards.add(vacancy_match.group(1))
+    return discards
 
 
 def _confirmed_no_new_topics(page: Page, seen_topic_ids: set[str], *, strict: bool) -> bool:

--- a/src/hhru_bot/responses.py
+++ b/src/hhru_bot/responses.py
@@ -47,7 +47,9 @@ NEGOTIATIONS_URL = f"{HH_BASE_URL}/applicant/negotiations"
 # и границы на живом html (бейдж и ссылка внутри одного среза, 20 карточек).
 _NEGOTIATION_CARD_RE = re.compile(r'data-qa=["\']negotiations-item["\']')
 _CARD_VACANCY_HREF_RE = re.compile(r'href=["\'][^"\']*?/vacancy/(\d+)')
-_CARD_BADGE_RE = re.compile(r'data-qa=["\']negotiations-tag[^"\']*["\'][^>]*>(.*?)</span>', re.DOTALL)
+_CARD_BADGE_RE = re.compile(
+    r'data-qa=["\']negotiations-tag[^"\']*["\'][^>]*>(.*?)</span>', re.DOTALL
+)
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 # Ждём появления карточек на JS-рендеренной странице. Достаточно для типичного

--- a/src/hhru_bot/selector_groups/negotiations.py
+++ b/src/hhru_bot/selector_groups/negotiations.py
@@ -109,3 +109,12 @@ QUICK_REPLY_BUTTON = "button[class*='magritte-button_mode-secondary']"
 # прежний плоский chatik-chat-message-input на живом DOM не совпадает.
 CHAT_MESSAGE_INPUT = _selector("negotiations.CHAT_MESSAGE_INPUT")
 CHAT_MESSAGE_SEND = _selector("negotiations.CHAT_MESSAGE_SEND")
+
+# Маркер закрытого диалога (#1104, census живых чатов 2026-09-09/10): после
+# отказа работодателя hh.ru скрывает композер и рендерит предупреждение
+# «Переписка будет доступна после приглашения работодателя». data-qa у
+# предупреждения нет — маркер ПРЕФИКС имени CSS-модуля
+# not-allowed-warning--<hash> (тот же паттерн, что QUICK_REPLY_*). Живой
+# контроль: закрытый чат — 1, живой чат с композером (Интайм Девелоп) — 0.
+# Элемент живёт внутри контейнера сообщений диалога, не в списке чатов.
+DIALOGUE_CLOSED_NOTICE = "div[class*='not-allowed-warning--']"

--- a/tests/test_negotiations_probe.py
+++ b/tests/test_negotiations_probe.py
@@ -341,3 +341,40 @@ def test_paginated_topic_refs_raises_not_authenticated_on_login_form(monkeypatch
 def test_chat_url_matches_hh_open_chat_route():
     assert chat_url("456") == "https://chatik.hh.ru/chat/456"
     assert chat_url("456", "https://chatik.example/") == "https://chatik.example/chat/456"
+
+
+def test_paginated_topic_refs_collects_discard_vacancy_ids(monkeypatch):
+    """#1104, слой 2: out-параметр собирает vacancy_id карточек с бейджем
+    «Отказ» из того же page.content(), что и SSR topicList, — ни одного
+    дополнительного перехода. None (по умолчанию) — прежнее поведение
+    пробников/robot_reply.
+    """
+    html = """
+    <template id="HH-Lux-InitialState">
+      {"applicantNegotiations":{"topicList":[
+        {"id":123,"chatId":456,"vacancyId":111},
+        {"id":124,"chatId":457,"vacancyId":222}
+      ]}}
+    </template>
+    <div data-qa="negotiations-item">
+      <span data-qa="negotiations-tag negotiations-item-discard">Отказ</span>
+      <a href="/vacancy/111?hhtmFrom=negotiation_list">Dev</a>
+    </div>
+    <div data-qa="negotiations-item">
+      <span data-qa="negotiations-tag">Просмотрен</span>
+      <a href="/vacancy/222?hhtmFrom=negotiation_list">PM</a>
+    </div>
+    """
+
+    class Page:
+        def content(self):
+            return html
+
+    monkeypatch.setattr("hhru_bot.browser.goto_hh", lambda page, url: None)
+    monkeypatch.setattr("hhru_bot.browser.has_auth_cookie", lambda _page: True)
+    monkeypatch.setattr("hhru_bot.browser.has_login_form", lambda _page: False)
+
+    discards: set[str] = set()
+    refs = paginated_topic_refs(Page(), max_pages=1, discard_vacancy_ids=discards)
+    assert [(r.topic_id, r.chat_id) for r in refs] == [("123", "456"), ("124", "457")]
+    assert discards == {"111"}

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -1284,10 +1284,10 @@ def test_reply_candidates_exclude_discard_status(tmp_path):
 
 def _discard_card_html(vacancy_id: str) -> str:
     return (
-        "<li><div data-qa=\"negotiations-item\">"
-        "<header><span data-qa=\"negotiations-tag negotiations-item-discard\">Отказ</span></header>"
-        f"<a href=\"/vacancy/{vacancy_id}?hhtmFrom=negotiation_list\">"
-        "<span data-qa=\"negotiations-item-vacancy\">Python dev</span></a>"
+        '<li><div data-qa="negotiations-item">'
+        '<header><span data-qa="negotiations-tag negotiations-item-discard">Отказ</span></header>'
+        f'<a href="/vacancy/{vacancy_id}?hhtmFrom=negotiation_list">'
+        '<span data-qa="negotiations-item-vacancy">Python dev</span></a>'
         "</div></li>"
     )
 

--- a/tests/test_reply_employers_command.py
+++ b/tests/test_reply_employers_command.py
@@ -117,6 +117,10 @@ def _patch_common(
     # #710: pre-click message count for wait_reply_confirmation's min_count
     # guard (--follow-up only) — the lightweight _Page fake has no locator().
     monkeypatch.setattr("hhru_bot.negotiations_chat.count_visible_messages", lambda page: 0)
+    # #1104: слой 3 гейта «не отвечать отказавшим» — маркер закрытого диалога
+    # читается locator'ом с той же страницы чата; по умолчанию диалог открыт
+    # (кейсы с закрытым диалогом перекрывают заглушку явно).
+    monkeypatch.setattr("hhru_bot.negotiations_chat.is_dialogue_closed", lambda page: False)
     monkeypatch.setattr(
         "hhru_bot.negotiations_chat.wait_reply_confirmation", lambda page, **k: confirmation
     )
@@ -234,7 +238,7 @@ def test_indeterminate_pagination_exits_cleanly(tmp_path, monkeypatch, capsys):
     _seed_response(history, vacancy_id="1", topic="tp1")
     _patch_common(monkeypatch, history)
 
-    def _boom(page, max_pages=5):
+    def _boom(page, max_pages=5, discard_vacancy_ids=None):
         raise ResponsesIndeterminate("пагинация не подтверждена")
 
     monkeypatch.setattr("hhru_bot.negotiations_probe.paginated_topic_refs", _boom)
@@ -1256,3 +1260,104 @@ def test_follow_up_successful_send_records_reply_and_action(tmp_path, monkeypatc
     assert reply_row["status"] == "success"
     assert reply_row["inbound_marker"].startswith("follow_up:")
     assert tuple(action_row) == ("reply", "success")
+
+
+# --- гейт «не отвечать отказавшим» (#1104) -----------------------------------
+
+
+def test_reply_candidates_exclude_discard_status(tmp_path):
+    """Слой 1: чаты с бейджем «Отказ» не попадают в очередь писем.
+
+    После отказа hh.ru закрывает переписку (композер не отрисуется никогда),
+    поэтому attempt в принципе недопустим — фильтр в SQL, тот же принцип, что
+    у follow_up_candidates («invitation/discard сюда не попадают»).
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+    history.upsert_response("2", "Acme", "discard", None, topic="tp2")
+    history.upsert_vacancy_seen("2", "q", title="Discarded dev")
+
+    candidates = history.reply_candidates()
+
+    assert [c["vacancy_id"] for c in candidates] == ["1"]
+
+
+def _discard_card_html(vacancy_id: str) -> str:
+    return (
+        "<li><div data-qa=\"negotiations-item\">"
+        "<header><span data-qa=\"negotiations-tag negotiations-item-discard\">Отказ</span></header>"
+        f"<a href=\"/vacancy/{vacancy_id}?hhtmFrom=negotiation_list\">"
+        "<span data-qa=\"negotiations-item-vacancy\">Python dev</span></a>"
+        "</div></li>"
+    )
+
+
+class _CardPage:
+    """Page stub: content() отдаёт html списка с одной discard-карточкой."""
+
+    def __init__(self, html: str):
+        self._html = html
+
+    def content(self):
+        return self._html
+
+
+def test_discard_badge_from_walk_skips_candidate_before_chat_read(tmp_path, monkeypatch, capsys):
+    """Слой 2: бейдж «Отказ», собранный из того же SSR-прохода, скипает
+    кандидата ДО read_chat — заведомо закрытый чат не стоит ни одного
+    браузерного чтения."""
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+
+    def _reader(page, topic, refs):
+        raise AssertionError("read_chat must not be called for a discarded vacancy")
+
+    _patch_common(
+        monkeypatch,
+        history,
+        page=_CardPage(_discard_card_html("1")),
+        refs=[TopicRef("tp1", "c1", None, "96223331")],
+        reader=_reader,
+    )
+
+    command.run(_args(force=True))
+    out = capsys.readouterr().out
+    assert "[skip]" in out and "работодатель отказал" in out
+    with history._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM replies").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0
+
+
+def test_dialogue_closed_marker_skips_before_send(tmp_path, monkeypatch, capsys):
+    """Слой 3: маркер закрытого диалога на открытом чате — skip без failed-строки.
+
+    hh.ru после отказа скрывает композер; это не дрейф селектора (который
+    должен остаться громким NoReplyForm-failed), а честное состояние диалога,
+    поэтому попытки письма не должно быть вовсе и в журнал оно идёт как skip.
+    """
+    history = History(tmp_path / "history.db")
+    _seed_response(history, vacancy_id="1", topic="tp1")
+
+    chat = ChatMessage(author="employer", inbound_marker="m1")
+    sent = {"called": False}
+
+    def _send(page, text):
+        sent["called"] = True
+
+    _patch_common(
+        monkeypatch,
+        history,
+        refs=[TopicRef("tp1", "c1", None, "96223331")],
+        reader=lambda page, topic, refs: chat,
+        send=_send,
+    )
+    # После _patch_common: перекрываем дефолтную заглушку (диалог открыт).
+    monkeypatch.setattr("hhru_bot.negotiations_chat.is_dialogue_closed", lambda page: True)
+
+    command.run(_args(force=True))
+    out = capsys.readouterr().out
+    assert "[skip]" in out and "закрыл диалог" in out
+    assert sent["called"] is False
+    with history._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM replies").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM actions").fetchone()[0] == 0

--- a/tests/test_responses_parser.py
+++ b/tests/test_responses_parser.py
@@ -18,6 +18,7 @@ from hhru_bot.responses import (
     ResponseStatus,
     _extract_topic,
     _extract_vacancy_id,
+    discard_vacancy_ids_from_html,
     normalize_status,
     parse_response_card,
 )
@@ -413,3 +414,48 @@ def test_response_item_dataclass_fields():
     assert item.topic is None
     assert item.date == ""
     assert item.raw_status == ""
+
+
+# --- гейт «не отвечать отказавшим», слой 2 (#1104) ---------------------------
+
+
+def test_discard_vacancy_ids_from_html_parses_badge_cards():
+    """Карточка с бейджем «Отказ» даёт vacancy_id; остальные статусы — нет.
+
+    Границы среза — точное data-qa="negotiations-item" (якорь с кавычкой, чтобы
+    negotiations-item-vacancy не матчился как контейнер). Бейдж читается
+    текстом через normalize_status — тот же источник правды, что и
+    fetch_responses; suффикс negotiations-item-discard в живом DOM сегодня
+    совпадает с текстом, но контрактом не является.
+    """
+    html = """
+    <li>
+      <div data-qa="negotiations-item">
+        <span data-qa="negotiations-tag negotiations-item-discard">Отказ</span>
+        <a href="/vacancy/111?hhtmFrom=negotiation_list">Dev</a>
+      </div>
+      <div data-qa="negotiations-item">
+        <span data-qa="negotiations-tag">Просмотрен</span>
+        <a href="/vacancy/222?hhtmFrom=negotiation_list">PM</a>
+      </div>
+      <div data-qa="negotiations-item">
+        <span data-qa="negotiations-tag">Приглашение</span>
+        <a href="/vacancy/333?hhtmFrom=negotiation_list">AIDev</a>
+      </div>
+      <div data-qa="negotiations-item">
+        <span data-qa="negotiations-tag">Отказ</span>
+      </div>
+    </li>
+    """
+    discards = discard_vacancy_ids_from_html(html)
+    assert discards == {"111"}
+
+
+def test_discard_vacancy_ids_from_html_fail_open_on_drift():
+    """Дрейф разметки (карточек нет) — пустой set, не исключение.
+
+    Гейт не должен ломать walk; страховка пропущенного отказа — слой 3
+    (is_dialogue_closed перед отправкой).
+    """
+    assert discard_vacancy_ids_from_html("<html><body>no cards</body></html>") == set()
+    assert discard_vacancy_ids_from_html("") == set()


### PR DESCRIPTION
## Проблема

Боевой прогон `reply-employers --force` (#1104): 16 из 21 письма не ушли. Живой браузерный census (IAB, read-only, 7/7 чатов) показал: **все классы отказов — чаты, где работодатель уже отказал**. hh.ru после отказа скрывает композер и рендерит «Переписка будет доступна после приглашения работодателя» — поле ответа не появится никогда. Бот же видел «последнее сообщение от работодателя» (= текст отказа) и решал «нужно ответить». Гипотезы о гидрации и дрейфе селектора опровергнуты: контрольный живой чат (Интайм) имеет композер 1/1 сразу, отказные — 0 даже через 30с.

Попытка письма отказавшему недопустима; вдобавок `failed` не дедуплицируется — 15 чатов фейлились бы в каждом прогоне вечно.

## Фикс — три слоя

1. **Очередь** (`reply_candidates`): `responses.status != 'discard'` — отказные чаты не становятся кандидатами (тот же принцип, что уже был в `follow_up_candidates`). У инцидентных чатов discard стоял в БД **за 6 часов** до прогона — слой 1 предотвратил бы весь инцидент.
2. **Свежий бейдж** (`paginated_topic_refs(discard_vacancy_ids=...)` + `discard_vacancy_ids_from_html`): карточки с бейджем «Отказ» парсятся из того же `page.content()` страниц `?page=N`, что и SSR topicList — ноль дополнительных переходов. Гейт стоит до `read_chat`.
3. **Правда чата** (`is_dialogue_closed`): маркер `div[class*='not-allowed-warning--']` (census: закрытый чат — 1, живой — 0) скипает перед отправкой. `NoReplyForm` намеренно остаётся `[FAIL] failed` — настоящий дрейф селектора должен быть громким. Известный остаток: кейс «приглашение с отказом в тексте без смены бейджа» (Елисеев 136563592) — редкий, остаётся громким failed.

## Acceptance (по стандарту проекта)

- Полный юнит-suite: 3941 passed, 2 skipped; `selector_contracts check` OK.
- Живой dry-run 2026-09-10 (read-only, root-аккаунт, RUN 48e73be3): attempted=0, **ни одной попытки отправки**, отказные чаты вне очереди, деградаций парсера нет.
- Живой парсер по всей пагинации: 22 discard-вакансии, включая 14/15 чатов класса 1 и все чаты классов 2–3 из #1104.

## Вне скоупа (фоллоу-апы, см. коммент в #1104)

- empty_chat при живом перечтении — один bounded re-read (класс 2).
- Титул вакансии из DOM-карточки: SSR `vacancyName` исчез из topicList 2026-09-09 (0 вхождений) — ступень резолва #1094 сейчас всегда пуста (класс 3).
- Census значений SSR `lastEmployerState` — потенциально самый дешёвый гейт на будущее.

Closes #1104

PR от агента (ветка `ao/hhru-1104/reply-refusal-gate`); мёрж — за владельцем.