### PR TITLE
v7: алиасы второго прогона аудита (1С:Предприятие, Adobe, ответственность, Windows 7)

### DIFF
--- a/src/hhru_bot/market_norm.py
+++ b/src/hhru_bot/market_norm.py
@@ -101,8 +101,14 @@ def fold_key(value: str) -> str:
 # прямой ключ, не другой алиас.
 KEY_ALIASES = {
     _fold_text("1С: Предприятие 7"): _fold_text("1С: Предприятие 8"),
+    _fold_text("1С: Предприятие"): _fold_text("1С: Предприятие 8"),
+    _fold_text("1С: Предприятие 8.3"): _fold_text("1С: Предприятие 8"),
     _fold_text("Нейросеть"): _fold_text("Нейросети"),
     _fold_text("Мерчандайзинг"): _fold_text("Мерчендайзинг"),
+    _fold_text("Adobe After Effect"): _fold_text("Adobe After Effects"),
+    _fold_text("Adobe Premier Pro"): _fold_text("Adobe Premiere Pro"),
+    _fold_text("Материальная отвественность"): _fold_text("Материальная ответственность"),
+    _fold_text("Windows 7"): _fold_text("Windows"),
 }
 
 # Семантический слой: кластеры профессий. Фолд склеивает НАПИСАНИЯ, кластер —
@@ -183,6 +189,9 @@ CANONICAL_DISPLAY = {
         "1С: Бухгалтерия",
         "промпт-инженер",
         "MS Excel",
+        "Adobe After Effects",
+        "Adobe Premiere Pro",
+        "Материальная ответственность",
     )
 } | {
     # Имена кластеров профессий: id кластера — читаемый литерал (не fold-ключ),

--- a/src/hhru_bot/market_norm.py
+++ b/src/hhru_bot/market_norm.py
@@ -192,6 +192,7 @@ CANONICAL_DISPLAY = {
         "Adobe After Effects",
         "Adobe Premiere Pro",
         "Материальная ответственность",
+        "Windows",
     )
 } | {
     # Имена кластеров профессий: id кластера — читаемый литерал (не fold-ключ),

--- a/src/hhru_bot/market_schema.py
+++ b/src/hhru_bot/market_schema.py
@@ -244,4 +244,6 @@ MIGRATION_MARKER_KEY = "migrated_from_history"
 #      число слова, парные написания — по аудиту дубликатов).
 # v6 — правило категорий прав и семантические кластеры ролей
 #      (role_cluster).
-BACKFILL_MARKER_KEY = "competitor_norm_backfill:v6"
+# v7 — алиасы аудита: «1С: Предприятие» и «8.3» → «…8», After Effect →
+#      After Effects (опечатка без S).
+BACKFILL_MARKER_KEY = "competitor_norm_backfill:v7"

--- a/tests/test_market_norm.py
+++ b/tests/test_market_norm.py
@@ -112,6 +112,9 @@ def test_key_aliases_v7_audit_pairs():
     assert fold_key("Adobe Premier Pro") == fold_key("Adobe Premiere Pro")
     assert fold_key("Материальная отвественность") == fold_key("Материальная ответственность")
     assert fold_key("Windows 7") == fold_key("Windows")
+    # Витрина канона «Windows» закреплена: без записи в словаре бакет мог
+    # называться «Windows 7» по частоте сырых форм.
+    assert canonical_display(fold_key("Windows"), Counter({"Windows 7": 3})) == "Windows"
     # Витрина слитой группы — словарное имя, а не самая частая опечатка.
     assert canonical_display(
         fold_key("Adobe After Effects"), Counter({"Adobe After Effect": 3})

--- a/tests/test_market_norm.py
+++ b/tests/test_market_norm.py
@@ -102,6 +102,25 @@ def test_key_aliases_merge_audit_pairs():
     assert fold_key("Мерчандайзинг") == fold_key("Мерчендайзинг")
 
 
+def test_key_aliases_v7_audit_pairs():
+    # v7 по аудиту: «1С: Предприятие» без версии и «8.3» — канон «…8»;
+    # After Effect без S и Premier без e — опечатки от словарных имён;
+    # «отвественность» — пропущенная буква; «Windows 7» — версия навыка.
+    assert fold_key("1С: Предприятие") == fold_key("1С: Предприятие 8")
+    assert fold_key("1С: Предприятие 8.3") == fold_key("1С: Предприятие 8")
+    assert fold_key("Adobe After Effect") == fold_key("Adobe After Effects")
+    assert fold_key("Adobe Premier Pro") == fold_key("Adobe Premiere Pro")
+    assert fold_key("Материальная отвественность") == fold_key("Материальная ответственность")
+    assert fold_key("Windows 7") == fold_key("Windows")
+    # Витрина слитой группы — словарное имя, а не самая частая опечатка.
+    assert canonical_display(
+        fold_key("Adobe After Effects"), Counter({"Adobe After Effect": 3})
+    ) == ("Adobe After Effects")
+    assert canonical_display(
+        fold_key("Материальная ответственность"), Counter({"Материальная отвественность": 3})
+    ) == ("Материальная ответственность")
+
+
 def test_key_aliases_do_not_merge_distinct_things():
     # Границы разумного: близкие по написанию, но разные сущности остаются
     # разными — алиасы точечные, правило фолда широкие классы не трогает.


### PR DESCRIPTION
## Суть

Второй прогон `scripts/audit_key_dupes.py` дал кандидатов ≥50 — закрыты
алиасами:

| пара | бакеты | канон |
|---|---|---|
| 1С: Предприятие (без версии) / 8 / 8.3 | 703 / 3689 / 80 | «1С: Предприятие 8» |
| Adobe After Effect / Effect**s** | 481 / 164 | After Effects |
| Adobe Premier / Prem**i**ere Pro | 371 / 69 | Premiere Pro |
| Материальная отв**е**ственность / ответственность | 316 / 75 | ответственность |
| Windows 7 / Windows | 339 / 73 | Windows |

Витрины слитых групп закреплены в `CANONICAL_DISPLAY` (частая опечатка
больше не «побеждает» в имени). Маркер → `:v7`.

**Осознанно НЕ склеены** (разные сущности, остались как пары выше порога):
Настройка ПО/ПК, B2B/B2C (маркетинг, продажи, marketing).

## Верификация

- Полная сюита 0 падений; ruff check + format --check.
- Контрольный аудит после backfill :v7: роли — 0 пар; навыки — только
  осознанные «разные вещи»; действенных кандидатов не осталось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
